### PR TITLE
Add NetStandard2.0 support (.NET Core) for the TraceEvent Nuget package

### DIFF
--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.FastSerialization</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.FastSerialization</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -661,9 +661,11 @@ namespace FastSerialization
             lock (inputStream)
             {
                 inputStream.Seek(positionInStream + endPosition, SeekOrigin.Begin);
-                for (;;)
+                for (; ; )
                 {
+#if !NETSTANDARD1_3
                     System.Threading.Thread.Sleep(0);       // allow for Thread.Interrupt
+#endif
                     int count = inputStream.Read(bytes, endPosition, bytes.Length - endPosition);
                     if (count == 0)
                         break;

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
@@ -3,7 +3,7 @@ REM
 REM *** This is mostly a template for doing the copy.      ****  
 REM *** Most likey you want this to be the current version ****
 REM *** PLEASE MODIFY THE VERSION NUMBER TO BE CURRENT!    ****
-xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.3\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
+xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.6\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
 
 @REM These are the binary files we need from somewhere to for the support package
 @REM lib\native\amd64\KernelTraceControl.dll

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.5">
     <id>Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles</id>
-    <version>1.0.3</version>
+    <version>1.0.6</version>
     <title>Non-Source files needed to Build TraceEvent</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="PerfView.SupportFiles" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
@@ -258,13 +258,13 @@
       <LogicalName>.\Microsoft.Diagnostics.Tracing.EventSource.dll</LogicalName>
       <Link>Microsoft.Diagnostics.Tracing.EventSource.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)net40\OSExtensions.dll">
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)netstandard1.1\OSExtensions.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\OSExtensions.dll</LogicalName>
       <Link>OSExtensions.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)net40\Dia2Lib.dll">
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)netstandard1.1\Dia2Lib.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Dia2Lib.dll</LogicalName>

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -34,23 +34,48 @@
     <!-- Native binaries -->
     <file src="$OutDir$net45\amd64\KernelTraceControl.dll" target="lib\native\amd64\KernelTraceControl.dll" />
     <file src="$OutDir$net45\amd64\msdia140.dll" target="lib\native\amd64\msdia140.dll" />
+
     <file src="$OutDir$net45\x86\KernelTraceControl.dll" target="lib\native\x86\KernelTraceControl.dll" />
     <file src="$OutDir$net45\x86\KernelTraceControl.Win61.dll" target="lib\native\x86\KernelTraceControl.Win61.dll" />
     <file src="$OutDir$net45\x86\msdia140.dll" target="lib\native\x86\msdia140.dll" />
 
-    <!-- Libraries and sources -->
+    <!-- NET45 Framework -->
+	
+    <!-- Built libraries -->
     <file src="$OutDir$net45\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\net45" />
     <file src="$OutDir$net45\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\net45" />
     <file src="$OutDir$net45\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\net45" />
-    <file exclude="obj\**\*.cs;bin\**\*.cs;TraceEvent.Tests\**\*.cs;Ctf\CtfTracing.Tests\**\*.cs" src="**\*.cs" target="src" />
-    <file src="obj\$Configuration$\**\*.cs" target="src\obj\$Configuration$" />
 
     <file src="$OutDir$net45\Microsoft.Diagnostics.FastSerialization.dll" target="lib\net45" />
     <file src="$OutDir$net45\Microsoft.Diagnostics.FastSerialization.xml" target="lib\net45" />
     <file src="$OutDir$net45\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\net45" />
-    <file exclude="..\FastSerialization\obj\**\*.cs;..\FastSerialization\bin\**\*.cs;..\FastSerialization\_README.cs" src="..\FastSerialization\**\*.cs" target="src" />
 
+    <!-- Support Dlls -->
+    <file src="$OutDir$net45\Dia2Lib.dll" target="lib\net45" />
+    <file src="$OutDir$net45\TraceReloggerLib.dll" target="lib\net45" />
     <file src="$OutDir$net45\OSExtensions.dll" target="lib\net45" />
+
+    <!-- NetStandard 2.0 Framework -->
+	
+    <!-- Built libraries -->
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\netstandard2.0" />
+
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.xml" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\netstandard2.0" />
+
+    <!-- Support Dlls -->
+    <file src="$OutDir$net45\Dia2Lib.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$net45\TraceReloggerLib.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$net45\OSExtensions.dll" target="lib\netstandard2.0" />
+
+
+    <!-- Source code (All Frameworks *) -->
+    <file exclude="obj\**\*.cs;bin\**\*.cs;TraceEvent.Tests\**\*.cs;Ctf\CtfTracing.Tests\**\*.cs" src="**\*.cs" target="src" />
+    <file exclude="..\FastSerialization\obj\**\*.cs;..\FastSerialization\bin\**\*.cs;..\FastSerialization\_README.cs" src="..\FastSerialization\**\*.cs" target="src" />
+    <file src="obj\$Configuration$\**\*.cs" target="src\obj\$Configuration$" />
   </files>
 
 </package>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,12 +35,26 @@
     <NoWarn>$(NoWarn),0649,0618</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Reference Include="System.IO.Compression" />
-  </ItemGroup>
+  <!--
+    Unconditional use of PackageReference would work if we targeted net46, but the reference APIs do not include
+    support for net45 targets. Work around the issue by using conditional references.
+  -->
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
+        <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'net45'">
+      <ItemGroup>
+        <Reference Include="System.IO.Compression" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.6" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This allows TraceEvent to be used in .NET Core scenarios.   I am likely to change details
of the package, but this is forward progress (I was able to build a TraceEvent application
in .NET Core.

I  used @sharwell's pull request #345 as a starting point, and fiddled with it to get my 
.NET Core TraceEvent app working.   I think this subsumes that PR.  