### PR TITLE
Remove packages.config from PerfView project

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -416,7 +416,6 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="app.config" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>


### PR DESCRIPTION
This file was referenced in the project but not in source control (hence it shows up with a warning triangle in Visual Studio's Solution Explorer).

Since PerfView.csproj doesn't use Nuget, it seems safe to remove the reference.
