### PR TITLE
Remove unnecessary static state

### DIFF
--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -1407,12 +1407,6 @@ namespace Microsoft.Diagnostics.Tracing
             Creator = creator;
             ExtraInfo = extraInfo;
             Index = (StartStopActivityIndex)index;
-
-            // generate a ID that makes this unique among all children of the creator. 
-            if (creator == null)
-                myChildID = (++s_nextChildID);
-            else
-                myChildID = (++creator.nextChildID);
         }
 
         /// <summary>
@@ -1427,10 +1421,6 @@ namespace Microsoft.Diagnostics.Tracing
                 this.DurationMSec = stopTimeRelativeMSec - StartTimeRelativeMSec;
             }
         }
-
-        static int s_nextChildID;       // Used to generate small IDs 
-        private int myChildID;
-        private int nextChildID;
 
         // these are used to implement deferred stops.  
         internal ActivityIndex activityIndex;     // the index for the task that was active at the time of the stop.  

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -50,10 +50,10 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 
                 // TODO FIX NOW I turned of Parallelism because there were signs of races and 
                 // I had higher priorities.   I would like to turn this back on.   
-                // if (DisableParallelism)
-                value.ForEach(AddSample);
-                // else
-                //     value.ParallelForEach(AddSample);
+                if (DisableParallelism)
+                    value.ForEach(AddSample);
+                else
+                    value.ParallelForEach(AddSample);
                 // And the basis for forming the % is total metric of stackSource.  
                 PercentageBasis = Math.Abs(Root.InclusiveMetric);       // People get confused if this swaps. 
 
@@ -211,7 +211,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// <summary>
         /// Turns off logic for computing call trees in parallel.   Safer but slower.  
         /// </summary>
-        public static bool DisableParallelism { get; set; }
+        public bool DisableParallelism { get; set; } = true;
+
         /// <summary>
         /// Break all links in the call tree to free as much memory as possible.   
         /// </summary>

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -48,8 +48,6 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 if (m_SampleInfo.IsGraphSource)
                     m_samplesToTreeNodes = new CallTreeNode[m_SampleInfo.SampleIndexLimit];
 
-                // TODO FIX NOW I turned of Parallelism because there were signs of races and 
-                // I had higher priorities.   I would like to turn this back on.   
                 if (DisableParallelism)
                     value.ForEach(AddSample);
                 else
@@ -211,6 +209,9 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// <summary>
         /// Turns off logic for computing call trees in parallel.   Safer but slower.  
         /// </summary>
+        /// <remarks>
+        /// <para>This is off by default following indications of race conditions.</para>
+        /// </remarks>
         public bool DisableParallelism { get; set; } = true;
 
         /// <summary>


### PR DESCRIPTION
* Make `DisableParallelism` an instance variable
* Remove static state in `StartStopActivityComputer` for an unused field