### PR TITLE
Remove reference to non-existent file

### DIFF
--- a/PerfView.sln
+++ b/PerfView.sln
@@ -19,7 +19,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		appveyor.yml = appveyor.yml
 		documentation\CodingStandards.md = documentation\CodingStandards.md
 		CONTRIBUTING.md = CONTRIBUTING.md
-		src\PerfView\Local.testsettings = src\PerfView\Local.testsettings
 		README.md = README.md
 		documentation\SettingUpRepoInVS.md = documentation\SettingUpRepoInVS.md
 	EndProjectSection


### PR DESCRIPTION
Now that we switched from MSTest to XUnit, the \*.testsettings files are no longer needed.