### PR TITLE
Update LibraryProvider to avoid loading a v2 CLR

### DIFF
--- a/src/HeapDump/Debugger/DumpDebugging/LibraryProvider.cs
+++ b/src/HeapDump/Debugger/DumpDebugging/LibraryProvider.cs
@@ -20,6 +20,10 @@ namespace Profiler
             CLRMetaHost mh = new CLRMetaHost();
             foreach (CLRRuntimeInfo rti in mh.EnumerateInstalledRuntimes())
             {
+                string versionString = rti.GetVersionString();
+                if (versionString.StartsWith("v2."))
+                    continue;
+
                 string libPath = Path.Combine(rti.GetRuntimeDirectory(), fileName);
                 if (DoesFileMatch(libPath, timestamp, sizeOfImage))
                 {


### PR DESCRIPTION
Prior to this change, the `LibraryProvider` always tried to load the V2 CLR libraries when converting a **.dmp** to a **.gcDump**. This resulted in a return code of **CORDBG_E_LIBRARY_PROVIDER_ERROR** which [results in an exception](https://github.com/Microsoft/perfview/blob/c1d0048aa563b0b902295edb46163c13a7549503/src/HeapDump/Debugger/Debugger.cs#L76).