### PR TITLE
Improved codecov reporting and performance

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -39,3 +39,7 @@ flags:
   Release:
     paths:
       - nonexistent/
+  # Filter out 2015 reports for performance
+  2015:
+    paths:
+      - nonexistent/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,9 @@ coverage:
     patch:
       default: false
 
+comment:
+  layout: "diff, flags, files, footer"
+
 flags:
   production:
     paths:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,9 +11,26 @@ coverage:
 flags:
   production:
     paths:
-      - StyleCop.Analyzers/StyleCop.Analyzers/
-      - StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/
+      - src/CSVReader/
+      - src/EtwClrProfiler/
+      - src/EtwHeapDump/
+      - src/FastSerialization/
+      - src/HeapDump/
+      - src/HeapDumpCommon/
+      - src/HeapDumpInterface/
+      - src/HtmlJs/
+      - src/MemoryGraph/
+      - src/PerfView/
+      - src/PerfView64/
+      - src/PerfViewExtensions/
+      - src/related/TraceEventAPIServer/
+      - src/TraceEvent/
+      - src/Utilities/
+      - src/VS/
   test:
     paths:
-      - StyleCop.Analyzers/StyleCop.Analyzers.Test/
-      - StyleCop.Analyzers/StyleCopTester/
+      - src/LinuxEvent.Tests/
+      - src/PerfView.Tests/
+      - src/PerfView.TestUtilities/
+      - src/TraceEvent/Ctf/CtfTracing.Tests/
+      - src/TraceEvent/TraceEvent.Tests/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -34,3 +34,8 @@ flags:
       - src/PerfView.TestUtilities/
       - src/TraceEvent/Ctf/CtfTracing.Tests/
       - src/TraceEvent/TraceEvent.Tests/
+  # Filter results to only show debug reports until the accuracy problems with
+  # the report merge process are fixed.
+  Release:
+    paths:
+      - nonexistent/


### PR DESCRIPTION
This pull request serves four purposes:

1. After codecov supports inferred flags from the .codecov.yml, it will correctly¹ apply the **production** and **test** flags to our existing code base.
2. Work around a problem merging the coverage information for Debug and Release builds (which have different sequence points in the debug information) by using a filter to suppress the reports from release builds.
3. Work around a performance problem related to merging very large reports by suppressing the reports from Visual Studio 2015 builds (these will go away anyway after #319).
4. Stop showing the graphic for coverage comments in pull requests

¹ There will be some minor visual discrepancies in the codecov UI until we stop nesting test projects in the folders of production code, but I'm waiting until after #319 is resolved to look at that.

/cc @stevepeak
