### PR TITLE
Fix bug in GetRelatedActivityID

### DIFF
--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Diagnostics.Tracing
             Debug.Assert((ulong)extendedData > 0x10000);          // Make sure this looks like a pointer.  
             for (int i = 0; i < eventRecord->ExtendedDataCount; i++)
                 if (extendedData[i].ExtType == TraceEventNativeMethods.EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID)
-                    return *((Guid*)extendedData->DataPtr);
+                    return *((Guid*)extendedData[i].DataPtr);
             return Guid.Empty;
         }
         #endregion


### PR DESCRIPTION
GetRelatedActivityID would read the wrong value if the related activity ID was not the first extended data value.

I haven't observed this bug in the wild, but I spotted it when porting the code to the ServiceProfiler agent.

@vancem for review
