### PR TITLE
Add trigger to stop collection on long BGC final pause

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -246,7 +246,8 @@ namespace PerfView
             parser.DefineOptionalQualifier("StopOnGCSuspendOverMSec", ref StopOnGCSuspendOverMSec,
                 "Trigger a stop of a collect command if there is a .NET Garbage Collection (GC) where suspending for the GC took over the given number of MSec.");
             parser.DefineOptionalQualifier("StopOnBGCFinalPauseOverMsec", ref StopOnBGCFinalPauseOverMsec,
-               "Trigger a stop of a collect command if there is a background .NET Garbage Collection (GC) whose final pause is longer than the given number of MSec.");
+               "Trigger a stop of a collect command if there is a background .NET Garbage Collection (GC) whose final pause is longer than the given number of MSec. To work correctly, "+
+               "this requires that heap survival and movement tracking is not enabled.");
             parser.DefineOptionalQualifier("StopOnAppFabricOverMsec", ref StopOnAppFabricOverMsec,
                 "Trigger a stop of a collect command if there is a AppFabric request is longer than the given number of MSec.");
 

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -79,7 +79,7 @@ namespace PerfView
 #endif
 
         // view options
-        public string Process;              // A process name to focus on.  
+        public string Process;              // A process name to focus on.
 
         // run Options 
         public string[] CommandAndArgs;     // This is broken up into words
@@ -93,6 +93,7 @@ namespace PerfView
         public string[] StopOnEtwEvent;
         public string StopOnException;
         public int StopOnGCOverMsec;
+        public int StopOnBGCFinalPauseOverMsec; // Stop on a BGC whose final pause is over this many ms
         public float DecayToZeroHours;          //causes 'StopOn*OverMSec' timeouts to decay to zero over this time period
         public int MinSecForTrigger;            // affects StopOnPerfCounter
         public string StopOnEventLogMessage;    // stop collection on event logs
@@ -236,13 +237,16 @@ namespace PerfView
 
             int StopOnRequestOverMsec = 0;
             int StopOnGCSuspendOverMSec = 0;
+
             // These are basically special cases of the /StopOnEtwEvent
             parser.DefineOptionalQualifier("StopOnRequestOverMsec", ref StopOnRequestOverMsec,
                 "Trigger a stop of a collect command if there is any IIS request that is longer than the given number of MSec.");
             parser.DefineOptionalQualifier("StopOnGCOverMsec", ref StopOnGCOverMsec,
                 "Trigger a stop of a collect command if there is a .NET Garbage Collection (GC) is longer than the given number of MSec.");
             parser.DefineOptionalQualifier("StopOnGCSuspendOverMSec", ref StopOnGCSuspendOverMSec,
-                "Trigger a stop of a collect command if there is a .NET Garbage Collection (GC) where suspending for the GC took over the given number of MSec .");
+                "Trigger a stop of a collect command if there is a .NET Garbage Collection (GC) where suspending for the GC took over the given number of MSec.");
+            parser.DefineOptionalQualifier("StopOnBGCFinalPauseOverMsec", ref StopOnBGCFinalPauseOverMsec,
+               "Trigger a stop of a collect command if there is a background .NET Garbage Collection (GC) whose final pause is longer than the given number of MSec.");
             parser.DefineOptionalQualifier("StopOnAppFabricOverMsec", ref StopOnAppFabricOverMsec,
                 "Trigger a stop of a collect command if there is a AppFabric request is longer than the given number of MSec.");
 

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1713,6 +1713,16 @@ namespace PerfView
                         TriggerStop(collectionCompleted, trigger.TriggeredMessage, parsedArgs.DelayAfterTriggerSec);
                     }));
                 }
+
+                if (parsedArgs.StopOnBGCFinalPauseOverMsec > 0)
+                {
+                    LogFile.WriteLine("[Enabling StopOnBGCFinalPauseOverMsec {0}.]", parsedArgs.StopOnBGCFinalPauseOverMsec);
+                    triggers.Add(ETWEventTrigger.BgcFinalPauseTooLong(parsedArgs.StopOnBGCFinalPauseOverMsec, parsedArgs.DecayToZeroHours, parsedArgs.Process, LogFile, delegate (ETWEventTrigger trigger)
+                    {
+                        TriggerStop(collectionCompleted, trigger.TriggeredMessage, parsedArgs.DelayAfterTriggerSec);
+                    }));
+                }
+
                 if (parsedArgs.StopOnException != null)
                 {
                     LogFile.WriteLine("[Enabling StopOnException {0}.]", parsedArgs.StopOnException);
@@ -2227,6 +2237,9 @@ namespace PerfView
                 cmdLineArgs += " /StopOnAppFabricOverMsec:" + parsedArgs.StopOnAppFabricOverMsec;
             if (parsedArgs.StopOnGCOverMsec != 0)
                 cmdLineArgs += " /StopOnGcOverMsec:" + parsedArgs.StopOnGCOverMsec;
+            if (parsedArgs.StopOnBGCFinalPauseOverMsec != 0)
+                cmdLineArgs += " /StopOnBGCFinalPauseOverMsec:" + parsedArgs.StopOnBGCFinalPauseOverMsec;
+
             if (parsedArgs.StopOnEtwEvent != null)
                 cmdLineArgs += " /StopOnEtwEvent:" + Command.Quote(string.Join(",", parsedArgs.StopOnEtwEvent));
             if (parsedArgs.StopOnException != null)

--- a/src/PerfView/Triggers.cs
+++ b/src/PerfView/Triggers.cs
@@ -378,6 +378,33 @@ namespace Triggers
             ret.Start();
             return ret;
         }
+
+        public static ETWEventTrigger BgcFinalPauseTooLong(int triggerDurationMSec, float decayToZeroHours, string processFilter, TextWriter log, Action<ETWEventTrigger> onTriggered)
+        {
+            var ret = new ETWEventTrigger(log);
+            ret.TriggerMSec = triggerDurationMSec;
+            ret.DecayToZeroHours = decayToZeroHours;
+            ret.OnTriggered = onTriggered;
+            ret.m_triggerName = "StopOnBGCFinalPauseOverMsec";
+            ret.ProcessFilter = processFilter;
+            ret.StartStopID = "ThreadID";
+
+            ret.ProviderGuid = ClrTraceEventParser.ProviderGuid;
+            ret.ProviderLevel = TraceEventLevel.Informational;
+            ret.ProviderKeywords = (ulong)ClrTraceEventParser.Keywords.GC;
+            ret.StartEvent = "GC/SuspendEEStart";
+            ret.StopEvent = "GC/RestartEEStop";
+
+            ret.TriggerPredicate = delegate (TraceEvent data)
+            {
+                var suspendEETraceData = (Microsoft.Diagnostics.Tracing.Parsers.Clr.GCSuspendEETraceData)data;
+                return suspendEETraceData.Reason == GCSuspendEEReason.SuspendForGCPrep;
+            };
+
+            ret.Start();
+            return ret;
+        }
+        
         /// <summary>
         /// Stops on a Gen 2 GC.  
         /// </summary>


### PR DESCRIPTION
This change adds a command line option to stop collection when a background GC is encountered whose final pause takes longer than the specified number of milliseconds.

@Maoni0 PTAL