### PR TITLE
Remove the /Finalizers switch

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -180,7 +180,6 @@ namespace PerfView
         public double SkipMSec;
         public bool ForceNgenRundown;
         public bool DumpHeap;
-        public bool Finalizers;
 
         // Collect options
         public bool NoGui;
@@ -421,8 +420,9 @@ namespace PerfView
                     KernelTraceEventParser.Keywords.Interrupt;
             }
 
+            bool Finalizers = false;
             parser.DefineOptionalQualifier("DumpHeap", ref DumpHeap, "Capture a heap snapshot on profile stop");
-            parser.DefineOptionalQualifier("Finalizers", ref Finalizers, "Track the number of objects of each type finalized.");
+            parser.DefineOptionalQualifier("Finalizers", ref Finalizers, "(Obsolete) This option is accepted for backward compatibility with tooling, but is no longer used.");
             parser.DefineOptionalQualifier("ClrEventLevel", ref ClrEventLevel, "The verbosity for CLR events");
             parser.DefineOptionalQualifier("ClrEvents", ref ClrEvents,
                 "A comma separated list of .NET CLR events to turn on.  See Users guide for details.");

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -551,7 +551,7 @@ namespace PerfView
                                 TraceEventLevel.Verbose, ulong.MaxValue);
 
                             EnableUserProvider(userModeSession, "CLRPrivate", ClrPrivateTraceEventParser.ProviderGuid,
-                                parsedArgs.Finalizers ? TraceEventLevel.Verbose : TraceEventLevel.Informational,
+                                TraceEventLevel.Informational,
                                 (ulong)(
                                     ClrPrivateTraceEventParser.Keywords.GC |
                                     ClrPrivateTraceEventParser.Keywords.Binding |
@@ -2360,8 +2360,6 @@ namespace PerfView
 
             if (parsedArgs.DumpHeap)
                 cmdLineArgs += " /DumpHeap";
-            if (parsedArgs.Finalizers)
-                cmdLineArgs += " /Finalizers";
 
             if (parsedArgs.GCOnly)
                 cmdLineArgs += " /GCOnly";

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -359,11 +359,7 @@
                     </TextBlock>
                     <CheckBox Grid.Row="0" Grid.Column="12" Name="HeapSnapshotCheckBox" VerticalAlignment="Center" />
 
-                    <TextBlock Grid.Row="0" Grid.Column="13" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Track the number of objects of each type finalized." >
-                    <Hyperlink Command="Help" CommandParameter="FinalizersCheckBox">Finalizers:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Column="14" Name="FinalizersCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Row="0" Grid.Column="14" VerticalAlignment="Center" Visibility="Hidden" Margin="0,2" />
                 </Grid>
 
                 <!-- Additional Providers -->

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -501,7 +501,6 @@ namespace PerfView
                 }
 
                 m_args.DumpHeap = HeapSnapshotCheckBox.IsChecked ?? false;
-                m_args.Finalizers = FinalizersCheckBox.IsChecked ?? false;
 
                 if (providers.Length > 0)
                     m_args.Providers = providers.Split(',');

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -71,7 +71,7 @@ namespace Stats
             }
             else
             {
-                writer.WriteLine("<LI><I>No finalized object counts available. No objects were finalized and/or the Finalizers option was not selected.</I></LI>");
+                writer.WriteLine("<LI><I>No finalized object counts available. No objects were finalized and/or the trace did not include the necessary information.</I></LI>");
             }
             writer.WriteLine("</UL>");
             writer.WriteLine("<Center>");

--- a/src/PerfView/SupportFiles/HtmlReportUsersGuide.htm
+++ b/src/PerfView/SupportFiles/HtmlReportUsersGuide.htm
@@ -36,10 +36,10 @@
         <a id="UnderstandingFinalization">Understanding Finalization Performance Data</a>
     </h3>
     <p>
-        By enabling the Finalizers option, PerfView causes the Runtime to log an event
-        every time a managed object is finalized, meaning that its finalizer (denoted in C#
-        with the ~ syntax) is executed.  For a detailed look at the costs involved in
-        finalization, see this <a href="http://blogs.msdn.com/b/cbrumme/archive/2004/02/20/77460.aspx">blog post</a>.
+        By default, PerfView causes the Runtime to log an event every time a managed object is
+        finalized, meaning that its finalizer (denoted in C# with the ~ syntax) is executed.
+        For a detailed look at the costs involved in finalization, see this
+        <a href="http://blogs.msdn.com/b/cbrumme/archive/2004/02/20/77460.aspx">blog post</a>.
     </p>
     <p>
         PerfView is unable to determine the stack that allocated a finalizable object,

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -4079,18 +4079,6 @@
             the Additional Providers textbox.&nbsp;&nbsp;&nbsp;
             The option /Providers=ClrStress can achive this at the command line.
         </li>
-        <li>
-            The <strong><a id="FinalizersCheckBox">Finalizers Checkbox</a></strong> - Turns on
-            .NET events that fire whenever an object is finalized, and tracks how many instances
-            of each finalizable object have their finalizers invoked.  The resulting counts are
-            shown on the <a href="#GCStats">GC Stats Report</a>.  This option can be useful in
-            tracking down reliability problems related to non-deterministic resource cleanup, helping
-            to identify objects that are being left for finalization rather than being disposed of
-            deterministically.  Not disposing of finalizable objects can also have a performance impact
-            on applications, as finalizable objects always survive at least one garbage collection, and
-            as a single finalization thread is responsible for processing all finalizers serially.  The
-            /Finalizers command line option achieves the same effect.
-        </li>
 
         <li>
             The <strong><a id="MemInfoCheckBox">MemInfo Checkbox</a></strong> - Turns on


### PR DESCRIPTION
The option itself is preserved for compatibility, but the behavior is disabled
and the checkbox for it is removed from the PerfView UI.

Fixes #242