### PR TITLE
Add support for Project N type names in GC/AllocationTick views

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -259,6 +259,7 @@
     <Compile Include="PerfViewEventSource.cs" />
     <Compile Include="PerfViewTraceEventParser.cs" />
     <Compile Include="PinningGCHeapSimulatorObject.cs" />
+    <Compile Include="ProjectNTypeNameResolver.cs" />
     <Compile Include="Screenshot.cs" />
     <Compile Include="StateMachineFramework\ServerRequestComputer.cs" />
     <Compile Include="StackViewer\CallerCalleeView.xaml.cs">

--- a/src/PerfView/ProjectNTypeNameResolver.cs
+++ b/src/PerfView/ProjectNTypeNameResolver.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Parsers.Symbol;
+
+using Address = System.UInt64;
+
+namespace PerfView
+{
+    /// <summary>
+    /// Maintains the state necessary to resolve GCAllocationTick typenames for Project N.
+    /// </summary>
+    public sealed class ProjectNTypeNameResolver
+    {
+        /// <summary>
+        /// The map that contains module information for each process.
+        /// Use ProcessIndex as the index variable.
+        /// </summary>
+        private static ProcessModuleList[] _ProcessModuleMap;
+
+        /// <summary>
+        /// Responsible for translating a module and symbol to a type name.
+        /// </summary>
+        private TypeNameSymbolResolver _TypeNameResolver;
+        
+        private TextWriter _Log;
+        private string _FilePath;
+
+        public ProjectNTypeNameResolver(TraceLogEventSource eventSource, TextWriter log, string filePath)
+        {
+            _Log = log;
+            _FilePath = filePath;
+            _TypeNameResolver = new TypeNameSymbolResolver(_FilePath, _Log);
+            _ProcessModuleMap = new ProcessModuleList[eventSource.TraceLog.Processes.Count];
+            RegisterModuleCallbacks(eventSource);
+        }
+
+        /// <summary>
+        /// Resolve a type name.
+        /// </summary>
+        public string ResolveTypeName(ProcessIndex processIndex, Address typeID)
+        {
+            // Get the Module for the allocation.
+            ProcessModuleList procModuleList = ModuleListForProcess(processIndex);
+            Graphs.Module mod = procModuleList.ModuleForEEType(typeID);
+
+            // Resolve the type name.
+            string typeName = null;
+            if (mod != null)
+            {
+                typeName = _TypeNameResolver.ResolveTypeName((int)(typeID - mod.ImageBase), mod);
+            }
+
+            // Trim the module from the type name.
+            if (!string.IsNullOrEmpty(typeName))
+            {
+                // Strip off the module name if present.
+                string[] typeNameParts = typeName.Split(new char[] { '!' }, 2);
+                if (typeNameParts.Length == 2)
+                {
+                    typeName = typeNameParts[1];
+                }
+            }
+
+            return typeName;
+        }
+
+        /// <summary>
+        /// Register TraceEvent callbacks for module events.
+        /// </summary>
+        /// <param name="eventSource"></param>
+        private void RegisterModuleCallbacks(TraceLogEventSource eventSource)
+        {
+            Dictionary<int, DbgIDRSDSTraceData> _ProcessToDbgDataMap = new Dictionary<int, DbgIDRSDSTraceData>();
+
+            var symbolParser = new SymbolTraceEventParser(eventSource);
+            symbolParser.ImageIDDbgID_RSDS += delegate(DbgIDRSDSTraceData data)
+            {
+                _ProcessToDbgDataMap[data.ProcessID] = (DbgIDRSDSTraceData)data.Clone();
+            };
+
+            eventSource.Kernel.ImageGroup += delegate(ImageLoadTraceData data)
+            {
+                ProcessModuleList procModuleList = ModuleListForProcess(data.Process().ProcessIndex);
+
+                Graphs.Module module = new Graphs.Module(data.ImageBase);
+                module.Path = data.FileName;
+                module.Size = data.ImageSize;
+                module.BuildTime = data.BuildTime;
+
+                DbgIDRSDSTraceData lastDbgData = null;
+                _ProcessToDbgDataMap.TryGetValue(data.ProcessID, out lastDbgData);
+
+                if (lastDbgData != null && data.TimeStampRelativeMSec == lastDbgData.TimeStampRelativeMSec)
+                {
+                    module.PdbGuid = lastDbgData.GuidSig;
+                    module.PdbAge = lastDbgData.Age;
+                    module.PdbName = lastDbgData.PdbFileName;
+
+                }
+                procModuleList.Modules[module.ImageBase] = module;
+            };
+        }
+
+        private ProcessModuleList ModuleListForProcess(ProcessIndex processIndex)
+        {
+            ProcessModuleList moduleList = _ProcessModuleMap[(int)processIndex];
+            if (moduleList == null)
+            {
+                moduleList = _ProcessModuleMap[(int)processIndex] = new ProcessModuleList();
+            }
+
+            return moduleList;
+        }
+    }
+
+    /// <summary>
+    /// Represents a map of modules per process.  Used to store and lookup module and PDB information for each process.
+    /// </summary>
+    internal sealed class ProcessModuleList
+    {
+        private Dictionary<Address, Graphs.Module> _Modules = new Dictionary<Address, Graphs.Module>();
+
+        /// <summary>
+        /// Exposes the list of modules for the process.
+        /// </summary>
+        public Dictionary<Address, Graphs.Module> Modules
+        {
+            get { return _Modules; }
+        }
+
+        /// <summary>
+        /// Get the module for the input EEType.
+        /// </summary>
+        /// <param name="eeTypePointer"></param>
+        /// <returns></returns>
+        public Graphs.Module ModuleForEEType(Address eeTypePointer)
+        {
+            foreach(Graphs.Module mod in _Modules.Values)
+            {
+                if ((eeTypePointer >= mod.ImageBase) && (eeTypePointer < (mod.ImageBase + (ulong)mod.Size)))
+                {
+                    return mod;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/PerfView/memory/GCPinnedObjectAnalyzer.cs
+++ b/src/PerfView/memory/GCPinnedObjectAnalyzer.cs
@@ -213,7 +213,7 @@ namespace PerfView
                 eventDispatcher.StopProcessing();
             };
 
-            var heapWithPinningInfo = new PinningStackAnalysis(eventDispatcher, _ProcessID, _StackSource);
+            var heapWithPinningInfo = new PinningStackAnalysis(eventDispatcher, _TraceLog.Processes.GetProcess(_ProcessID, _TraceLog.SessionDuration.TotalMilliseconds), _StackSource);
             // Process the ETL file up until we detect that the heap snapshot was taken.
             eventDispatcher.Process();
 
@@ -487,8 +487,8 @@ namespace PerfView
     /// </summary>
     internal sealed class PinningStackAnalysis : GCHeapSimulator
     {
-        public PinningStackAnalysis(TraceEventDispatcher source, int processID, MutableTraceEventStackSource stackSource)
-            : base(source, processID, stackSource)
+        public PinningStackAnalysis(TraceEventDispatcher source, TraceProcess process, MutableTraceEventStackSource stackSource)
+            : base(source, process, stackSource)
         {
             var clrPrivateParser = new ClrPrivateTraceEventParser(source);
             clrPrivateParser.GCSetGCHandle += OnSetGCHandle;

--- a/src/TraceEvent/Stacks/Stacks.cs
+++ b/src/TraceEvent/Stacks/Stacks.cs
@@ -1018,7 +1018,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// <summary>
         ///  Allows an existing frame to be updated in place (thus all references to the old name go to the new name).  
         /// </summary>
-        internal void UpdateFrameName(StackSourceFrameIndex frameIndex, string newName)
+        public void UpdateFrameName(StackSourceFrameIndex frameIndex, string newName)
         {
             int relFrameIndex = frameIndex - m_frameStartIndex;
             Debug.Assert(relFrameIndex >= 0);


### PR DESCRIPTION
This change adds the necessary support to consume the updated Project N GC/AllocationTick events in the (coarse) allocation views.
