### PR TITLE
Fix errors related to multiple wrappers for the same object

### DIFF
--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1271,7 +1271,7 @@ public class GCHeapDumper
                             }
 
                             // Create a CCW node that represents the COM object that has one child that points at the managed object.  
-                            var ccwNode = m_gcHeapDump.MemoryGraph.GetNodeIndex(comPtr);
+                            var ccwNode = m_gcHeapDump.MemoryGraph.GetNodeIndex(ccwInfo.Handle);
                             var typeName = "[CCW";
                             var targetType = m_dotNetHeap.GetObjectType(root.Object);
                             if (targetType != null)


### PR DESCRIPTION
`comPtr` is not necessary unique in a heap dump, but the `ccwInfo.Handle` is. This change updates the CCW node to use a unique handle so we don't try to call `SetNode` twice for the same address.