### PR TITLE
Fix bug that occurs when there are no samples in a Linux trace

### DIFF
--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
@@ -301,6 +301,11 @@ namespace Diagnostics.Tracing.StackSources
 		{
 			Contract.Requires(_samples != null, nameof(_samples));
 
+			if (!_samples.Any())
+			{
+				return;
+			}
+
 			List<StackSourceSample> samples = _samples.ToList();
 			samples.Sort((x, y) => x.TimeRelativeMSec.CompareTo(y.TimeRelativeMSec));
 			double startTime = samples[0].TimeRelativeMSec;
@@ -396,7 +401,7 @@ namespace Diagnostics.Tracing.StackSources
 			archive = null;
 			if (path.EndsWith(".zip"))
 			{
-                archive = ZipFile.OpenRead(path);
+				archive = ZipFile.OpenRead(path);
 				ZipArchiveEntry foundEntry = null;
 
 				foreach (ZipArchiveEntry entry in archive.Entries)


### PR DESCRIPTION
I ran into this today and thought I'd send a PR to fix it.

The code in `AddSamples` tries to get the timestamp from the first and last sample in the set of samples passed in. When that set is empty, we blow up trying to read `samples[0]`.

Instead, let's first check whether the IEnumerable has any elements and if not, bail out of the function since there's nothing to add.

With this fix, when opening a trace with no samples, the view successfully opens (and obviously has no data).

@vancem  
