### PR TITLE
Improve the performance of user data lookups by changing from string to enum

### DIFF
--- a/src/TraceEvent/Computers/TraceProcess.cs
+++ b/src/TraceEvent/Computers/TraceProcess.cs
@@ -36,16 +36,18 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
                 // establish listeners
                 if(m_currentSource != source) SetupCallbacks(source);
 
-                source.UserData["Computers/Processes"] = processes;
+                source.UserData[KnownUserData.Computers_Processes] = processes;
             }
 
             m_currentSource = source;
         }
         public static TraceProcesses Processes(this TraceEventSource source)
         {
-            if (source.UserData.ContainsKey("Computers/Processes")) return source.UserData["Computers/Processes"] as TraceProcesses;
-            else return null;
+            object result;
+            source.UserData.TryGetValue(KnownUserData.Computers_Processes, out result);
+            return result as TraceProcesses;
         }
+
         public static TraceProcess Process(this TraceEvent _event)
         {
             return _event.source.Processes().GetOrCreateProcess(_event.ProcessID, _event.TimeStampQPC);
@@ -60,16 +62,17 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
 
         public static void SetSampleIntervalMSec(this TraceProcess process, float sampleIntervalMSec)
         {
-            if (!process.Source.UserData.ContainsKey("Computers/Processes/SampleIntervalMSec")) process.Source.UserData.Add("Computers/Processes/SampleIntervalMSec", new Dictionary<ProcessIndex, float>());
-            var map = (Dictionary<ProcessIndex, float>)process.Source.UserData["Computers/Processes/SampleIntervalMSec"];
+            if (!process.Source.UserData.ContainsKey(KnownUserData.Computers_Processes_SampleIntervalMSec)) process.Source.UserData.Add(KnownUserData.Computers_Processes_SampleIntervalMSec, new Dictionary<ProcessIndex, float>());
+            var map = (Dictionary<ProcessIndex, float>)process.Source.UserData[KnownUserData.Computers_Processes_SampleIntervalMSec];
             if (!map.ContainsKey(process.ProcessIndex)) map[process.ProcessIndex] = sampleIntervalMSec;
         }
 
         public static float SampleIntervalMSec(this TraceProcess process)
         {
-            if (!process.Source.UserData.ContainsKey("Computers/Processes/SampleIntervalMSec")) process.Source.UserData.Add("Computers/Processes/SampleIntervalMSec", new Dictionary<ProcessIndex, float>());
-            var map = (Dictionary<ProcessIndex, float>)process.Source.UserData["Computers/Processes/SampleIntervalMSec"];
-            if (map.ContainsKey(process.ProcessIndex)) return map[process.ProcessIndex];
+            if (!process.Source.UserData.ContainsKey(KnownUserData.Computers_Processes_SampleIntervalMSec)) process.Source.UserData.Add(KnownUserData.Computers_Processes_SampleIntervalMSec, new Dictionary<ProcessIndex, float>());
+            var map = (Dictionary<ProcessIndex, float>)process.Source.UserData[KnownUserData.Computers_Processes_SampleIntervalMSec];
+            float interval;
+            if (map.TryGetValue(process.ProcessIndex, out interval)) return interval;
             else return 1; // defualt 1 ms
         }
 

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -11,6 +11,7 @@ using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using Microsoft.Diagnostics.Utilities;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -311,14 +312,64 @@ namespace Microsoft.Diagnostics.Tracing
         /// store them in UserData under the key 'parsers\(ParserName)' 
         /// </para>
         /// </summary>
-        public IDictionary<string, object> UserData { get { return userData; } }
+        public Dictionary<KnownUserData, object> UserData { get { return userData; } }
 
         #region protected
 
         internal /*protected*/ TraceEventSource()
+            : this(new Dictionary<KnownUserData, object>())
         {
-            userData = new Dictionary<string, object>();
+        }
+
+        internal TraceEventSource(Dictionary<KnownUserData, object> userData)
+        {
+            this.userData = userData;
             _QPCFreq = 1;   // Anything non-zero so we don't get divide by zero failures in degenerate cases.  
+        }
+
+        static TraceEventSource()
+        {
+            knownUserData = new ConcurrentDictionary<string, KnownUserData>();
+            userDataKeys = new ConcurrentDictionary<KnownUserData, string>();
+            foreach (KnownUserData item in Enum.GetValues(typeof(KnownUserData)))
+            {
+                string key = item.ToString().Replace('_', '/');
+                knownUserData[key] = item;
+                userDataKeys[item] = key;
+            }
+
+            Debug.Assert(knownUserData.Count == userDataKeys.Count);
+        }
+
+        internal static KnownUserData GetOrCreateKnownUserData(string key)
+        {
+            KnownUserData data;
+            if (knownUserData.TryGetValue(key, out data))
+                return data;
+
+            return GetOrCreateKnownUserDataSlow(key);
+        }
+
+        private static KnownUserData GetOrCreateKnownUserDataSlow(string key)
+        {
+            lock (knownUserData)
+            {
+                KnownUserData data = (KnownUserData)knownUserData.Count;
+                if (knownUserData.TryAdd(key, data))
+                {
+                    userDataKeys.TryAdd(data, key);
+                    return data;
+                }
+                else
+                {
+                    return knownUserData[key];
+                }
+            }
+        }
+
+        internal static string GetUserDataKey(KnownUserData userData)
+        {
+            return userDataKeys[userData];
         }
 
         // [SecuritySafeCritical]
@@ -377,7 +428,10 @@ namespace Microsoft.Diagnostics.Tracing
         }
         #endregion
 
-        internal /*protected*/ IDictionary<string, object> userData;
+        private static readonly ConcurrentDictionary<string, KnownUserData> knownUserData;
+        private static readonly ConcurrentDictionary<KnownUserData, string> userDataKeys;
+
+        private Dictionary<KnownUserData, object> userData;
 
         internal /*protected*/ int pointerSize;
         internal /*protected*/ int numberOfProcessors;
@@ -492,6 +546,14 @@ namespace Microsoft.Diagnostics.Tracing
             return Guid.Empty;
         }
         #endregion
+    }
+
+    // Dev note: These cannot have explicit (numeric) values assigned!
+    public enum KnownUserData
+    {
+        Computers_LoadedDotNetRuntimes,
+        Computers_Processes,
+        Computers_Processes_SampleIntervalMSec,
     }
 
     /// <summary>
@@ -2365,7 +2427,7 @@ namespace Microsoft.Diagnostics.Tracing
         {
             Debug.Assert(source != null);
             this.source = source;
-            this.stateKey = @"parsers\" + this.GetType().FullName;
+            this.stateKey = TraceEventSource.GetOrCreateKnownUserData(@"parsers\" + this.GetType().FullName);
 
             if (!dontRegister)
                 this.source.RegisterParser(this);
@@ -2659,7 +2721,7 @@ namespace Microsoft.Diagnostics.Tracing
         internal protected ITraceParserServices source;
         GrowableArray<SubscriptionRequest> m_subscriptionRequests;
 
-        private string stateKey;
+        private KnownUserData stateKey;
         #endregion
     }
 
@@ -2904,6 +2966,16 @@ namespace Microsoft.Diagnostics.Tracing
             unhandledEventTemplate.source = this;
             ReHash();       // Allocates the hash table
         }
+
+        internal TraceEventDispatcher(Dictionary<KnownUserData, object> userData)
+            : base(userData)
+        {
+            // Initialize our data structures. 
+            unhandledEventTemplate = new UnhandledTraceEvent();
+            unhandledEventTemplate.source = this;
+            ReHash();       // Allocates the hash table
+        }
+
         internal override void RegisterUnhandledEventImpl(Func<TraceEvent, bool> callback)
         {
             if (lastChanceHandlers == null)


### PR DESCRIPTION
This change updates the `UserData` dictionary to use enum keys instead of string keys, resulting in a marginal (observable to an astute user) performance improvement in opening the GCStats window. It may improve other areas as well, but I have not collected data to say for sure.

⚠️ I believe this is an API change in the TraceEvent library, and based on the name I must assume that users will notice. The `GetOrCreateKnownUserData` method aims to provide a new way to accomplish the same underlying operation. I'm not sure what the project stance on long-term compatibility is, or how users feel about API changes which are implemented to improve overall performance.