### PR TITLE
Faster testing

### DIFF
--- a/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Collections.Generic;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace TraceEventTests
 {
@@ -15,6 +16,13 @@ namespace TraceEventTests
         static string TestDataDir = @".\inputs";
         static string UnZippedDataDir = @".\unzipped";
         static string OutputDir = @".\output";
+
+        private readonly ITestOutputHelper _output;
+
+        public GeneralParsing(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         /// <summary>
         ///  Tries to find the original place in the source base where input data comes from 
@@ -72,13 +80,13 @@ namespace TraceEventTests
         [Fact]
         public void ETW_GeneralParsing_Basic()
         {
-            Trace.WriteLine("In ETW_General_Basic");
+            _output.WriteLine("In ETW_General_Basic");
             Assert.True(Directory.Exists(TestDataDir));
             UnzipDataFiles();
             if (Directory.Exists(OutputDir))
                 Directory.Delete(OutputDir, true);
             Directory.CreateDirectory(OutputDir);
-            Trace.WriteLine(string.Format("OutputDir: {0}", Path.GetFullPath(OutputDir)));
+            _output.WriteLine(string.Format("OutputDir: {0}", Path.GetFullPath(OutputDir)));
 
             bool anyFailure = false;
             foreach (var etlFilePath in Directory.EnumerateFiles(UnZippedDataDir, "*.etl"))
@@ -87,7 +95,7 @@ namespace TraceEventTests
                 if (!etlFilePath.EndsWith("etl", StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                Trace.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", Path.GetFullPath(etlFilePath)));
+                _output.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", Path.GetFullPath(etlFilePath)));
                 string eltxFilePath = Path.ChangeExtension(etlFilePath, ".etlx");
 
                 // See if we have a cooresponding baseline file 
@@ -102,11 +110,11 @@ namespace TraceEventTests
                     baselineFile = File.OpenText(baselineName);
                 else
                 {
-                    Trace.WriteLine("WARNING: No baseline file");
-                    Trace.WriteLine(string.Format("    ETL FILE: {0}", Path.GetFullPath(etlFilePath)));
-                    Trace.WriteLine(string.Format("    NonExistant Baseline File: {0}", baselineName));
-                    Trace.WriteLine("To Create a baseline file");
-                    Trace.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
+                    _output.WriteLine("WARNING: No baseline file");
+                    _output.WriteLine(string.Format("    ETL FILE: {0}", Path.GetFullPath(etlFilePath)));
+                    _output.WriteLine(string.Format("    NonExistant Baseline File: {0}", baselineName));
+                    _output.WriteLine("To Create a baseline file");
+                    _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
                         Path.GetFullPath(outputName),
                         Path.GetFullPath(baselineName)
                         ));
@@ -183,18 +191,18 @@ namespace TraceEventTests
                         {
                             firstFailLineNum = lineNum;
                             anyFailure = true;
-                            Trace.WriteLine(string.Format("ERROR: File {0}: event not equal to expected on line {1}", etlFilePath, lineNum));
-                            Trace.WriteLine(string.Format("   Expected: {0}", expectedParsedEvent));
-                            Trace.WriteLine(string.Format("   Actual  : {0}", parsedEvent));
+                            _output.WriteLine(string.Format("ERROR: File {0}: event not equal to expected on line {1}", etlFilePath, lineNum));
+                            _output.WriteLine(string.Format("   Expected: {0}", expectedParsedEvent));
+                            _output.WriteLine(string.Format("   Actual  : {0}", parsedEvent));
 
-                            Trace.WriteLine("To Compare output and baseline (baseline is SECOND)");
-                            Trace.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
+                            _output.WriteLine("To Compare output and baseline (baseline is SECOND)");
+                            _output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
                                 Path.GetFullPath(outputName),
                                 Path.GetFullPath(baselineName)
                                 ));
 
-                            Trace.WriteLine("To Update baseline file");
-                            Trace.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
+                            _output.WriteLine("To Update baseline file");
+                            _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
                                 Path.GetFullPath(outputName),
                                 Path.Combine(OriginalBaselineDir, Path.GetFileNameWithoutExtension(etlFilePath) + ".baseline.txt")
                                 ));
@@ -211,7 +219,7 @@ namespace TraceEventTests
                             eventName != "Windows Kernel/DiskIO/Opcode(16)" &&
                             eventName != "Windows Kernel/SysConfig/Opcode(37)")
                         {
-                            Trace.WriteLine(string.Format("ERROR: File {0}: has unknown event {1} at {2:n3} MSec",
+                            _output.WriteLine(string.Format("ERROR: File {0}: has unknown event {1} at {2:n3} MSec",
                                 etlFilePath, eventName, data.TimeStampRelativeMSec));
 
                             // Assert throws an exception which gets swallowed in Process() so instead
@@ -239,17 +247,17 @@ namespace TraceEventTests
                     if (!histogramMismatch && expectedistogramLine != histogramLine)
                     {
                         histogramMismatch = true;
-                        Trace.WriteLine(string.Format("ERROR: File {0}: histogram not equal on  {1}", etlFilePath, lineNum));
-                        Trace.WriteLine(string.Format("   Expected: {0}", histogramLine));
-                        Trace.WriteLine(string.Format("   Actual  : {0}", expectedistogramLine));
+                        _output.WriteLine(string.Format("ERROR: File {0}: histogram not equal on  {1}", etlFilePath, lineNum));
+                        _output.WriteLine(string.Format("   Expected: {0}", histogramLine));
+                        _output.WriteLine(string.Format("   Actual  : {0}", expectedistogramLine));
 
-                        Trace.WriteLine("To Compare output and baseline (baseline is SECOND)");
-                        Trace.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
+                        _output.WriteLine("To Compare output and baseline (baseline is SECOND)");
+                        _output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
                             Path.GetFullPath(outputName),
                             Path.GetFullPath(baselineName)
                             ));
-                        Trace.WriteLine("To Update baseline file");
-                        Trace.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
+                        _output.WriteLine("To Update baseline file");
+                        _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
                             Path.GetFullPath(outputName),
                             Path.GetFullPath(baselineName)
                             ));
@@ -259,7 +267,7 @@ namespace TraceEventTests
 
                 outputFile.Close();
                 if (mismatchCount > 0)
-                    Trace.WriteLine(string.Format("ERROR: File {0}: had {1} mismatches", etlFilePath, mismatchCount));
+                    _output.WriteLine(string.Format("ERROR: File {0}: had {1} mismatches", etlFilePath, mismatchCount));
 
                 // If this fires, check the output for the TraceLine just before it for more details.  
                 Assert.False(unexpectedUnknownEvent, "Check trace output for details.  Search for ERROR");

--- a/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
@@ -92,7 +92,7 @@ namespace TraceEventTests
         [MemberData(nameof(TestEtlFiles))]
         public void ETW_GeneralParsing_Basic(string etlFileName)
         {
-            _output.WriteLine("In ETW_General_Basic");
+            _output.WriteLine($"In {nameof(ETW_GeneralParsing_Basic)}(\"{etlFileName}\")");
             Assert.True(Directory.Exists(TestDataDir));
             UnzipDataFiles();
             if (Directory.Exists(OutputDir))

--- a/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
@@ -116,7 +116,7 @@ namespace TraceEventTests
                 int firstFailLineNum = 0;
                 int mismatchCount = 0;
                 int lineNum = 0;
-                var histogram = new SortedDictionary<string, int>();
+                var histogram = new SortedDictionary<string, int>(StringComparer.Ordinal);
 
                 // TraceLog traceLog = TraceLog.OpenOrConvert(etlFilePath);    // This one can be used during developent of test itself
                 TraceLog traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(etlFilePath));

--- a/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.IO;
-using Microsoft.Diagnostics.Tracing.Etlx;
-using Microsoft.Diagnostics.Tracing;
-using System.Diagnostics;
-using System.Text;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -71,14 +72,25 @@ namespace TraceEventTests
             s_fileUnzipped = true;
         }
 
+        public static IEnumerable<object[]> TestEtlFiles
+        {
+            get
+            {
+                // The test data is contained in files of the same name, but with a .zip extension.
+                // Only the names are returned since the extracted files will be in a different directory.
+                return from file in Directory.EnumerateFiles(TestDataDir, "*.etl.zip")
+                       select new[] { Path.GetFileNameWithoutExtension(file) };
+            }
+        }
+
         /// <summary>
         /// This test simply scans all the events in the ETL.ZIP files in TestDataDir
         /// and scans them (so you should get asserts if there is parsing problem)
         /// and insures that no more than .1% of the events are 
         /// </summary>
-
-        [Fact]
-        public void ETW_GeneralParsing_Basic()
+        [Theory]
+        [MemberData(nameof(TestEtlFiles))]
+        public void ETW_GeneralParsing_Basic(string etlFileName)
         {
             _output.WriteLine("In ETW_General_Basic");
             Assert.True(Directory.Exists(TestDataDir));
@@ -88,192 +100,186 @@ namespace TraceEventTests
             Directory.CreateDirectory(OutputDir);
             _output.WriteLine(string.Format("OutputDir: {0}", Path.GetFullPath(OutputDir)));
 
+            string etlFilePath = Path.Combine(UnZippedDataDir, etlFileName);
             bool anyFailure = false;
-            foreach (var etlFilePath in Directory.EnumerateFiles(UnZippedDataDir, "*.etl"))
+            _output.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", Path.GetFullPath(etlFilePath)));
+            string eltxFilePath = Path.ChangeExtension(etlFilePath, ".etlx");
+
+            // See if we have a cooresponding baseline file 
+            string baselineName = Path.Combine(Path.GetFullPath(TestDataDir),
+                Path.GetFileNameWithoutExtension(etlFilePath) + ".baseline.txt");
+            string outputName = Path.Combine(OutputDir,
+                Path.GetFileNameWithoutExtension(etlFilePath) + ".txt");
+            TextWriter outputFile = File.CreateText(outputName);
+
+            StreamReader baselineFile = null;
+            if (File.Exists(baselineName))
+                baselineFile = File.OpenText(baselineName);
+            else
             {
-                // *.etl includes *.etlx (don't know why), filter those out.   
-                if (!etlFilePath.EndsWith("etl", StringComparison.OrdinalIgnoreCase))
-                    continue;
+                _output.WriteLine("WARNING: No baseline file");
+                _output.WriteLine(string.Format("    ETL FILE: {0}", Path.GetFullPath(etlFilePath)));
+                _output.WriteLine(string.Format("    NonExistant Baseline File: {0}", baselineName));
+                _output.WriteLine("To Create a baseline file");
+                _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
+                    Path.GetFullPath(outputName),
+                    Path.GetFullPath(baselineName)
+                    ));
+            }
 
-                _output.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", Path.GetFullPath(etlFilePath)));
-                string eltxFilePath = Path.ChangeExtension(etlFilePath, ".etlx");
+            bool unexpectedUnknownEvent = false;
+            int firstFailLineNum = 0;
+            int mismatchCount = 0;
+            int lineNum = 0;
+            var histogram = new SortedDictionary<string, int>(StringComparer.Ordinal);
 
-                // See if we have a cooresponding baseline file 
-                string baselineName = Path.Combine(Path.GetFullPath(TestDataDir),
-                    Path.GetFileNameWithoutExtension(etlFilePath) + ".baseline.txt");
-                string outputName = Path.Combine(OutputDir,
-                    Path.GetFileNameWithoutExtension(etlFilePath) + ".txt");
-                TextWriter outputFile = File.CreateText(outputName);
+            // TraceLog traceLog = TraceLog.OpenOrConvert(etlFilePath);    // This one can be used during developent of test itself
+            TraceLog traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(etlFilePath));
 
-                StreamReader baselineFile = null;
-                if (File.Exists(baselineName))
-                    baselineFile = File.OpenText(baselineName);
-                else
+            var traceSource = traceLog.Events.GetSource();
+            traceSource.AllEvents += delegate (TraceEvent data)
+            {
+                string eventName = data.ProviderName + "/" + data.EventName;
+
+                // We are going to skip dynamic events from the CLR provider.
+                // The issue is that this depends on exactly which manifest is present
+                // on the machine, and I just don't want to deal with the noise of 
+                // failures because you have a slightly different one.   
+                if (data.ProviderName == "DotNet")
+                    return;
+
+                // We don't want to use the manifest for CLR Private events since 
+                // different machines might have different manifests.  
+                if (data.ProviderName == "Microsoft-Windows-DotNETRuntimePrivate")
                 {
-                    _output.WriteLine("WARNING: No baseline file");
-                    _output.WriteLine(string.Format("    ETL FILE: {0}", Path.GetFullPath(etlFilePath)));
-                    _output.WriteLine(string.Format("    NonExistant Baseline File: {0}", baselineName));
-                    _output.WriteLine("To Create a baseline file");
-                    _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
-                        Path.GetFullPath(outputName),
-                        Path.GetFullPath(baselineName)
-                        ));
+                    if (data.GetType().Name == "DynamicTraceEventData" || data.EventName.StartsWith("EventID"))
+                        return;
                 }
-
-                bool unexpectedUnknownEvent = false;
-                int firstFailLineNum = 0;
-                int mismatchCount = 0;
-                int lineNum = 0;
-                var histogram = new SortedDictionary<string, int>(StringComparer.Ordinal);
-
-                // TraceLog traceLog = TraceLog.OpenOrConvert(etlFilePath);    // This one can be used during developent of test itself
-                TraceLog traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(etlFilePath));
-
-                var traceSource = traceLog.Events.GetSource();
-                traceSource.AllEvents += delegate (TraceEvent data)
+                // Same problem with classic OS events.   We don't want to rely on the OS to parse since this could vary between baseline and test. 
+                else if (data.ProviderName == "MSNT_SystemTrace")
                 {
-                    string eventName = data.ProviderName + "/" + data.EventName;
-
-                    // We are going to skip dynamic events from the CLR provider.
-                    // The issue is that this depends on exactly which manifest is present
-                    // on the machine, and I just don't want to deal with the noise of 
-                    // failures because you have a slightly different one.   
-                    if (data.ProviderName == "DotNet")
+                    // However we to allow a couple of 'known good' ones through so we test some aspects of the OS parsing logic in TraceEvent.   
+                    if (data.EventName != "SystemConfig/Platform" && data.EventName != "Image/KernelBase")
                         return;
-
-                    // We don't want to use the manifest for CLR Private events since 
-                    // different machines might have different manifests.  
-                    if (data.ProviderName == "Microsoft-Windows-DotNETRuntimePrivate")
-                    {
-                        if (data.GetType().Name == "DynamicTraceEventData" || data.EventName.StartsWith("EventID"))
-                            return;
-                    }
-                    // Same problem with classic OS events.   We don't want to rely on the OS to parse since this could vary between baseline and test. 
-                    else if (data.ProviderName == "MSNT_SystemTrace")
-                    {
-                        // However we to allow a couple of 'known good' ones through so we test some aspects of the OS parsing logic in TraceEvent.   
-                        if (data.EventName != "SystemConfig/Platform" && data.EventName != "Image/KernelBase")
-                            return;
-                    }
-                    // In theory we have the same problem with any event that the OS supplies the parsing.   I dont want to be too agressive about 
-                    // turning them off, however becasuse I want those code paths tested
+                }
+                // In theory we have the same problem with any event that the OS supplies the parsing.   I dont want to be too agressive about 
+                // turning them off, however becasuse I want those code paths tested
 
 
-                    // TODO FIX NOW, this is broken and should be fixed.  
-                    // We are hacking it here so we don't turn off the test completely.  
-                    if (eventName == "DotNet/CLR.SKUOrVersion")
-                        return;
+                // TODO FIX NOW, this is broken and should be fixed.  
+                // We are hacking it here so we don't turn off the test completely.  
+                if (eventName == "DotNet/CLR.SKUOrVersion")
+                    return;
 
-                    int count = IncCount(histogram, eventName);
+                int count = IncCount(histogram, eventName);
 
-                    // To keep the baseline size under control, we only check at
-                    // most 5 of each event type.  
-                    const int MaxEventPerType = 5;
+                // To keep the baseline size under control, we only check at
+                // most 5 of each event type.  
+                const int MaxEventPerType = 5;
 
-                    if (count > MaxEventPerType)
-                        return;
+                if (count > MaxEventPerType)
+                    return;
 
-                    string parsedEvent = Parse(data);
-                    lineNum++;
-                    outputFile.WriteLine(parsedEvent);      // Make the new output file.
+                string parsedEvent = Parse(data);
+                lineNum++;
+                outputFile.WriteLine(parsedEvent);      // Make the new output file.
 
-                    string expectedParsedEvent = null;
-                    if (baselineFile != null)
-                        expectedParsedEvent = baselineFile.ReadLine();
-                    if (expectedParsedEvent == null)
-                        expectedParsedEvent = "";
+                string expectedParsedEvent = null;
+                if (baselineFile != null)
+                    expectedParsedEvent = baselineFile.ReadLine();
+                if (expectedParsedEvent == null)
+                    expectedParsedEvent = "";
 
-                    // If we have baseline, it should match what we have in the file.  
-                    if (baselineFile != null && parsedEvent != expectedParsedEvent)
-                    {
-                        mismatchCount++;
-                        if (firstFailLineNum == 0)
-                        {
-                            firstFailLineNum = lineNum;
-                            anyFailure = true;
-                            _output.WriteLine(string.Format("ERROR: File {0}: event not equal to expected on line {1}", etlFilePath, lineNum));
-                            _output.WriteLine(string.Format("   Expected: {0}", expectedParsedEvent));
-                            _output.WriteLine(string.Format("   Actual  : {0}", parsedEvent));
-
-                            _output.WriteLine("To Compare output and baseline (baseline is SECOND)");
-                            _output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
-                                Path.GetFullPath(outputName),
-                                Path.GetFullPath(baselineName)
-                                ));
-
-                            _output.WriteLine("To Update baseline file");
-                            _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
-                                Path.GetFullPath(outputName),
-                                Path.Combine(OriginalBaselineDir, Path.GetFileNameWithoutExtension(etlFilePath) + ".baseline.txt")
-                                ));
-                        }
-                    }
-
-                    // Even if we don't have a baseline, we can check that the event names are OK.  
-                    if (0 <= eventName.IndexOf('('))   // Unknown events have () in them 
-                    {
-                        // Some expected events we don't handle today.   
-                        if (data.EventName != "EventID(65534)" &&       // Manifest events 
-                            data.ProviderName != "Microsoft-Windows-DNS-Client" &&
-                            eventName != "KernelTraceControl/ImageID/Opcode(34)" &&
-                            eventName != "Windows Kernel/DiskIO/Opcode(16)" &&
-                            eventName != "Windows Kernel/SysConfig/Opcode(37)")
-                        {
-                            _output.WriteLine(string.Format("ERROR: File {0}: has unknown event {1} at {2:n3} MSec",
-                                etlFilePath, eventName, data.TimeStampRelativeMSec));
-
-                            // Assert throws an exception which gets swallowed in Process() so instead
-                            // we remember that we failed and assert outside th callback.  
-                            unexpectedUnknownEvent = true;
-                        }
-                    }
-                };
-
-                /********************* PROCESSING ***************************/
-                traceSource.Process();
-
-                // Validation after processing, first we check that the histograms are the same as the baseline
-
-                // We also want to check that the count of events is the same as the baseline. 
-                bool histogramMismatch = false;
-                foreach (var keyValue in histogram)
+                // If we have baseline, it should match what we have in the file.  
+                if (baselineFile != null && parsedEvent != expectedParsedEvent)
                 {
-                    var histogramLine = "COUNT " + keyValue.Key + ":" + keyValue.Value;
-
-                    outputFile.WriteLine(histogramLine);
-                    var expectedistogramLine = baselineFile.ReadLine();
-                    lineNum++;
-
-                    if (!histogramMismatch && expectedistogramLine != histogramLine)
+                    mismatchCount++;
+                    if (firstFailLineNum == 0)
                     {
-                        histogramMismatch = true;
-                        _output.WriteLine(string.Format("ERROR: File {0}: histogram not equal on  {1}", etlFilePath, lineNum));
-                        _output.WriteLine(string.Format("   Expected: {0}", histogramLine));
-                        _output.WriteLine(string.Format("   Actual  : {0}", expectedistogramLine));
+                        firstFailLineNum = lineNum;
+                        anyFailure = true;
+                        _output.WriteLine(string.Format("ERROR: File {0}: event not equal to expected on line {1}", etlFilePath, lineNum));
+                        _output.WriteLine(string.Format("   Expected: {0}", expectedParsedEvent));
+                        _output.WriteLine(string.Format("   Actual  : {0}", parsedEvent));
 
                         _output.WriteLine("To Compare output and baseline (baseline is SECOND)");
                         _output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
                             Path.GetFullPath(outputName),
                             Path.GetFullPath(baselineName)
                             ));
+
                         _output.WriteLine("To Update baseline file");
                         _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
                             Path.GetFullPath(outputName),
-                            Path.GetFullPath(baselineName)
+                            Path.Combine(OriginalBaselineDir, Path.GetFileNameWithoutExtension(etlFilePath) + ".baseline.txt")
                             ));
-                        anyFailure = true;
                     }
                 }
 
-                outputFile.Close();
-                if (mismatchCount > 0)
-                    _output.WriteLine(string.Format("ERROR: File {0}: had {1} mismatches", etlFilePath, mismatchCount));
+                // Even if we don't have a baseline, we can check that the event names are OK.  
+                if (0 <= eventName.IndexOf('('))   // Unknown events have () in them 
+                {
+                    // Some expected events we don't handle today.   
+                    if (data.EventName != "EventID(65534)" &&       // Manifest events 
+                        data.ProviderName != "Microsoft-Windows-DNS-Client" &&
+                        eventName != "KernelTraceControl/ImageID/Opcode(34)" &&
+                        eventName != "Windows Kernel/DiskIO/Opcode(16)" &&
+                        eventName != "Windows Kernel/SysConfig/Opcode(37)")
+                    {
+                        _output.WriteLine(string.Format("ERROR: File {0}: has unknown event {1} at {2:n3} MSec",
+                            etlFilePath, eventName, data.TimeStampRelativeMSec));
 
-                // If this fires, check the output for the TraceLine just before it for more details.  
-                Assert.False(unexpectedUnknownEvent, "Check trace output for details.  Search for ERROR");
-                Assert.True(lineNum > 0);     // We had some events.  
+                        // Assert throws an exception which gets swallowed in Process() so instead
+                        // we remember that we failed and assert outside th callback.  
+                        unexpectedUnknownEvent = true;
+                    }
+                }
+            };
 
+            /********************* PROCESSING ***************************/
+            traceSource.Process();
+
+            // Validation after processing, first we check that the histograms are the same as the baseline
+
+            // We also want to check that the count of events is the same as the baseline. 
+            bool histogramMismatch = false;
+            foreach (var keyValue in histogram)
+            {
+                var histogramLine = "COUNT " + keyValue.Key + ":" + keyValue.Value;
+
+                outputFile.WriteLine(histogramLine);
+                var expectedistogramLine = baselineFile.ReadLine();
+                lineNum++;
+
+                if (!histogramMismatch && expectedistogramLine != histogramLine)
+                {
+                    histogramMismatch = true;
+                    _output.WriteLine(string.Format("ERROR: File {0}: histogram not equal on  {1}", etlFilePath, lineNum));
+                    _output.WriteLine(string.Format("   Expected: {0}", histogramLine));
+                    _output.WriteLine(string.Format("   Actual  : {0}", expectedistogramLine));
+
+                    _output.WriteLine("To Compare output and baseline (baseline is SECOND)");
+                    _output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
+                        Path.GetFullPath(outputName),
+                        Path.GetFullPath(baselineName)
+                        ));
+                    _output.WriteLine("To Update baseline file");
+                    _output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
+                        Path.GetFullPath(outputName),
+                        Path.GetFullPath(baselineName)
+                        ));
+                    anyFailure = true;
+                }
             }
+
+            outputFile.Close();
+            if (mismatchCount > 0)
+                _output.WriteLine(string.Format("ERROR: File {0}: had {1} mismatches", etlFilePath, mismatchCount));
+
+            // If this fires, check the output for the TraceLine just before it for more details.  
+            Assert.False(unexpectedUnknownEvent, "Check trace output for details.  Search for ERROR");
+            Assert.True(lineNum > 0);     // We had some events.  
+
             Assert.False(anyFailure, "Check trace output for details.  Search for ERROR");
         }
 

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x64.baseline.txt
@@ -488,6 +488,8 @@ COUNT KernelTraceControl/ImageID/None:24
 COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:49110
@@ -551,8 +553,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:43
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:39
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:2
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -595,8 +595,8 @@ COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/IRQ:13
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:118
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x86.baseline.txt
@@ -488,6 +488,8 @@ COUNT KernelTraceControl/ImageID/None:25
 COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:49110
@@ -551,8 +553,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:43
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:39
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:2
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -593,8 +593,8 @@ COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/IRQ:13
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:118
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x64.baseline.txt
@@ -545,6 +545,8 @@ COUNT KernelTraceControl/ImageID/None:30
 COUNT KernelTraceControl/ImageID/Opcode37:104
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
 COUNT Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:6
@@ -620,8 +622,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:43
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:39
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:2
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -663,8 +663,8 @@ COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/IRQ:13
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:117
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x86.baseline.txt
@@ -548,6 +548,8 @@ COUNT KernelTraceControl/ImageID/None:34
 COUNT KernelTraceControl/ImageID/Opcode37:104
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
 COUNT Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:5
@@ -623,8 +625,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:43
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:39
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:2
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -666,8 +666,8 @@ COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/IRQ:13
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:117
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x64.baseline.txt
@@ -502,6 +502,8 @@ COUNT KernelTraceControl/ImageID/None:29
 COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:53307
@@ -563,8 +565,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:43
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:43
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:2
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -607,8 +607,8 @@ COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/IRQ:13
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:117
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x86.baseline.txt
@@ -500,6 +500,8 @@ COUNT KernelTraceControl/ImageID/None:32
 COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:52698
@@ -561,8 +563,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:43
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:39
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:2
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -605,8 +605,8 @@ COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/IRQ:13
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:117
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.6.2.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.6.2.x86.baseline.txt
@@ -941,6 +941,8 @@ COUNT KernelTraceControl/ImageID/Opcode(34):2
 COUNT KernelTraceControl/ImageID/Opcode37:4394
 COUNT KernelTraceControl/MetaData/EventInfo:153
 COUNT KernelTraceControl/MetaData/EventMapInfo:30
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-IE/Mshtml_CMarkup_Layout/Start:1056
 COUNT Microsoft-IE/Mshtml_CMarkup_Layout/Stop:1056
 COUNT Microsoft-IE/Mshtml_CWindow_Script/Start:45
@@ -1015,7 +1017,6 @@ COUNT Microsoft-Windows-DNS-Client/DnsServerForInterface:2
 COUNT Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:16
 COUNT Microsoft-Windows-DotNETRuntime/Contention/Start:1
 COUNT Microsoft-Windows-DotNETRuntime/Contention/Stop:1
-COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:5
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:52713
 COUNT Microsoft-Windows-DotNETRuntime/GC/BulkSurvivingObjectRanges:202
 COUNT Microsoft-Windows-DotNETRuntime/GC/CreateSegment:4
@@ -1035,6 +1036,7 @@ COUNT Microsoft-Windows-DotNETRuntime/GC/Stop:1050
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStart:1052
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStop:1052
 COUNT Microsoft-Windows-DotNETRuntime/GC/Triggered:1050
+COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:5
 COUNT Microsoft-Windows-DotNETRuntime/IOThreadCreation/Start:7
 COUNT Microsoft-Windows-DotNETRuntime/IOThreadCreation/Stop:6
 COUNT Microsoft-Windows-DotNETRuntime/IOThreadRetirement/Stop:1
@@ -1090,8 +1092,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:98
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:113
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:1
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:1
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/ManifestData:3
@@ -1154,8 +1154,8 @@ COUNT Windows Kernel/SysConfig/VolumeMapping:9
 COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:100
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x64.baseline.txt
@@ -560,10 +560,11 @@ COUNT KernelTraceControl/ImageID/None:60
 COUNT KernelTraceControl/ImageID/Opcode37:356
 COUNT KernelTraceControl/MetaData/EventInfo:54
 COUNT KernelTraceControl/MetaData/EventMapInfo:24
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/DnsNoServerConfigV6:1
 COUNT Microsoft-Windows-DNS-Client/DnsServerForInterface:3
 COUNT Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:6
-COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:2
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:53307
 COUNT Microsoft-Windows-DotNETRuntime/GC/BulkSurvivingObjectRanges:202
 COUNT Microsoft-Windows-DotNETRuntime/GC/CreateSegment:4
@@ -583,6 +584,7 @@ COUNT Microsoft-Windows-DotNETRuntime/GC/Stop:850
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStart:852
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStop:852
 COUNT Microsoft-Windows-DotNETRuntime/GC/Triggered:850
+COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:2
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AppDomainLoad:4
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AppDomainUnload:4
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AssemblyLoad:11
@@ -629,8 +631,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:106
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:108
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:1
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -680,8 +680,8 @@ COUNT Windows Kernel/SysConfig/VolumeMapping:9
 COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:100
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x86.baseline.txt
@@ -537,10 +537,11 @@ COUNT KernelTraceControl/ImageID/None:36
 COUNT KernelTraceControl/ImageID/Opcode37:78
 COUNT KernelTraceControl/MetaData/EventInfo:51
 COUNT KernelTraceControl/MetaData/EventMapInfo:24
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/DnsNoServerConfigV6:1
 COUNT Microsoft-Windows-DNS-Client/DnsServerForInterface:3
 COUNT Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:6
-COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:2
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:52698
 COUNT Microsoft-Windows-DotNETRuntime/GC/BulkSurvivingObjectRanges:202
 COUNT Microsoft-Windows-DotNETRuntime/GC/CreateSegment:4
@@ -560,6 +561,7 @@ COUNT Microsoft-Windows-DotNETRuntime/GC/Stop:1050
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStart:1052
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStop:1052
 COUNT Microsoft-Windows-DotNETRuntime/GC/Triggered:1050
+COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:2
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AppDomainLoad:4
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AppDomainUnload:4
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AssemblyLoad:11
@@ -605,8 +607,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:97
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:92
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:1
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -652,8 +652,8 @@ COUNT Windows Kernel/SysConfig/VolumeMapping:9
 COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:100
 COUNT Windows Kernel/SystemConfig/Power:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/sl.5.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/sl.5.x86.baseline.txt
@@ -579,6 +579,8 @@ COUNT KernelTraceControl/ImageID/None:40
 COUNT KernelTraceControl/ImageID/Opcode37:96
 COUNT KernelTraceControl/MetaData/EventInfo:69
 COUNT KernelTraceControl/MetaData/EventMapInfo:24
+COUNT MSNT_SystemTrace/Image/KernelBase:1
+COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-JScript/MethodRundown/DCEndComplete:1
 COUNT Microsoft-JScript/MethodRundown/DCEndInit:1
 COUNT Microsoft-JScript/MethodRundown/DCStartComplete:1
@@ -600,7 +602,6 @@ COUNT Microsoft-Windows-DNS-Client/EventID(3018):2
 COUNT Microsoft-Windows-DNS-Client/EventID(3019):2
 COUNT Microsoft-Windows-DNS-Client/EventID(3020):2
 COUNT Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:4
-COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:1
 COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:11438
 COUNT Microsoft-Windows-DotNETRuntime/GC/CreateSegment:2
 COUNT Microsoft-Windows-DotNETRuntime/GC/FinalizeObject:22
@@ -613,6 +614,7 @@ COUNT Microsoft-Windows-DotNETRuntime/GC/Start:234
 COUNT Microsoft-Windows-DotNETRuntime/GC/Stop:234
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStart:235
 COUNT Microsoft-Windows-DotNETRuntime/GC/SuspendEEStop:235
+COUNT Microsoft-Windows-DotNETRuntime/GarbageCollection/IncreaseMemoryPressure:1
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AppDomainLoad:2
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AppDomainUnload:2
 COUNT Microsoft-Windows-DotNETRuntime/Loader/AssemblyLoad:9
@@ -668,8 +670,6 @@ COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_ENABLE:
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_REGISTER:74
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_PROVIDER/ETW_OPCODE_UNREGISTER:66
 COUNT Microsoft-Windows-Kernel-EventTracing/ETW_TASK_SESSION/ETW_OPCODE_STOP:1
-COUNT MSNT_SystemTrace/Image/KernelBase:1
-COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT PerfView/ClrEnableParameters:2
 COUNT PerfView/CommandLineParameters:3
 COUNT PerfView/KernelEnableParameters:1
@@ -715,8 +715,8 @@ COUNT Windows Kernel/SysConfig/VolumeMapping:9
 COUNT Windows Kernel/SystemConfig/CPU:1
 COUNT Windows Kernel/SystemConfig/IDEChannel:2
 COUNT Windows Kernel/SystemConfig/LogDisk:1
-COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/NIC:3
+COUNT Windows Kernel/SystemConfig/Network:1
 COUNT Windows Kernel/SystemConfig/PhyDisk:1
 COUNT Windows Kernel/SystemConfig/PnP:100
 COUNT Windows Kernel/SystemConfig/Power:1


### PR DESCRIPTION
Improve testing speed and granularity

* Use `StringComparer.Ordinal` instead of the current culture
* Use `[Theory]` instead of `[Fact]` to separate a test with several sub-tests
* Fix test output not showing up when run from **Test Explorer** in Visual Studio (only covers one test where I was trying to review the output)