### PR TITLE
Fix it so that clean installs of 2017 works

### DIFF
--- a/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
@@ -66,6 +66,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <AdditionalIncludeDirectories>$(NetFxKitsDir)\include\um;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
@@ -66,7 +66,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <PreprocessToFile>false</PreprocessToFile>
-      <AdditionalIncludeDirectories>$(NetFxKitsDir)\include\um</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(NetFxKitsDir)\include\um;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
@@ -66,6 +66,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <PreprocessToFile>false</PreprocessToFile>
+      <AdditionalIncludeDirectories>$(NetFxKitsDir)\include\um</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
It turns out that the header files that are needed for PerfView's ETWClrProfiler code
are in a different place in newer versions of the Windows SDK.

If you had installed an older SDK, and upgraded, the header files ended up both places and so things 'just worked'
But if you installed the SDK clean (as you do when you install VS 2017 on a new machine) it is only in the new place.

Basically add the new place to the include search paths to fix.