### PR TITLE
Fix LinuxPerfScriptEventParser when parsing timespamp event

### DIFF
--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Diagnostics.Tracing.StackSources;
 using Microsoft.Diagnostics.Tracing.Stacks;
+using PerfView.TestUtilities;
 using Xunit;
 
 namespace LinuxTracing.Tests
@@ -94,6 +92,16 @@ namespace LinuxTracing.Tests
 				new List<string>{ "module!symbol", "Thread (0)", "comm", null }
 			});
 		}
+
+        [Fact]
+        [UseCulture("fr-FR")]
+        public void OneStackButWithAnotherCulture()
+        {
+            string path = Constants.GetTestingPerfDumpPath("onegeneric");
+            this.DoStackTraceTest(path, doBlockedTime: false, callerStacks: new List<List<string>> {
+                new List<string>{ "module!symbol", "Thread (0)", "comm", null }
+            });
+        }
 
         [Fact(Skip = "FIX NOW")]
         public void ResolvingSymbols()

--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptEventParser.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using Microsoft.Diagnostics.Tracing.Stacks;
 using PerfView.Utilities;
 
 namespace Diagnostics.Tracing.StackSources
@@ -328,7 +327,7 @@ namespace Diagnostics.Tracing.StackSources
                 source.SkipWhiteSpace();
                 source.ReadAsciiStringUpTo(':', sb);
 
-                double time = double.Parse(sb.ToString()) * 1000; // To convert to MSec
+                double time = double.Parse(sb.ToString(), CultureInfo.InvariantCulture) * 1000; // To convert to MSec
                 sb.Clear();
                 source.MoveNext(); // Move past ":"
 


### PR DESCRIPTION
When parsing timestamp of an event ("0.0") with the current culture set to "fr-FR", a System.FormatException is raised.