### PR TITLE
Fix non-deterministic error with OneStack test

### DIFF
--- a/src/LinuxEvent.Tests/Constants.cs
+++ b/src/LinuxEvent.Tests/Constants.cs
@@ -30,23 +30,24 @@ namespace LinuxTracing.Tests
 
 		public static void WaitUntilFileIsReady(string fileName)
 		{
-			while (!IsFileReady(fileName))
-			{
-				Thread.Sleep(50);
-			}
-		}
+            // This used to have logic that polled until the file existed.
+            // This seems like a hack, and the polling logic happened to
+            // open the file read-write, which caused file sharing conflicts
+            // with concurrent tests.    
 
-		public static bool IsFileReady(string fileName)
-		{
-			try
-			{
-				// Still doesn't resolve the problem - kind of weird
-				return new FileInfo(fileName).Length > 0;
-			}
-			catch (IOException)
-			{
-				return false;
-			}
+            // Note that on windows even doing a File.Exists(XXX) LOCKS the
+            // file for a short time.   THus we don't want to do things like
+            // that since it can interfer (this is unfortunate).  If we need
+            // a file probe, we need to do it with a FileOpen with appropriate 
+            // File sharing attributes.  
+
+            // None of this should be necessary.   I am reomving it and if
+            // This method should go away if we don't have problems with it 
+            // for a while. 
+            // -- vance 5/17/2017
+
+            // Thread.Sleep(2);
+            
 		}
 	}
 }

--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -157,7 +157,6 @@ namespace LinuxTracing.Tests
 				});
 		}
 
-		[Fact(Skip = "Fails non-deteministically with file access issue")]
 		public void NonSchedHeader()
 		{
 			string path = Constants.GetTestingPerfDumpPath("onegeneric");


### PR DESCRIPTION
We have a non-determinstic failure with the oneStack test because of a file acess issue.
Caused by probing for the file by concurrent tests.
Removed the probing.