### PR TITLE
Update TraceEvent to include a .NET Standard 2.0 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 branches:
   only:
   - master
-image: Visual Studio 2017
+image: Visual Studio 2017 Preview
 init:
 - git config --global core.autocrlf true
 configuration:

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.FastSerialization</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.FastSerialization</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -663,7 +663,9 @@ namespace FastSerialization
                 inputStream.Seek(positionInStream + endPosition, SeekOrigin.Begin);
                 for (;;)
                 {
+#if !NETSTANDARD1_3
                     System.Threading.Thread.Sleep(0);       // allow for Thread.Interrupt
+#endif
                     int count = inputStream.Read(bytes, endPosition, bytes.Length - endPosition);
                     if (count == 0)
                         break;

--- a/src/TraceEvent/RegisteredTraceEventParser.cs
+++ b/src/TraceEvent/RegisteredTraceEventParser.cs
@@ -7,12 +7,14 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Text.RegularExpressions;
 using FastSerialization;
-using System.Diagnostics.Eventing;
 using Microsoft.Diagnostics.Tracing.Session;
 using Microsoft.Diagnostics.Tracing.Extensions;
 using System.IO;
 using System.Threading;
 
+#if !NETSTANDARD2_0
+using System.Diagnostics.Eventing;
+#endif
 
 namespace Microsoft.Diagnostics.Tracing.Parsers
 {
@@ -1075,6 +1077,88 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             public int Flags;
             public EVENT_PROPERTY_INFO EventPropertyInfoArray;  // Actually an array, this is the first element.  
         }
+
+#if NETSTANDARD2_0
+        [StructLayout(LayoutKind.Explicit, Size = 16)]
+        internal struct EventDescriptor
+        {
+            [FieldOffset(0)]
+            private int m_traceloggingId;
+
+            [FieldOffset(0)]
+            private ushort m_id;
+
+            [FieldOffset(2)]
+            private byte m_version;
+
+            [FieldOffset(3)]
+            private byte m_channel;
+
+            [FieldOffset(4)]
+            private byte m_level;
+
+            [FieldOffset(5)]
+            private byte m_opcode;
+
+            [FieldOffset(6)]
+            private ushort m_task;
+
+            [FieldOffset(8)]
+            private long m_keywords;
+
+            public int EventId => m_id;
+
+            public byte Version => m_version;
+
+            public byte Channel => m_channel;
+
+            public byte Level => m_level;
+
+            public byte Opcode => m_opcode;
+
+            public int Task => m_task;
+
+            public long Keywords => m_keywords;
+
+            public override bool Equals(object obj)
+            {
+                return obj is EventDescriptor
+                    && Equals((EventDescriptor)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return m_id
+                    ^ m_version
+                    ^ m_channel
+                    ^ m_level
+                    ^ m_opcode
+                    ^ m_task
+                    ^ (int)m_keywords;
+            }
+
+            public bool Equals(EventDescriptor other)
+            {
+                return m_id == other.m_id
+                    && m_version == other.m_version
+                    && m_channel == other.m_channel
+                    && m_level == other.m_level
+                    && m_opcode == other.m_opcode
+                    && m_task == other.m_task
+                    && m_keywords == other.m_keywords;
+            }
+
+            public static bool operator ==(EventDescriptor event1, EventDescriptor event2)
+            {
+                return event1.Equals(event2);
+            }
+
+            public static bool operator !=(EventDescriptor event1, EventDescriptor event2)
+            {
+                return !event1.Equals(event2);
+            }
+        }
+#endif
 
         internal struct EVENT_PROPERTY_INFO
         {

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -35,10 +35,23 @@
     <NoWarn>$(NoWarn),0649,0618</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-  </ItemGroup>
+  <!--
+    Unconditional use of PackageReference would work if we targeted net46, but the reference APIs do not include
+    support for net45 targets. Work around the issue by using conditional references.
+  -->
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
+        <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'net45'">
+      <ItemGroup>
+        <Reference Include="System.IO.Compression" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.2" PrivateAssets="all" />

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -36,7 +36,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.IO.Compression" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
:memo: This updates the project to produce the new outputs, but the NuGet package specification still needs to be updated to include the new binaries.