### PR TITLE
Add the OSExtentions DLL to the TraceEvent Nuget package

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -49,6 +49,8 @@
     <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.xml" target="lib\net45" />
     <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.pdb" target="lib\net45" />
     <file exclude="..\FastSerialization\obj\**\*.cs;..\FastSerialization\bin\**\*.cs;..\FastSerialization\_README.cs" src="..\FastSerialization\**\*.cs" target="src" />
+
+    <file src="$OutDir$OSExtensions.dll" target="lib\net45" />
   </files>
 
 </package>


### PR DESCRIPTION
This is missing and is an essential part of the package.