### PR TITLE
Ensure StatusBar.m_work is assigned before the work starts

### DIFF
--- a/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml.cs
+++ b/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml.cs
@@ -206,8 +206,13 @@ namespace PerfView
             // back (this.BeginInvoke), to finish it off.
             var currentCulture = CultureInfo.CurrentCulture;
             var currentUICulture = CultureInfo.CurrentUICulture;
+            var workSemaphore = new SemaphoreSlim(1);
+            workSemaphore.Wait();
             m_work = Task.Run(() =>
             {
+                // Wait for the m_work variable to actually get assigned
+                workSemaphore.Wait();
+
                 var oldCulture = Tuple.Create(CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
                 try
                 {
@@ -266,6 +271,9 @@ namespace PerfView
                     Thread.CurrentThread.CurrentUICulture = oldCulture.Item2;
                 }
             });
+
+            // Now that m_work is assigned, allow the operation to proceed
+            workSemaphore.Release();
 
             SignalPropertyChange(nameof(IsWorking));
             SignalPropertyChange(nameof(IsNotWorking));


### PR DESCRIPTION
Fixes an occasional assertion failure (and subsequent test hang) where `EndWork` was called before `m_work` was assigned.