### PR TITLE
Update the MemoryProcessMemInfoTraceData class so it can parse V2 of the event

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1793,7 +1793,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             ushort originalUserDataLength = data.eventRecord->UserDataLength;
 
             // change the size so that the array of information is exactly 1 count in size. 
-            data.eventRecord->UserDataLength = (ushort)(data.HostOffset(20, 4) + 4);
+            data.eventRecord->UserDataLength = (ushort)(data.ElementSize + 4);
             int newCount = 1;
             // For every MemInfoWSData (that is for every process) 
             for (int i = 0; i < data.Count; i++)


### PR DESCRIPTION
Microsoft-Windows-Kernel-Memory/MemoryProcessMemInfo was showing bogus payloads because the additional payloads were added to the MemoryProcessMemInfoValues structure in Version2 and PerfView only knows how to parse the payloads from Version1. This has been happening for at least several months but we need these events for a metric we want to report in our perf tests so I'd like to get this fixed. This change makes it so TraceEvent can parse events from either version 1 or version 2.