### PR TITLE
Add ZippedETL.cs to files to build for TraceEvent project

### DIFF
--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Utilities\command.cs" />
     <Compile Include="TraceUtilities\HistoryDictionary.cs" />
     <Compile Include="WPPTraceEventParser.cs" />
+    <Compile Include="ZippedETL.cs" />
     <Compile Include="_README.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes compilation errors in the samples about ZippedETLReader and ZippedETLWriter not being available when using the DLLs built for PerfView.
