### PR TITLE
Fix assertion handling during unit tests

### DIFF
--- a/PerfView.sln
+++ b/PerfView.sln
@@ -58,6 +58,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfView64", "src\PerfView6
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfView.Tests", "src\PerfView.Tests\PerfView.Tests.csproj", "{A0248EF2-8C39-478A-951E-324DDF4FF3EC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfView.TestUtilities", "src\PerfView.TestUtilities\PerfView.TestUtilities.csproj", "{FE5CC86D-E87E-4560-8004-8852F3DE6794}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -124,6 +126,10 @@ Global
 		{A0248EF2-8C39-478A-951E-324DDF4FF3EC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{A0248EF2-8C39-478A-951E-324DDF4FF3EC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{A0248EF2-8C39-478A-951E-324DDF4FF3EC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{FE5CC86D-E87E-4560-8004-8852F3DE6794}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FE5CC86D-E87E-4560-8004-8852F3DE6794}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FE5CC86D-E87E-4560-8004-8852F3DE6794}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FE5CC86D-E87E-4560-8004-8852F3DE6794}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
+++ b/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
@@ -60,6 +60,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\PerfView.TestUtilities\DebugAssertionTests.cs">
+      <Link>DebugAssertionTests.cs</Link>
+    </Compile>
     <Compile Include="BlockedTimeTests.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="EventParseTests.cs" />

--- a/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
+++ b/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
@@ -127,6 +127,10 @@
       <Project>{6bac7496-6953-41b8-9042-aae45405a095}</Project>
       <Name>PerfView</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PerfView.TestUtilities\PerfView.TestUtilities.csproj">
+      <Project>{fe5cc86d-e87e-4560-8004-8852f3de6794}</Project>
+      <Name>PerfView.TestUtilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\traceEvent\TraceEvent.csproj">
       <Project>{b68f4968-a7cf-41cc-ad6e-373db5e67944}</Project>
       <Name>TraceEvent</Name>

--- a/src/PerfView.TestUtilities/DebugAssertionTests.cs
+++ b/src/PerfView.TestUtilities/DebugAssertionTests.cs
@@ -1,0 +1,45 @@
+﻿namespace PerfView.TestUtilities
+{
+    using System;
+    using System.Diagnostics;
+    using Xunit;
+
+    /// <summary>
+    /// This class verifies the behavior of <see cref="Debug.Assert(bool)"/> and <see cref="Debug.Fail(string)"/> when
+    /// called during unit testing.
+    /// </summary>
+    /// <remarks>
+    /// <para>This file can be linked into any project which needs to validate that assertions are behaving correctly
+    /// for the purpose of unit testing.</para>
+    /// </remarks>
+    public class DebugAssertionTests
+    {
+#if DEBUG
+        [Fact]
+        public void TestDebugAssertThrowsException()
+        {
+            Debug.Assert(true);
+
+            Assert.ThrowsAny<Exception>(() => Debug.Assert(false));
+        }
+
+        [Fact]
+        public void TestDebugFailThrowsException()
+        {
+            Assert.ThrowsAny<Exception>(() => Debug.Fail("Bad things"));
+        }
+#endif
+
+        [Fact]
+        public void TestTraceAssertThrowsException()
+        {
+            Assert.ThrowsAny<Exception>(() => Trace.Assert(false));
+        }
+
+        [Fact]
+        public void TestTraceFailThrowsException()
+        {
+            Assert.ThrowsAny<Exception>(() => Trace.Fail("Bad things"));
+        }
+    }
+}

--- a/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
+++ b/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
@@ -73,6 +73,7 @@
     <Compile Include="WorkItemAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="DebugAssertionTests.cs" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
+++ b/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FE5CC86D-E87E-4560-8004-8852F3DE6794}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PerfView.TestUtilities</RootNamespace>
+    <AssemblyName>PerfView.TestUtilities</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!--
+      Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+      not report warnings for missing comments.
+
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+    -->
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn),1573,1591</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
+++ b/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
@@ -68,6 +68,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UseCultureAttribute.cs" />
+    <Compile Include="WorkItemAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
+++ b/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
@@ -68,6 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ThrowingTraceListener.cs" />
     <Compile Include="UseCultureAttribute.cs" />
     <Compile Include="WorkItemAttribute.cs" />
   </ItemGroup>

--- a/src/PerfView.TestUtilities/Properties/AssemblyInfo.cs
+++ b/src/PerfView.TestUtilities/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PerfView.TestUtilities")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PerfView.TestUtilities")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fe5cc86d-e87e-4560-8004-8852f3de6794")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/PerfView.TestUtilities/ThrowingTraceListener.cs
+++ b/src/PerfView.TestUtilities/ThrowingTraceListener.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace PerfView.TestUtilities
+{
+    // To enable this for a process, add the following to the app.config for the project:
+    //
+    // <configuration>
+    //  <system.diagnostics>
+    //    <trace>
+    //      <listeners>
+    //        <remove name="Default" />
+    //        <add name="ThrowingTraceListener" type="PerfView.TestUtilities.ThrowingTraceListener, PerfView.TestUtilities" />
+    //      </listeners>
+    //    </trace>
+    //  </system.diagnostics>
+    //</configuration>
+    public sealed class ThrowingTraceListener : TraceListener
+    {
+        public override void Fail(string message, string detailMessage)
+        {
+            throw new DebugAssertFailureException(message + Environment.NewLine + detailMessage);
+        }
+
+        public override void Write(object o)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, o?.ToString());
+            }
+        }
+
+        public override void Write(object o, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, o?.ToString());
+            }
+        }
+
+        public override void Write(string message)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, message);
+            }
+        }
+
+        public override void Write(string message, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, message);
+            }
+        }
+
+        public override void WriteLine(object o)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, o?.ToString() + Environment.NewLine);
+            }
+        }
+
+        public override void WriteLine(object o, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, o?.ToString() + Environment.NewLine);
+            }
+        }
+
+        public override void WriteLine(string message)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, message + Environment.NewLine);
+            }
+        }
+
+        public override void WriteLine(string message, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, message + Environment.NewLine);
+            }
+        }
+
+        [Serializable]
+        public class DebugAssertFailureException : Exception
+        {
+            public DebugAssertFailureException() { }
+            public DebugAssertFailureException(string message) : base(message) { }
+            public DebugAssertFailureException(string message, Exception inner) : base(message, inner) { }
+            protected DebugAssertFailureException(
+              System.Runtime.Serialization.SerializationInfo info,
+              System.Runtime.Serialization.StreamingContext context) : base(info, context)
+            { }
+        }
+    }
+}

--- a/src/PerfView.TestUtilities/UseCultureAttribute.cs
+++ b/src/PerfView.TestUtilities/UseCultureAttribute.cs
@@ -9,7 +9,7 @@ using Xunit.Sdk;
  * https://github.com/xunit/samples.xunit/blob/master/UseCulture/UseCultureAttribute.cs
  */
 
-namespace PerfViewTests.Utilities
+namespace PerfView.TestUtilities
 {
     /// <summary>
     /// Apply this attribute to your test method to replace the

--- a/src/PerfView.TestUtilities/WorkItemAttribute.cs
+++ b/src/PerfView.TestUtilities/WorkItemAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace PerfViewTests.Utilities
+namespace PerfView.TestUtilities
 {
     /// <summary>
     /// Used to tag test methods or types which are created for a given WorkItem

--- a/src/PerfView.TestUtilities/packages.config
+++ b/src/PerfView.TestUtilities/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" />
+</packages>

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -88,6 +88,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -80,6 +80,10 @@
       <Project>{6bac7496-6953-41b8-9042-aae45405a095}</Project>
       <Name>PerfView</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PerfView.TestUtilities\PerfView.TestUtilities.csproj">
+      <Project>{fe5cc86d-e87e-4560-8004-8852f3de6794}</Project>
+      <Name>PerfView.TestUtilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TraceEvent\TraceEvent.csproj">
       <Project>{B68F4968-A7CF-41CC-AD6E-373DB5E67944}</Project>
       <Name>TraceEvent</Name>

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -68,6 +68,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\PerfView.TestUtilities\DebugAssertionTests.cs">
+      <Link>DebugAssertionTests.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StackViewer\StackWindowTests.cs" />
     <Compile Include="Utilities\PerfViewTestBase.cs" />

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -71,9 +71,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StackViewer\StackWindowTests.cs" />
     <Compile Include="Utilities\PerfViewTestBase.cs" />
-    <Compile Include="Utilities\UseCultureAttribute.cs" />
     <Compile Include="Utilities\VoidResult.cs" />
-    <Compile Include="Utilities\WorkItemAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PerfView\PerfView.csproj">

--- a/src/PerfView.Tests/StackViewer/StackWindowTests.cs
+++ b/src/PerfView.Tests/StackViewer/StackWindowTests.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using Microsoft.Diagnostics.Tracing.Stacks;
 using Microsoft.VisualStudio.Threading;
 using PerfView;
+using PerfView.TestUtilities;
 using PerfViewTests.Utilities;
 using Xunit;
 using DataGridCellInfo = System.Windows.Controls.DataGridCellInfo;

--- a/src/PerfView.Tests/app.config
+++ b/src/PerfView.Tests/app.config
@@ -1,8 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
-  </startup>
   <system.diagnostics>
     <trace>
       <listeners>

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
@@ -52,6 +52,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\PerfView.TestUtilities\DebugAssertionTests.cs">
+      <Link>DebugAssertionTests.cs</Link>
+    </Compile>
     <Compile Include="CtfTraceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
@@ -56,6 +56,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\PerfView.TestUtilities\PerfView.TestUtilities.csproj">
+      <Project>{fe5cc86d-e87e-4560-8004-8852f3de6794}</Project>
+      <Name>PerfView.TestUtilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\TraceEvent.csproj">
       <Project>{b68f4968-a7cf-41cc-ad6e-373db5e67944}</Project>
       <Name>TraceEvent</Name>

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
@@ -71,6 +71,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/app.config
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/app.config
@@ -1,8 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
-  </startup>
   <system.diagnostics>
     <trace>
       <listeners>

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -60,6 +60,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\PerfView.TestUtilities\PerfView.TestUtilities.csproj">
+      <Project>{fe5cc86d-e87e-4560-8004-8852f3de6794}</Project>
+      <Name>PerfView.TestUtilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TraceEvent.csproj">
       <Project>{B68F4968-A7CF-41CC-AD6E-373DB5E67944}</Project>
       <Name>TraceEvent</Name>

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -53,6 +53,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\PerfView.TestUtilities\DebugAssertionTests.cs">
+      <Link>DebugAssertionTests.cs</Link>
+    </Compile>
     <Compile Include="DispatchTests.cs" />
     <Compile Include="EtlTestBase.cs" />
     <Compile Include="GeneralParsing.cs" />

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -75,6 +75,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/TraceEvent/TraceEvent.Tests/app.config
+++ b/src/TraceEvent/TraceEvent.Tests/app.config
@@ -1,8 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
-  </startup>
   <system.diagnostics>
     <trace>
       <listeners>


### PR DESCRIPTION
⚠️ This pull request builds on the work in #274, and its diff will be simplified after that one is merged. 

This change alters the behavior of `Debug.Assert`, `Debug.Fail`, and the related methods in the `Trace` class to throw exceptions rather than show the assertion UI during testing. The assertion UI would hang the AppVeyor tests making it near impossible to understand the cause of a failure.

The approach has been adopted from the one used by the Roslyn project.