### PR TITLE
Eliminate (mostly) allocations in GetEventCounts

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3679,14 +3679,14 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 #if DEBUG
             if (data.IsClassicProvider)
             {
-                Debug.Assert(countsForEvent.m_classicProvider);
+                Debug.Assert(countsForEvent.IsClassic);
                 Debug.Assert(countsForEvent.TaskGuid == data.taskGuid);
                 if (!data.lookupAsWPP)
                     Debug.Assert(countsForEvent.Opcode == data.Opcode || data.Opcode == TraceEventOpcode.Info);
             }
             else
             {
-                Debug.Assert(!countsForEvent.m_classicProvider);
+                Debug.Assert(!countsForEvent.IsClassic);
                 Debug.Assert(countsForEvent.ProviderGuid == data.ProviderGuid);
                 Debug.Assert(countsForEvent.EventID == data.ID);
             }


### PR DESCRIPTION
3.2% of time spent in GetEventCounts due to allocating a 'key' to look-up in the event counts index. Look-ups are far more frequent than additions.
The fix is to extract the "key" part of the index into a separate struct so that look-ups can be allocation free.
The change looks extensive, but it's all ripple effects from this refactoring.
