### PR TITLE
Use new null propagation operator to invoke delegates

### DIFF
--- a/src/CSVReader/ETLStackBrowse/ZL/DeflateStreamAsyncResult.cs
+++ b/src/CSVReader/ETLStackBrowse/ZL/DeflateStreamAsyncResult.cs
@@ -119,9 +119,7 @@ namespace System.IO.Compression2
             }
 
             if (Interlocked.Increment(ref m_InvokedCallback) == 1) {
-                if (m_AsyncCallback != null) {
-                    m_AsyncCallback(this);
-                }
+                m_AsyncCallback?.Invoke(this);
             }
         }
 

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -2787,8 +2787,8 @@ internal static class GCRootNames
                                         // Console.WriteLine("Succeeded with thread local field {0}", fieldName);
                                     }
                                 }
-                                if (onClass != null)
-                                    onClass(className, moduleName);
+
+                                onClass?.Invoke(className, moduleName);
                             }
                             catch (Exception e)
                             {

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -1610,8 +1610,7 @@ public class SpanningTree
             }
 
             // Return the node.  
-            if (callback != null)
-                callback(node.Index);
+            callback?.Invoke(node.Index);
         }
     }
 

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -524,8 +524,7 @@ namespace PerfView
                         {
                             m_timer.IsEnabled = false;
                             Hide();
-                            if (m_continuation != null)
-                                m_continuation();
+                            m_continuation?.Invoke();
                         },
                         delegate
                         {

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -258,8 +258,7 @@ namespace PerfViewExtensibility
                         perfViewStackSource.ConfigureStackWindow(stackWindow);
 
                     LogFile.WriteLine("[Opened stack viewer {0}]", filePath);
-                    if (OnOpened != null)
-                        OnOpened(stackWindow);
+                    OnOpened?.Invoke(stackWindow);
                 });
                 stackWindow.Show();
             });

--- a/src/PerfView/GuiUtilities/HistoryComboBox/HistoryCombBox.cs
+++ b/src/PerfView/GuiUtilities/HistoryComboBox/HistoryCombBox.cs
@@ -107,9 +107,7 @@ namespace Controls
 
             if (prevFocus)
             {
-                var textEntered = TextEntered;
-                if (textEntered != null)
-                    textEntered(sender, e);
+                TextEntered?.Invoke(sender, e);
                 ValueUpdate();
             }
         }
@@ -148,9 +146,7 @@ namespace Controls
             if (enter != null)
                 Enter(sender, e);
 
-            var textEntered = TextEntered;
-            if (textEntered != null)
-                textEntered(sender, e);
+            TextEntered?.Invoke(sender, e);
 
             ValueUpdate();
         }

--- a/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml.cs
+++ b/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml.cs
@@ -307,10 +307,8 @@ namespace PerfView
                     m_work = null;
                     SignalPropertyChange(nameof(IsWorking));
                     SignalPropertyChange(nameof(IsNotWorking));
-                    if (response != null)
-                        response();
-                    if (m_finally != null)
-                        m_finally();
+                    response?.Invoke();
+                    m_finally?.Invoke();
                 }
             });
             m_worker = null;        // After we call end-work, you don't want to be able to abort the thread
@@ -476,9 +474,7 @@ namespace PerfView
         public event PropertyChangedEventHandler PropertyChanged;
         private void SignalPropertyChange(string propertyName)
         {
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged != null)
-                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         // These are GUI state, and only the GUI thread cares about it.    

--- a/src/PerfView/HeapView/HeapView.cs
+++ b/src/PerfView/HeapView/HeapView.cs
@@ -212,8 +212,7 @@ namespace PerfView
             {
                 m_mainWindow.Focus();
 
-                if (doAfter != null)
-                    doAfter();
+                doAfter?.Invoke();
             }
         }
 

--- a/src/PerfView/HeapView/Toolbox.cs
+++ b/src/PerfView/HeapView/Toolbox.cs
@@ -1208,10 +1208,7 @@ namespace PerfView
 
             dc.DrawGeometry(null, new Pen(Brushes.Brown, 1), new RectangleGeometry(rect));
 
-            if (m_addExtra != null)
-            {
-                m_addExtra(dc, m_startPoint, m_endPoint);
-            }
+            m_addExtra?.Invoke(dc, m_startPoint, m_endPoint);
         }
 
         ContextMenu m_selectMenu;

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1265,8 +1265,7 @@ namespace PerfView
                     if (openNext != null)
                         Open(openNext);
 
-                    if (continuation != null)
-                        continuation();
+                    continuation?.Invoke();
                 });
             }, finally_);
         }

--- a/src/PerfView/OtherSources/XMLStackSource.cs
+++ b/src/PerfView/OtherSources/XMLStackSource.cs
@@ -38,8 +38,7 @@ namespace Diagnostics.Tracing.StackSources
                 writer.WriteStartElement("StackWindow");
                 XmlStackSourceWriter.WriteStacks(source, writer);
 
-                if (additionalData != null)
-                    additionalData(writer);
+                additionalData?.Invoke(writer);
                 writer.WriteEndElement();
             }
         }

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -81,9 +81,7 @@ namespace PerfView
         public event PropertyChangedEventHandler PropertyChanged;
         protected void FirePropertyChanged(string propertyName)
         {
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged != null)
-                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         /// <summary>
@@ -186,8 +184,7 @@ namespace PerfView
             if (mainWindow != null)
                 mainWindow.OpenPath(FilePath);
 
-            if (doAfter != null)
-                doAfter();
+            doAfter?.Invoke();
         }
         /// <summary>
         /// Close the file
@@ -266,8 +263,7 @@ namespace PerfView
         // Groups do no semantic action.   All the work is in the visual GUI part.  
         public override void Open(Window parentWindow, StatusBar worker, Action doAfter = null)
         {
-            if (doAfter != null)
-                doAfter();
+            doAfter?.Invoke();
         }
         public override void Close() { }
 
@@ -483,8 +479,8 @@ namespace PerfView
 
                         if (continuation != null)
                             continuation(doAfter);
-                        else if (doAfter != null)
-                            doAfter();
+                        else
+                            doAfter?.Invoke();
                     });
                 });
             }
@@ -650,8 +646,7 @@ namespace PerfView
                 // By default we have a singleton source (which we don't show on the GUI) and we immediately open it
                 m_singletonStackSource = new PerfViewStackSource(this, "");
                 m_singletonStackSource.Open(parentWindow, worker);
-                if (doAfter != null)
-                    doAfter();
+                doAfter?.Invoke();
             };
         }
 
@@ -1011,10 +1006,8 @@ table {
                                     {
                                         if (message != null)
                                             Viewer.StatusBar.Log(message);
-                                        if (continuation != null)
-                                        {
-                                            continuation();
-                                        }
+
+                                        continuation?.Invoke();
                                     });
                                 });
                             }
@@ -1026,16 +1019,14 @@ table {
                         WebBrowserWindow.Navigate(Viewer.Browser, reportFileName);
                         Viewer.Show();
 
-                        if (doAfter != null)
-                            doAfter();
+                        doAfter?.Invoke();
                     });
                 });
             }
             else
             {
                 Viewer.Focus();
-                if (doAfter != null)
-                    doAfter();
+                doAfter?.Invoke();
             }
         }
 
@@ -2244,13 +2235,12 @@ table {
                     {
                         m_Children = newChildren;
                         FirePropertyChanged("Children");
-                        if (doAfter != null)
-                            doAfter();
+                        doAfter?.Invoke();
                     });
                 });
             }
-            if (doAfter != null)
-                doAfter();
+
+            doAfter?.Invoke();
         }
         /// <summary>
         /// Close the file
@@ -2322,16 +2312,14 @@ table {
                             throw new ApplicationException("Not a file type that supports the EventView.");
                         Viewer = new EventWindow(parentWindow, this);
                         Viewer.Show();
-                        if (doAfter != null)
-                            doAfter();
+                        doAfter?.Invoke();
                     });
                 });
             }
             else
             {
                 Viewer.Focus();
-                if (doAfter != null)
-                    doAfter();
+                doAfter?.Invoke();
             }
         }
         public override void Close() { }
@@ -2482,8 +2470,7 @@ table {
                                             Viewer.Width = width;
                                         }
                                         FirstAction(Viewer);
-                                        if (doAfter != null)
-                                            doAfter();
+                                        doAfter?.Invoke();
                                     });
                                 });
                             });
@@ -2514,8 +2501,7 @@ table {
             else
             {
                 Viewer.Focus();
-                if (doAfter != null)
-                    doAfter();
+                doAfter?.Invoke();
             }
         }
 
@@ -5886,8 +5872,7 @@ table {
                 // By default we have a singleton source (which we dont show on the GUI) and we immediately open it
                 m_singletonStackSource = new PerfViewStackSource(this, "");
                 m_singletonStackSource.Open(parentWindow, worker);
-                if (doAfter != null)
-                    doAfter();
+                doAfter?.Invoke();
             };
         }
 
@@ -6649,10 +6634,7 @@ table {
 
                         IsExpanded = true;
 
-                        if (doAfter != null)
-                        {
-                            doAfter();
-                        }
+                        doAfter?.Invoke();
                     });
                 });
             }

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -386,8 +386,7 @@ namespace PerfView
 
                     // TODO this is a bit of a hack, as it might replace other instances of the string.  
                     Title = Regex.Replace(Title, @" Stacks(\([^)]*\))? ", " Stacks(" + CallTree.Root.InclusiveMetric.ToString("n0") + " metric) ");
-                    if (onComplete != null)
-                        onComplete();
+                    onComplete?.Invoke();
                 });
             });
         }

--- a/src/PerfView/Triggers.cs
+++ b/src/PerfView/Triggers.cs
@@ -239,8 +239,7 @@ namespace Triggers
                     m_log.WriteLine("Error: heapdump failed with error code {0}", m_cmd.ExitCode);
                 else
                 {
-                    if (m_triggered != null)
-                        m_triggered(this);
+                    m_triggered?.Invoke(this);
                 }
                 m_cmd = null;
             });

--- a/src/PerfView/memory/ClrProfilerParser.cs
+++ b/src/PerfView/memory/ClrProfilerParser.cs
@@ -587,8 +587,7 @@ namespace ClrProfiler
 						ProfilerStackTraceID firstStackId = GetStackIdForFileId(fileFirstStackId);
 						VerboseDebug("Module " + moduleId + " Addr=" + address + " stack=S" + firstStackId + " name=" + name);
 						ProfilerModule newModule = CreateModule((ProfilerModuleID)moduleId, name, address, firstStackId);
-						if (ModuleLoad != null)
-							ModuleLoad(newModule);
+						ModuleLoad?.Invoke(newModule);
 					}
 				}
 				else if (c == 'y')

--- a/src/PerfView/memory/GCHeapSimulator.cs
+++ b/src/PerfView/memory/GCHeapSimulator.cs
@@ -81,8 +81,7 @@ namespace PerfView
         GCHeapSimulator CreateNewSimulator(TraceProcess process)
         {
             var ret = new GCHeapSimulator(m_source, process, m_stackSource, m_log, UseOnlyAllocTicks);
-            if (OnNewGCHeapSimulator != null)
-                OnNewGCHeapSimulator(ret);
+            OnNewGCHeapSimulator?.Invoke(ret);
             return ret;
         }
 
@@ -364,8 +363,7 @@ namespace PerfView
                 {
                     Debug.WriteLine(string.Format("Destroying {0:x} from Gen {1}", liveObjectPair.Key, curGenNum));
                     m_currentHeapSize -= (uint)liveObjectPair.Value.RepresentativeSize;
-                    if (OnObjectDestroy != null)
-                        OnObjectDestroy(gcTime, m_condemedGenerationNum, liveObjectPair.Key, liveObjectPair.Value);
+                    OnObjectDestroy?.Invoke(gcTime, m_condemedGenerationNum, liveObjectPair.Key, liveObjectPair.Value);
                 }
 
                 curGen.Clear();


### PR DESCRIPTION
Consistently use the latest recommended pattern for delegate invocation (including events).