### PR TITLE
Show LinuxTracing.Tests as a test project in Solution Explorer

### DIFF
--- a/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
+++ b/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
@@ -6,6 +6,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C42873F2-D4A5-4AC7-9ADB-9CD8E1856A9B}</ProjectGuid>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LinuxTracing.Tests</RootNamespace>


### PR DESCRIPTION
This is not a functional change, but improves the experience slightly. See dotnet/roslyn#18363 for example screenshot of the difference.