### PR TITLE
Test hardening

### DIFF
--- a/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
+++ b/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
@@ -70,6 +70,8 @@ namespace PerfViewTests.Utilities
             if (disposing)
             {
                 GuiApp.MainWindow?.Close();
+
+                JoinableTaskFactory?.Context.Dispose();
             }
         }
     }

--- a/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
+++ b/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
@@ -55,6 +55,9 @@ namespace PerfViewTests.Utilities
 
         private void CreateMainWindow()
         {
+            GuiApp.MainWindow?.Close();
+            JoinableTaskFactory?.Context.Dispose();
+
             GuiApp.MainWindow = new MainWindow();
             JoinableTaskFactory = new JoinableTaskFactory(new JoinableTaskContext());
         }
@@ -70,6 +73,7 @@ namespace PerfViewTests.Utilities
             if (disposing)
             {
                 GuiApp.MainWindow?.Close();
+                GuiApp.MainWindow = null;
 
                 JoinableTaskFactory?.Context.Dispose();
             }

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -3005,42 +3005,27 @@ namespace PerfView
             ret = Regex.Replace(ret, @"^[ |+]*", "");               // Remove spaces or | (for tree view) at the start).  
             return ret;
         }
-        private static IList<DataGridCellInfo> SelectedCells()
+        private IList<DataGridCellInfo> SelectedCells()
         {
             var dataGrid = GetDataGrid();
             if (dataGrid == null)
                 return null;
             return dataGrid.SelectedCells;
         }
-        internal static DataGrid GetDataGrid()
+        internal DataGrid GetDataGrid()
         {
-            var focus = Keyboard.FocusedElement;
-            var asDO = focus as DependencyObject;
-            if (asDO != null)
-            {
-                var dataGrid = Helpers.AncestorOfType<DataGrid>(asDO);
-                if (dataGrid != null)
-                    return dataGrid;
-
-                // TODO FIX NOW this is a hack,
-                // Symptom is that the find box is selected after a Find, not the grid element.  
-                // Debug.Assert(false, "(Ignorable) Did not find gridView as expected");
-                var stackWindow = Helpers.AncestorOfType<StackWindow>(asDO);
-                if (stackWindow != null)
-                {
-                    if (stackWindow.ByNameTab.IsSelected)
-                        return stackWindow.ByNameDataGrid.Grid;
-                    else if (stackWindow.CallerCalleeTab.IsSelected)
-                        return stackWindow.CallTreeDataGrid.Grid;
-                    else if (stackWindow.CalleesTab.IsSelected)
-                        return stackWindow.CallerCalleeView.CalleesGrid.Grid;
-                    else if (stackWindow.CallersTab.IsSelected)
-                        return stackWindow.CallerCalleeView.CallersGrid.Grid;
-                }
-            }
-            return null;
+            if (ByNameTab.IsSelected)
+                return ByNameDataGrid.Grid;
+            else if (CallerCalleeTab.IsSelected)
+                return CallTreeDataGrid.Grid;
+            else if (CalleesTab.IsSelected)
+                return CallerCalleeView.CalleesGrid.Grid;
+            else if (CallersTab.IsSelected)
+                return CallerCalleeView.CallersGrid.Grid;
+            else
+                return null;
         }
-        private static IEnumerable<string> SelectedCellsStringValue()
+        private IEnumerable<string> SelectedCellsStringValue()
         {
             var dataGrid = GetDataGrid();
             if (dataGrid == null)
@@ -3076,7 +3061,7 @@ namespace PerfView
         /// <summary>
         /// Returns the string value for a single selected cell.  Will return null on error 
         /// </summary>
-        private static string SelectedCellStringValue()
+        private string SelectedCellStringValue()
         {
             var dataGrid = GetDataGrid();
             if (dataGrid == null)


### PR DESCRIPTION
@vancem During local testing I observed a couple issues which could cause test failures in the StackWindowTests. One of these, a reliance on `Keyboard.FocusedElement`, represents a true race condition in the product that is fixed by this.

:memo: I was not able to specifically reproduce the *hang* seen during testing, but it's possible it was some side effect of the test failing due to the above case.