### PR TITLE
Fix selected cells issue in the StackViewer

### DIFF
--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -355,7 +355,7 @@ namespace PerfView
                 var selectedCells = Grid.SelectedCells;
                 if (selectedCells.Count == 1 || selectedCells.Count == 2)
                 {
-                    string start = PerfView.StackWindow.GetCellStringValue(selectedCells[0]);
+                    string start = GetCellStringValue(selectedCells[0]);
                     double parsedStart;
                     if (!double.TryParse(start, out parsedStart))
                     {
@@ -372,7 +372,7 @@ namespace PerfView
                         endTimeRelativeMSec = parsedStart;
                         if (selectedCells.Count == 2)
                         {
-                            string end = PerfView.StackWindow.GetCellStringValue(selectedCells[1]);
+                            string end = GetCellStringValue(selectedCells[1]);
                             if (!double.TryParse(end, out endTimeRelativeMSec))
                             {
                                 StatusBar.LogError("Could not parse " + end + " as a number.");
@@ -452,7 +452,7 @@ namespace PerfView
             if (selectedCells.Count != 1)
                 throw new ApplicationException("No cells selected.");
 
-            ProcessFilterTextBox.Text = PerfView.StackWindow.GetCellStringValue(selectedCells[0]); ;
+            ProcessFilterTextBox.Text = GetCellStringValue(selectedCells[0]);
             Update();
         }
         private void DoRangeFilter(object sender, ExecutedRoutedEventArgs e)
@@ -478,8 +478,8 @@ namespace PerfView
                 StatusBar.LogError("You must select two cells to set the range.");
                 return;
             }
-            StartTextBox.Text = PerfView.StackWindow.GetCellStringValue(selectedCells[0]);
-            EndTextBox.Text = PerfView.StackWindow.GetCellStringValue(selectedCells[1]);
+            StartTextBox.Text = GetCellStringValue(selectedCells[0]);
+            EndTextBox.Text = GetCellStringValue(selectedCells[1]);
             Update();
         }
         private void DoEventTypesKey(object sender, KeyEventArgs e)
@@ -687,8 +687,8 @@ namespace PerfView
             {
                 double min = 0;
                 double max = 0;
-                if (double.TryParse(PerfView.StackWindow.GetCellStringValue(cells[0]), out min) &&
-                    double.TryParse(PerfView.StackWindow.GetCellStringValue(cells[cells.Count - 1]), out max))
+                if (double.TryParse(GetCellStringValue(cells[0]), out min) &&
+                    double.TryParse(GetCellStringValue(cells[cells.Count - 1]), out max))
                 {
                     // Swap them if necessary.  
                     if (max < min)

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1097,11 +1097,20 @@ namespace PerfView
             InitializeFeedback();
         }
         public PerfViewDirectory CurrentDirectory { get { return m_CurrentDirectory; } }
+        private static string UnquoteIfNecessary(string path) // If that path is quoted (i.e. the user right clicked on the file and chose Copy As Path), remove the quotes.
+        {
+            if (!path.StartsWith("\"") || path.EndsWith("\"") || path.Length <= 2)
+            {
+                return path;
+            }
+            return path.Substring(1, path.Length - 2);
+        }
         /// <summary>
         /// Set the left pane to the specified directory.  If it is a file name, then that file name is opened
         /// </summary>
         public void OpenPath(string path, bool force = false)
         {
+            path = UnquoteIfNecessary(path);
             if (System.IO.Directory.Exists(path))
             {
                 var fullPath = App.MakeUniversalIfPossible(Path.GetFullPath(path));

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
@@ -243,6 +243,27 @@ namespace PerfView
         }
         public static string GetCellStringValue(DataGridCellInfo cell)
         {
+            CallTreeNodeBase model = cell.Item as CallTreeNodeBase;
+            if (model != null)
+            {
+                switch (((TextBlock)cell.Column.Header).Name)
+                {
+                    case "NameColumn": return model.DisplayName;
+                    case "IncPercentColumn": return model.InclusiveMetricPercent.ToString("n1");
+                    case "IncColumn": return model.InclusiveMetric.ToString("n1");
+                    case "IncAvgColumn": return model.AverageInclusiveMetric.ToString("n1");
+                    case "IncCountColumn": return model.InclusiveCount.ToString("n0");
+                    case "ExcPercentColumn": return model.ExclusiveMetricPercent.ToString("n1");
+                    case "ExcColumn": return model.ExclusiveMetric.ToString("n0");
+                    case "ExcCountColumn": return model.ExclusiveCount.ToString("n0");
+                    case "FoldColumn": return model.ExclusiveFoldedMetric.ToString("n0");
+                    case "FoldCountColumn": return model.ExclusiveFoldedCount.ToString("n0");
+                    case "TimeHistogramColumn": return model.InclusiveMetricByTimeString;
+                    case "ScenarioHistogramColumn": return model.InclusiveMetricByScenarioString;
+                    case "FirstColumn": return model.FirstTimeRelativeMSec.ToString("n3");
+                    case "LastColumn": return model.LastTimeRelativeMSec.ToString("n3");
+                }
+            }
             var frameworkElement = cell.Column.GetCellContent(cell.Item);
             if (frameworkElement == null)
                 return "";

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -866,6 +866,9 @@ namespace PerfView
                 // Use the same configuration as the base window.  
                 DataSource.DataFile.ConfigureStackWindow("", stackWindow);
             }
+
+            stackWindow.GuiState = GuiState;
+
             stackWindow.Show();
 
             stackWindow.StatusBar.StartWork("Computing " + dataFile.Name, delegate()
@@ -1895,7 +1898,7 @@ namespace PerfView
             }
 
             //create the list of module names to look up
-            var moduleNames = new List<string>();
+            var moduleNames = new HashSet<string>();
             var success = DoForSelectedModules(delegate(string moduleName)
             {
                 moduleNames.Add(moduleName);
@@ -3166,12 +3169,11 @@ namespace PerfView
                 bool firstCell = true;
                 foreach (var cell in cells)
                 {
-                    var content = cell.Column.GetCellContent(cell.Item);
-                    var asTextBlock = content as TextBlock;
-                    if (asTextBlock != null)
+                    var content = PerfDataGrid.GetCellStringValue(cell);
+                    if (content != null)
                     {
                         double num;
-                        if (double.TryParse(asTextBlock.Text, out num))
+                        if (double.TryParse(content, out num))
                         {
                             if (count == 0)
                                 first = num;


### PR DESCRIPTION
Currently, when selecting cells in the StackWindow it only selects cells that are visible. This prevents you from selecting every frame in the By Name tab and looking up symbols for every module. The fix is to get the selected cell's content from the CallTreeNodeBase instead of the cells TextBlock.
