### PR TITLE
Enable two tests which are currently working

### DIFF
--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -190,7 +190,7 @@ namespace LinuxTracing.Tests
 				switches: null);
 		}
 
-        [Fact(Skip = "FIX NOW")]
+        [Fact]
         public void SchedHeader()
 		{
 			string path = Constants.GetTestingPerfDumpPath("one_complete_switch");
@@ -199,7 +199,7 @@ namespace LinuxTracing.Tests
 				pids: new int[] { 0, 1 },
 				tids: new int[] { 0, 1 },
 				cpus: new int[] { 0, 1 },
-				times: new double[] { 0.0, 1.0 },
+				times: new double[] { 0.0, 1000.0 },
 				timeProperties: new int[] { 1, 1 },
 				events: new string[] { "sched", "sched" },
 				eventProperties: new string[] { "sched_switch: prev_comm=comm1 prev_pid=0 prev_prio=0 prev_state=S ==> next_comm=comm2 next_pid=1 next_prio=1", "sched_switch: prev_comm=comm2 prev_pid=1 prev_prio=0 prev_state=S ==> next_comm=comm1 next_pid=0 next_prio=1" },

--- a/src/LinuxEvent.Tests/InterningTests.cs
+++ b/src/LinuxEvent.Tests/InterningTests.cs
@@ -19,8 +19,8 @@ namespace LinuxTracing.Tests
 			Assert.Equal(expectedStackCount, stackSource.Interner.CallStackCount);
 		}
 
-        [Fact(Skip = "FIX NOW")]
-        public void OneSample()
+		[Fact]
+		public void OneSample()
 		{
 			string path = Constants.GetTestingPerfDumpPath("onegeneric");
 			this.InterningStackCountTest(path, expectedStackCount: 3);


### PR DESCRIPTION
One test had a simple mistake in the expected results which was corrected.