### PR TITLE
Fix flaky tests due to file access errors

### DIFF
--- a/src/LinuxEvent.Tests/BlockedTimeTests.cs
+++ b/src/LinuxEvent.Tests/BlockedTimeTests.cs
@@ -21,8 +21,6 @@ namespace LinuxTracing.Tests
 		public static int? StartLook = null;
 		private void TotalBlockedTimeTest(string source, double expectedTotalBlockedPeriod, bool concurrentTest = false)
 		{
-			Constants.WaitUntilFileIsReady(source);
-
 			if (concurrentTest)
 			{
 				StartLook = 10;

--- a/src/LinuxEvent.Tests/Constants.cs
+++ b/src/LinuxEvent.Tests/Constants.cs
@@ -27,27 +27,5 @@ namespace LinuxTracing.Tests
 		{
 			return Path.Combine(Environment.CurrentDirectory, OutputFolder, string.Format("{0}", filename));
 		}
-
-		public static void WaitUntilFileIsReady(string fileName)
-		{
-            // This used to have logic that polled until the file existed.
-            // This seems like a hack, and the polling logic happened to
-            // open the file read-write, which caused file sharing conflicts
-            // with concurrent tests.    
-
-            // Note that on windows even doing a File.Exists(XXX) LOCKS the
-            // file for a short time.   THus we don't want to do things like
-            // that since it can interfer (this is unfortunate).  If we need
-            // a file probe, we need to do it with a FileOpen with appropriate 
-            // File sharing attributes.  
-
-            // None of this should be necessary.   I am reomving it and if
-            // This method should go away if we don't have problems with it 
-            // for a while. 
-            // -- vance 5/17/2017
-
-            // Thread.Sleep(2);
-            
-		}
 	}
 }

--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -14,8 +14,6 @@ namespace LinuxTracing.Tests
 	{
 		private void DoStackTraceTest(string path, bool doBlockedTime, List<List<string>> callerStacks)
 		{
-			Constants.WaitUntilFileIsReady(path);
-
 			ParallelLinuxPerfScriptStackSource stackSource = new ParallelLinuxPerfScriptStackSource(path, doBlockedTime);
 
 			for (int i = 0; i < stackSource.SampleIndexLimit; i++)
@@ -47,9 +45,6 @@ namespace LinuxTracing.Tests
 			ScheduleSwitch[] switches
 			)
 		{
-
-			Constants.WaitUntilFileIsReady(source);
-
 			using (Stream stream = File.Open(source, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				LinuxPerfScriptEventParser parser = new LinuxPerfScriptEventParser();

--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -50,7 +50,7 @@ namespace LinuxTracing.Tests
 
 			Constants.WaitUntilFileIsReady(source);
 
-			using (Stream stream = File.Open(source, FileMode.Open))
+			using (Stream stream = File.Open(source, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				LinuxPerfScriptEventParser parser = new LinuxPerfScriptEventParser();
 				List<LinuxEvent> samples = parser.ParseSkippingPreamble(stream).ToList();

--- a/src/LinuxEvent.Tests/FastStreamTests.cs
+++ b/src/LinuxEvent.Tests/FastStreamTests.cs
@@ -14,7 +14,6 @@ namespace LinuxTracing.Tests
 	{
 		private FastStream GetTestStream()
 		{
-			Constants.WaitUntilFileIsReady(Constants.GetTestingFilePath("faststream.txt"));
 			return new FastStream(Constants.GetTestingFilePath("faststream.txt"));
 		}
 

--- a/src/LinuxEvent.Tests/InterningTests.cs
+++ b/src/LinuxEvent.Tests/InterningTests.cs
@@ -13,8 +13,6 @@ namespace LinuxTracing.Tests
 	{
 		private void InterningStackCountTest(string source, int expectedStackCount)
 		{
-			Constants.WaitUntilFileIsReady(source);
-
 			ParallelLinuxPerfScriptStackSource stackSource = new ParallelLinuxPerfScriptStackSource(source);
 			Assert.Equal(expectedStackCount, stackSource.Interner.CallStackCount);
 		}

--- a/src/LinuxEvent.Tests/XMLWriting.cs
+++ b/src/LinuxEvent.Tests/XMLWriting.cs
@@ -17,8 +17,6 @@ namespace LinuxTracing.Tests
 	{
 		private static void Write(string source)
 		{
-			Constants.WaitUntilFileIsReady(source);
-
 			var stackSource = new ParallelLinuxPerfScriptStackSource(source);
 			XmlStackSourceWriter.WriteStackViewAsZippedXml(stackSource,
 				Constants.GetOutputPath(Path.GetFileNameWithoutExtension(source) + ".perfView.xml.zip"));

--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
@@ -411,7 +411,7 @@ namespace Diagnostics.Tracing.StackSources
                 return foundEntry?.Open();
             }
             else
-                return new FileStream(path, FileMode.Open);
+                return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
         private double? SampleEndTime;


### PR DESCRIPTION
The tests all read from files located in source control. As long as the tests only take non-exclusive read locks, they will no longer fail due to exceptions seen during several recent AppVeyor builds.