### PR TITLE
Fix for #108 and similar code path

### DIFF
--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -1928,6 +1928,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         /// <returns></returns>
         public bool IsNotCompacting()
         {
+            if (GlobalHeapHistory == null) return true;
             return ((GlobalHeapHistory.GlobalMechanisms & (GCGlobalMechanisms.Compaction)) != 0);
         }
         /// <summary>
@@ -1939,11 +1940,11 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         {
             // Older versions of the runtime does not have this event. So even for a complete GC, we may not have this
             // info.
-            if (PerHeapCondemnedReasons == null)
+            if (PerHeapCondemnedReasons == null || PerHeapCondemnedReasons.Length == 0)
                 return;
 
             int HeapIndexHighestGen = 0;
-            if (PerHeapCondemnedReasons.Length != 1)
+            if (PerHeapCondemnedReasons.Length > 1)
             {
                 HeapIndexHighestGen = FindFirstHighestCondemnedHeap();
             }


### PR DESCRIPTION
Two similar 'used before initialized' crashes.  IsNotCompacting fails if GlobalHistory event was not seen for this GC - checked for null.  GetCondemnedReasons fails if the length of the CondemnedReasons does not include details even for the first heap - added a check to exit gracefully.

Fix for #108 