### PR TITLE
Fix for missing callstacks in real time Tracelog sessions (issue 332)

### DIFF
--- a/src/TraceEvent/ETWReloggerTraceEventSource.cs
+++ b/src/TraceEvent/ETWReloggerTraceEventSource.cs
@@ -407,7 +407,7 @@ namespace Microsoft.Diagnostics.Tracing
                         // first event (real time case).   This is really a problem, as we need that information, but we will go ahead and
                         // try to initialize as best we can. 
 
-                        m_source.pointerSize = sizeof(IntPtr);
+                        m_source.pointerSize = Environment.Is64BitOperatingSystem ? 8 : 4;
                         m_source.numberOfProcessors = Environment.ProcessorCount;
                         m_source._QPCFreq = Stopwatch.Frequency;
                         m_source._syncTimeUTC = DateTime.UtcNow;
@@ -515,6 +515,6 @@ namespace Microsoft.Diagnostics.Tracing
         TraceEventNativeMethods.EVENT_RECORD* m_curTraceEventRecord;             // This is the TraceEvent eventRecord that corresponds to the ITraceEvent. 
         TraceLoggingEventId m_traceLoggingEventId;                               // Used to give TraceLogging events Event IDs. 
 
-#endregion
+        #endregion
     }
 }

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -455,9 +455,9 @@ namespace Microsoft.Diagnostics.Tracing
                 sessionEndTimeQPC = this.UTCDateTimeToQPC(maxSessionEndTimeUTC);
             }
             Debug.Assert(_QPCFreq != 0);
-            if (pointerSize == 0)       // Real time does not set this (grrr). 
+            if (pointerSize == 0 || IsRealTime)  // We get on x64 OS 4 as pointer size which is wrong for realtime sessions. Fix it up. 
             {
-                pointerSize = sizeof(IntPtr);
+                pointerSize = Environment.Is64BitOperatingSystem ? 8 : 4;
                 Debug.Assert((logFiles[0].LogFileMode & TraceEventNativeMethods.EVENT_TRACE_REAL_TIME_MODE) != 0);
             }
             Debug.Assert(pointerSize == 4 || pointerSize == 8);

--- a/src/TraceEvent/NativeDlls.cs
+++ b/src/TraceEvent/NativeDlls.cs
@@ -15,7 +15,9 @@ class NativeDlls
     /// <param name="simpleName"></param>
     public static void LoadNative(string simpleName)
     {
-        var thisDllDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().ManifestModule.FullyQualifiedName);
+        // When TraceEvent is loaded as embedded assembly the executing assembly is mscorlib which points to the wrong path.
+        // We use therefore the executable as entry point
+        var thisDllDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().ManifestModule.FullyQualifiedName);
         var dllName = Path.Combine(Path.Combine(thisDllDir, ProcessArchitectureDirectory), simpleName);
         var ret = LoadLibrary(dllName);
         if (ret == IntPtr.Zero)


### PR DESCRIPTION
When using  Realtime tracing the call stacks of x64 processes did come up empty because the code addresses were treated as kernel addresses which did result in the assignment of 0 (IDLE) process instead of the real processes where the stack was generated.  See issue #332 