### PR TITLE
Use ordinal comparison in IsRecursiveTask

### DIFF
--- a/src/TraceEvent/Computers/ActivityComputer.cs
+++ b/src/TraceEvent/Computers/ActivityComputer.cs
@@ -1023,7 +1023,7 @@ namespace Microsoft.Diagnostics.Tracing
 
             var frameIdx = m_outputSource.GetFrameIndex(existingStacks);
             var frameName = m_outputSource.GetFrameName(frameIdx, false);
-            if (!frameName.StartsWith("STARTING TASK on Thread"))
+            if (!frameName.StartsWith("STARTING TASK on Thread", StringComparison.Ordinal))
                 return StackSourceFrameIndex.Invalid;
             return frameIdx;
         }


### PR DESCRIPTION
This is responsible for ~3% CPU when analyzing the trace with a long task chain
