### PR TITLE
TraceEventSession.Merge is unconditionally compressing the merged ETL…

### DIFF
--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1264,7 +1264,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                     TraceEventNativeMethods.EVENT_TRACE_MERGE_EXTENDED_DATA.EVENT_METADATA |
                     TraceEventNativeMethods.EVENT_TRACE_MERGE_EXTENDED_DATA.VOLUME_MAPPING;
 
-                if ((options | TraceEventMergeOptions.Compress) != 0)
+                if ((options & TraceEventMergeOptions.Compress) != 0)
                     flags |= TraceEventNativeMethods.EVENT_TRACE_MERGE_EXTENDED_DATA.COMPRESS_TRACE;
 
                 int retValue = TraceEventNativeMethods.CreateMergedTraceFile(outputETLFileName, inputETLFileNames, inputETLFileNames.Length, flags);


### PR DESCRIPTION
TraceEventSession.Merge is unconditionally compressing the merged ETL file ignoring the TraceEventMergeOptions parameter. It was doing a bitwise or ((options | TraceEventMergeOptions.Compress) != 0) but it should be doing a bitwise and ((options & TraceEventMergeOptions.Compress) != 0)
