### PR TITLE
Fix native symbol lookup failure

### DIFF
--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
@@ -2,8 +2,8 @@ REM copies from an existing build to a nuget package creation area (so that *.Ma
 REM
 REM *** This is mostly a template for doing the copy.      ****  
 REM *** Most likey you want this to be the current version ****
-REM 
-xcopy /s ..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.0.2\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
+REM *** PLEASE MODIFY THE VERSION NUMBER TO BE CURRENT!    ****
+xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.3\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
 
 @REM These are the binary files we need from somewhere to for the support package
 @REM lib\native\amd64\KernelTraceControl.dll
@@ -12,6 +12,6 @@ xcopy /s ..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.1.
 @REM lib\native\x86\KernelTraceControl.dll
 @REM lib\native\x86\KernelTraceControl.Win61.dll
 @REM lib\native\x86\msdia140.dll
-@REM lib\net40\Interop.Dia2Lib.dll
+@REM lib\net40\Dia2Lib.dll
 @REM lib\net40\OSExtensions.dll
 @REM lib\net40\TraceReloggerLib.dll

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.5">
     <id>Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <title>Non-Source files needed to Build TraceEvent</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/NugetSupportFiles/PerfView.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/PerfView.SupportFiles.Populate.bat
@@ -2,9 +2,10 @@ REM copies from an existing build to a nuget package creation area (so that *.Ma
 REM
 REM *** This is mostly a template for doing the copy.      ****  
 REM *** Most likey you want this to be the current version ****
+REM *** PLEASE MODIFY THE VERSION NUMBER TO BE CURRENT!    ****
 REM 
-xcopy /s /y ..\..\packages\PerfView.SupportFiles.1.0.3\*.dll PerfView.SupportFiles
-xcopy /s /y ..\..\packages\PerfView.SupportFiles.1.0.3\*.exe PerfView.SupportFiles
+xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\PerfView.SupportFiles\1.0.3\*.dll PerfView.SupportFiles
+xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\PerfView.SupportFiles\1.0.3\*.exe PerfView.SupportFiles
 
 @REM These are the binary files we need from somewhere to for the support package
 @REM lib\native\x86\DiagnosticsHub.Packaging.dll

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="PerfView.SupportFiles" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
@@ -264,11 +264,11 @@
       <LogicalName>.\OSExtensions.dll</LogicalName>
       <Link>OSExtensions.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)net40\Interop.Dia2Lib.dll">
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)net40\Dia2Lib.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
-      <LogicalName>.\Interop.Dia2Lib.dll</LogicalName>
-      <Link>Interop.Dia2Lib.dll</Link>
+      <LogicalName>.\Dia2Lib.dll</LogicalName>
+      <Link>Dia2Lib.dll</Link>
     </EmbeddedResource>
     <EmbeddedResource Include="SupportFiles\tutorial.exe">
       <Type>Non-Resx</Type>

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -2864,7 +2864,7 @@ namespace Dia2Lib
     /// From there you can do anything you need.  
     /// 
     /// In order to get IDiaDataSource3 which includes'getStreamSize' API, you need to use the 
-    /// vctools\langapi\idl\dia2_internal.idl file from devdiv to produce Interop.Dia2Lib.dll
+    /// vctools\langapi\idl\dia2_internal.idl file from devdiv to produce Dia2Lib.dll
     /// 
     /// roughly what you need to do is 
     ///     copy vctools\langapi\idl\dia2_internal.idl .
@@ -2873,7 +2873,7 @@ namespace Dia2Lib
     ///     Change dia2.idl to include interface IDiaDataSource3 inside library Dia2Lib->importlib->coclass DiaSource
     ///     midl dia2_internal.idl /D CC_DP_CXX
     ///     tlbimp dia2_internal.tlb
-    ///     xcopy Dia2Lib.dll Interop.Dia2Lib.dll
+    ///     REM result is Dia2Lib.dll 
     /// </summary>
     internal static class DiaLoader
     {

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When we updated the build scripts to use the new 2.0 CSPROJ format
we lost the fact that we emed the Interop code for the Interop.Dia2lib.dll
This caused any native symbol lookups to fail (since it is needed to interface to msdia140.dll)

It is not clear that the new build system supports embedding Interop code but we
did not really need it (We coudl just load the interop DLL for real).   However for this
to work the DLL needs to be named Dia2Lib.    It is unclear why this DLL was named
Interop.Dia2lib.dll before so we are just going to change it.

Do do this rename, we need to update the Support library package (since Interop.Dia2lib.dll
is in there), and then update to refrence the new version (with the rename).

@sharwell - if you are interested, having a test that confirms that fails if native symbols don't get lookup up would be valuable.  