### PR TITLE
More complex uses of Need* artitecture need to guard against redundant calls with the same source

### DIFF
--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             // ensure there are base processes
             source.NeedProcesses();
 
-            TraceLoadedDotNetRuntime.SetupCallbacks(source);
+            if (m_currentSource != source) TraceLoadedDotNetRuntime.SetupCallbacks(source);
             source.UserData["Computers/LoadedDotNetRuntimes"] = new Dictionary<ProcessIndex, DotNetRuntime>();
 
             m_currentSource = source;
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
         {
             Debug.Assert(process.Source != null);
             Debug.Assert(m_currentSource == process.Source);
-            Dictionary<ProcessIndex, DotNetRuntime> map = (Dictionary<ProcessIndex, DotNetRuntime>)process.Source.UserData["Computers/LoadedDotNetRuntimes"];
+            Dictionary<ProcessIndex, DotNetRuntime> map = process.Source.UserData["Computers/LoadedDotNetRuntimes"] as Dictionary<ProcessIndex, DotNetRuntime>;
             if (map.ContainsKey(process.ProcessIndex)) return map[process.ProcessIndex].Runtime;
             else return null;
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             Debug.Assert(m_currentSource == process.Source);
             Dictionary<ProcessIndex, DotNetRuntime> map = (Dictionary<ProcessIndex, DotNetRuntime>)process.Source.UserData["Computers/LoadedDotNetRuntimes"];
             if (!map.ContainsKey(process.ProcessIndex)) map.Add(process.ProcessIndex, new DotNetRuntime());
-            map[process.ProcessIndex].OnLoaded = OnDotNetRuntimeLoaded;
+            map[process.ProcessIndex].OnLoaded += OnDotNetRuntimeLoaded;
         }
 
         public static void SetMutableTraceEventStackSource(this TraceProcess process, MutableTraceEventStackSource stackSource)
@@ -77,6 +77,12 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             Dictionary<ProcessIndex, DotNetRuntime> map = (Dictionary<ProcessIndex, DotNetRuntime>)process.Source.UserData["Computers/LoadedDotNetRuntimes"];
             if (map.ContainsKey(process.ProcessIndex)) return map[process.ProcessIndex].StackSource;
             else return null;
+        }
+
+        public static bool HasMutableTraceEventStackSource(this TraceEventDispatcher source)
+        {
+            Dictionary<ProcessIndex, DotNetRuntime> map = (Dictionary<ProcessIndex, DotNetRuntime>)source.UserData["Computers/LoadedDotNetRuntimes"];
+            return map.Any(kv => kv.Value.StackSource != null);
         }
 
         #region private
@@ -280,37 +286,40 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
                 source.Kernel.PerfInfoSample += delegate (SampledProfileTraceData data)
                 {
                     RecentCpuSamples.Add(new ThreadWorkSpan(data));
-                    TraceLoadedDotNetRuntime loadedRuntime = null;
-                    TraceProcess gcProcess = null;
-                    foreach (var proc in source.Processes())
+                    if (source.HasMutableTraceEventStackSource())
                     {
-                        var tmpMang = proc.LoadedDotNetRuntime();
-                        if (tmpMang == null) continue;
-
-                        TraceGC e = TraceGarbageCollector.GetCurrentGC(tmpMang);
-                        // If we are in the middle of a GC.
-                        if (e != null)
+                        TraceLoadedDotNetRuntime loadedRuntime = null;
+                        TraceProcess gcProcess = null;
+                        foreach (var proc in source.Processes())
                         {
-                            if ((e.Type != GCType.BackgroundGC) && (tmpMang.GC.m_stats.IsServerGCUsed == 1))
+                            var tmpMang = proc.LoadedDotNetRuntime();
+                            if (tmpMang == null) continue;
+
+                            TraceGC e = TraceGarbageCollector.GetCurrentGC(tmpMang);
+                            // If we are in the middle of a GC.
+                            if (e != null)
                             {
-                                e.AddServerGcSample(new ThreadWorkSpan(data));
-                                loadedRuntime = tmpMang;
-                                gcProcess = proc;
+                                if ((e.Type != GCType.BackgroundGC) && (tmpMang.GC.m_stats.IsServerGCUsed == 1))
+                                {
+                                    e.AddServerGcSample(new ThreadWorkSpan(data));
+                                    loadedRuntime = tmpMang;
+                                    gcProcess = proc;
+                                }
                             }
                         }
-                    }
 
-                    if (loadedRuntime != null && gcProcess != null && gcProcess.MutableTraceEventStackSource() != null)
-                    {
-                        var stackSource = gcProcess.MutableTraceEventStackSource();
-                        TraceGC e = TraceGarbageCollector.GetCurrentGC(loadedRuntime);
-                        StackSourceSample sample = new StackSourceSample(stackSource);
-                        sample.Metric = 1;
-                        sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
-                        var nodeName = string.Format("Server GCs #{0} in {1} (PID:{2})", e.Number, gcProcess.Name, gcProcess.ProcessID);
-                        var nodeIndex = stackSource.Interner.FrameIntern(nodeName);
-                        sample.StackIndex = stackSource.Interner.CallStackIntern(nodeIndex, stackSource.GetCallStack(data.CallStackIndex(), data));
-                        stackSource.AddSample(sample);
+                        if (loadedRuntime != null && gcProcess != null && gcProcess.MutableTraceEventStackSource() != null)
+                        {
+                            var stackSource = gcProcess.MutableTraceEventStackSource();
+                            TraceGC e = TraceGarbageCollector.GetCurrentGC(loadedRuntime);
+                            StackSourceSample sample = new StackSourceSample(stackSource);
+                            sample.Metric = 1;
+                            sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
+                            var nodeName = string.Format("Server GCs #{0} in {1} (PID:{2})", e.Number, gcProcess.Name, gcProcess.ProcessID);
+                            var nodeIndex = stackSource.Interner.FrameIntern(nodeName);
+                            sample.StackIndex = stackSource.Interner.CallStackIntern(nodeIndex, stackSource.GetCallStack(data.CallStackIndex(), data));
+                            stackSource.AddSample(sample);
+                        }
                     }
 
                     TraceProcess tmpProc = data.Process();


### PR DESCRIPTION
As I explored more complex uses of NeedProcesses and NeedLoadedDotNetRuntimes I found that the check for when to add callbacks was too aggressive.  I built a NeedThreadPool* extension for CAP and was receiving mulitiple JIT callbacks because for a given source callbacks were added mulitple times.  For more complex scenarios NeedLoadedDotNetRuntimes may be called multiple times witht the same source.

Tested with the more complex case and PerfView scenarios.

Note this case is not hit in PerfView, but as more complex external scenarios are built it is an important scenario.