### PR TITLE
Merge TraceEvent changes from ServiceProfiler back to PerfView.

### DIFF
--- a/src/TraceEvent/Computers/ThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/ThreadTimeComputer.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Diagnostics.Tracing
         /// Generate the thread time stacks, outputting to 'stackSource'.  
         /// </summary>
         /// <param name="outputStackSource"></param>
-        public void GenerateThreadTimeStacks(MutableTraceEventStackSource outputStackSource)
+        /// <param name="traceEvents">Optional filtered trace events.</param>
+        public void GenerateThreadTimeStacks(MutableTraceEventStackSource outputStackSource, TraceEvents traceEvents = null)
         {
             this.m_outputStackSource = outputStackSource;
             m_sample = new StackSourceSample(outputStackSource);
@@ -92,8 +93,8 @@ namespace Microsoft.Diagnostics.Tracing
             m_readyFrameIndex = outputStackSource.Interner.FrameIntern("READIED_TIME (waiting for cpu)");
             m_networkFrameIndex = outputStackSource.Interner.FrameIntern("NETWORK_TIME (probably)");
 
-            TraceLogEventSource eventSource = m_eventLog.Events.GetSource();        // TODO: We don't restrict to a range because we don't start up accurately.
-
+            TraceLogEventSource eventSource = traceEvents == null ? m_eventLog.Events.GetSource() :
+                                                                     traceEvents.GetSource();
             if (GroupByStartStopActivity)
                 UseTasks = true;
 

--- a/src/TraceEvent/Symbols/SymbolPath.cs
+++ b/src/TraceEvent/Symbols/SymbolPath.cs
@@ -332,7 +332,8 @@ namespace Microsoft.Diagnostics.Symbols
                 if (Target == null)
                     return false;
 
-                if (Target.StartsWith("http:/", StringComparison.OrdinalIgnoreCase))
+                if (Target.StartsWith("http:/", StringComparison.OrdinalIgnoreCase)
+                    || Target.StartsWith("https:/", StringComparison.OrdinalIgnoreCase))
                     return true;
                 return false;
             }

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -36,7 +36,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;COMMAND_PUBLIC;PEFILE_PUBLIC</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;COMMAND_PUBLIC;PEFILE_PUBLIC;PERFVIEW</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Diagnostics.Tracing.TraceEvent.xml</DocumentationFile>

--- a/src/TraceEvent/TraceEventStacks.cs
+++ b/src/TraceEvent/TraceEventStacks.cs
@@ -81,9 +81,10 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// <summary>
         /// Looks up symbols for all modules that have an inclusive count >= minCount. 
         /// stackSource, if given, can be used to be the filter.  If null, 'this' is used.
-        /// If stackSource is given, it needs to use the same indexes for frames as 'this'
+        /// If stackSource is given, it needs to use the same indexes for frames as 'this'.
+        /// shouldLoadSymbols, if given, can be used to filter the modules.
         /// </summary>
-        public void LookupWarmSymbols(int minCount, SymbolReader reader, StackSource stackSource = null)
+        public void LookupWarmSymbols(int minCount, SymbolReader reader, StackSource stackSource = null, Predicate<TraceModuleFile> shouldLoadSymbols = null)
         {
             if (stackSource == null)
                 stackSource = this;
@@ -131,8 +132,11 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 if (moduleCounts[i] >= minCount)
                 {
                     var moduleFile = TraceLog.ModuleFiles[(ModuleFileIndex)i];
-                    reader.Log.WriteLine("Resolving symbols (count={0}) for module {1} ", moduleCounts[i], moduleFile.FilePath);
-                    TraceLog.CallStacks.CodeAddresses.LookupSymbolsForModule(reader, moduleFile);
+                    if (shouldLoadSymbols == null || shouldLoadSymbols(moduleFile))
+                    {
+                        reader.Log.WriteLine("Resolving symbols (count={0}) for module {1} ", moduleCounts[i], moduleFile.FilePath);
+                        TraceLog.CallStacks.CodeAddresses.LookupSymbolsForModule(reader, moduleFile);
+                    }
                 }
             }
             reader.Log.WriteLine("Done Resolving all symbols for modules with inclusive times > {0}", minCount);

--- a/src/TraceEvent/ZippedETL.cs
+++ b/src/TraceEvent/ZippedETL.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// <summary>
         /// Actually do the work specified by the ZippedETLWriter constructors and other methods.  
         /// </summary>
-        public bool WriteArchive()
+        public bool WriteArchive(CompressionLevel compressionLevel = CompressionLevel.Optimal)
         {
             List<string> pdbFileList = PrepForWrite();
 
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Tracing
                 Log.WriteLine("[Zipping ETL file {0}]", m_etlFilePath);
                 using (var zipArchive = ZipFile.Open(newFileName, ZipArchiveMode.Create))
                 {
-                    zipArchive.CreateEntryFromFile(m_etlFilePath, Path.GetFileName(m_etlFilePath));
+                    zipArchive.CreateEntryFromFile(m_etlFilePath, Path.GetFileName(m_etlFilePath), compressionLevel);
                     if (pdbFileList != null)
                     {
                         Log.WriteLine("[Writing {0} PDBS to Zip file]", pdbFileList.Count);
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Tracing
                             var archivePath = Path.Combine("symbols", relativePath);
 
                             // log.WriteLine("Writing PDB {0} to archive.", archivePath);
-                            zipArchive.CreateEntryFromFile(pdb, archivePath);
+                            zipArchive.CreateEntryFromFile(pdb, archivePath, compressionLevel);
                         }
                         Log.Flush();
 
@@ -127,7 +127,7 @@ namespace Microsoft.Diagnostics.Tracing
                                 using (Stream fs = File.Open(additionalFile.Item1, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                                 {
                                     // Item2 tells you the path in the archive.  
-                                    var entry = zipArchive.CreateEntry(additionalFile.Item2);
+                                    var entry = zipArchive.CreateEntry(additionalFile.Item2, compressionLevel);
                                     using (Stream es = entry.Open())
                                         fs.CopyTo(es);
                                 }


### PR DESCRIPTION
1. StartStopActivityComputer.cs : support activity grouping node; fix the actiivty path string issue (//)
2. ThreadTimeComputer.cs: support custom trace events source.
3. SymbolReader.cs: support conditional build for Symbol_Lookup_At_Collection_Time. In Service Profiler, the agent doesn't need symbol lookup but the server does.
4. TraceEvent.csproj: the PERFVIEW defintion seems missing in debug build.
5. TraceEventStacks.cs: support load negn module symbol only (eg, in user code mode).
6. ZippedETL.cs: support CompressionLevel in WriteArchive function.

@vancem @pharring 
