### PR TITLE
Diag session fix 

### DIFF
--- a/src/HeapDump/HeapDumpX64.csproj
+++ b/src/HeapDump/HeapDumpX64.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props" Condition="Exists('..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props')" />
+  <Import Project="..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props" Condition="Exists('..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -42,20 +42,21 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiagnosticsHub.Packaging.Interop, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\DiagnosticsHub.Packaging.Interop.dll</HintPath>
+    <Reference Include="DiagnosticsHub.Packaging.Interop">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\DiagnosticsHub.Packaging.Interop.dll</HintPath>
       <Private>True</Private>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Runtime, Version=0.8.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Diagnostics.Runtime.0.8.31-beta\lib\net40\Microsoft.Diagnostics.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=0.0.0.0, Culture=neutral, PublicKeyToken=13e5ffd4e05db186, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.DiagnosticsHub.Packaging.InteropEx, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\Microsoft.DiagnosticsHub.Packaging.InteropEx.dll</HintPath>
+    <Reference Include="Microsoft.DiagnosticsHub.Packaging.InteropEx">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\Microsoft.DiagnosticsHub.Packaging.InteropEx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -134,7 +135,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props'))" />
+    <Error Condition="!Exists('..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/HeapDump/HeapDumpX86.csproj
+++ b/src/HeapDump/HeapDumpX86.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props" Condition="Exists('..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props')" />
+  <Import Project="..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props" Condition="Exists('..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -45,20 +45,21 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiagnosticsHub.Packaging.Interop, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\DiagnosticsHub.Packaging.Interop.dll</HintPath>
+    <Reference Include="DiagnosticsHub.Packaging.Interop">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\DiagnosticsHub.Packaging.Interop.dll</HintPath>
       <Private>True</Private>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Runtime, Version=0.8.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Diagnostics.Runtime.0.8.31-beta\lib\net40\Microsoft.Diagnostics.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=0.0.0.0, Culture=neutral, PublicKeyToken=13e5ffd4e05db186, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.DiagnosticsHub.Packaging.InteropEx, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\Microsoft.DiagnosticsHub.Packaging.InteropEx.dll</HintPath>
+    <Reference Include="Microsoft.DiagnosticsHub.Packaging.InteropEx">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\Microsoft.DiagnosticsHub.Packaging.InteropEx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -136,7 +137,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props'))" />
+    <Error Condition="!Exists('..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/HeapDump/packages.config
+++ b/src/HeapDump/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Diagnostics.Runtime" version="0.8.31-beta" targetFramework="net45" />
-  <package id="PerfView.SupportFiles" version="1.0.2" targetFramework="net45" />
+  <package id="PerfView.SupportFiles" version="1.0.3" targetFramework="net45" />
 </packages>

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/build/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.props
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/build/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TraceEventSupportFilesBase>$(MSBuildThisFileDirectory)..\lib\</TraceEventSupportFilesBase>
+  </PropertyGroup>
+</Project>

--- a/src/NugetSupportFiles/PerfView.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/PerfView.SupportFiles.Populate.bat
@@ -3,8 +3,8 @@ REM
 REM *** This is mostly a template for doing the copy.      ****  
 REM *** Most likey you want this to be the current version ****
 REM 
-xcopy /s /y ..\..\packages\PerfView.SupportFiles.1.0.2\*.dll PerfView.SupportFiles
-xcopy /s /y ..\..\packages\PerfView.SupportFiles.1.0.2\*.exe PerfView.SupportFiles
+xcopy /s /y ..\..\packages\PerfView.SupportFiles.1.0.3\*.dll PerfView.SupportFiles
+xcopy /s /y ..\..\packages\PerfView.SupportFiles.1.0.3\*.exe PerfView.SupportFiles
 
 @REM These are the binary files we need from somewhere to for the support package
 @REM lib\native\x86\DiagnosticsHub.Packaging.dll

--- a/src/NugetSupportFiles/PerfView.SupportFiles/build/PerfView.SupportFiles.props
+++ b/src/NugetSupportFiles/PerfView.SupportFiles/build/PerfView.SupportFiles.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PerfViewSupportFilesBase>$(MSBuildThisFileDirectory)..\lib\</PerfViewSupportFilesBase>
+  </PropertyGroup>
+</Project>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props" Condition="Exists('..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props')" />
   <Import Project="..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.0.2\build\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.props" Condition="Exists('..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.0.2\build\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.props')" />
-  <Import Project="..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props" Condition="Exists('..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -76,20 +76,20 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiagnosticsHub.Packaging.Interop, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\DiagnosticsHub.Packaging.Interop.dll</HintPath>
-      <Private>True</Private>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="Dia2Lib, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.0.2\lib\net40\Interop.Dia2Lib.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=0.0.0.0, Culture=neutral, PublicKeyToken=13e5ffd4e05db186, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+    <Reference Include="DiagnosticsHub.Packaging.Interop, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\DiagnosticsHub.Packaging.Interop.dll</HintPath>
+      <Private>True</Private>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.DiagnosticsHub.Packaging.InteropEx, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.2\lib\net40\Microsoft.DiagnosticsHub.Packaging.InteropEx.dll</HintPath>
+    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=0.0.0.0, Culture=neutral, PublicKeyToken=13e5ffd4e05db186, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.DiagnosticsHub.Packaging.InteropEx, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PerfView.SupportFiles.1.0.3\lib\net40\Microsoft.DiagnosticsHub.Packaging.InteropEx.dll</HintPath>
     </Reference>
     <Reference Include="OSExtensions, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.0.2\lib\net40\OSExtensions.dll</HintPath>
@@ -472,6 +472,8 @@
     <Copy SourceFiles="$(TraceEventSupportFilesBase)native\amd64\KernelTraceControl.dll" DestinationFolder="$(OutDir)amd64" />
     <Copy SourceFiles="$(TraceEventSupportFilesBase)native\x86\msdia140.dll" DestinationFolder="$(OutDir)x86" />
     <Copy SourceFiles="$(TraceEventSupportFilesBase)native\amd64\msdia140.dll" DestinationFolder="$(OutDir)amd64" />
+    <Copy SourceFiles="$(PerfViewSupportFilesBase)native\x86\DiagnosticsHub.Packaging.dll" DestinationFolder="$(OutDir)x86" />
+    <Copy SourceFiles="$(PerfViewSupportFilesBase)native\amd64\DiagnosticsHub.Packaging.dll" DestinationFolder="$(OutDir)x64" />
   </Target>
   <ItemGroup>
     <EmbeddedResource Include="..\HeapDump\$(OutDir)\x64\HeapDump.exe">
@@ -547,11 +549,17 @@
       <LogicalName>.\x86\DiagnosticsHub.Packaging.dll</LogicalName>
       <Link>x86\DiagnosticsHub.Packaging.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PerfViewSupportFilesBase)native\x86\DiagnosticsHub.Packaging.Interop.dll">
+    <EmbeddedResource Include="$(PerfViewSupportFilesBase)native\amd64\DiagnosticsHub.Packaging.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
-      <LogicalName>.\x86\DiagnosticsHub.Packaging.Interop.dll</LogicalName>
-      <Link>x86\DiagnosticsHub.Packaging.Interop.dll</Link>
+      <LogicalName>.\amd64\DiagnosticsHub.Packaging.dll</LogicalName>
+      <Link>x64\DiagnosticsHub.Packaging.dll</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PerfViewSupportFilesBase)net40\DiagnosticsHub.Packaging.Interop.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\DiagnosticsHub.Packaging.Interop.dll</LogicalName>
+      <Link>DiagnosticsHub.Packaging.Interop.dll</Link>
     </EmbeddedResource>
     <EmbeddedResource Include="$(PerfViewSupportFilesBase)net40\Microsoft.Diagnostics.Tracing.EventSource.dll">
       <Type>Non-Resx</Type>
@@ -754,8 +762,8 @@ REM  deleting Dlls so we pick them up from the deployment dir.</PostBuildEvent>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PerfView.SupportFiles.1.0.2\build\PerfView.SupportFiles.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.0.2\build\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.0.2\build\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.props'))" />
+    <Error Condition="!Exists('..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PerfView.SupportFiles.1.0.3\build\PerfView.SupportFiles.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/PerfView/packages.config
+++ b/src/PerfView/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" version="1.0.2" targetFramework="net45" />
-  <package id="PerfView.SupportFiles" version="1.0.2" targetFramework="net45" />
+  <package id="PerfView.SupportFiles" version="1.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This fixes issue #277 

A new package with updated DiagnosticHub dlls (now Dev 15).  

The vast majority of the update is updating the version for the support package.

however the key fix is to move the DiagnosticHub.Interop.dll OUT of the architecture specific directory. 