### PR TITLE
TraceEvent fixes

### DIFF
--- a/src/TraceEvent/RegisteredTraceEventParser.cs
+++ b/src/TraceEvent/RegisteredTraceEventParser.cs
@@ -935,7 +935,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                         }
                         else
                         {
-                            propertyFetch.Size = arraySize;
+                            propertyFetch.Size = (ushort)(arraySize | (propertyFetch.Size & DynamicTraceEventData.IS_ANSI));
                             propertyFetch.Offset = arrayFieldOffset;
                         }
 


### PR DESCRIPTION
This fixes a few issues identified when attempting to use the TraceEvent library to parse events from the WinINet provider.

This does slightly break compatibility with older versions of the library because serialized DynamicTraceEventData objects now properly store the IS_ANSI indicator in the Size attribute.  This will cause all length-prefixed ASCII strings to decode as "[CANT PARSE STRING]" instead of being misinterpreted as Unicode when read by older versions.  This may not be much of an issue though because PerfView appears to delete and regenerate .etlx files created different versions of the program.
