### PR TITLE
Add Image Events to /GCCollectOnly

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -403,7 +403,8 @@ namespace PerfView
             if (GCCollectOnly)
             {
                 // TODO this logic is cloned.  We need it in only one place.  If you update it do the other location as well
-                KernelEvents = KernelTraceEventParser.Keywords.Process;     // For process names
+                // The process events are so we get process names.  The ImageLoad events are so that we get version information about the DLLs 
+                KernelEvents = KernelTraceEventParser.Keywords.Process | KernelTraceEventParser.Keywords.ImageLoad;     
                 ClrEvents = ClrTraceEventParser.Keywords.GC | ClrTraceEventParser.Keywords.Exception;
                 ClrEventLevel = TraceEventLevel.Informational;
                 NoRundown = true;

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -430,7 +430,8 @@ namespace PerfView
                 {
                     m_args.GCCollectOnly = true;
 
-                    m_args.KernelEvents = KernelTraceEventParser.Keywords.Process;     // For process names
+                    // The process events are so we get process names.  The ImageLoad events are so that we get version information about the DLLs 
+                    m_args.KernelEvents = KernelTraceEventParser.Keywords.Process | KernelTraceEventParser.Keywords.ImageLoad;
                     m_args.ClrEvents = ClrTraceEventParser.Keywords.GC | ClrTraceEventParser.Keywords.Exception;
                     m_args.ClrEventLevel = TraceEventLevel.Informational;
                     m_args.NoRundown = true;

--- a/src/PerfView/Properties/AssemblyInfo.cs
+++ b/src/PerfView/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.9.53")]  
+[assembly: AssemblyFileVersion("1.9.54")]  
 [assembly:  InternalsVisibleTo("PerfViewTests")] 

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -8044,6 +8044,16 @@
         </li>
         -->
         <li>
+            Version 1.9.55 5/9/17
+            <ul>
+                <li>
+                    Change /GCCollectOnly so that it also collect Kernel Image load events.   This is useful because
+                    it allows you to get software version information which otherwise is unavailable without increasing
+                    the size of the resulting file significantly.  
+                </li>
+            </ul>
+        </li> 
+        <li>
             Version 1.9.54 5/5/17
             <ul>
                 <li>


### PR DESCRIPTION
It is useful for /GCCollectOnly to have version information on the runtime.  We can get this
by simply turning on the kernel events for Image loads.   This does not increase the size of the file
significanctly.