### PR TITLE
Enable /features:strict in C# projects

### DIFF
--- a/src/CSVReader/CSVReader.csproj
+++ b/src/CSVReader/CSVReader.csproj
@@ -14,6 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -28,6 +28,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>GROWABLEARRAY_PUBLIC;STREAMREADER_PUBLIC;FASTSERIALIZATION_PUBLIC;$(DefineConstants)</DefineConstants>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/HeapDump/HeapDumpX64.csproj
+++ b/src/HeapDump/HeapDumpX64.csproj
@@ -16,6 +16,7 @@
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/src/HeapDump/HeapDumpX86.csproj
+++ b/src/HeapDump/HeapDumpX86.csproj
@@ -16,6 +16,7 @@
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/src/HeapDumpInterface/HeapDumpInterface.csproj
+++ b/src/HeapDumpInterface/HeapDumpInterface.csproj
@@ -15,6 +15,7 @@
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
+++ b/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
@@ -16,6 +16,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -16,6 +16,7 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -34,6 +34,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/src/PerfView/memory/ClrProfilerSources.cs
+++ b/src/PerfView/memory/ClrProfilerSources.cs
@@ -84,7 +84,7 @@ namespace ClrProfiler
         {
             if (frameIndex < StackSourceFrameIndex.Start)
                 return System.Enum.GetName(typeof(StackSourceFrameIndex), frameIndex);      // TODO can be more efficient
-            frameIndex = (StackSourceFrameIndex)((int)frameIndex - StackSourceFrameIndex.Start);
+            frameIndex = (StackSourceFrameIndex)(frameIndex - StackSourceFrameIndex.Start);
 
             // a frame index might be a CLRProfiler method index, or it might be CLRProfiler nodeId index
             if ((uint)frameIndex < (uint)m_clrProfiler.MethodIdLimit)

--- a/src/PerfView64/PerfView64.csproj
+++ b/src/PerfView64/PerfView64.csproj
@@ -15,6 +15,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/PerfView64/PerfView64.csproj
+++ b/src/PerfView64/PerfView64.csproj
@@ -14,6 +14,7 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/PerfViewExtensions/GlobalSrc/Global.csproj
+++ b/src/PerfViewExtensions/GlobalSrc/Global.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
@@ -17,6 +17,7 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -16,6 +16,7 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -30,6 +30,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <LangVersion>6</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This change enables some compiler warnings and errors which could not be enabled in recent releases for backwards compatibility reasons, but help to identify real problems in code.