### PR TITLE
Avoid an infinite loop in the ActivityComputer.

### DIFF
--- a/src/TraceEvent/Computers/ActivityComputer.cs
+++ b/src/TraceEvent/Computers/ActivityComputer.cs
@@ -758,6 +758,10 @@ namespace Microsoft.Diagnostics.Tracing
                     m_threadToCurrentActivity[(int)thread.ThreadIndex] = cur.prevActivityOnThread;
                     break;
                 }
+                if (cur.kind == TraceActivity.ActivityKind.Initial)
+                {
+                    break;
+                }
                 if (activity != null)
                 {
                     if (!NeedsImplicitCompletion(cur.kind))


### PR DESCRIPTION
Since I don't know the code, I don't know how complete or correct this is, but it does solve the problem of the infinite loop in the ActivityComputer on the trace that brought down ServiceProfiler's TraceComputer service.

@vancem @northtyphoon Please take a look
