### PR TITLE
Fix ObservableTests

### DIFF
--- a/src/TraceEvent/Ctf/CtfTraceEventSource.cs
+++ b/src/TraceEvent/Ctf/CtfTraceEventSource.cs
@@ -517,11 +517,18 @@ namespace Microsoft.Diagnostics.Tracing
                 var hdr = InitEventRecord(header, entry.Reader, etw);
                 TraceEvent traceEvent = Lookup(hdr);
                 traceEvent.eventRecord = hdr;
-                traceEvent.userData = entry.Reader.BufferPtr;
-                traceEvent.EventTypeUserData = evt;
+                try
+                {
+                    traceEvent.userData = entry.Reader.BufferPtr;
+                    traceEvent.EventTypeUserData = evt;
 
-                traceEvent.DebugValidate();
-                Dispatch(traceEvent);
+                    traceEvent.DebugValidate();
+                    Dispatch(traceEvent);
+                }
+                finally
+                {
+                    traceEvent.eventRecord = null;
+                }
             }
 
             sessionEndTimeQPC = (long)lastTimestamp;

--- a/src/TraceEvent/TraceEvent.Tests/DispatchTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/DispatchTests.cs
@@ -745,7 +745,14 @@ namespace TraceEventTests
                 rawData->EventHeader.Flags = TraceEventNativeMethods.EVENT_HEADER_FLAG_CLASSIC_HEADER;
 
             var event_ = m_dispatcher.Lookup(rawData);
-            m_dispatcher.Dispatch(event_);
+            try
+            {
+                m_dispatcher.Dispatch(event_);
+            }
+            finally
+            {
+                event_.eventRecord = null;
+            }
         }
 
         public string Dump()

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -4273,7 +4273,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-            throw new NotImplementedException(); // GetEnumerator
+            return ((IEnumerable<TraceEvent>)this).GetEnumerator();
         }
 
         internal abstract class EventEnumeratorBase
@@ -4308,7 +4308,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             public void Reset()
             {
-                throw new Exception("The method or operation is not implemented.");
+                throw new NotSupportedException();
             }
             protected unsafe TraceEvent GetNext()
             {


### PR DESCRIPTION
Fixes #249

The root cause of the test failures is the following:

1. [This sanity check](https://github.com/Microsoft/perfview/blob/da21a66c08816ca95664adcd91461300b21d992c/src/TraceEvent/DynamicTraceEventParser.cs#L513) failed with an exception [here](https://github.com/Microsoft/perfview/blob/da21a66c08816ca95664adcd91461300b21d992c/src/TraceEvent/DynamicTraceEventParser.cs#L1009), seemingly due to an `addDomain` field which is possible related to [this TODO](https://github.com/Microsoft/perfview/blob/da21a66c08816ca95664adcd91461300b21d992c/src/TraceEvent/Computers/ActivityComputer.cs#L818) (e.g. if the appDomain field doesn't appear in the baseline files due to some omission in the TPL parser; the details here are totally outside my current understanding)
1. [This exception handler](https://github.com/Microsoft/perfview/blob/da21a66c08816ca95664adcd91461300b21d992c/src/TraceEvent/DynamicTraceEventParser.cs#L531) resulted in a string being assigned to a field
1. The string value [failed to convert to a long](https://github.com/Microsoft/perfview/blob/da21a66c08816ca95664adcd91461300b21d992c/src/TraceEvent/DynamicTraceEventParser.cs#L831)
1. The exception was [caught in `Dispatch`](https://github.com/Microsoft/perfview/blob/da21a66c08816ca95664adcd91461300b21d992c/src/TraceEvent/TraceEvent.cs#L2960-L2964), bypassing the code which assigns `eventRecord` back to null
1. When the event was eventually unsubscribed, [this assertion failed](https://github.com/Microsoft/perfview/blob/da21a66c08816ca95664adcd91461300b21d992c/src/TraceEvent/TraceEvent.cs#L568) causing the test to hang

This pull request modifies the event dispatch mechanism to ensure `eventRecord` is set back to null after dispatch in all cases.