### PR TITLE
Fix an incorrectly quoted key in .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -43,6 +43,6 @@ flags:
     paths:
       - nonexistent/
   # Filter out 2015 reports for performance
-  2015:
+  '2015':
     paths:
       - nonexistent/


### PR DESCRIPTION
Command used to validate this:

```powershell
Invoke-RestMethod -Uri https://codecov.io/validate -Body (Get-Content -Raw -LiteralPath .\.codecov.yml) -Method post
```

:link: Source: https://docs.codecov.io/docs/codecov-yaml#section-validate-your-repository-yaml