### PR TITLE
Remember history of additional providers

### DIFF
--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -375,7 +375,7 @@
                                ToolTip="A comma separated list of additional providers to turn on during data collection." >
                     <Hyperlink Command="Help" CommandParameter="AdditionalProvidersTextBox">Additional Providers:</Hyperlink>
                     </TextBlock>
-                    <TextBox  Grid.Column="1" Name="AdditionalProvidersTextBox" Margin="2,2,5,2" />
+                    <controls:HistoryComboBox  x:Name="AdditionalProvidersTextBox" Grid.Column="1" Margin="2,2,5,2" />
                     <Button Grid.Column="2" Margin="0,2,5,2" Content=" Provider Browser " Click="ProviderBrowserButtonClick" 
                             ToolTip="Click to browse the available ETW providers."/>
                     <TextBlock  Grid.Column="3" Margin="2,0,10,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -160,6 +160,11 @@ namespace PerfView
             if ((args.KernelEvents & KernelTraceEventParser.Keywords.Handle) != 0)
                 HandleCheckBox.IsChecked = true;
 
+            // Initialize history of additional providers
+            var additionalProvidersHistory = App.ConfigData["AdditionalProvidersHistory"];
+            if (additionalProvidersHistory != null)
+                AdditionalProvidersTextBox.SetHistory(additionalProvidersHistory.Split(';'));
+
             if (args.Providers != null)
             {
                 var str = "";
@@ -469,6 +474,24 @@ namespace PerfView
                 string cpuCounters = CpuCountersTextBox.Text;
                 if (cpuCounters.Length != 0)
                     m_args.CpuCounters = cpuCounters.Split(' ');
+
+                if (AdditionalProvidersTextBox.Text.Length > 0)
+                {
+                    if (AdditionalProvidersTextBox.AddToHistory(AdditionalProvidersTextBox.Text))
+                    {
+                        StringBuilder sb = new StringBuilder();
+                        foreach (string item in AdditionalProvidersTextBox.Items)
+                        {
+                            if ((item != "") && !item.Contains(";"))
+                            {
+                                if (sb.Length != 0)
+                                    sb.Append(';');
+                                sb.Append(item);
+                            }
+                        }
+                        App.ConfigData["AdditionalProvidersHistory"] = sb.ToString();
+                    }
+                }
 
                 var providers = AdditionalProvidersTextBox.Text;
                 if ((IISCheckBox.IsChecked ?? false) && providers.IndexOf("Microsoft-Windows-IIS", StringComparison.OrdinalIgnoreCase) < 0)


### PR DESCRIPTION
This is a naive attempt to fix #88 - I just implemented the same as for command history (with same history length == 10).
I was thinking to refactor code a little and extract concatenating logic into separate method, but decided not to, because actual logic varies a little (reg. ';' handling in items).
But if this is good idea, I can introduce that as well.