### PR TITLE
Accommodating for the scenario where we are missing mark events

### DIFF
--- a/src/PerfView/CAP.cs
+++ b/src/PerfView/CAP.cs
@@ -1164,6 +1164,8 @@ namespace ClrCap
                     continue;
                 if (_event.PerHeapMarkTimes == null)
                     continue;
+                if (!(_event.AllHeapsSeenMark()))
+                    continue;
 
                 int index = ((_event.GCGeneration == 2) ? 1 : 0);
                 if (_event.Type != GCType.BackgroundGC)

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -1642,7 +1642,10 @@ namespace Stats
 
             GCEvent _event = GetLastGC();
             if (_event != null)
+            {
                 _event.GlobalHeapHistory = (GCGlobalHeapHistoryTraceData)data.Clone();
+                _event.SetHeapCount(heapCount);
+            }
         }
 
         private void ProcessPerHeapHistory(GCPerHeapHistoryTraceData data)
@@ -2010,6 +2013,24 @@ namespace Stats
             totalPinnedPlugSize = -1;
             totalUserPinnedPlugSize = -1;
             duplicatedPinningReports = 0;
+        }
+
+        public void SetHeapCount(int count)
+        {
+            if (heapCount == -1)
+            {
+                heapCount = count;
+            }
+        }
+
+        // Unfortunately sometimes we just don't get mark events from all heaps, even for GCs that we have seen GCStart for.
+        // So accommodating this scenario.
+        public bool AllHeapsSeenMark()
+        {
+            if (PerHeapMarkTimes != null)
+                return (heapCount == PerHeapMarkTimes.Count);
+            else
+                return false;
         }
 
         public class ServerGcHistory


### PR DESCRIPTION
@vancem I am seeing cases where we see the GCStart/GCEnd event for a GC yet we are missing mark events from some heaps. So we need to accommodate for this scenario.
