### PR TITLE
Remove CAP GCStats dependency on ETLX

### DIFF
--- a/src/PerfView/CapClrStats.cs
+++ b/src/PerfView/CapClrStats.cs
@@ -52,11 +52,11 @@ namespace PerfView.CapStats
             this.eventDispatcher = eventDispatcher;
         }
 
-        internal ProcessLookup<GCProcess> Collect(string etlDataFilePath, TraceLog traceLog)
+        internal ProcessLookup<GCProcess> Collect(string etlDataFilePath, ETWTraceEventSource eventSource)
         {
             CapCollection.SetupCapCollectors(eventDispatcher, Report);
             ProcessLookup<GCProcess> stats = Stats.GCProcess.Collect(eventDispatcher, 1);
-            CapCollection.UpdateCommonInfo(etlDataFilePath, traceLog, Report);
+            CapCollection.UpdateCommonInfo(etlDataFilePath, eventSource, Report);
             return stats;
         }
     }
@@ -78,7 +78,7 @@ namespace PerfView.CapStats
         {
             CapCollection.SetupCapCollectors(Source, Report);
             ProcessLookup<JitCapProcess> stats = JitCapProcess.Collect(this);
-            CapCollection.UpdateCommonInfo(EtlDataFile.FilePath, TraceLog, Report);
+            //CapCollection.UpdateCommonInfo(EtlDataFile.FilePath, TraceLog, Report);
             return stats;
         }
 
@@ -186,7 +186,7 @@ namespace PerfView.CapStats
             };
         }
 
-        public static void UpdateCommonInfo(string savedEtlFile, TraceLog source, ClrCap.CAPAnalysisBase report)
+        public static void UpdateCommonInfo(string savedEtlFile, ETWTraceEventSource source, ClrCap.CAPAnalysisBase report)
         {
             report.TraceInfo.NumberOfLostEvents = source.EventsLost;
             report.TraceInfo.TraceDurationSeconds = source.SessionDuration.TotalSeconds;
@@ -194,7 +194,7 @@ namespace PerfView.CapStats
             report.TraceInfo.TraceStart = source.SessionStartTime;
             report.TraceInfo.FileLocation = Path.GetFullPath(savedEtlFile);
             report.OSInfo.Version = source.OSVersion.ToString();
-            report.EventStats.PopulateEventCounts(source.Stats);
+            //report.EventStats.PopulateEventCounts(source.Stats);
         }
     }
 

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -2982,9 +2982,9 @@ namespace PerfViewExtensibility
         {
             string savedEtlFile = etlFile;
             ETLPerfViewData.UnZipIfNecessary(ref etlFile, LogFile);
-            TraceLog source = TraceLog.OpenOrConvert(etlFile);
+            ETWTraceEventSource source = new ETWTraceEventSource(etlFile, TraceEventSourceType.MergeAll);
 
-            GcCapCollector gcCollector = new GcCapCollector(source.Events.GetSource());
+            GcCapCollector gcCollector = new GcCapCollector(source);
             var gcStats = gcCollector.Collect(etlFile, source);
             ClrCap.CAP.GenerateCAPReport(gcStats, gcCollector.Report);
             gcCollector.Report.WriteToFileXML(StripFileExt(savedEtlFile));


### PR DESCRIPTION
Generation of the ETLX file is very costly from a time a disk I/O perspective, and we don't actually need it for GC information processing.  We do need it for EventStats and JIT processing, so those are both disabled at this time so that we can catch up on traces.
