### PR TITLE
Minor Documentation Fix

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -97,7 +97,7 @@
             See <a href="#BlockedTimeInvestigation">Blocked / Wall Clock Time Investigation</a> for more.
         </li>
         <li>
-            <strong></strong> Memory Investigations:</strong> You can also turn on events every time the OS heap memory
+            <strong> Memory Investigations:</strong> You can also turn on events every time the OS heap memory
             allocator allocates or frees an object.   Using these events you can see what call
             stacks are responsible for the most net unmanaged memory allocations.
             See <a href="#InvestigatingMemoryData">Investigating Memory</a> and


### PR DESCRIPTION
- Removed an extra closing `</strong>` tag that prevented the "Memory Investigations:" label from being bolded in the users guide.