### PR TITLE
Fix artifact path for debug builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,5 +19,5 @@ build:
 cache:
   - packages -> **\packages.config
 artifacts:
-- path: 'src\PerfView\bin\Release\PerfView.exe'
-- path: 'src\PerfView64\bin\Release\PerfView64.exe'
+- path: 'src\PerfView\bin\$(configuration)\PerfView.exe'
+- path: 'src\PerfView64\bin\$(configuration)\PerfView64.exe'


### PR DESCRIPTION
Currently build artifacts are only getting uploaded for the Release configuration jobs. This change updates the AppVeyor definition to include artifacts for all build jobs.