### PR TITLE
Make TraceLog.s_skipCount an instance variable

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -4922,7 +4922,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
 #if DEBUG
             var preCount = 0;
-            if (s_skipCount == 0)
+            if (_skipCount == 0)
                 preCount = JitTableCount();
 #endif
             if (index < 0)
@@ -4969,13 +4969,13 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             RETURN:;
 #if DEBUG
             // Confirm that we did not break anything.  
-            if (s_skipCount == 0)
+            if (_skipCount == 0)
             {
                 CheckJitTables();
                 Debug.Assert(preCount + 1 == JitTableCount());
-                s_skipCount = 32;
+                _skipCount = 32;
             }
-            --s_skipCount;
+            --_skipCount;
 #endif
         }
 
@@ -4995,7 +4995,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             }
         }
 #if DEBUG
-        static int s_skipCount;
+        /// <summary>
+        /// The JIT table checks are expensive. They are only enabled in debug builds, and even then do not run every
+        /// time a method is added. This field counts down each time <see cref="InsertJITTEDMethod"/> is called; when it
+        /// reaches zero the sanity checks are run and it is reset to an unspecified positive value.
+        /// </summary>
+        static int _skipCount;
 
         private int JitTableCount()
         {


### PR DESCRIPTION
This field was not providing particular value as a static variable. Changing it to an instance variable means one less thing to worry about when it comes to test determinism.