### PR TITLE
Remove unnecessary call to GetFrameName in IsRecursiveTask

### DIFF
--- a/src/TraceEvent/Computers/ActivityComputer.cs
+++ b/src/TraceEvent/Computers/ActivityComputer.cs
@@ -1010,7 +1010,6 @@ namespace Microsoft.Diagnostics.Tracing
                 StackSourceFrameIndex newFrameIdx = m_outputSource.GetFrameIndex(newFrameCodeAddressIndex);
                 if (newFrameIdx != existingFrameIdx)
                 {
-                    var existingFrameName = m_outputSource.GetFrameName(m_outputSource.GetFrameIndex(existingStacks), false);
                     var newFrameMethodIndex = m_eventLog.CodeAddresses.MethodIndex(newFrameCodeAddressIndex);
                     if (newFrameMethodIndex == MethodIndex.Invalid)
                         return StackSourceFrameIndex.Invalid;


### PR DESCRIPTION
It looks like the call to GetFrameName is entirely unnecessary. I can't be sure there were no unintended side-effects, though since GetFrameName is virtual. @vancem what do you think?

This was responsible for over 50% of allocations in the long task chain scenario, so it's certainly an attractive target.
