### PR TITLE
VersionRecognized should return true when V4_0 is true!

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -3910,7 +3910,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
                 {
                     return this.V4_5;
                 }
-                return false;
+                return true;
             }
         }
 


### PR DESCRIPTION
Accidently introduced this bug with the change I did a while ago wrt public/private event changes. @vancem please CR.
