### PR TITLE
Add PerfView64, a wrapper around PerfView

### DIFF
--- a/PerfView.sln
+++ b/PerfView.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CtfTracing.Tests", "src\Tra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraceEvent.Tests", "src\TraceEvent\TraceEvent.Tests\TraceEvent.Tests.csproj", "{19281902-FBC4-48C0-962B-9FDADAF5C783}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfView64", "src\PerfView64\PerfView64.csproj", "{F7419073-A62B-42E0-9B8C-4C2C4CE243A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -104,6 +106,10 @@ Global
 		{19281902-FBC4-48C0-962B-9FDADAF5C783}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{19281902-FBC4-48C0-962B-9FDADAF5C783}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{19281902-FBC4-48C0-962B-9FDADAF5C783}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F7419073-A62B-42E0-9B8C-4C2C4CE243A3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F7419073-A62B-42E0-9B8C-4C2C4CE243A3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F7419073-A62B-42E0-9B8C-4C2C4CE243A3}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F7419073-A62B-42E0-9B8C-4C2C4CE243A3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -363,10 +363,10 @@ namespace PerfView
                 }
 
                 // To support intellisense for extensions, we need the PerfView.exe to be next to the .XML file that describes it
-                var targetExe = Path.Combine(SupportFiles.SupportFileDir, Path.GetFileName(SupportFiles.ExePath));
+                var targetExe = Path.Combine(SupportFiles.SupportFileDir, Path.GetFileName(SupportFiles.MainAssemblyPath));
                 if (!File.Exists(targetExe))
                 {
-                    File.Copy(SupportFiles.ExePath, targetExe);
+                    File.Copy(SupportFiles.MainAssemblyPath, targetExe);
                     // This file indicates that we need to copy the extensions if we use this EXE to run from
                     File.WriteAllText(Path.Combine(SupportFiles.SupportFileDir, "ExtensionsNotCopied"), "");
                 }
@@ -431,7 +431,7 @@ namespace PerfView
                 return;
 
             // Is the EXE on a network share 
-            var exe = SupportFiles.ExePath;
+            var exe = SupportFiles.MainAssemblyPath;
             if (!exe.StartsWith(@"\\"))
                 return;
 

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2398,7 +2398,7 @@ namespace PerfView
         public void LaunchPerfViewElevated(string command, CommandLineArgs parsedArgs)
         {
             Debug.Assert(!App.IsElevated);
-            var perfView = SupportFiles.ExePath;
+            var perfView = SupportFiles.ExePathForRelaunch;
 
             if (parsedArgs.RestartingToElevelate != null)
                 throw new ApplicationException("PerfView has attempted to restart to gain Administrative Permissions but failed to do so.");

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1527,7 +1527,7 @@ namespace PerfView
             var extensionDebugName = extensionProjName + ".user";
             var extensionDebugData = File.ReadAllText(Path.Combine(SupportFiles.SupportFileDir, @"ExtensionTemplate\Global.csproj.user"));
             extensionDebugData = Regex.Replace(extensionDebugData, "<StartProgram>.*</StartProgram>",
-                "<StartProgram>" + SupportFiles.ExePath + "</StartProgram>");
+                "<StartProgram>" + SupportFiles.MainAssemblyPath + "</StartProgram>");
             extensionDebugData = Regex.Replace(extensionDebugData, "Global", parsedArgs.ExtensionName);
             File.WriteAllText(extensionDebugName, extensionDebugData);
             LogFile.WriteLine("Created new project {0}", extensionProjName);

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2398,7 +2398,7 @@ namespace PerfView
         public void LaunchPerfViewElevated(string command, CommandLineArgs parsedArgs)
         {
             Debug.Assert(!App.IsElevated);
-            var perfView = SupportFiles.ExePathForRelaunch;
+            var perfView = SupportFiles.ExePath;
 
             if (parsedArgs.RestartingToElevelate != null)
                 throw new ApplicationException("PerfView has attempted to restart to gain Administrative Permissions but failed to do so.");

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -1129,7 +1129,7 @@ namespace PerfViewExtensibility
             {
                 if (s_ExtensionsDirectory == null)
                 {
-                    var exeDir = Path.GetDirectoryName(SupportFiles.ExePath);
+                    var exeDir = Path.GetDirectoryName(SupportFiles.MainAssemblyPath);
                     // This is for development ease development of perfView itself.  
                     if (exeDir.EndsWith(@"\perfView\bin\Release", StringComparison.OrdinalIgnoreCase))
                         exeDir = exeDir.Substring(0, exeDir.Length - 20);

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1475,7 +1475,7 @@ namespace PerfView
         }
         private void DoVideoClick(object sender, RoutedEventArgs e)
         {
-            var videoUrl = Path.Combine(Path.GetDirectoryName(SupportFiles.ExePath), @"PerfViewVideos\PerfViewVideos.htm");
+            var videoUrl = Path.Combine(Path.GetDirectoryName(SupportFiles.MainAssemblyPath), @"PerfViewVideos\PerfViewVideos.htm");
             if (!File.Exists(videoUrl))
             {
                 if (!AllowNativateToWeb)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -1178,7 +1178,7 @@ table {
             {
                 var csvFile = CacheFiles.FindFile(FilePath, ".processesSummary.csv");
                 if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                    File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                    File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                 {
                     this.MakeProcessesCsv(m_processes, csvFile);
                 }
@@ -1190,7 +1190,7 @@ table {
             {
                 var csvFile = CacheFiles.FindFile(FilePath, ".processesModule.csv");
                 if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                    File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                    File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                 {
                     this.MakeModuleCsv(m_processes, csvFile);
                 }
@@ -1759,7 +1759,7 @@ table {
                 {
                     var csvFile = CacheFiles.FindFile(FilePath, ".aspnet.requests.csv");
                     if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                     {
                         CreateCSVFile(m_requests, csvFile);
                     }
@@ -1950,7 +1950,7 @@ table {
             {
                 var csvFile = CacheFiles.FindFile(FilePath, ".eventstats.csv");
                 if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                    File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                    File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                 {
                     //make the csv
                     this.MakeEventStatCsv(m_counts, csvFile);
@@ -2002,7 +2002,7 @@ table {
                     var mang = Microsoft.Diagnostics.Tracing.Analysis.TraceLoadedDotNetRuntimeExtensions.LoadedDotNetRuntime(gcProc);
                     var csvFile = CacheFiles.FindFile(FilePath, ".gcStats." + processId.ToString() + raw + ".csv");
                     if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                     {
                         if (raw.Length != 0)
                             Stats.GcStats.PerGenerationCsv(csvFile, mang);
@@ -2023,7 +2023,7 @@ table {
                     var mang = Microsoft.Diagnostics.Tracing.Analysis.TraceLoadedDotNetRuntimeExtensions.LoadedDotNetRuntime(gcProc);
                     var csvFile = CacheFiles.FindFile(FilePath, ".gcStats.Finalization." + processId.ToString() + ".csv");
                     if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                     {
                         Stats.GcStats.ToCsvFinalization(csvFile, mang);
                     }
@@ -2042,7 +2042,7 @@ table {
                     var xmlOutputName = CacheFiles.FindFile(FilePath, ".gcStats." + processId.ToString() + ".xml");
                     var csvFile = CacheFiles.FindFile(FilePath, ".gcStats." + processId.ToString() + ".csv");
                     if (!File.Exists(xmlOutputName) || File.GetLastWriteTimeUtc(xmlOutputName) < File.GetLastWriteTimeUtc(FilePath) ||
-                        File.GetLastWriteTimeUtc(xmlOutputName) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                        File.GetLastWriteTimeUtc(xmlOutputName) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                     {
                         using (var writer = File.CreateText(xmlOutputName))
                             Stats.GcStats.ToXml(writer, gcProc, mang, "");
@@ -2097,7 +2097,7 @@ table {
                     var mang = Microsoft.Diagnostics.Tracing.Analysis.TraceLoadedDotNetRuntimeExtensions.LoadedDotNetRuntime(jitProc);
                     var csvFile = CacheFiles.FindFile(FilePath, ".jitStats." + processId.ToString() + ".csv");
                     if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                         Stats.JitStats.ToCsv(csvFile, mang);
                     Command.Run(Command.Quote(csvFile), new CommandOptions().AddStart().AddTimeout(CommandOptions.Infinite));
                     System.Threading.Thread.Sleep(500);     // Give it time to start a bit.  
@@ -2114,7 +2114,7 @@ table {
                     var mang = Microsoft.Diagnostics.Tracing.Analysis.TraceLoadedDotNetRuntimeExtensions.LoadedDotNetRuntime(jitProc);
                     var csvFile = CacheFiles.FindFile(FilePath, ".jitInliningStats." + processId.ToString() + ".csv");
                     if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                         Stats.JitStats.ToInliningCsv(csvFile, mang);
                     Command.Run(Command.Quote(csvFile), new CommandOptions().AddStart().AddTimeout(CommandOptions.Infinite));
                     System.Threading.Thread.Sleep(500);     // Give it time to start a bit.  
@@ -2132,7 +2132,7 @@ table {
                     List<object> events = m_bgJitEvents[processId];
                     var csvFile = CacheFiles.FindFile(FilePath, ".BGjitStats." + processId.ToString() + ".csv");
                     if (!File.Exists(csvFile) || File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(FilePath) ||
-                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.ExePath))
+                        File.GetLastWriteTimeUtc(csvFile) < File.GetLastWriteTimeUtc(SupportFiles.MainAssemblyPath))
                         Stats.JitStats.BackgroundDiagCsv(csvFile, mang, events);
                     Command.Run(Command.Quote(csvFile), new CommandOptions().AddStart().AddTimeout(CommandOptions.Infinite));
                     System.Threading.Thread.Sleep(500);     // Give it time to start a bit.  

--- a/src/PerfView/Utilities/SupportFiles.cs
+++ b/src/PerfView/Utilities/SupportFiles.cs
@@ -177,26 +177,18 @@ namespace Utilities
             }
         }
         /// <summary>
-        /// The path to the executable for relaunching PerfView with administrator privileges.
+        /// The path to the entry executable.
         /// </summary>
-        public static string ExePathForRelaunch
+        public static string ExePath
         {
             get
             {
-                if (s_exePathForRelaunch == null)
+                if (s_exePath == null)
                 {
-                    // As a special case, handle the 64-bit entry point of PerfView64
-                    var entryAssembly = Assembly.GetEntryAssembly();
-                    if (string.Equals(entryAssembly.ManifestModule.Name, "PerfView64.exe", StringComparison.OrdinalIgnoreCase))
-                    {
-                        s_exePathForRelaunch = entryAssembly.ManifestModule.FullyQualifiedName;
-                    }
-                    else
-                    {
-                        s_exePathForRelaunch = ExePath;
-                    }
+                    s_exePath = Assembly.GetEntryAssembly().ManifestModule.FullyQualifiedName;
+                    Debug.Assert(s_exePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
                 }
-                return s_exePathForRelaunch;
+                return s_exePath;
             }
         }
         /// <summary>
@@ -346,7 +338,7 @@ namespace Utilities
         private static string s_supportFileDir;
         private static string s_supportFileDirBase;
         private static string s_mainAssemblyPath;
-        private static string s_exePathForRelaunch;
+        private static string s_exePath;
         private static List<string> s_managedDllSearchPaths;
 #endregion
     }

--- a/src/PerfView/Utilities/SupportFiles.cs
+++ b/src/PerfView/Utilities/SupportFiles.cs
@@ -124,7 +124,7 @@ namespace Utilities
             get
             {
                 {
-                    var exeLastWriteTime = File.GetLastWriteTime(ExePath);
+                    var exeLastWriteTime = File.GetLastWriteTime(MainAssemblyPath);
                     var version = exeLastWriteTime.ToString("VER.yyyy'-'MM'-'dd'.'HH'.'mm'.'ss.fff");
                     s_supportFileDir = Path.Combine(SupportFileDirBase, version);
                 }
@@ -144,14 +144,14 @@ namespace Utilities
             {
                 if (s_supportFileDirBase == null)
                 {
-                    string appName = Path.GetFileNameWithoutExtension(ExePath);
+                    string appName = Path.GetFileNameWithoutExtension(MainAssemblyPath);
 
                     string appData = Environment.GetEnvironmentVariable(appName + "_APPDATA");
                     if (appData == null)
                     {
                         appData = Environment.GetEnvironmentVariable("APPDATA");
                         if (appData == null)
-                            appData = Path.GetFileName(ExePath);
+                            appData = Path.GetFileName(MainAssemblyPath);
                     }
                     s_supportFileDirBase = Path.Combine(appData, appName);
                 }
@@ -160,21 +160,20 @@ namespace Utilities
             set { s_supportFileDirBase = value; }
         }
         /// <summary>
-        /// The path to the executable.   You should not be writing here! that is what SupportFileDir is for.  
+        /// The path to the assembly containing <see cref="SupportFiles"/>. You should not be writing here! that is what
+        /// <see cref="SupportFileDir"/> is for.
         /// </summary>
-        public static string ExePath
+        public static string MainAssemblyPath
         {
             get
             {
-                if (s_exePath == null)
+                if (s_mainAssemblyPath == null)
                 {
-                    // We used to use GetEntryAssembly, but that means you can use the EXE as a component 
-                    // of some other EXE.   This means that SupportFiles.cs needs to be in the main exe.  
-                    var exeAssembly = Assembly.GetExecutingAssembly();
-                    s_exePath = exeAssembly.ManifestModule.FullyQualifiedName;
-                    Debug.Assert(s_exePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+                    var mainAssembly = Assembly.GetExecutingAssembly();
+                    s_mainAssemblyPath = mainAssembly.ManifestModule.FullyQualifiedName;
                 }
-                return s_exePath;
+
+                return s_mainAssemblyPath;
             }
         }
         /// <summary>
@@ -346,7 +345,7 @@ namespace Utilities
 
         private static string s_supportFileDir;
         private static string s_supportFileDirBase;
-        private static string s_exePath;
+        private static string s_mainAssemblyPath;
         private static string s_exePathForRelaunch;
         private static List<string> s_managedDllSearchPaths;
 #endregion

--- a/src/PerfView/Utilities/SupportFiles.cs
+++ b/src/PerfView/Utilities/SupportFiles.cs
@@ -178,6 +178,29 @@ namespace Utilities
             }
         }
         /// <summary>
+        /// The path to the executable for relaunching PerfView with administrator privileges.
+        /// </summary>
+        public static string ExePathForRelaunch
+        {
+            get
+            {
+                if (s_exePathForRelaunch == null)
+                {
+                    // As a special case, handle the 64-bit entry point of PerfView64
+                    var entryAssembly = Assembly.GetEntryAssembly();
+                    if (string.Equals(entryAssembly.ManifestModule.Name, "PerfView64.exe", StringComparison.OrdinalIgnoreCase))
+                    {
+                        s_exePathForRelaunch = entryAssembly.ManifestModule.FullyQualifiedName;
+                    }
+                    else
+                    {
+                        s_exePathForRelaunch = ExePath;
+                    }
+                }
+                return s_exePathForRelaunch;
+            }
+        }
+        /// <summary>
         /// Get the name of the architecture of the current process
         /// </summary>
         public static string ProcessArch
@@ -323,7 +346,8 @@ namespace Utilities
 
         private static string s_supportFileDir;
         private static string s_supportFileDirBase;
-        internal static string s_exePath;
+        private static string s_exePath;
+        private static string s_exePathForRelaunch;
         private static List<string> s_managedDllSearchPaths;
 #endregion
     }

--- a/src/PerfView64/App.config
+++ b/src/PerfView64/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    </startup>
+</configuration>

--- a/src/PerfView64/App.cs
+++ b/src/PerfView64/App.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace PerfView64
+{
+    public class App
+    {
+        [STAThread]
+        [DebuggerNonUserCode]
+        public static int Main(string[] args)
+        {
+            return PerfView.App.Main(args);
+        }
+    }
+}

--- a/src/PerfView64/App.cs
+++ b/src/PerfView64/App.cs
@@ -3,6 +3,12 @@ using System.Diagnostics;
 
 namespace PerfView64
 {
+    /// <summary>
+    /// This application simply loads and calls the main PerfView executable, passing along the command line arguments
+    /// as they were received. It works as a 64-bit application by leveraging the ability of AnyCPU binaries to run as
+    /// either 32- or 64-bit applications, and while the main PerfView executable has the "prefer 32-bit" option set,
+    /// the 64-bit wrapper does not (and thus is launched by the OS as a 64-bit image where available).
+    /// </summary>
     public class App
     {
         [STAThread]

--- a/src/PerfView64/PerfView64.csproj
+++ b/src/PerfView64/PerfView64.csproj
@@ -40,22 +40,6 @@
     <ApplicationIcon>..\PerfView\performance.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="App.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>

--- a/src/PerfView64/PerfView64.csproj
+++ b/src/PerfView64/PerfView64.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F7419073-A62B-42E0-9B8C-4C2C4CE243A3}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>PerfView64</RootNamespace>
+    <AssemblyName>PerfView64</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>..\PerfView\performance.ico</ApplicationIcon>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PerfView\PerfView.csproj">
+      <Project>{6bac7496-6953-41b8-9042-aae45405a095}</Project>
+      <Name>PerfView</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Resource Include="..\PerfView\performance.ico">
+      <Link>performance.ico</Link>
+    </Resource>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/PerfView64/Properties/AssemblyInfo.cs
+++ b/src/PerfView64/Properties/AssemblyInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Windows;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -29,14 +28,14 @@ using System.Windows;
 //[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
 
 
-[assembly: ThemeInfo(
-    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-                                     //(used if a resource is not found in the page,
-                                     // or application resource dictionaries)
-    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-                                              //(used if a resource is not found in the page,
-                                              // app, or any theme specific resource dictionaries)
-)]
+//[assembly: ThemeInfo(
+//    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+//                                     //(used if a resource is not found in the page,
+//                                     // or application resource dictionaries)
+//    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+//                                              //(used if a resource is not found in the page,
+//                                              // app, or any theme specific resource dictionaries)
+//)]
 
 
 // Version information for an assembly consists of the following four values:

--- a/src/PerfView64/Properties/AssemblyInfo.cs
+++ b/src/PerfView64/Properties/AssemblyInfo.cs
@@ -49,4 +49,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.9.53")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/PerfView64/Properties/AssemblyInfo.cs
+++ b/src/PerfView64/Properties/AssemblyInfo.cs
@@ -1,0 +1,53 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PerfView64")]
+[assembly: AssemblyDescription("A 64-bit launcher for PerfView")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("PerfView")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2010")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+//In order to begin building localizable applications, set
+//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
+//inside a <PropertyGroup>.  For example, if you are using US english
+//in your source files, set the <UICulture> to en-US.  Then uncomment
+//the NeutralResourceLanguage attribute below.  Update the "en-US" in
+//the line below to match the UICulture setting in the project file.
+
+//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]
+
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.9.53")]


### PR DESCRIPTION
This change introduces **PerfView64**, a 12KiB file wrapper executable which launches **PerfView** as a 64-bit application.

In this initial form, the intent is the **PerfView64** executable would be attached to the GitHub release alongside the **PerfView** executable. Users could optionally download the executable, and would be responsible for launching through it if they need to use more memory during analysis.

Fixes #175
Fixes #171