### PR TITLE
Eliminate delegate allocation in FindCallee

### DIFF
--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -1264,7 +1264,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                             {
                                 // Make up a new table for this node.  
                                 var newCalleeLookup = new ConcurrentDictionary<StackSourceFrameIndex, CallTreeNode>();
-                                foreach (var node in m_callees)
+                                foreach (var node in nodeToAddToCache.m_callees)
                                     newCalleeLookup[node.m_id] = node;
                                 return newCalleeLookup;
                             });


### PR DESCRIPTION
Avoids capturing 'this' in the delegate which allows it to be cached as a static field.
This saves 1.2% of allocations
