### PR TITLE
Naming updates (per conversation with Vance).

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
                 // if (!removeFromStream && data.Opcode != TraceEventOpcode.DataCollectionStart && data.ProcessID != 0 && data.ProviderGuid != ClrRundownTraceEventParser.ProviderGuid)
                 //     Trace.WriteLine("REAL TIME QUEUE:  " + data.ToString());
-                TraceEventCounts countForEvent = this.stats.GetEventCounts(data);
+                TraceEventCounts countForEvent = this.Stats.GetEventCounts(data);
                 Debug.Assert((int)data.EventIndex == this.eventCount);
                 countForEvent.m_count++;
                 countForEvent.m_eventDataLenTotal += data.EventDataLength;


### PR DESCRIPTION
1) Fixed a build break in TraceLog.cs when Stats was renames to Stats()
2) Renamed TraceManagedProcess to TraceLoadedDotNetRuntime and changed the semantics from "is a" to "has a"
3) Renamed Enums to align with managed standards
4) Fixed callbacks.  They now chain in this way:
TraceProcesses.OnProcessStart
  TraceProcess.OnDotNetRuntimeLoad
    TraceLoadedDotNetRuntime.GCStart/GCEnd/JITMethodStart/JITMethodEnd
5) Marked the majority of APIs as obsolete (experimental) to indicate common case from advanced.
