### PR TITLE
Correct typo in ZippedETLReader.UnpackArchive()

### DIFF
--- a/src/EtwHeapDump/DotNetHeapDumper.cs
+++ b/src/EtwHeapDump/DotNetHeapDumper.cs
@@ -34,7 +34,7 @@ public class DotNetHeapDumper
             var options = new TraceEventProviderOptions() { ProcessIDFilter = new List<int>() { processID } };
 
             // There is a bug in the runtime 4.6.2 and earlier where we only clear the table of types we have already emitted when you ENABLE 
-            // the Clr Provider WITHOUT the ClrTraceEventParser.Keywords.Type keyword.  we achive this by turning on just the GC events, 
+            // the Clr Provider WITHOUT the ClrTraceEventParser.Keywords.Type keyword. We achieve this by turning on just the GC events,
             // (which clears the Type table) and then turn all the events we need on.   
             // Note we do this here, as well as in Dump() because it only works if the CLR Type keyword is off (and we turn it on below)
             session.EnableProvider(ClrTraceEventParser.ProviderGuid, TraceEventLevel.Informational, (ulong) ClrTraceEventParser.Keywords.GC, options);

--- a/src/HtmlJs/PerfDataService/CallTreeDataProviderFactory.cs
+++ b/src/HtmlJs/PerfDataService/CallTreeDataProviderFactory.cs
@@ -148,7 +148,7 @@
                             ZippedETLReader reader = new ZippedETLReader(filename, Console.Out);
                             reader.SymbolDirectory = defaultSymbolCache;
                             reader.EtlFileName = Path.ChangeExtension(etlxFilePath, etlExtension);
-                            reader.UnpackAchive();
+                            reader.UnpackArchive();
                             TraceLog.CreateFromEventTraceLogFile(reader.EtlFileName, etlxFilePath);
                         }
                         else

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -5315,7 +5315,7 @@ table {
                 }
                 log.WriteLine("Putting symbols in {0}", etlReader.SymbolDirectory);
 
-                etlReader.UnpackAchive();
+                etlReader.UnpackArchive();
                 inputFileName = unzipedEtlFile;
             }
         }

--- a/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
@@ -35,7 +35,7 @@ namespace TraceEventTests
                     var zipReader = new ZippedETLReader(dataFile);
                     zipReader.SymbolDirectory = Path.Combine(UnZippedDataDir, "Symbols");
                     zipReader.EtlFileName = etlFilePath;
-                    zipReader.UnpackAchive();
+                    zipReader.UnpackArchive();
                 }
                 else
                     Trace.WriteLine(string.Format("using cached ETL file {0}", etlFilePath));

--- a/src/TraceEvent/ZippedETL.cs
+++ b/src/TraceEvent/ZippedETL.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// After setting any properties to override default behavior, calling this method
         /// will actually do the unpacking.  
         /// </summary>
-        public void UnpackAchive()
+        public void UnpackArchive()
         {
             if (Log == null)
                 Log = new StringWriter();


### PR DESCRIPTION
Correct two related typos

1. `ZippedETLReader.UnpackAchive()` --> `.UnpackArchive()`
2. Comment in `DotNetHeapDumper` "achive" --> "achieve"

Note that this is technically a breaking change because
`ZippedETLWriter.UnpackArchive()` is public