### PR TITLE
Merge PerfScript and LTTng file types so that they can be opened as a single file

### DIFF
--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
@@ -418,7 +418,7 @@ namespace Diagnostics.Tracing.StackSources
 				}
 			}
 
-			throw new Exception("Not a valid input file");
+			throw new FileNotFoundException("Invalid perf script file or no perf script file found in the specified archive.");
 		}
 
 		private double? SampleEndTime;


### PR DESCRIPTION
Today, perf script and LTTng data need to be opened in two different ways.  This means that perf script data opens nicely (just double click on the file in PerfView), but LTTng data does not.  LTTng data requires renaming the file to *.lttng.zip (from *.trace.zip), opening it, and then re-opening the resulting .etlx file that is generated to get to the views.

This change resolves all of these issues so that double clicking on the trace.zip file will open up the appropriate views.

Additional improvements:
1. Bring back the folder structure for views.
2. LTTng based views only show up if data is present to drive the views.
