### PR TITLE
Avoid renaming handle fields during extraction

### DIFF
--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1247,7 +1247,7 @@ public class GCHeapDumper
                 string name = root.Name;
                 if (name == "RefCount handle")
                     name = "COM/WinRT Objects";
-                else if (name == "local var" || name.EndsWith("handle", StringComparison.OrdinalIgnoreCase))
+                else if (name == "local var" || name.EndsWith(" handle", StringComparison.OrdinalIgnoreCase))
                     name += "s";
                 MemoryNodeBuilder nodeToAddRootTo = dotNetRoot;
 


### PR DESCRIPTION
Previously, static fields with a name ending in `Handle` were getting renamed during heap extraction (by appending an `s`). The renaming was never meant to apply to these roots, but rather to the container nodes for handle roots.