### PR TITLE
HistoryDictionary: Replace manually sorted list with SortedDictionary

### DIFF
--- a/src/TraceEvent/TraceUtilities/HistoryDictionary.cs
+++ b/src/TraceEvent/TraceUtilities/HistoryDictionary.cs
@@ -40,11 +40,20 @@ namespace Microsoft.Diagnostics.Tracing.Utilities
 
                 // See if we can jump ahead.  Currently we only do this of the first entry, 
                 // But you could imagine using some of the other nodes's skipAhead entries.   
-                if (firstEntry.skipAhead != null && firstEntry.skipAhead.startTime < startTime)
+                if (firstEntry.skipAhead != null && firstEntry.skipAhead.startTime <= startTime)
                     entry = firstEntry.skipAhead;
 
                 for (; ; )
                 {
+                    // We found exact match
+                    if (startTime == entry.StartTime)
+                    {
+                        // Just update the value and exit immediately as there is no need to
+                        // update skipAhead or increment count
+                        entry.value = value;
+                        return;
+                    }
+
                     if (entry.next == null)
                     {
                         entry.next = new HistoryValue(startTime, id, value);


### PR DESCRIPTION
This is the attempt to fix issue #297.

I made an attempt to replace manually sorted list which spends a lot of time in linear search inside `Add` with tree-based `SortedDictionary`.

After the fix the same file is opened within half a minute as opposed to 4 minutes in the original case:

```
159 distinct processes.
Totals
  2 856 343 events.
  1 771 483 events with stack traces.
   141 728 events with code addresses in them.
  62 855 364 total code address instances. (stacks or other)
   168 745 unique code addresses. 
  1 699 553 unique stacks.
     2 971 unique managed methods parsed.
   101 257 CLR method event records.
[Conversion complete 2 856 343 events.  Conversion took 25 sec.]
A total of 168745 symbolic addresses were looked up.
Addresses outside any module: 2091 out of 168745 (1,2%)
Done with symbolic lookup.
ETL Size 1 035,141 MB ETLX Size 531,210 MB
Completed: Opening PerfViewData-mosaictest12.etl.zip   (Elapsed Time: 32,745 sec)
```

I didn't experience any issues using PerfView with these changes for a few weeks.

The only 'business logic' change I made is that only single entry is stored for any given timestamp as opposed to the old version. But the lookup algorithm from the old version would have always found the latest added entry and not others, so I made a conclusion that my code should work as well.

If more performance comparison are required - let me know about particular scenarios to test.