### PR TITLE
Include Microsoft.Diagnostics.FastSerialization in the TraceEvent package

### DIFF
--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -45,6 +45,17 @@
     <OutputPath>bin\release\</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <!--
+      Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+      not report warnings for missing comments.
+
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+    -->
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn),1573,1591</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -44,6 +44,11 @@
     <file src="$OutDir$Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\net45" />
     <file exclude="obj\**\*.cs;bin\**\*.cs;TraceEvent.Tests\**\*.cs;Ctf\CtfTracing.Tests\**\*.cs" src="**\*.cs" target="src" />
     <file src="obj\$Configuration$\**\*.cs" target="src\obj\$Configuration$" />
+
+    <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.dll" target="lib\net45" />
+    <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.xml" target="lib\net45" />
+    <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.pdb" target="lib\net45" />
+    <file exclude="..\FastSerialization\obj\**\*.cs;..\FastSerialization\bin\**\*.cs;..\FastSerialization\_README.cs" src="..\FastSerialization\**\*.cs" target="src" />
   </files>
 
 </package>

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -42,7 +42,7 @@
     <file src="$OutDir$Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\net45" />
     <file src="$OutDir$Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\net45" />
     <file src="$OutDir$Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\net45" />
-    <file exclude="obj\**\*.cs" src="**\*.cs" target="src" />
+    <file exclude="obj\**\*.cs;bin\**\*.cs;TraceEvent.Tests\**\*.cs;Ctf\CtfTracing.Tests\**\*.cs" src="**\*.cs" target="src" />
     <file src="obj\$Configuration$\**\*.cs" target="src\obj\$Configuration$" />
   </files>
 


### PR DESCRIPTION
Currently the **Microsoft.Diagnostics.Tracing.TraceEvent** assembly depends on **Microsoft.Diagnostics.FastSerialization**, but no dependency was added to the NuGet package. Rather than deal with separate NuGet packages at this time, this change simply includes the dependency in the original NuGet package.

:memo: If we ever need to split these in the future, we can trivially do so and add a dependency from the current NuGet package to the new one without breaking upgrade scenarios. Since this makes distribution a little bit more complex (managing multiple NuGet releases from one repository) and didn't seem essential at this time, I chose the simplest route to packaging for my initial proposed approach.