### PR TITLE
Remove dependency on System.Diagnostics.Eventing.EventDescriptor

### DIFF
--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -160,6 +160,7 @@ namespace LinuxTracing.Tests
 				});
 		}
 
+        [Fact]
 		public void NonSchedHeader()
 		{
 			string path = Constants.GetTestingPerfDumpPath("onegeneric");

--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -1,7 +1,6 @@
 ﻿using System.Xml;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 


### PR DESCRIPTION
We had been using System.Diagnostics.Eventing.EventDescriptor in some of our PINVOKE structures that happend to exist in the Desktop Runtime
However this type was removed for NetStandard.

There was no particular reason to take this depencency (it just happened to already exist).  This change changes its use to a local defintion
(using the name EVENT_DESRIPTOR (which is how it is defined in C++ and using the C++ names for the fields (basically what we would have
done if it was just another structure needed for PINOVOKE).

This change is in peparation for compiling TraceEvent against NetStandard (not just desktop).

Also so fixed a mintor unreleated test issue that showed up during testing (added a missing [Fact] attribute).