### PR TITLE
Several minor updates

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -352,7 +352,9 @@ namespace PerfView
                 bool hasTpl = false;
                 foreach (var provider in onlyProviders)
                 {
-                    if (0 <= provider.IndexOf(":stack", StringComparison.OrdinalIgnoreCase))
+                    if (0 <= provider.IndexOf("@StacksEnabled=true", StringComparison.OrdinalIgnoreCase))
+                        hasStacks = true;
+                    if (0 <= provider.IndexOf("@EventIDStacksToEnable", StringComparison.OrdinalIgnoreCase))
                         hasStacks = true;
                     if (provider.StartsWith(".NETTasks", StringComparison.OrdinalIgnoreCase))
                         hasTpl = true;

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2257,6 +2257,8 @@ namespace PerfView
                 cmdLineArgs += " /MaxCollectSec:" + parsedArgs.MaxCollectSec;
             if (parsedArgs.RundownTimeout != 120)
                 cmdLineArgs += " /RundownTimeout:" + parsedArgs.RundownTimeout;
+            if (parsedArgs.CpuCounters != null)
+                cmdLineArgs += " /CpuCounters:" + Command.Quote(string.Join(",", parsedArgs.CpuCounters));
 
             if (parsedArgs.SafeMode)
                 cmdLineArgs += " /SafeMode";

--- a/src/PerfView/Properties/AssemblyInfo.cs
+++ b/src/PerfView/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.9.55")]  
+[assembly: AssemblyFileVersion("1.9.58")]  
 [assembly:  InternalsVisibleTo("PerfViewTests")] 

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -6767,7 +6767,7 @@
         not unlike ETW, and in particular knows how to capture CPU stacks at a periodic interval (e.g. 1msec)  PerfView knows how to read this data,
         so it is possible to collect data using the Perf Events tool on Linux copy the data over to a Windows machine and view it with PerfView's
         stack viewer.   Much of the rest of this section is a clone of the <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md">linux-performance-tracing.md</a>
-        document.   You may wish to check there as well to see if there for the lastest version of these instructions. 
+        document.   You may wish to check there as well to see if there for the latest version of these instructions. 
     </p>
     <h3>Setup</h3>
     <h4>Getting perfcollect script</h4>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -6766,7 +6766,8 @@
         Linux has a kernel level event logging system called <a href="https://en.wikipedia.org/wiki/Perf_%28Linux%29">Perf Events</a> which is
         not unlike ETW, and in particular knows how to capture CPU stacks at a periodic interval (e.g. 1msec)  PerfView knows how to read this data,
         so it is possible to collect data using the Perf Events tool on Linux copy the data over to a Windows machine and view it with PerfView's
-        stack viewer.
+        stack viewer.   Much of the rest of this section is a clone of the <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md">linux-performance-tracing.md</a>
+        document.   You may wish to check there as well to see if there for the lastest version of these instructions. 
     </p>
     <h3>Setup</h3>
     <h4>Getting perfcollect script</h4>


### PR DESCRIPTION
Added a link to more documenation about collecting on Linux machines.
Updated logic so that /OnlyProviders will collect addtion events if the user asks for stacks on those events (there was logic but it was geared to old syntax).
Fix a bug with creating large data that might exceed 4GB (happened with some large heap dumps).
Fixed bug where /CpuCounters argument was lost if PerfView had to elevate.