### PR TITLE
Make help text editors readonly

### DIFF
--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1544,7 +1544,7 @@ namespace PerfView
             TakeHeapShapshot(null);
         }
 
-        // The Help menu callbacksC:\Users\vancem\Documents\etw\EtwClrProfiler\Debug\x86\EtwClrProfiler.dll
+        // The Help menu callbacks
         internal void DoCommandLineHelp(object sender, RoutedEventArgs e)
         {
             var editor = new TextEditorWindow();
@@ -1552,6 +1552,7 @@ namespace PerfView
             editor.Height = 600;
             editor.Title = "PerfView Command Line Help";
             editor.TextEditor.AppendText(CommandLineArgs.GetHelpString(120));
+            editor.TextEditor.IsReadOnly = true;
             editor.Show();
         }
         internal void DoUserCommandHelp(object sender, RoutedEventArgs e)
@@ -1565,6 +1566,7 @@ namespace PerfView
             editor.Height = 600;
             editor.Title = "PerfView Command Line Help";
             editor.TextEditor.AppendText(sw.ToString());
+            editor.TextEditor.IsReadOnly = true;
             editor.Show();
         }
 


### PR DESCRIPTION
I noticed that "Command Line Help" and "User Command Help" open in editable controls, which is not useful. This change fixes that and also removes a file path that (I think) was accidentally included in a comment.