### PR TITLE
EventCounter data visualization

### DIFF
--- a/src/PerfView/EventViewer/EventCounterWindow.xaml
+++ b/src/PerfView/EventViewer/EventCounterWindow.xaml
@@ -1,0 +1,21 @@
+﻿<Window x:Class="PerfView.EventCounterWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:sparrow="http://sparrowtoolkit.codeplex.com/wpf"
+        xmlns:local="clr-namespace:PerfView"
+        mc:Ignorable="d"
+        Title="Mean plot" Height="493" Width="989">
+    <Grid>
+      <sparrow:SparrowChart Margin="50">
+        <sparrow:SparrowChart.XAxis>
+          <sparrow:LinearXAxis/>
+        </sparrow:SparrowChart.XAxis>
+        <sparrow:SparrowChart.YAxis>
+          <sparrow:LinearYAxis/>
+        </sparrow:SparrowChart.YAxis>
+        <sparrow:LineSeries PointsSource="{Binding EventPoints}" XPath="X" YPath="Y"/>
+      </sparrow:SparrowChart>
+    </Grid>
+</Window>

--- a/src/PerfView/EventViewer/EventCounterWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventCounterWindow.xaml.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace PerfView
+{
+    public class EventCounterPoint
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+
+        public EventCounterPoint(double x, double y)
+        {
+            this.X = x;
+            this.Y = y;
+        }
+    }
+
+    /// <summary>
+    /// Interaction logic for EventCounterWindow.xaml
+    /// </summary>
+    public partial class EventCounterWindow : Window
+    {
+        private ObservableCollection<EventCounterPoint> eventPoints;
+
+        public EventCounterWindow()
+        {
+            InitializeComponent();
+            this.DataContext = this;
+        }
+
+        public ObservableCollection<EventCounterPoint> EventPoints
+        {
+            get
+            {
+                if (this.eventPoints == null)
+                {
+                    this.eventPoints = new ObservableCollection<EventCounterPoint>();
+                }
+
+                return this.eventPoints;
+            }
+        }
+
+    }
+}

--- a/src/PerfView/EventViewer/EventWindow.xaml
+++ b/src/PerfView/EventViewer/EventWindow.xaml
@@ -27,6 +27,7 @@
             <CommandBinding Command="{x:Static src:EventWindow.OpenAnyStartStopStacksCommand}" Executed="DoOpenAnyStartStopStacks"/>
             <CommandBinding Command="{x:Static src:EventWindow.OpenAnyTaskTreeStacksCommand}" Executed="DoOpenAnyTaskTreeStacks"/>
             <CommandBinding Command="{x:Static src:EventWindow.SetProcessFilterCommand}" Executed="DoProcessFilter"/>
+            <CommandBinding Command="{x:Static src:EventWindow.ShowEventCounterGraphCommand}" Executed="DoShowEventCounterGraph"/>
             <CommandBinding Command="{x:Static src:EventWindow.SetRangeFilterCommand}" Executed="DoRangeFilter"/>
             <CommandBinding Command="{x:Static src:EventWindow.NewWindowCommand}" Executed="DoNewWindow"/>
             <CommandBinding Command="{x:Static src:EventWindow.CancelCommand}" Executed="DoCancel"/>
@@ -41,6 +42,8 @@
             <ContextMenu>
                 <MenuItem Command="{x:Static src:EventWindow.NewWindowCommand}" />
                 <MenuItem Command="{x:Static src:EventWindow.UpdateCommand}" />
+                <Separator/>
+                <MenuItem Command="{x:Static src:EventWindow.ShowEventCounterGraphCommand}" />
                 <Separator/>
                 <MenuItem Command="{x:Static src:EventWindow.SetProcessFilterCommand}" />
                 <MenuItem Command="{x:Static src:EventWindow.SetRangeFilterCommand}" />

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -47,6 +47,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" PrivateAssets="all" />
     <PackageReference Include="PerfView.SupportFiles" Version="$(PerfViewSupportFilesVersion)" PrivateAssets="all" />
+    <PackageReference Include="Sparrow.Chart.Wpf" Version="13.1.0.118" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change create a new context menu option on the EventWindow to allow EventCounter data to be visualized as a graph.

Currently, it shows only a plot of mean against time, we can potentially add more visualization for max/min/standard deviation data.

The charting capability is currently using SparrowChart from https://sparrowtoolkit.codeplex.com/, unfortunately the project is current discontinued, if we have better charting control for WPF we should definitely switch.

The option would show up like this:
![image](https://cloud.githubusercontent.com/assets/3410332/20580128/806646ae-b185-11e6-9f9e-825dd78d239f.png)

The generated plot would look like this.
![image](https://cloud.githubusercontent.com/assets/3410332/20580098/55d899c8-b185-11e6-896e-50eae546d270.png)

Comments welcomed!