### PR TITLE
Cleaning up the IisTraceEventParser.cs to have the right opcode names

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -1328,7 +1328,7 @@ table {
             int endcount = 0;
 
 
-            iis.IIS_TransStart += delegate (W3GeneralStartNewRequest request)
+            iis.IISGeneralGeneralRequestStart += delegate (W3GeneralStartNewRequest request)
             {
 
                 IisRequest req = new IisRequest();
@@ -1349,7 +1349,7 @@ table {
 
             };
 
-            iis.IIS_TransStop += delegate (W3GeneralEndNewRequest req)
+            iis.IISGeneralGeneralRequestEnd += delegate (W3GeneralEndNewRequest req)
             {
                 IisRequest request;
                 if (m_Requests.TryGetValue(req.ContextId, out request))
@@ -1366,7 +1366,7 @@ table {
             };
 
 
-            iis.IISRequestNotificationEventsDC_Stop += delegate (IISRequestNotificationPreBeginStart preBeginEvent)
+            iis.IISRequestNotificationPreBeginRequestStart += delegate (IISRequestNotificationPreBeginStart preBeginEvent)
             {
                 IisRequest request;
                 if (!m_Requests.TryGetValue(preBeginEvent.ContextId, out request))
@@ -1388,7 +1388,7 @@ table {
                 request.PipelineEvents.Add(iisPrebeginModuleEvent);
             };
 
-            iis.IISRequestNotificationEventsExtension += delegate (IISRequestNotificationPreBeginEnd preBeginEvent)
+            iis.IISRequestNotificationPreBeginRequestEnd += delegate (IISRequestNotificationPreBeginEnd preBeginEvent)
             {
                 IisRequest request;
                 if (m_Requests.TryGetValue(preBeginEvent.ContextId, out request))
@@ -1410,7 +1410,7 @@ table {
                 //else { }  
             };
 
-            iis.IISRequestNotificationEventsStart += delegate (IISRequestNotificationEventsStart moduleEvent)
+            iis.IISRequestNotificationNotifyModuleStart += delegate (IISRequestNotificationEventsStart moduleEvent)
             {
                 IisRequest request;
                 if (!m_Requests.TryGetValue(moduleEvent.ContextId, out request))
@@ -1434,7 +1434,7 @@ table {
                 request.PipelineEvents.Add(iisModuleEvent);
             };
 
-            iis.IISRequestNotificationEventsStop += delegate (IISRequestNotificationEventsEnd moduleEvent)
+            iis.IISRequestNotificationNotifyModuleEnd += delegate (IISRequestNotificationEventsEnd moduleEvent)
             {
                 IisRequest request;
                 if (m_Requests.TryGetValue(moduleEvent.ContextId, out request))
@@ -1456,7 +1456,7 @@ table {
 
             };
 
-            iis.IISRequestNotificationEventsOpcode16 += delegate (IISRequestNotificationEventsResponseErrorStatus responseErrorStatusNotification)
+            iis.IISRequestNotificationModuleSetResponseErrorStatus += delegate (IISRequestNotificationEventsResponseErrorStatus responseErrorStatusNotification)
             {
                 IisRequest request;
                 if (m_Requests.TryGetValue(responseErrorStatusNotification.ContextId, out request))
@@ -1472,43 +1472,43 @@ table {
                 }
             };
 
-            iis.IIS_TransOpcode35 += delegate (W3GeneralFlushResponseStart traceEvent)
-            {
-                AddGenericStartEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3GeneralFlushResponse", traceEvent.TimeStampRelativeMSec);
+            iis.IISGeneralGeneralFlushResponseStart += delegate (W3GeneralFlushResponseStart traceEvent)
+            {                
+                AddGenericStartEventToRequest(traceEvent.ContextId , traceEvent);
             };
 
-            iis.IIS_TransOpcode36 += delegate (W3GeneralFlushResponseEnd traceEvent)
+            iis.IISGeneralGeneralFlushResponseEnd += delegate (W3GeneralFlushResponseEnd traceEvent)
             {
-                AddGenericStopEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3GeneralFlushResponse", traceEvent.TimeStampRelativeMSec);
+                AddGenericStopEventToRequest(traceEvent.ContextId, traceEvent);
             };
 
-            iis.IIS_TransOpcode37 += delegate (W3GeneralReadEntityStart traceEvent)
+            iis.IISGeneralGeneralReadEntityStart += delegate (W3GeneralReadEntityStart traceEvent)
             {
-                AddGenericStartEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3GeneralReadEntity", traceEvent.TimeStampRelativeMSec);
+                AddGenericStartEventToRequest(traceEvent.ContextId, traceEvent);
             };
 
-            iis.IIS_TransOpcode38 += delegate (W3GeneralReadEntityEnd traceEvent)
+            iis.IISGeneralGeneralReadEntityEnd += delegate (W3GeneralReadEntityEnd traceEvent)
             {
-                AddGenericStopEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3GeneralReadEntity", traceEvent.TimeStampRelativeMSec);
+                AddGenericStopEventToRequest(traceEvent.ContextId, traceEvent);
             };
 
-            iis.IIS_Cache_TransOpcode10 += delegate (W3CacheFileCacheAccessStart traceEvent)
+            iis.IISCacheFileCacheAccessStart += delegate (W3CacheFileCacheAccessStart traceEvent)
             {
-                AddGenericStartEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3CacheFileCacheAccess", traceEvent.TimeStampRelativeMSec);
+                AddGenericStartEventToRequest(traceEvent.ContextId, traceEvent);
             };
 
-            iis.IIS_Cache_TransOpcode11 += delegate (W3CacheFileCacheAccessEnd traceEvent)
+            iis.IISCacheFileCacheAccessEnd += delegate (W3CacheFileCacheAccessEnd traceEvent)
             {
-                AddGenericStopEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3CacheFileCacheAccess", traceEvent.TimeStampRelativeMSec);
+                AddGenericStopEventToRequest(traceEvent.ContextId, traceEvent);
             };
-            iis.IIS_Cache_TransOpcode12 += delegate (W3CacheURLCacheAccessStart traceEvent)
+            iis.IISCacheUrlCacheAccessStart += delegate (W3CacheURLCacheAccessStart traceEvent)
             {
-                AddGenericStartEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3CacheURLCacheAccess", traceEvent.TimeStampRelativeMSec);
+                AddGenericStartEventToRequest(traceEvent.ContextId, traceEvent);
             };
 
-            iis.IIS_Cache_TransOpcode13 += delegate (W3CacheURLCacheAccessEnd traceEvent)
+            iis.IISCacheUrlCacheAccessEnd += delegate (W3CacheURLCacheAccessEnd traceEvent)
             {
-                AddGenericStopEventToRequest(traceEvent.ThreadID, traceEvent.ContextId, "W3CacheURLCacheAccess", traceEvent.TimeStampRelativeMSec);
+                AddGenericStopEventToRequest(traceEvent.ContextId, traceEvent);
             };
 
 
@@ -1843,7 +1843,7 @@ table {
             return request;
         }
 
-        private void AddGenericStartEventToRequest(int threadId, Guid contextId, string eventName, double timeStamp)
+        private void AddGenericStartEventToRequest(Guid contextId, TraceEvent traceEvent)
         {
             IisRequest request;
 
@@ -1853,27 +1853,28 @@ table {
                 // event but we got a Module Event fired for this request 
                 // so we do our best to create a FAKE start request event
                 // populating as much information as we can.
-                request = GenerateFakeIISRequest(contextId, null, timeStamp);
+                request = GenerateFakeIISRequest(contextId, null, traceEvent.TimeStampRelativeMSec);
                 m_Requests.Add(contextId, request);
             }
 
 
             var iisPipelineEvent = new IisPipelineEvent();
-            iisPipelineEvent.Name = eventName;
-            iisPipelineEvent.StartTimeRelativeMSec = timeStamp;
-            iisPipelineEvent.StartThreadId = threadId;
+            iisPipelineEvent.Name = traceEvent.OpcodeName.Substring(0, traceEvent.OpcodeName.Length - 6);
+            iisPipelineEvent.StartTimeRelativeMSec = traceEvent.TimeStampRelativeMSec;
+            iisPipelineEvent.StartThreadId = traceEvent.ThreadID;
             request.PipelineEvents.Add(iisPipelineEvent);
 
         }
 
-        private void AddGenericStopEventToRequest(int threadId, Guid contextId, string eventName, double timeStamp)
+        private void AddGenericStopEventToRequest(Guid contextId, TraceEvent traceEvent)
         {
             IisRequest request;
             if (m_Requests.TryGetValue(contextId, out request))
             {
+                string eventName = traceEvent.OpcodeName.Substring(0, traceEvent.OpcodeName.Length - 4);
                 var iisPipelineEvent = request.PipelineEvents.FirstOrDefault(m => (m.Name == eventName) && m.EndTimeRelativeMSec == 0);
-                iisPipelineEvent.EndTimeRelativeMSec = timeStamp;
-                iisPipelineEvent.EndThreadId = threadId;
+                iisPipelineEvent.EndTimeRelativeMSec = traceEvent.TimeStampRelativeMSec;
+                iisPipelineEvent.EndThreadId = traceEvent.ThreadID;
             }
         }
         private IisPipelineEvent GetSlowestEvent(Guid contextId, List<IisPipelineEvent> pipeLineEvents)

--- a/src/TraceEvent/Parsers/IisTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/IisTraceEventParser.cs
@@ -35,2850 +35,2623 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
     {
         public static string ProviderName = "IIS_Trace";
         public static Guid ProviderGuid = new Guid(unchecked((int)0x3a2a4e84), unchecked((short)0x4c21), unchecked((short)0x4981), 0xae, 0x10, 0x3f, 0xda, 0x0d, 0x9b, 0x0f, 0x83);
-        public static Guid IISTransGuid = Guid.Parse("{d42cf7ef-de92-473e-8b6c-621ea663113a}");
-        public static Guid IISAuthenticationTransGuid = Guid.Parse("{c33bbe8f-985b-4080-81e6-005f1a06b9e2}");
-        public static Guid IISSecurityTransGuid = Guid.Parse("{29347ffb-ba48-41e6-bffd-469c5e543ca5}");
-        public static Guid IISFilterTransGuid = Guid.Parse("{00237f0d-73eb-4bcf-a232-126693595847}");
-        public static Guid IISStaticFileTransGuid = Guid.Parse("{79b02104-0db9-4cda-a552-058d97c2ecfd}");
-        public static Guid IsapiTransGuid = Guid.Parse("{2e94e6c7-eda0-4b73-9010-2529edce1c27}");
-        public static Guid IISCgiTransGuid = Guid.Parse("{e2e55403-0d2e-4609-a470-be0da04013c0}");
-        public static Guid IISFastCgiTransGuid = Guid.Parse("{e3642acc-3627-42b0-8372-867baa033b07}");
-        public static Guid IISWebSocketTransGuid = Guid.Parse("{2ce74327-08be-425c-bfc5-1534fe7fefa6}");
-        public static Guid IISCompressionTransGuid = Guid.Parse("{e60cee96-4472-448d-a13c-2170b18220ec}");
-        public static Guid IISCacheTransGuid = Guid.Parse("{ac1d69f1-bf33-4ca0-9313-bca13873e1dc}");
-        public static Guid IISRequestNotificationEventsGuid = Guid.Parse("{002e91e3-e7ae-44ab-8e07-99230ffa6ade}");
-        public static Guid IISModuleEventsGuid = Guid.Parse("{d79a948e-95f1-417b-a731-b7a79dec7ae5}");
+        public static Guid IISGeneralGuid = Guid.Parse("{d42cf7ef-de92-473e-8b6c-621ea663113a}");
+        public static Guid IISAuthenticationGuid = Guid.Parse("{c33bbe8f-985b-4080-81e6-005f1a06b9e2}");
+        public static Guid IISSecurityGuid = Guid.Parse("{29347ffb-ba48-41e6-bffd-469c5e543ca5}");
+        public static Guid IISFilterGuid = Guid.Parse("{00237f0d-73eb-4bcf-a232-126693595847}");
+        public static Guid IISStaticFileGuid = Guid.Parse("{79b02104-0db9-4cda-a552-058d97c2ecfd}");
+        public static Guid IISISAPIGuid = Guid.Parse("{2e94e6c7-eda0-4b73-9010-2529edce1c27}");
+        public static Guid IISCGIGuid = Guid.Parse("{e2e55403-0d2e-4609-a470-be0da04013c0}");
+        public static Guid IISFastCGIGuid = Guid.Parse("{e3642acc-3627-42b0-8372-867baa033b07}");
+        public static Guid IISWebSocketGuid = Guid.Parse("{2ce74327-08be-425c-bfc5-1534fe7fefa6}");
+        public static Guid IISCompressionGuid = Guid.Parse("{e60cee96-4472-448d-a13c-2170b18220ec}");
+        public static Guid IISCacheGuid = Guid.Parse("{ac1d69f1-bf33-4ca0-9313-bca13873e1dc}");
+        public static Guid IISRequestNotificationGuid = Guid.Parse("{002e91e3-e7ae-44ab-8e07-99230ffa6ade}");
+        public static Guid IISModuleGuid = Guid.Parse("{d79a948e-95f1-417b-a731-b7a79dec7ae5}");
         public enum Keywords : long
         {
         };
 
-
-
         public IisTraceEventParser(TraceEventSource source) : base(source) { }
 
-        public event Action<W3AuthStart> IIS_Authentication_TransOpcode10
+        public event Action<W3AuthAnonPasswdChangeNeeded> IISAuthenticationAuthAnonPasswdChangeNeeded
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode10Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthAnonPasswdChangeNeededTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10051, ProviderGuid);
             }
         }
-        public event Action<W3AuthSucceeded> IIS_Authentication_TransOpcode11
+        public event Action<W3AuthBadBasicHeader> IISAuthenticationAuthBadBasicHeader
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode11Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthBadBasicHeaderTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10042, ProviderGuid);
             }
         }
-        public event Action<W3AuthTypeNotSupported> IIS_Authentication_TransOpcode12
+        public event Action<W3AuthBasicLogonFailed> IISAuthenticationAuthBasicLogonFailed
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode12Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthBasicLogonFailedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10043, ProviderGuid);
             }
         }
-        public event Action<W3AuthInvalidAnonAccount> IIS_Authentication_TransOpcode13
+        public event Action<W3AuthEnd> IISAuthenticationAuthEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode13Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10053, ProviderGuid);
             }
         }
-        public event Action<W3AuthPasswdChangeNeeded> IIS_Authentication_TransOpcode14
+        public event Action<W3AuthIISDigestLogonFailed> IISAuthenticationAuthIisdigestLogonFailed
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode14Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthIisdigestLogonFailedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10045, ProviderGuid);
             }
         }
-        public event Action<W3AuthPasswdChangeDisabled> IIS_Authentication_TransOpcode15
+        public event Action<W3AuthInvalidAnonAccount> IISAuthenticationAuthInvalidAnonAccount
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode15Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthInvalidAnonAccountTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10039, ProviderGuid);
             }
         }
-        public event Action<W3AuthBadBasicHeader> IIS_Authentication_TransOpcode16
+        public event Action<W3AuthKerberosFailed> IISAuthenticationAuthKerberosFailed
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode16Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthKerberosFailedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10050, ProviderGuid);
             }
         }
-        public event Action<W3AuthBasicLogonFailed> IIS_Authentication_TransOpcode17
+        public event Action<W3AuthNTLMNullSession> IISAuthenticationAuthNtlmNullSession
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode17Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthNtlmNullSessionTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10048, ProviderGuid);
             }
         }
-        public event Action<W3AuthWDigestLogonFailed> IIS_Authentication_TransOpcode18
+        public event Action<W3AuthPassportLogonFailed> IISAuthenticationAuthPassportLogonFailed
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode18Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthPassportLogonFailedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10046, ProviderGuid);
             }
         }
-        public event Action<W3AuthIISDigestLogonFailed> IIS_Authentication_TransOpcode19
+        public event Action<W3AuthPasswdChangeDisabled> IISAuthenticationAuthPasswdChangeDisabled
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode19Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthPasswdChangeDisabledTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10041, ProviderGuid);
             }
         }
-        public event Action<W3AuthPassportLogonFailed> IIS_Authentication_TransOpcode20
+        public event Action<W3AuthPasswdChangeNeeded> IISAuthenticationAuthPasswdChangeNeeded
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode20Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthPasswdChangeNeededTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10040, ProviderGuid);
             }
         }
-        public event Action<W3AuthSSPILogonFailed> IIS_Authentication_TransOpcode21
+        public event Action<W3AuthRequestAuthType> IISAuthenticationAuthRequestAuthType
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode21Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthRequestAuthTypeTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10052, ProviderGuid);
             }
         }
-        public event Action<W3AuthNTLMNullSession> IIS_Authentication_TransOpcode22
+        public event Action<W3AuthSSPIContinueNeeded> IISAuthenticationAuthSspiContinueNeeded
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode22Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthSspiContinueNeededTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10049, ProviderGuid);
             }
         }
-        public event Action<W3AuthSSPIContinueNeeded> IIS_Authentication_TransOpcode23
+        public event Action<W3AuthSSPILogonFailed> IISAuthenticationAuthSspiLogonFailed
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode23Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthSspiLogonFailedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10047, ProviderGuid);
             }
         }
-        public event Action<W3AuthAnonPasswdChangeNeeded> IIS_Authentication_TransOpcode24
+        public event Action<W3AuthStart> IISAuthenticationAuthStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode24Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10036, ProviderGuid);
             }
         }
-        public event Action<W3AuthRequestAuthType> IIS_Authentication_TransOpcode27
+        public event Action<W3AuthSucceeded> IISAuthenticationAuthSucceeded
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode27Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthSucceededTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10037, ProviderGuid);
             }
         }
-        public event Action<W3AuthEnd> IIS_Authentication_TransOpcode28
+        public event Action<W3AuthTypeNotSupported> IISAuthenticationAuthTypeNotSupported
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode28Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthTypeNotSupportedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10038, ProviderGuid);
             }
         }
-        public event Action<W3AuthKerberosFailed> IIS_Authentication_TransOpcode55
+        public event Action<W3AuthWDigestLogonFailed> IISAuthenticationAuthWdigestLogonFailed
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Authentication_TransOpcode55Template(value));
+                source.RegisterEventTemplate(IISAuthenticationAuthWdigestLogonFailedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10044, ProviderGuid);
             }
         }
-        public event Action<W3CacheFileCacheAccessStart> IIS_Cache_TransOpcode10
+        public event Action<W3CacheFileCacheAccessEnd> IISCacheFileCacheAccessEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode10Template(value));
+                source.RegisterEventTemplate(IISCacheFileCacheAccessEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10148, ProviderGuid);
             }
         }
-        public event Action<W3CacheFileCacheAccessEnd> IIS_Cache_TransOpcode11
+        public event Action<W3CacheFileCacheAccessStart> IISCacheFileCacheAccessStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode11Template(value));
+                source.RegisterEventTemplate(IISCacheFileCacheAccessStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10147, ProviderGuid);
             }
         }
-        public event Action<W3CacheURLCacheAccessStart> IIS_Cache_TransOpcode12
+        public event Action<W3CacheHttpsysCacheable> IISCacheHttpsysCacheable
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode12Template(value));
+                source.RegisterEventTemplate(IISCacheHttpsysCacheableTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10151, ProviderGuid);
             }
         }
-        public event Action<W3CacheURLCacheAccessEnd> IIS_Cache_TransOpcode13
+        public event Action<W3OutputCacheDisabled> IISCacheOutputCacheDisabled
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode13Template(value));
+                source.RegisterEventTemplate(IISCacheOutputCacheDisabledTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10156, ProviderGuid);
             }
         }
-        public event Action<W3CacheHttpsysCacheable> IIS_Cache_TransOpcode14
+        public event Action<W3OutputCacheLookupEnd> IISCacheOutputCacheLookupEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode14Template(value));
+                source.RegisterEventTemplate(IISCacheOutputCacheLookupEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10153, ProviderGuid);
             }
         }
-        public event Action<W3OutputCacheLookupStart> IIS_Cache_TransOpcode15
+        public event Action<W3OutputCacheLookupStart> IISCacheOutputCacheLookupStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode15Template(value));
+                source.RegisterEventTemplate(IISCacheOutputCacheLookupStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10152, ProviderGuid);
             }
         }
-        public event Action<W3OutputCacheLookupEnd> IIS_Cache_TransOpcode16
+        public event Action<W3OutputCacheUpdateEnd> IISCacheOutputCacheUpdateEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode16Template(value));
+                source.RegisterEventTemplate(IISCacheOutputCacheUpdateEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10155, ProviderGuid);
             }
         }
-        public event Action<W3OutputCacheUpdateStart> IIS_Cache_TransOpcode17
+        public event Action<W3OutputCacheUpdateStart> IISCacheOutputCacheUpdateStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode17Template(value));
+                source.RegisterEventTemplate(IISCacheOutputCacheUpdateStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10154, ProviderGuid);
             }
         }
-        public event Action<W3OutputCacheUpdateEnd> IIS_Cache_TransOpcode18
+        public event Action<W3CacheURLCacheAccessEnd> IISCacheUrlCacheAccessEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode18Template(value));
+                source.RegisterEventTemplate(IISCacheUrlCacheAccessEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10150, ProviderGuid);
             }
         }
-        public event Action<W3OutputCacheDisabled> IIS_Cache_TransOpcode19
+        public event Action<W3CacheURLCacheAccessStart> IISCacheUrlCacheAccessStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode19Template(value));
+                source.RegisterEventTemplate(IISCacheUrlCacheAccessStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10149, ProviderGuid);
             }
         }
-        public event Action<W3CacheFileCacheCreateFile> IIS_Cache_TransOpcode20
+        public event Action<W3CGIEnd> IISCGICgiEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cache_TransOpcode20Template(value));
+                source.RegisterEventTemplate(IISCGICgiEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10091, ProviderGuid);
             }
         }
-        public event Action<W3CGILaunch> IIS_Cgi_TransDC_Start
+        public event Action<W3CGIHeadersReceived> IISCGICgiHeadersReceived
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cgi_TransDC_StartTemplate(value));
+                source.RegisterEventTemplate(IISCGICgiHeadersReceivedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10096, ProviderGuid);
             }
         }
-        public event Action<W3CGITimeout> IIS_Cgi_TransDC_Stop
+        public event Action<W3CGILaunch> IISCGICgiLaunch
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cgi_TransDC_StopTemplate(value));
+                source.RegisterEventTemplate(IISCGICgiLaunchTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10092, ProviderGuid);
             }
         }
-        public event Action<W3CGIPrematureTermination> IIS_Cgi_TransExtension
+        public event Action<W3CGIPrematureTermination> IISCGICgiPrematureTermination
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cgi_TransExtensionTemplate(value));
+                source.RegisterEventTemplate(IISCGICgiPrematureTerminationTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10094, ProviderGuid);
             }
         }
-        public event Action<W3CGIRequestEntitySent> IIS_Cgi_TransReply
+        public event Action<W3CGIRequestEntitySent> IISCGICgiRequestEntitySent
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cgi_TransReplyTemplate(value));
+                source.RegisterEventTemplate(IISCGICgiRequestEntitySentTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10095, ProviderGuid);
             }
         }
-        public event Action<W3CGIHeadersReceived> IIS_Cgi_TransResume
+        public event Action<W3CGIStart> IISCGICgiStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cgi_TransResumeTemplate(value));
+                source.RegisterEventTemplate(IISCGICgiStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10090, ProviderGuid);
             }
         }
-        public event Action<W3CGIStart> IIS_Cgi_TransStart
+        public event Action<W3CGITimeout> IISCGICgiTimeout
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cgi_TransStartTemplate(value));
+                source.RegisterEventTemplate(IISCGICgiTimeoutTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10093, ProviderGuid);
             }
         }
-        public event Action<W3CGIEnd> IIS_Cgi_TransStop
+        public event Action<W3DynamicCompressionDo> IISCompressionDynamicCompressionDo
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Cgi_TransStopTemplate(value));
+                source.RegisterEventTemplate(IISCompressionDynamicCompressionDoTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10144, ProviderGuid);
             }
         }
-        public event Action<W3StaticCompressionNotSuccess> IIS_Compression_TransDC_Start
+        public event Action<W3DynamicCompressionEnd> IISCompressionDynamicCompressionEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransDC_StartTemplate(value));
+                source.RegisterEventTemplate(IISCompressionDynamicCompressionEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10145, ProviderGuid);
             }
         }
-        public event Action<W3StaticCompressionCreateStart> IIS_Compression_TransDC_Stop
+        public event Action<W3DynamicCompressionNotSuccess> IISCompressionDynamicCompressionNotSuccess
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransDC_StopTemplate(value));
+                source.RegisterEventTemplate(IISCompressionDynamicCompressionNotSuccessTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10143, ProviderGuid);
             }
         }
-        public event Action<W3StaticCompressionCreateEnd> IIS_Compression_TransExtension
+        public event Action<W3DynamicCompressionStart> IISCompressionDynamicCompressionStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransExtensionTemplate(value));
+                source.RegisterEventTemplate(IISCompressionDynamicCompressionStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10141, ProviderGuid);
             }
         }
-        public event Action<W3DynamicCompressionEnd> IIS_Compression_TransOpcode10
+        public event Action<W3DynamicCompressionSuccess> IISCompressionDynamicCompressionSuccess
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransOpcode10Template(value));
+                source.RegisterEventTemplate(IISCompressionDynamicCompressionSuccessTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10142, ProviderGuid);
             }
         }
-        public event Action<W3StaticCompressionEnd> IIS_Compression_TransOpcode11
+        public event Action<W3StaticCompressionCreateEnd> IISCompressionStaticCompressionCreateEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransOpcode11Template(value));
+                source.RegisterEventTemplate(IISCompressionStaticCompressionCreateEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10140, ProviderGuid);
             }
         }
-        public event Action<W3DynamicCompressionStart> IIS_Compression_TransReply
+        public event Action<W3StaticCompressionCreateStart> IISCompressionStaticCompressionCreateStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransReplyTemplate(value));
+                source.RegisterEventTemplate(IISCompressionStaticCompressionCreateStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10139, ProviderGuid);
             }
         }
-        public event Action<W3DynamicCompressionSuccess> IIS_Compression_TransResume
+        public event Action<W3StaticCompressionEnd> IISCompressionStaticCompressionEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransResumeTemplate(value));
+                source.RegisterEventTemplate(IISCompressionStaticCompressionEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10146, ProviderGuid);
             }
         }
-        public event Action<W3DynamicCompressionDo> IIS_Compression_TransSend
+        public event Action<W3StaticCompressionNotSuccess> IISCompressionStaticCompressionNotSuccess
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransSendTemplate(value));
+                source.RegisterEventTemplate(IISCompressionStaticCompressionNotSuccessTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10138, ProviderGuid);
             }
         }
-        public event Action<W3StaticCompressionStart> IIS_Compression_TransStart
+        public event Action<W3StaticCompressionStart> IISCompressionStaticCompressionStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransStartTemplate(value));
+                source.RegisterEventTemplate(IISCompressionStaticCompressionStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10136, ProviderGuid);
             }
         }
-        public event Action<W3StaticCompressionSuccess> IIS_Compression_TransStop
+        public event Action<W3StaticCompressionSuccess> IISCompressionStaticCompressionSuccess
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransStopTemplate(value));
+                source.RegisterEventTemplate(IISCompressionStaticCompressionSuccessTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10137, ProviderGuid);
             }
         }
-        public event Action<W3DynamicCompressionNotSuccess> IIS_Compression_TransSuspend
+        public event Action<W3CGIFActivityTimeout> IISFastCGIFastcgiActivityTimeout
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Compression_TransSuspendTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiActivityTimeoutTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10097, ProviderGuid);
             }
         }
-        public event Action<W3CGIFUnexpectedExit> IIS_FastCgi_TransDC_Start
+        public event Action<W3CGIFAddJobObjectFail> IISFastCGIFastcgiAddJobobjectFail
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransDC_StartTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiAddJobobjectFailTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10103, ProviderGuid);
             }
         }
-        public event Action<W3CGIFRapidFailureProtection> IIS_FastCgi_TransDC_Stop
+        public event Action<W3CGIFAppMgrShutdown> IISFastCGIFastcgiApplicationManagerShutdown
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransDC_StopTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiApplicationManagerShutdownTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10104, ProviderGuid);
             }
         }
-        public event Action<W3CGIFPathNotFound> IIS_FastCgi_TransExtension
+        public event Action<W3CGIFAssignProcess> IISFastCGIFastcgiAssignProcess
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransExtensionTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiAssignProcessTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10113, ProviderGuid);
             }
         }
-        public event Action<W3CGIFUnknownError> IIS_FastCgi_TransOpcode10
+        public event Action<W3CGIFEnd> IISFastCGIFastcgiEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode10Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10115, ProviderGuid);
             }
         }
-        public event Action<W3CGIFResponseWritten> IIS_FastCgi_TransOpcode11
+        public event Action<W3CGIFPathNotFound> IISFastCGIFastcgiPathNotFound
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode11Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiPathNotFoundTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10101, ProviderGuid);
             }
         }
-        public event Action<W3CGIFWaitingForResponse> IIS_FastCgi_TransOpcode12
+        public event Action<W3CGIFQueueFull> IISFastCGIFastcgiQueueFull
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode12Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiQueueFullTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10105, ProviderGuid);
             }
         }
-        public event Action<W3CGIFTraceError> IIS_FastCgi_TransOpcode13
+        public event Action<W3CGIFQueueRequest> IISFastCGIFastcgiQueueRequest
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode13Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiQueueRequestTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10112, ProviderGuid);
             }
         }
-        public event Action<W3CGIFTraceWarning> IIS_FastCgi_TransOpcode14
+        public event Action<W3CGIFRapidFailureProtection> IISFastCGIFastcgiRapidFailureProtection
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode14Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiRapidFailureProtectionTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10100, ProviderGuid);
             }
         }
-        public event Action<W3CGIFTraceInfo> IIS_FastCgi_TransOpcode15
+        public event Action<W3CGIFRequestTimeout> IISFastCGIFastcgiRequestTimeout
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode15Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiRequestTimeoutTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10098, ProviderGuid);
             }
         }
-        public event Action<W3CGIFQueueRequest> IIS_FastCgi_TransOpcode16
+        public event Action<W3CGIFResponseWritten> IISFastCGIFastcgiResponseWritten
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode16Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiResponseWrittenTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10107, ProviderGuid);
             }
         }
-        public event Action<W3CGIFAssignProcess> IIS_FastCgi_TransOpcode17
+        public event Action<W3CGIFScriptProcessorMissing> IISFastCGIFastcgiScriptProcessorMissing
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode17Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiScriptProcessorMissingTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10102, ProviderGuid);
             }
         }
-        public event Action<W3CGIFStart> IIS_FastCgi_TransOpcode18
+        public event Action<W3CGIFStart> IISFastCGIFastcgiStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode18Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10114, ProviderGuid);
             }
         }
-        public event Action<W3CGIFEnd> IIS_FastCgi_TransOpcode19
+        public event Action<W3CGIFTraceError> IISFastCGIFastcgiStderrTraceError
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransOpcode19Template(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiStderrTraceErrorTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10109, ProviderGuid);
             }
         }
-        public event Action<W3CGIFScriptProcessorMissing> IIS_FastCgi_TransReply
+        public event Action<W3CGIFTraceInfo> IISFastCGIFastcgiStderrTraceInfo
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransReplyTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiStderrTraceInfoTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10111, ProviderGuid);
             }
         }
-        public event Action<W3CGIFAddJobObjectFail> IIS_FastCgi_TransResume
+        public event Action<W3CGIFTraceWarning> IISFastCGIFastcgiStderrTraceWarning
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransResumeTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiStderrTraceWarningTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10110, ProviderGuid);
             }
         }
-        public event Action<W3CGIFQueueFull> IIS_FastCgi_TransSend
+        public event Action<W3CGIFUnexpectedExit> IISFastCGIFastcgiUnexpectedExit
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransSendTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiUnexpectedExitTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10099, ProviderGuid);
             }
         }
-        public event Action<W3CGIFActivityTimeout> IIS_FastCgi_TransStart
+        public event Action<W3CGIFUnknownError> IISFastCGIFastcgiUnknownError
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransStartTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiUnknownErrorTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10106, ProviderGuid);
             }
         }
-        public event Action<W3CGIFRequestTimeout> IIS_FastCgi_TransStop
+        public event Action<W3CGIFWaitingForResponse> IISFastCGIFastcgiWaitingForResponse
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransStopTemplate(value));
+                source.RegisterEventTemplate(IISFastCGIFastcgiWaitingForResponseTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10108, ProviderGuid);
             }
         }
-        public event Action<W3CGIFAppMgrShutdown> IIS_FastCgi_TransSuspend
+        public event Action<W3FilterAccessDeniedEnd> IISFilterFilterAccessDeniedEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_FastCgi_TransSuspendTemplate(value));
+                source.RegisterEventTemplate(IISFilterFilterAccessDeniedEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10083, ProviderGuid);
             }
         }
-        public event Action<W3FilterError> IIS_Filter_TransOpcode12
+        public event Action<W3FilterAccessDeniedStart> IISFilterFilterAccessDeniedStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode12Template(value));
+                source.RegisterEventTemplate(IISFilterFilterAccessDeniedStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10082, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterAddReqHeader> IISFilterFilterAddReqHeader
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterAddReqHeaderTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10085, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterAddRespHeader> IISFilterFilterAddRespHeader
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterAddRespHeaderTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10087, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterAuthCompleteEnd> IISFilterFilterAuthCompleteEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterAuthCompleteEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10073, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterAuthCompleteStart> IISFilterFilterAuthCompleteStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterAuthCompleteStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10072, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterAuthenticationEnd> IISFilterFilterAuthenticationEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterAuthenticationEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10071, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterAuthenticationStart> IISFilterFilterAuthenticationStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterAuthenticationStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10070, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterEnd> IISFilterFilterEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10064, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterEndOfRequestEnd> IISFilterFilterEndOfRequestEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterEndOfRequestEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10077, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterEndOfRequestStart> IISFilterFilterEndOfRequestStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterEndOfRequestStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10076, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterError> IISFilterFilterError
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterErrorTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10065, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterLogEnd> IISFilterFilterLogEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterLogEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10079, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterLogStart> IISFilterFilterLogStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterLogStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10078, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterPreprocEnd> IISFilterFilterPreprocHeadersEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterPreprocHeadersEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10067, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterPreprocStart> IISFilterFilterPreprocHeadersStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterPreprocHeadersStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10066, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterSendRawDataEnd> IISFilterFilterSendRawDataEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterSendRawDataEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10081, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterSendRawDataStart> IISFilterFilterSendRawDataStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterSendRawDataStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10080, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterSendResponseEnd> IISFilterFilterSendResponseEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterSendResponseEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10075, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterSendResponseStart> IISFilterFilterSendResponseStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterSendResponseStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10074, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterSetReqHeader> IISFilterFilterSetReqHeader
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterSetReqHeaderTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10084, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterSetRespHeader> IISFilterFilterSetRespHeader
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterSetRespHeaderTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10086, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterStart> IISFilterFilterStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10063, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterURLMapEnd> IISFilterFilterUrlMapEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterUrlMapEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10069, ProviderGuid);
+            }
+        }
+        public event Action<W3FilterURLMapStart> IISFilterFilterUrlMapStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISFilterFilterUrlMapStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10068, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralConfigChangeNotification> IISGeneralConfigChangeNotification
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralConfigChangeNotificationTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10020, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralFileChangeNotification> IISGeneralFileChangeNotification
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralFileChangeNotificationTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10019, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralCGIHandler> IISGeneralGeneralCgiHandler
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralCgiHandlerTemplate(value));
             }
             remove
             {
                 source.UnregisterEventTemplate(value, 10003, ProviderGuid);
             }
         }
-        public event Action<W3FilterPreprocStart> IIS_Filter_TransOpcode13
+        public event Action<W3GeneralChildRequestEnd> IISGeneralGeneralChildRequestEnd
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode13Template(value));
+                source.RegisterEventTemplate(IISGeneralGeneralChildRequestEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10012, ProviderGuid);
             }
         }
-        public event Action<W3FilterPreprocEnd> IIS_Filter_TransOpcode14
+        public event Action<W3GeneralChildRequestStart> IISGeneralGeneralChildRequestStart
         {
             add
             {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode14Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterURLMapStart> IIS_Filter_TransOpcode15
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode15Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterURLMapEnd> IIS_Filter_TransOpcode16
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode16Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAuthenticationStart> IIS_Filter_TransOpcode17
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode17Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAuthenticationEnd> IIS_Filter_TransOpcode18
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode18Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAuthCompleteStart> IIS_Filter_TransOpcode19
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode19Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAuthCompleteEnd> IIS_Filter_TransOpcode20
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode20Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterSendResponseStart> IIS_Filter_TransOpcode21
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode21Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterSendResponseEnd> IIS_Filter_TransOpcode22
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode22Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterEndOfRequestStart> IIS_Filter_TransOpcode23
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode23Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterEndOfRequestEnd> IIS_Filter_TransOpcode24
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode24Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterLogStart> IIS_Filter_TransOpcode25
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode25Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterLogEnd> IIS_Filter_TransOpcode26
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode26Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterSendRawDataStart> IIS_Filter_TransOpcode27
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode27Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterSendRawDataEnd> IIS_Filter_TransOpcode28
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode28Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAccessDeniedStart> IIS_Filter_TransOpcode29
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode29Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAccessDeniedEnd> IIS_Filter_TransOpcode30
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode30Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterSetReqHeader> IIS_Filter_TransOpcode31
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode31Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAddReqHeader> IIS_Filter_TransOpcode32
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode32Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterSetRespHeader> IIS_Filter_TransOpcode33
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode33Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterAddRespHeader> IIS_Filter_TransOpcode34
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransOpcode34Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterStart> IIS_Filter_TransStart
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransStartTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3FilterEnd> IIS_Filter_TransStop
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Filter_TransStopTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10003, ProviderGuid);
-            }
-        }
-        public event Action<W3SecIllegalShortFilename> IIS_Security_TransOpcode10
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode10Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecRejectedIP> IIS_Security_TransOpcode11
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode11Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecRejectedHostname> IIS_Security_TransOpcode12
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode12Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecRequireSSL128> IIS_Security_TransOpcode13
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode13Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecFileAccessDenied> IIS_Security_TransOpcode14
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode14Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecDeniedByMimemap> IIS_Security_TransOpcode15
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode15Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecDeniedByISAPIRestriction> IIS_Security_TransOpcode16
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode16Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecDeniedByCGIRestriction> IIS_Security_TransOpcode17
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode17Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3SecDeniedByAccessFlags> IIS_Security_TransOpcode18
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_Security_TransOpcode18Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralStaticFileHandler> IIS_TransOpcode10
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode10Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralCGIHandler> IIS_TransOpcode11
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode11Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralISAPIHandler> IIS_TransOpcode12
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode12Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralOopISAPIHandler> IIS_TransOpcode13
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode13Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralRedirectionHandler> IIS_TransOpcode14
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode14Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralDavHandler> IIS_TransOpcode15
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode15Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralOptionsHandler> IIS_TransOpcode16
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode16Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralTraceHandler> IIS_TransOpcode17
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode17Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3SendResponse> IIS_TransOpcode18
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode18Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3SendResponse> IIS_TransOpcode19
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode19Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3SendResponse> IIS_TransOpcode20
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode20Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3SendResponse> IIS_TransOpcode21
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode21Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3SendResponse> IIS_TransOpcode22
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode22Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3SendResponse> IIS_TransOpcode23
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode23Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3SendResponse> IIS_TransOpcode24
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode24Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralGetURLMetadata> IIS_TransOpcode30
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode30Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralChildRequestStart> IIS_TransOpcode31
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode31Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralChildRequestEnd> IIS_TransOpcode32
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode32Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralSendCustomError> IIS_TransOpcode33
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode33Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralMapHandler> IIS_TransOpcode34
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode34Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralFlushResponseStart> IIS_TransOpcode35
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode35Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralFlushResponseEnd> IIS_TransOpcode36
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode36Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralReadEntityStart> IIS_TransOpcode37
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode37Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralReadEntityEnd> IIS_TransOpcode38
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode38Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralFileChangeNotification> IIS_TransOpcode39
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode39Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralConfigChangeNotification> IIS_TransOpcode40
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode40Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralVirtualModuleUnresolved> IIS_TransOpcode41
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode41Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralUrlChanged> IIS_TransOpcode42
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode42Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralHandlerChanged> IIS_TransOpcode43
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode43Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralUserSet> IIS_TransOpcode44
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode44Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralModulePreconditionNotMatch> IIS_TransOpcode45
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode45Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<IISGeneralHandlerPreconditionNotMatch> IIS_TransOpcode46
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode46Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralResponseHeaders> IIS_TransOpcode47
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode47Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralResponseEntityFile> IIS_TransOpcode48
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode48Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralResponseEntityBuffer> IIS_TransOpcode49
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode49Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralRequestHeaders> IIS_TransOpcode50
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode50Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralRequestEntity> IIS_TransOpcode51
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode51Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralNotSendCustomError> IIS_TransOpcode52
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode52Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralSetRequestHeader> IIS_TransOpcode53
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode53Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralModuleFactoryFailed> IIS_TransOpcode54
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode54Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralEndpointInformation> IIS_TransOpcode55
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode55Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralSetResponseHeader> IIS_TransOpcode56
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransOpcode56Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralStartNewRequest> IIS_TransStart
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransStartTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3GeneralEndNewRequest> IIS_TransStop
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_TransStopTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketEndSuccess> IIS_WebSocket_TransDC_Start
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransDC_StartTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketEndFailure> IIS_WebSocket_TransDC_Stop
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransDC_StopTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketReadFragmentStart> IIS_WebSocket_TransExtension
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransExtensionTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketWriteFragmentEndPending> IIS_WebSocket_TransOpcode10
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode10Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketWriteFragmentEndSuccess> IIS_WebSocket_TransOpcode11
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode11Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketWriteFragmentEndFailure> IIS_WebSocket_TransOpcode12
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode12Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketApplicationCloseConnection> IIS_WebSocket_TransOpcode13
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode13Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketModuleCloseConnection> IIS_WebSocket_TransOpcode14
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode14Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketReadIoFailed> IIS_WebSocket_TransOpcode15
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode15Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketWriteIoFailed> IIS_WebSocket_TransOpcode16
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode16Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketCloseReceived> IIS_WebSocket_TransOpcode17
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode17Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketCloseSendStart> IIS_WebSocket_TransOpcode18
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode18Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketCloseSendSuccess> IIS_WebSocket_TransOpcode19
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode19Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketCloseSendFailure> IIS_WebSocket_TransOpcode20
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransOpcode20Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketReadFragmentEndPending> IIS_WebSocket_TransReply
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransReplyTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketReadFragmentEndSuccess> IIS_WebSocket_TransResume
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransResumeTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketWriteFragmentStart> IIS_WebSocket_TransSend
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransSendTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketInitializeNotSuccess> IIS_WebSocket_TransStart
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransStartTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketStart> IIS_WebSocket_TransStop
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransStopTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<W3WebSocketReadFragmentEndFailure> IIS_WebSocket_TransSuspend
-        {
-            add
-            {
-                source.RegisterEventTemplate(IIS_WebSocket_TransSuspendTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
-            }
-        }
-        public event Action<IISModuleEventsModuleCriticalError> IISModuleEventsDC_Start
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISModuleEventsDC_StartTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralChildRequestStartTemplate(value));
             }
             remove
             {
                 source.UnregisterEventTemplate(value, 10011, ProviderGuid);
             }
         }
-        public event Action<IISModuleEventsModuleError> IISModuleEventsDC_Stop
+        public event Action<W3GeneralDavHandler> IISGeneralGeneralDavHandler
         {
             add
             {
-                source.RegisterEventTemplate(IISModuleEventsDC_StopTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralDavHandlerTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10011, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10007, ProviderGuid);
             }
         }
-        public event Action<IISModuleEventsModuleWarning> IISModuleEventsExtension
+        public event Action<W3GeneralEndpointInformation> IISGeneralGeneralEndpointInformation
         {
             add
             {
-                source.RegisterEventTemplate(IISModuleEventsExtensionTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralEndpointInformationTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10011, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10035, ProviderGuid);
             }
         }
-        public event Action<IISModuleEventsModuleInformation> IISModuleEventsReply
+        public event Action<W3GeneralFlushResponseEnd> IISGeneralGeneralFlushResponseEnd
         {
             add
             {
-                source.RegisterEventTemplate(IISModuleEventsReplyTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralFlushResponseEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10011, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10016, ProviderGuid);
             }
         }
-        public event Action<IISModuleEventsModuleVerbose> IISModuleEventsResume
+        public event Action<W3GeneralFlushResponseStart> IISGeneralGeneralFlushResponseStart
         {
             add
             {
-                source.RegisterEventTemplate(IISModuleEventsResumeTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralFlushResponseStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10011, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10015, ProviderGuid);
             }
         }
-        public event Action<IISModuleEventsModuleStart> IISModuleEventsStart
+        public event Action<W3GeneralGetURLMetadata> IISGeneralGeneralGetUrlMetadata
         {
             add
             {
-                source.RegisterEventTemplate(IISModuleEventsStartTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10011, ProviderGuid);
-            }
-        }
-        public event Action<IISModuleEventsModuleEnd> IISModuleEventsStop
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISModuleEventsStopTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10011, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationEventsCompletion> IISRequestNotificationEventsDC_Start
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsDC_StartTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralGetUrlMetadataTemplate(value));
             }
             remove
             {
                 source.UnregisterEventTemplate(value, 10010, ProviderGuid);
             }
         }
-        public event Action<IISRequestNotificationPreBeginStart> IISRequestNotificationEventsDC_Stop
+        public event Action<W3GeneralISAPIHandler> IISGeneralGeneralIsapiHandler
         {
             add
             {
-                source.RegisterEventTemplate(IISRequestNotificationEventsDC_StopTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationPreBeginEnd> IISRequestNotificationEventsExtension
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsExtensionTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationEventsError> IISRequestNotificationEventsOpcode15
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsOpcode15Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationEventsResponseErrorStatus> IISRequestNotificationEventsOpcode16
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsOpcode16Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationEventsResponseSuccessStatus> IISRequestNotificationEventsOpcode17
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsOpcode17Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationEventsResponseErrorDescription> IISRequestNotificationEventsOpcode18
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsOpcode18Template(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationEventsStart> IISRequestNotificationEventsStart
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsStartTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IISRequestNotificationEventsEnd> IISRequestNotificationEventsStop
-        {
-            add
-            {
-                source.RegisterEventTemplate(IISRequestNotificationEventsStopTemplate(value));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 10010, ProviderGuid);
-            }
-        }
-        public event Action<IsapiDeleteContext> Isapi_TransOpcode10
-        {
-            add
-            {
-                source.RegisterEventTemplate(Isapi_TransOpcode10Template(value));
+                source.RegisterEventTemplate(IISGeneralGeneralIsapiHandlerTemplate(value));
             }
             remove
             {
                 source.UnregisterEventTemplate(value, 10004, ProviderGuid);
             }
         }
-        public event Action<IsapiDeleteContext> Isapi_TransOpcode11
+        public event Action<W3GeneralMapHandler> IISGeneralGeneralMapHandler
         {
             add
             {
-                source.RegisterEventTemplate(Isapi_TransOpcode11Template(value));
+                source.RegisterEventTemplate(IISGeneralGeneralMapHandlerTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10004, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10014, ProviderGuid);
             }
         }
-        public event Action<IsapiDeleteContext> Isapi_TransOpcode12
+        public event Action<W3GeneralModuleFactoryFailed> IISGeneralGeneralModuleFactoryFailed
         {
             add
             {
-                source.RegisterEventTemplate(Isapi_TransOpcode12Template(value));
+                source.RegisterEventTemplate(IISGeneralGeneralModuleFactoryFailedTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10004, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10034, ProviderGuid);
             }
         }
-        public event Action<IsapiDeleteContext> Isapi_TransOpcode13
+        public event Action<W3GeneralNotSendCustomError> IISGeneralGeneralNotSendCustomError
         {
             add
             {
-                source.RegisterEventTemplate(Isapi_TransOpcode13Template(value));
+                source.RegisterEventTemplate(IISGeneralGeneralNotSendCustomErrorTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10004, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10032, ProviderGuid);
             }
         }
-        public event Action<IsapiDeleteContext> Isapi_TransOpcode14
+        public event Action<W3GeneralOopISAPIHandler> IISGeneralGeneralOopIsapiHandler
         {
             add
             {
-                source.RegisterEventTemplate(Isapi_TransOpcode14Template(value));
+                source.RegisterEventTemplate(IISGeneralGeneralOopIsapiHandlerTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10004, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10005, ProviderGuid);
             }
         }
-        public event Action<IsapiDeleteContext> Isapi_TransOpcode15
+        public event Action<W3GeneralOptionsHandler> IISGeneralGeneralOptionsHandler
         {
             add
             {
-                source.RegisterEventTemplate(Isapi_TransOpcode15Template(value));
+                source.RegisterEventTemplate(IISGeneralGeneralOptionsHandlerTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10004, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10008, ProviderGuid);
             }
         }
-        public event Action<W3ISAPIStart> Isapi_TransStart
+        public event Action<W3GeneralReadEntityEnd> IISGeneralGeneralReadEntityEnd
         {
             add
             {
-                source.RegisterEventTemplate(Isapi_TransStartTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralReadEntityEndTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10004, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10018, ProviderGuid);
             }
         }
-        public event Action<W3ISAPIEnd> Isapi_TransStop
+        public event Action<W3GeneralReadEntityStart> IISGeneralGeneralReadEntityStart
         {
             add
             {
-                source.RegisterEventTemplate(Isapi_TransStopTemplate(value));
+                source.RegisterEventTemplate(IISGeneralGeneralReadEntityStartTemplate(value));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 10004, ProviderGuid);
+                source.UnregisterEventTemplate(value, 10017, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralRedirectionHandler> IISGeneralGeneralRedirectionHandler
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralRedirectionHandlerTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10006, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralEndNewRequest> IISGeneralGeneralRequestEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralRequestEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10001, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralRequestEntity> IISGeneralGeneralRequestEntity
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralRequestEntityTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10031, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralRequestHeaders> IISGeneralGeneralRequestHeaders
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralRequestHeadersTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10030, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralStartNewRequest> IISGeneralGeneralRequestStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralRequestStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10000, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralResponseEntityBuffer> IISGeneralGeneralResponseEntityBuffer
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralResponseEntityBufferTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10029, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralResponseEntityFile> IISGeneralGeneralResponseEntityFile
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralResponseEntityFileTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10028, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralResponseHeaders> IISGeneralGeneralResponseHeaders
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralResponseHeadersTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10027, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralSendCustomError> IISGeneralGeneralSendCustomError
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralSendCustomErrorTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10013, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralSetRequestHeader> IISGeneralGeneralSetRequestHeader
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralSetRequestHeaderTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10033, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralStaticFileHandler> IISGeneralGeneralStaticFileHandler
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralStaticFileHandlerTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10002, ProviderGuid);
+            }
+        }
+        public event Action<W3GeneralTraceHandler> IISGeneralGeneralTraceHandler
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralGeneralTraceHandlerTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10009, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralHandlerChanged> IISGeneralHandlerChanged
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralHandlerChangedTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10023, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralHandlerPreconditionNotMatch> IISGeneralHandlerPreconditionNotMatch
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralHandlerPreconditionNotMatchTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10026, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralModulePreconditionNotMatch> IISGeneralModulePreconditionNotMatch
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralModulePreconditionNotMatchTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10025, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralUrlChanged> IISGeneralUrlChanged
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralUrlChangedTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10022, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralUserSet> IISGeneralUserSet
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralUserSetTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10024, ProviderGuid);
+            }
+        }
+        public event Action<IISGeneralVirtualModuleUnresolved> IISGeneralVirtualModuleUnresolved
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISGeneralVirtualModuleUnresolvedTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10021, ProviderGuid);
+            }
+        }
+        public event Action<W3ISAPIEnd> IISISAPIIsapiEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISISAPIIsapiEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10089, ProviderGuid);
+            }
+        }
+        public event Action<W3ISAPIStart> IISISAPIIsapiStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISISAPIIsapiStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10088, ProviderGuid);
+            }
+        }
+        public event Action<IISModuleEventsModuleCriticalError> IISModuleModuleCriticalError
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISModuleModuleCriticalErrorTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10168, ProviderGuid);
+            }
+        }
+        public event Action<IISModuleEventsModuleEnd> IISModuleModuleEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISModuleModuleEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10167, ProviderGuid);
+            }
+        }
+        public event Action<IISModuleEventsModuleError> IISModuleModuleError
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISModuleModuleErrorTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10169, ProviderGuid);
+            }
+        }
+        public event Action<IISModuleEventsModuleInformation> IISModuleModuleInformation
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISModuleModuleInformationTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10171, ProviderGuid);
+            }
+        }
+        public event Action<IISModuleEventsModuleStart> IISModuleModuleStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISModuleModuleStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10166, ProviderGuid);
+            }
+        }
+        public event Action<IISModuleEventsModuleVerbose> IISModuleModuleVerbose
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISModuleModuleVerboseTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10172, ProviderGuid);
+            }
+        }
+        public event Action<IISModuleEventsModuleWarning> IISModuleModuleWarning
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISModuleModuleWarningTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10170, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationEventsResponseErrorStatus> IISRequestNotificationModuleSetResponseErrorStatus
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationModuleSetResponseErrorStatusTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10163, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationEventsResponseSuccessStatus> IISRequestNotificationModuleSetResponseSuccessStatus
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationModuleSetResponseSuccessStatusTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10164, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationEventsCompletion> IISRequestNotificationNotifyModuleCompletion
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationNotifyModuleCompletionTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10159, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationEventsEnd> IISRequestNotificationNotifyModuleEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationNotifyModuleEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10158, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationEventsStart> IISRequestNotificationNotifyModuleStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationNotifyModuleStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10157, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationPreBeginEnd> IISRequestNotificationPreBeginRequestEnd
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationPreBeginRequestEndTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10161, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationPreBeginStart> IISRequestNotificationPreBeginRequestStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationPreBeginRequestStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10160, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationEventsError> IISRequestNotificationRequestProcessingError
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationRequestProcessingErrorTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10162, ProviderGuid);
+            }
+        }
+        public event Action<IISRequestNotificationEventsResponseErrorDescription> IISRequestNotificationSetResponseErrorDescription
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISRequestNotificationSetResponseErrorDescriptionTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10165, ProviderGuid);
+            }
+        }
+        public event Action<W3SecDeniedByAccessFlags> IISSecuritySecurityDeniedByAccessFlags
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityDeniedByAccessFlagsTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10062, ProviderGuid);
+            }
+        }
+        public event Action<W3SecDeniedByCGIRestriction> IISSecuritySecurityDeniedByCgiRestriction
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityDeniedByCgiRestrictionTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10061, ProviderGuid);
+            }
+        }
+        public event Action<W3SecDeniedByISAPIRestriction> IISSecuritySecurityDeniedByIsapiRestriction
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityDeniedByIsapiRestrictionTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10060, ProviderGuid);
+            }
+        }
+        public event Action<W3SecDeniedByMimemap> IISSecuritySecurityDeniedByMimemap
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityDeniedByMimemapTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10059, ProviderGuid);
+            }
+        }
+        public event Action<W3SecFileAccessDenied> IISSecuritySecurityFileAccessDenied
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityFileAccessDeniedTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10058, ProviderGuid);
+            }
+        }
+        public event Action<W3SecIllegalShortFilename> IISSecuritySecurityIllegalShortFilename
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityIllegalShortFilenameTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10054, ProviderGuid);
+            }
+        }
+        public event Action<W3SecRejectedHostname> IISSecuritySecurityRejectedHostname
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityRejectedHostnameTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10056, ProviderGuid);
+            }
+        }
+        public event Action<W3SecRejectedIP> IISSecuritySecurityRejectedIp
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityRejectedIpTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10055, ProviderGuid);
+            }
+        }
+        public event Action<W3SecRequireSSL128> IISSecuritySecurityRejectedRequireSsl128
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISSecuritySecurityRejectedRequireSsl128Template(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10057, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketApplicationCloseConnection> IISWebSocketWebsocketApplicationCloseConnection
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketApplicationCloseConnectionTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10128, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketEndFailure> IISWebSocketWebsocketHandshakeNotSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketHandshakeNotSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10119, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketStart> IISWebSocketWebsocketHandshakeStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketHandshakeStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10117, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketEndSuccess> IISWebSocketWebsocketHandshakeSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketHandshakeSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10118, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketInitializeNotSuccess> IISWebSocketWebsocketInitializeFailed
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketInitializeFailedTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10116, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketModuleCloseConnection> IISWebSocketWebsocketModuleCloseConnection
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketModuleCloseConnectionTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10129, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketReadFragmentEndFailure> IISWebSocketWebsocketReadFragmentEndNotSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketReadFragmentEndNotSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10123, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketReadFragmentEndPending> IISWebSocketWebsocketReadFragmentEndPending
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketReadFragmentEndPendingTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10121, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketReadFragmentEndSuccess> IISWebSocketWebsocketReadFragmentEndSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketReadFragmentEndSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10122, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketReadFragmentStart> IISWebSocketWebsocketReadFragmentStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketReadFragmentStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10120, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketReadIoFailed> IISWebSocketWebsocketReadIoNotSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketReadIoNotSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10130, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketCloseReceived> IISWebSocketWebsocketReceivedClose
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketReceivedCloseTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10132, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketCloseSendFailure> IISWebSocketWebsocketSendCloseEndNotSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketSendCloseEndNotSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10135, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketCloseSendSuccess> IISWebSocketWebsocketSendCloseEndSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketSendCloseEndSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10134, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketCloseSendStart> IISWebSocketWebsocketSendCloseStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketSendCloseStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10133, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketWriteFragmentEndFailure> IISWebSocketWebsocketWriteFragmentEndNotSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketWriteFragmentEndNotSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10127, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketWriteFragmentEndPending> IISWebSocketWebsocketWriteFragmentEndPending
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketWriteFragmentEndPendingTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10125, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketWriteFragmentEndSuccess> IISWebSocketWebsocketWriteFragmentEndSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketWriteFragmentEndSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10126, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketWriteFragmentStart> IISWebSocketWebsocketWriteFragmentStart
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketWriteFragmentStartTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10124, ProviderGuid);
+            }
+        }
+        public event Action<W3WebSocketWriteIoFailed> IISWebSocketWebsocketWriteIoNotSuccess
+        {
+            add
+            {
+                source.RegisterEventTemplate(IISWebSocketWebsocketWriteIoNotSuccessTemplate(value));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10131, ProviderGuid);
             }
         }
 
         #region private
         protected override string GetProviderName() { return ProviderName; }
 
-        static private W3AuthStart IIS_Authentication_TransOpcode10Template(Action<W3AuthStart> action)
+        static private W3AuthAnonPasswdChangeNeeded IISAuthenticationAuthAnonPasswdChangeNeededTemplate(Action<W3AuthAnonPasswdChangeNeeded> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthStart(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
+            return new W3AuthAnonPasswdChangeNeeded(action, 10051, 1, "IISAuthentication", IISAuthenticationGuid, 24, "AUTH_ANON_PASSWD_CHANGE_NEEDED", ProviderGuid, ProviderName);
         }
-        static private W3AuthSucceeded IIS_Authentication_TransOpcode11Template(Action<W3AuthSucceeded> action)
+        static private W3AuthBadBasicHeader IISAuthenticationAuthBadBasicHeaderTemplate(Action<W3AuthBadBasicHeader> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthSucceeded(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
+            return new W3AuthBadBasicHeader(action, 10042, 1, "IISAuthentication", IISAuthenticationGuid, 16, "AUTH_BAD_BASIC_HEADER", ProviderGuid, ProviderName);
         }
-        static private W3AuthTypeNotSupported IIS_Authentication_TransOpcode12Template(Action<W3AuthTypeNotSupported> action)
+        static private W3AuthBasicLogonFailed IISAuthenticationAuthBasicLogonFailedTemplate(Action<W3AuthBasicLogonFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthTypeNotSupported(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
+            return new W3AuthBasicLogonFailed(action, 10043, 1, "IISAuthentication", IISAuthenticationGuid, 17, "AUTH_BASIC_LOGON_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3AuthInvalidAnonAccount IIS_Authentication_TransOpcode13Template(Action<W3AuthInvalidAnonAccount> action)
+        static private W3AuthEnd IISAuthenticationAuthEndTemplate(Action<W3AuthEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthInvalidAnonAccount(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
+            return new W3AuthEnd(action, 10053, 1, "IISAuthentication", IISAuthenticationGuid, 28, "AUTH_END", ProviderGuid, ProviderName);
         }
-        static private W3AuthPasswdChangeNeeded IIS_Authentication_TransOpcode14Template(Action<W3AuthPasswdChangeNeeded> action)
+        static private W3AuthIISDigestLogonFailed IISAuthenticationAuthIisdigestLogonFailedTemplate(Action<W3AuthIISDigestLogonFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthPasswdChangeNeeded(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
+            return new W3AuthIISDigestLogonFailed(action, 10045, 1, "IISAuthentication", IISAuthenticationGuid, 19, "AUTH_IISDIGEST_LOGON_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3AuthPasswdChangeDisabled IIS_Authentication_TransOpcode15Template(Action<W3AuthPasswdChangeDisabled> action)
+        static private W3AuthInvalidAnonAccount IISAuthenticationAuthInvalidAnonAccountTemplate(Action<W3AuthInvalidAnonAccount> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthPasswdChangeDisabled(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
+            return new W3AuthInvalidAnonAccount(action, 10039, 1, "IISAuthentication", IISAuthenticationGuid, 13, "AUTH_INVALID_ANON_ACCOUNT", ProviderGuid, ProviderName);
         }
-        static private W3AuthBadBasicHeader IIS_Authentication_TransOpcode16Template(Action<W3AuthBadBasicHeader> action)
+        static private W3AuthKerberosFailed IISAuthenticationAuthKerberosFailedTemplate(Action<W3AuthKerberosFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthBadBasicHeader(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 16, "Opcode16", ProviderGuid, ProviderName);
+            return new W3AuthKerberosFailed(action, 10050, 1, "IISAuthentication", IISAuthenticationGuid, 55, "AUTH_KERBEROS_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3AuthBasicLogonFailed IIS_Authentication_TransOpcode17Template(Action<W3AuthBasicLogonFailed> action)
+        static private W3AuthNTLMNullSession IISAuthenticationAuthNtlmNullSessionTemplate(Action<W3AuthNTLMNullSession> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthBasicLogonFailed(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 17, "Opcode17", ProviderGuid, ProviderName);
+            return new W3AuthNTLMNullSession(action, 10048, 1, "IISAuthentication", IISAuthenticationGuid, 22, "AUTH_NTLM_NULL_SESSION", ProviderGuid, ProviderName);
         }
-        static private W3AuthWDigestLogonFailed IIS_Authentication_TransOpcode18Template(Action<W3AuthWDigestLogonFailed> action)
+        static private W3AuthPassportLogonFailed IISAuthenticationAuthPassportLogonFailedTemplate(Action<W3AuthPassportLogonFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthWDigestLogonFailed(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 18, "Opcode18", ProviderGuid, ProviderName);
+            return new W3AuthPassportLogonFailed(action, 10046, 1, "IISAuthentication", IISAuthenticationGuid, 20, "AUTH_PASSPORT_LOGON_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3AuthIISDigestLogonFailed IIS_Authentication_TransOpcode19Template(Action<W3AuthIISDigestLogonFailed> action)
+        static private W3AuthPasswdChangeDisabled IISAuthenticationAuthPasswdChangeDisabledTemplate(Action<W3AuthPasswdChangeDisabled> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthIISDigestLogonFailed(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 19, "Opcode19", ProviderGuid, ProviderName);
+            return new W3AuthPasswdChangeDisabled(action, 10041, 1, "IISAuthentication", IISAuthenticationGuid, 15, "AUTH_PASSWD_CHANGE_DISABLED", ProviderGuid, ProviderName);
         }
-        static private W3AuthPassportLogonFailed IIS_Authentication_TransOpcode20Template(Action<W3AuthPassportLogonFailed> action)
+        static private W3AuthPasswdChangeNeeded IISAuthenticationAuthPasswdChangeNeededTemplate(Action<W3AuthPasswdChangeNeeded> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthPassportLogonFailed(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 20, "Opcode20", ProviderGuid, ProviderName);
+            return new W3AuthPasswdChangeNeeded(action, 10040, 1, "IISAuthentication", IISAuthenticationGuid, 14, "AUTH_PASSWD_CHANGE_NEEDED", ProviderGuid, ProviderName);
         }
-        static private W3AuthSSPILogonFailed IIS_Authentication_TransOpcode21Template(Action<W3AuthSSPILogonFailed> action)
+        static private W3AuthRequestAuthType IISAuthenticationAuthRequestAuthTypeTemplate(Action<W3AuthRequestAuthType> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthSSPILogonFailed(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 21, "Opcode21", ProviderGuid, ProviderName);
+            return new W3AuthRequestAuthType(action, 10052, 1, "IISAuthentication", IISAuthenticationGuid, 27, "AUTH_REQUEST_AUTH_TYPE", ProviderGuid, ProviderName);
         }
-        static private W3AuthNTLMNullSession IIS_Authentication_TransOpcode22Template(Action<W3AuthNTLMNullSession> action)
+        static private W3AuthSSPIContinueNeeded IISAuthenticationAuthSspiContinueNeededTemplate(Action<W3AuthSSPIContinueNeeded> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthNTLMNullSession(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 22, "Opcode22", ProviderGuid, ProviderName);
+            return new W3AuthSSPIContinueNeeded(action, 10049, 1, "IISAuthentication", IISAuthenticationGuid, 23, "AUTH_SSPI_CONTINUE_NEEDED", ProviderGuid, ProviderName);
         }
-        static private W3AuthSSPIContinueNeeded IIS_Authentication_TransOpcode23Template(Action<W3AuthSSPIContinueNeeded> action)
+        static private W3AuthSSPILogonFailed IISAuthenticationAuthSspiLogonFailedTemplate(Action<W3AuthSSPILogonFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthSSPIContinueNeeded(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 23, "Opcode23", ProviderGuid, ProviderName);
+            return new W3AuthSSPILogonFailed(action, 10047, 1, "IISAuthentication", IISAuthenticationGuid, 21, "AUTH_SSPI_LOGON_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3AuthAnonPasswdChangeNeeded IIS_Authentication_TransOpcode24Template(Action<W3AuthAnonPasswdChangeNeeded> action)
+        static private W3AuthStart IISAuthenticationAuthStartTemplate(Action<W3AuthStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthAnonPasswdChangeNeeded(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 24, "Opcode24", ProviderGuid, ProviderName);
+            return new W3AuthStart(action, 10036, 1, "IISAuthentication", IISAuthenticationGuid, 10, "AUTH_START", ProviderGuid, ProviderName);
         }
-        static private W3AuthRequestAuthType IIS_Authentication_TransOpcode27Template(Action<W3AuthRequestAuthType> action)
+        static private W3AuthSucceeded IISAuthenticationAuthSucceededTemplate(Action<W3AuthSucceeded> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthRequestAuthType(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 27, "Opcode27", ProviderGuid, ProviderName);
+            return new W3AuthSucceeded(action, 10037, 1, "IISAuthentication", IISAuthenticationGuid, 11, "AUTH_SUCCEEDED", ProviderGuid, ProviderName);
         }
-        static private W3AuthEnd IIS_Authentication_TransOpcode28Template(Action<W3AuthEnd> action)
+        static private W3AuthTypeNotSupported IISAuthenticationAuthTypeNotSupportedTemplate(Action<W3AuthTypeNotSupported> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthEnd(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 28, "Opcode28", ProviderGuid, ProviderName);
+            return new W3AuthTypeNotSupported(action, 10038, 1, "IISAuthentication", IISAuthenticationGuid, 12, "AUTH_TYPE_NOT_SUPPORTED", ProviderGuid, ProviderName);
         }
-        static private W3AuthKerberosFailed IIS_Authentication_TransOpcode55Template(Action<W3AuthKerberosFailed> action)
+        static private W3AuthWDigestLogonFailed IISAuthenticationAuthWdigestLogonFailedTemplate(Action<W3AuthWDigestLogonFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3AuthKerberosFailed(action, 10001, 1, "IIS_Authentication_Trans", IISAuthenticationTransGuid, 55, "Opcode55", ProviderGuid, ProviderName);
+            return new W3AuthWDigestLogonFailed(action, 10044, 1, "IISAuthentication", IISAuthenticationGuid, 18, "AUTH_WDIGEST_LOGON_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3CacheFileCacheAccessStart IIS_Cache_TransOpcode10Template(Action<W3CacheFileCacheAccessStart> action)
+        static private W3CacheFileCacheAccessEnd IISCacheFileCacheAccessEndTemplate(Action<W3CacheFileCacheAccessEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CacheFileCacheAccessStart(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
+            return new W3CacheFileCacheAccessEnd(action, 10148, 10, "IISCache", IISCacheGuid, 11, "FILE_CACHE_ACCESS_END", ProviderGuid, ProviderName);
         }
-        static private W3CacheFileCacheAccessEnd IIS_Cache_TransOpcode11Template(Action<W3CacheFileCacheAccessEnd> action)
+        static private W3CacheFileCacheAccessStart IISCacheFileCacheAccessStartTemplate(Action<W3CacheFileCacheAccessStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CacheFileCacheAccessEnd(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
+            return new W3CacheFileCacheAccessStart(action, 10147, 10, "IISCache", IISCacheGuid, 10, "FILE_CACHE_ACCESS_START", ProviderGuid, ProviderName);
         }
-        static private W3CacheURLCacheAccessStart IIS_Cache_TransOpcode12Template(Action<W3CacheURLCacheAccessStart> action)
+        static private W3CacheHttpsysCacheable IISCacheHttpsysCacheableTemplate(Action<W3CacheHttpsysCacheable> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CacheURLCacheAccessStart(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
+            return new W3CacheHttpsysCacheable(action, 10151, 10, "IISCache", IISCacheGuid, 14, "HTTPSYS_CACHEABLE", ProviderGuid, ProviderName);
         }
-        static private W3CacheURLCacheAccessEnd IIS_Cache_TransOpcode13Template(Action<W3CacheURLCacheAccessEnd> action)
+        static private W3OutputCacheDisabled IISCacheOutputCacheDisabledTemplate(Action<W3OutputCacheDisabled> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CacheURLCacheAccessEnd(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
+            return new W3OutputCacheDisabled(action, 10156, 10, "IISCache", IISCacheGuid, 19, "OUTPUT_CACHE_DISABLED", ProviderGuid, ProviderName);
         }
-        static private W3CacheHttpsysCacheable IIS_Cache_TransOpcode14Template(Action<W3CacheHttpsysCacheable> action)
+        static private W3OutputCacheLookupEnd IISCacheOutputCacheLookupEndTemplate(Action<W3OutputCacheLookupEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CacheHttpsysCacheable(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
+            return new W3OutputCacheLookupEnd(action, 10153, 10, "IISCache", IISCacheGuid, 16, "OUTPUT_CACHE_LOOKUP_END", ProviderGuid, ProviderName);
         }
-        static private W3OutputCacheLookupStart IIS_Cache_TransOpcode15Template(Action<W3OutputCacheLookupStart> action)
+        static private W3OutputCacheLookupStart IISCacheOutputCacheLookupStartTemplate(Action<W3OutputCacheLookupStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3OutputCacheLookupStart(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
+            return new W3OutputCacheLookupStart(action, 10152, 10, "IISCache", IISCacheGuid, 15, "OUTPUT_CACHE_LOOKUP_START", ProviderGuid, ProviderName);
         }
-        static private W3OutputCacheLookupEnd IIS_Cache_TransOpcode16Template(Action<W3OutputCacheLookupEnd> action)
+        static private W3OutputCacheUpdateEnd IISCacheOutputCacheUpdateEndTemplate(Action<W3OutputCacheUpdateEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3OutputCacheLookupEnd(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 16, "Opcode16", ProviderGuid, ProviderName);
+            return new W3OutputCacheUpdateEnd(action, 10155, 10, "IISCache", IISCacheGuid, 18, "OUTPUT_CACHE_UPDATE_END", ProviderGuid, ProviderName);
         }
-        static private W3OutputCacheUpdateStart IIS_Cache_TransOpcode17Template(Action<W3OutputCacheUpdateStart> action)
+        static private W3OutputCacheUpdateStart IISCacheOutputCacheUpdateStartTemplate(Action<W3OutputCacheUpdateStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3OutputCacheUpdateStart(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 17, "Opcode17", ProviderGuid, ProviderName);
+            return new W3OutputCacheUpdateStart(action, 10154, 10, "IISCache", IISCacheGuid, 17, "OUTPUT_CACHE_UPDATE_START", ProviderGuid, ProviderName);
         }
-        static private W3OutputCacheUpdateEnd IIS_Cache_TransOpcode18Template(Action<W3OutputCacheUpdateEnd> action)
+        static private W3CacheURLCacheAccessEnd IISCacheUrlCacheAccessEndTemplate(Action<W3CacheURLCacheAccessEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3OutputCacheUpdateEnd(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 18, "Opcode18", ProviderGuid, ProviderName);
+            return new W3CacheURLCacheAccessEnd(action, 10150, 10, "IISCache", IISCacheGuid, 13, "URL_CACHE_ACCESS_END", ProviderGuid, ProviderName);
         }
-        static private W3OutputCacheDisabled IIS_Cache_TransOpcode19Template(Action<W3OutputCacheDisabled> action)
+        static private W3CacheURLCacheAccessStart IISCacheUrlCacheAccessStartTemplate(Action<W3CacheURLCacheAccessStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3OutputCacheDisabled(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 19, "Opcode19", ProviderGuid, ProviderName);
+            return new W3CacheURLCacheAccessStart(action, 10149, 10, "IISCache", IISCacheGuid, 12, "URL_CACHE_ACCESS_START", ProviderGuid, ProviderName);
         }
-        static private W3CacheFileCacheCreateFile IIS_Cache_TransOpcode20Template(Action<W3CacheFileCacheCreateFile> action)
+        static private W3CGIEnd IISCGICgiEndTemplate(Action<W3CGIEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CacheFileCacheCreateFile(action, 10009, 10, "IIS_Cache_Trans", IISCacheTransGuid, 20, "Opcode20", ProviderGuid, ProviderName);
+            return new W3CGIEnd(action, 10091, 6, "IISCGI", IISCGIGuid, 2, "CGI_END", ProviderGuid, ProviderName);
         }
-        static private W3CGILaunch IIS_Cgi_TransDC_StartTemplate(Action<W3CGILaunch> action)
+        static private W3CGIHeadersReceived IISCGICgiHeadersReceivedTemplate(Action<W3CGIHeadersReceived> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGILaunch(action, 10005, 6, "IIS_Cgi_Trans", IISCgiTransGuid, 3, "DC_Start", ProviderGuid, ProviderName);
+            return new W3CGIHeadersReceived(action, 10096, 6, "IISCGI", IISCGIGuid, 7, "CGI_HEADERS_RECEIVED", ProviderGuid, ProviderName);
         }
-        static private W3CGITimeout IIS_Cgi_TransDC_StopTemplate(Action<W3CGITimeout> action)
+        static private W3CGILaunch IISCGICgiLaunchTemplate(Action<W3CGILaunch> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGITimeout(action, 10005, 6, "IIS_Cgi_Trans", IISCgiTransGuid, 4, "DC_Stop", ProviderGuid, ProviderName);
+            return new W3CGILaunch(action, 10092, 6, "IISCGI", IISCGIGuid, 3, "CGI_LAUNCH", ProviderGuid, ProviderName);
         }
-        static private W3CGIPrematureTermination IIS_Cgi_TransExtensionTemplate(Action<W3CGIPrematureTermination> action)
+        static private W3CGIPrematureTermination IISCGICgiPrematureTerminationTemplate(Action<W3CGIPrematureTermination> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIPrematureTermination(action, 10005, 6, "IIS_Cgi_Trans", IISCgiTransGuid, 5, "Extension", ProviderGuid, ProviderName);
+            return new W3CGIPrematureTermination(action, 10094, 6, "IISCGI", IISCGIGuid, 5, "CGI_PREMATURE_TERMINATION", ProviderGuid, ProviderName);
         }
-        static private W3CGIRequestEntitySent IIS_Cgi_TransReplyTemplate(Action<W3CGIRequestEntitySent> action)
+        static private W3CGIRequestEntitySent IISCGICgiRequestEntitySentTemplate(Action<W3CGIRequestEntitySent> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIRequestEntitySent(action, 10005, 6, "IIS_Cgi_Trans", IISCgiTransGuid, 6, "Reply", ProviderGuid, ProviderName);
+            return new W3CGIRequestEntitySent(action, 10095, 6, "IISCGI", IISCGIGuid, 6, "CGI_REQUEST_ENTITY_SENT", ProviderGuid, ProviderName);
         }
-        static private W3CGIHeadersReceived IIS_Cgi_TransResumeTemplate(Action<W3CGIHeadersReceived> action)
+        static private W3CGIStart IISCGICgiStartTemplate(Action<W3CGIStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIHeadersReceived(action, 10005, 6, "IIS_Cgi_Trans", IISCgiTransGuid, 7, "Resume", ProviderGuid, ProviderName);
+            return new W3CGIStart(action, 10090, 6, "IISCGI", IISCGIGuid, 1, "CGI_START", ProviderGuid, ProviderName);
         }
-        static private W3CGIStart IIS_Cgi_TransStartTemplate(Action<W3CGIStart> action)
+        static private W3CGITimeout IISCGICgiTimeoutTemplate(Action<W3CGITimeout> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIStart(action, 10005, 6, "IIS_Cgi_Trans", IISCgiTransGuid, 1, "Start", ProviderGuid, ProviderName);
+            return new W3CGITimeout(action, 10093, 6, "IISCGI", IISCGIGuid, 4, "CGI_TIMEOUT", ProviderGuid, ProviderName);
         }
-        static private W3CGIEnd IIS_Cgi_TransStopTemplate(Action<W3CGIEnd> action)
+        static private W3DynamicCompressionDo IISCompressionDynamicCompressionDoTemplate(Action<W3DynamicCompressionDo> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIEnd(action, 10005, 6, "IIS_Cgi_Trans", IISCgiTransGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new W3DynamicCompressionDo(action, 10144, 9, "IISCompression", IISCompressionGuid, 9, "DYNAMIC_COMPRESSION_DO", ProviderGuid, ProviderName);
         }
-        static private W3StaticCompressionNotSuccess IIS_Compression_TransDC_StartTemplate(Action<W3StaticCompressionNotSuccess> action)
+        static private W3DynamicCompressionEnd IISCompressionDynamicCompressionEndTemplate(Action<W3DynamicCompressionEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3StaticCompressionNotSuccess(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 3, "DC_Start", ProviderGuid, ProviderName);
+            return new W3DynamicCompressionEnd(action, 10145, 9, "IISCompression", IISCompressionGuid, 10, "DYNAMIC_COMPRESSION_END", ProviderGuid, ProviderName);
         }
-        static private W3StaticCompressionCreateStart IIS_Compression_TransDC_StopTemplate(Action<W3StaticCompressionCreateStart> action)
+        static private W3DynamicCompressionNotSuccess IISCompressionDynamicCompressionNotSuccessTemplate(Action<W3DynamicCompressionNotSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3StaticCompressionCreateStart(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 4, "DC_Stop", ProviderGuid, ProviderName);
+            return new W3DynamicCompressionNotSuccess(action, 10143, 9, "IISCompression", IISCompressionGuid, 8, "DYNAMIC_COMPRESSION_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3StaticCompressionCreateEnd IIS_Compression_TransExtensionTemplate(Action<W3StaticCompressionCreateEnd> action)
+        static private W3DynamicCompressionStart IISCompressionDynamicCompressionStartTemplate(Action<W3DynamicCompressionStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3StaticCompressionCreateEnd(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 5, "Extension", ProviderGuid, ProviderName);
+            return new W3DynamicCompressionStart(action, 10141, 9, "IISCompression", IISCompressionGuid, 6, "DYNAMIC_COMPRESSION_START", ProviderGuid, ProviderName);
         }
-        static private W3DynamicCompressionEnd IIS_Compression_TransOpcode10Template(Action<W3DynamicCompressionEnd> action)
+        static private W3DynamicCompressionSuccess IISCompressionDynamicCompressionSuccessTemplate(Action<W3DynamicCompressionSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3DynamicCompressionEnd(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
+            return new W3DynamicCompressionSuccess(action, 10142, 9, "IISCompression", IISCompressionGuid, 7, "DYNAMIC_COMPRESSION_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3StaticCompressionEnd IIS_Compression_TransOpcode11Template(Action<W3StaticCompressionEnd> action)
+        static private W3StaticCompressionCreateEnd IISCompressionStaticCompressionCreateEndTemplate(Action<W3StaticCompressionCreateEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3StaticCompressionEnd(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
+            return new W3StaticCompressionCreateEnd(action, 10140, 9, "IISCompression", IISCompressionGuid, 5, "STATIC_COMPRESSION_CREATE_END", ProviderGuid, ProviderName);
         }
-        static private W3DynamicCompressionStart IIS_Compression_TransReplyTemplate(Action<W3DynamicCompressionStart> action)
+        static private W3StaticCompressionCreateStart IISCompressionStaticCompressionCreateStartTemplate(Action<W3StaticCompressionCreateStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3DynamicCompressionStart(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 6, "Reply", ProviderGuid, ProviderName);
+            return new W3StaticCompressionCreateStart(action, 10139, 9, "IISCompression", IISCompressionGuid, 4, "STATIC_COMPRESSION_CREATE_START", ProviderGuid, ProviderName);
         }
-        static private W3DynamicCompressionSuccess IIS_Compression_TransResumeTemplate(Action<W3DynamicCompressionSuccess> action)
+        static private W3StaticCompressionEnd IISCompressionStaticCompressionEndTemplate(Action<W3StaticCompressionEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3DynamicCompressionSuccess(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 7, "Resume", ProviderGuid, ProviderName);
+            return new W3StaticCompressionEnd(action, 10146, 9, "IISCompression", IISCompressionGuid, 11, "STATIC_COMPRESSION_END", ProviderGuid, ProviderName);
         }
-        static private W3DynamicCompressionDo IIS_Compression_TransSendTemplate(Action<W3DynamicCompressionDo> action)
+        static private W3StaticCompressionNotSuccess IISCompressionStaticCompressionNotSuccessTemplate(Action<W3StaticCompressionNotSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3DynamicCompressionDo(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 9, "Send", ProviderGuid, ProviderName);
+            return new W3StaticCompressionNotSuccess(action, 10138, 9, "IISCompression", IISCompressionGuid, 3, "STATIC_COMPRESSION_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3StaticCompressionStart IIS_Compression_TransStartTemplate(Action<W3StaticCompressionStart> action)
+        static private W3StaticCompressionStart IISCompressionStaticCompressionStartTemplate(Action<W3StaticCompressionStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3StaticCompressionStart(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 1, "Start", ProviderGuid, ProviderName);
+            return new W3StaticCompressionStart(action, 10136, 9, "IISCompression", IISCompressionGuid, 1, "STATIC_COMPRESSION_START", ProviderGuid, ProviderName);
         }
-        static private W3StaticCompressionSuccess IIS_Compression_TransStopTemplate(Action<W3StaticCompressionSuccess> action)
+        static private W3StaticCompressionSuccess IISCompressionStaticCompressionSuccessTemplate(Action<W3StaticCompressionSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3StaticCompressionSuccess(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new W3StaticCompressionSuccess(action, 10137, 9, "IISCompression", IISCompressionGuid, 2, "STATIC_COMPRESSION_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3DynamicCompressionNotSuccess IIS_Compression_TransSuspendTemplate(Action<W3DynamicCompressionNotSuccess> action)
+        static private W3CGIFActivityTimeout IISFastCGIFastcgiActivityTimeoutTemplate(Action<W3CGIFActivityTimeout> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3DynamicCompressionNotSuccess(action, 10008, 9, "IIS_Compression_Trans", IISCompressionTransGuid, 8, "Suspend", ProviderGuid, ProviderName);
+            return new W3CGIFActivityTimeout(action, 10097, 7, "IISFastCGI", IISFastCGIGuid, 1, "FASTCGI_ACTIVITY_TIMEOUT", ProviderGuid, ProviderName);
         }
-        static private W3CGIFUnexpectedExit IIS_FastCgi_TransDC_StartTemplate(Action<W3CGIFUnexpectedExit> action)
+        static private W3CGIFAddJobObjectFail IISFastCGIFastcgiAddJobobjectFailTemplate(Action<W3CGIFAddJobObjectFail> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFUnexpectedExit(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 3, "DC_Start", ProviderGuid, ProviderName);
+            return new W3CGIFAddJobObjectFail(action, 10103, 7, "IISFastCGI", IISFastCGIGuid, 7, "FASTCGI_ADD_JOBOBJECT_FAIL", ProviderGuid, ProviderName);
         }
-        static private W3CGIFRapidFailureProtection IIS_FastCgi_TransDC_StopTemplate(Action<W3CGIFRapidFailureProtection> action)
+        static private W3CGIFAppMgrShutdown IISFastCGIFastcgiApplicationManagerShutdownTemplate(Action<W3CGIFAppMgrShutdown> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFRapidFailureProtection(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 4, "DC_Stop", ProviderGuid, ProviderName);
+            return new W3CGIFAppMgrShutdown(action, 10104, 7, "IISFastCGI", IISFastCGIGuid, 8, "FASTCGI_APPLICATION_MANAGER_SHUTDOWN", ProviderGuid, ProviderName);
         }
-        static private W3CGIFPathNotFound IIS_FastCgi_TransExtensionTemplate(Action<W3CGIFPathNotFound> action)
+        static private W3CGIFAssignProcess IISFastCGIFastcgiAssignProcessTemplate(Action<W3CGIFAssignProcess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFPathNotFound(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 5, "Extension", ProviderGuid, ProviderName);
+            return new W3CGIFAssignProcess(action, 10113, 7, "IISFastCGI", IISFastCGIGuid, 17, "FASTCGI_ASSIGN_PROCESS", ProviderGuid, ProviderName);
         }
-        static private W3CGIFUnknownError IIS_FastCgi_TransOpcode10Template(Action<W3CGIFUnknownError> action)
+        static private W3CGIFEnd IISFastCGIFastcgiEndTemplate(Action<W3CGIFEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFUnknownError(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
+            return new W3CGIFEnd(action, 10115, 7, "IISFastCGI", IISFastCGIGuid, 19, "FASTCGI_END", ProviderGuid, ProviderName);
         }
-        static private W3CGIFResponseWritten IIS_FastCgi_TransOpcode11Template(Action<W3CGIFResponseWritten> action)
+        static private W3CGIFPathNotFound IISFastCGIFastcgiPathNotFoundTemplate(Action<W3CGIFPathNotFound> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFResponseWritten(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
+            return new W3CGIFPathNotFound(action, 10101, 7, "IISFastCGI", IISFastCGIGuid, 5, "FASTCGI_PATH_NOT_FOUND", ProviderGuid, ProviderName);
         }
-        static private W3CGIFWaitingForResponse IIS_FastCgi_TransOpcode12Template(Action<W3CGIFWaitingForResponse> action)
+        static private W3CGIFQueueFull IISFastCGIFastcgiQueueFullTemplate(Action<W3CGIFQueueFull> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFWaitingForResponse(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
+            return new W3CGIFQueueFull(action, 10105, 7, "IISFastCGI", IISFastCGIGuid, 9, "FASTCGI_QUEUE_FULL", ProviderGuid, ProviderName);
         }
-        static private W3CGIFTraceError IIS_FastCgi_TransOpcode13Template(Action<W3CGIFTraceError> action)
+        static private W3CGIFQueueRequest IISFastCGIFastcgiQueueRequestTemplate(Action<W3CGIFQueueRequest> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFTraceError(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
+            return new W3CGIFQueueRequest(action, 10112, 7, "IISFastCGI", IISFastCGIGuid, 16, "FASTCGI_QUEUE_REQUEST", ProviderGuid, ProviderName);
         }
-        static private W3CGIFTraceWarning IIS_FastCgi_TransOpcode14Template(Action<W3CGIFTraceWarning> action)
+        static private W3CGIFRapidFailureProtection IISFastCGIFastcgiRapidFailureProtectionTemplate(Action<W3CGIFRapidFailureProtection> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFTraceWarning(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
+            return new W3CGIFRapidFailureProtection(action, 10100, 7, "IISFastCGI", IISFastCGIGuid, 4, "FASTCGI_RAPID_FAILURE_PROTECTION", ProviderGuid, ProviderName);
         }
-        static private W3CGIFTraceInfo IIS_FastCgi_TransOpcode15Template(Action<W3CGIFTraceInfo> action)
+        static private W3CGIFRequestTimeout IISFastCGIFastcgiRequestTimeoutTemplate(Action<W3CGIFRequestTimeout> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFTraceInfo(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
+            return new W3CGIFRequestTimeout(action, 10098, 7, "IISFastCGI", IISFastCGIGuid, 2, "FASTCGI_REQUEST_TIMEOUT", ProviderGuid, ProviderName);
         }
-        static private W3CGIFQueueRequest IIS_FastCgi_TransOpcode16Template(Action<W3CGIFQueueRequest> action)
+        static private W3CGIFResponseWritten IISFastCGIFastcgiResponseWrittenTemplate(Action<W3CGIFResponseWritten> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFQueueRequest(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 16, "Opcode16", ProviderGuid, ProviderName);
+            return new W3CGIFResponseWritten(action, 10107, 7, "IISFastCGI", IISFastCGIGuid, 11, "FASTCGI_RESPONSE_WRITTEN", ProviderGuid, ProviderName);
         }
-        static private W3CGIFAssignProcess IIS_FastCgi_TransOpcode17Template(Action<W3CGIFAssignProcess> action)
+        static private W3CGIFScriptProcessorMissing IISFastCGIFastcgiScriptProcessorMissingTemplate(Action<W3CGIFScriptProcessorMissing> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFAssignProcess(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 17, "Opcode17", ProviderGuid, ProviderName);
+            return new W3CGIFScriptProcessorMissing(action, 10102, 7, "IISFastCGI", IISFastCGIGuid, 6, "FASTCGI_SCRIPT_PROCESSOR_MISSING", ProviderGuid, ProviderName);
         }
-        static private W3CGIFStart IIS_FastCgi_TransOpcode18Template(Action<W3CGIFStart> action)
+        static private W3CGIFStart IISFastCGIFastcgiStartTemplate(Action<W3CGIFStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFStart(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 18, "Opcode18", ProviderGuid, ProviderName);
+            return new W3CGIFStart(action, 10114, 7, "IISFastCGI", IISFastCGIGuid, 18, "FASTCGI_START", ProviderGuid, ProviderName);
         }
-        static private W3CGIFEnd IIS_FastCgi_TransOpcode19Template(Action<W3CGIFEnd> action)
+        static private W3CGIFTraceError IISFastCGIFastcgiStderrTraceErrorTemplate(Action<W3CGIFTraceError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFEnd(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 19, "Opcode19", ProviderGuid, ProviderName);
+            return new W3CGIFTraceError(action, 10109, 7, "IISFastCGI", IISFastCGIGuid, 13, "FASTCGI_STDERR_TRACE_ERROR", ProviderGuid, ProviderName);
         }
-        static private W3CGIFScriptProcessorMissing IIS_FastCgi_TransReplyTemplate(Action<W3CGIFScriptProcessorMissing> action)
+        static private W3CGIFTraceInfo IISFastCGIFastcgiStderrTraceInfoTemplate(Action<W3CGIFTraceInfo> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFScriptProcessorMissing(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 6, "Reply", ProviderGuid, ProviderName);
+            return new W3CGIFTraceInfo(action, 10111, 7, "IISFastCGI", IISFastCGIGuid, 15, "FASTCGI_STDERR_TRACE_INFO", ProviderGuid, ProviderName);
         }
-        static private W3CGIFAddJobObjectFail IIS_FastCgi_TransResumeTemplate(Action<W3CGIFAddJobObjectFail> action)
+        static private W3CGIFTraceWarning IISFastCGIFastcgiStderrTraceWarningTemplate(Action<W3CGIFTraceWarning> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFAddJobObjectFail(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 7, "Resume", ProviderGuid, ProviderName);
+            return new W3CGIFTraceWarning(action, 10110, 7, "IISFastCGI", IISFastCGIGuid, 14, "FASTCGI_STDERR_TRACE_WARNING", ProviderGuid, ProviderName);
         }
-        static private W3CGIFQueueFull IIS_FastCgi_TransSendTemplate(Action<W3CGIFQueueFull> action)
+        static private W3CGIFUnexpectedExit IISFastCGIFastcgiUnexpectedExitTemplate(Action<W3CGIFUnexpectedExit> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFQueueFull(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 9, "Send", ProviderGuid, ProviderName);
+            return new W3CGIFUnexpectedExit(action, 10099, 7, "IISFastCGI", IISFastCGIGuid, 3, "FASTCGI_UNEXPECTED_EXIT", ProviderGuid, ProviderName);
         }
-        static private W3CGIFActivityTimeout IIS_FastCgi_TransStartTemplate(Action<W3CGIFActivityTimeout> action)
+        static private W3CGIFUnknownError IISFastCGIFastcgiUnknownErrorTemplate(Action<W3CGIFUnknownError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFActivityTimeout(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 1, "Start", ProviderGuid, ProviderName);
+            return new W3CGIFUnknownError(action, 10106, 7, "IISFastCGI", IISFastCGIGuid, 10, "FASTCGI_UNKNOWN_ERROR", ProviderGuid, ProviderName);
         }
-        static private W3CGIFRequestTimeout IIS_FastCgi_TransStopTemplate(Action<W3CGIFRequestTimeout> action)
+        static private W3CGIFWaitingForResponse IISFastCGIFastcgiWaitingForResponseTemplate(Action<W3CGIFWaitingForResponse> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFRequestTimeout(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new W3CGIFWaitingForResponse(action, 10108, 7, "IISFastCGI", IISFastCGIGuid, 12, "FASTCGI_WAITING_FOR_RESPONSE", ProviderGuid, ProviderName);
         }
-        static private W3CGIFAppMgrShutdown IIS_FastCgi_TransSuspendTemplate(Action<W3CGIFAppMgrShutdown> action)
+        static private W3FilterAccessDeniedEnd IISFilterFilterAccessDeniedEndTemplate(Action<W3FilterAccessDeniedEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3CGIFAppMgrShutdown(action, 10006, 7, "IIS_FastCgi_Trans", IISFastCgiTransGuid, 8, "Suspend", ProviderGuid, ProviderName);
+            return new W3FilterAccessDeniedEnd(action, 10083, 3, "IISFilter", IISFilterGuid, 30, "FILTER_ACCESS_DENIED_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterError IIS_Filter_TransOpcode12Template(Action<W3FilterError> action)
+        static private W3FilterAccessDeniedStart IISFilterFilterAccessDeniedStartTemplate(Action<W3FilterAccessDeniedStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterError(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
+            return new W3FilterAccessDeniedStart(action, 10082, 3, "IISFilter", IISFilterGuid, 29, "FILTER_ACCESS_DENIED_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterPreprocStart IIS_Filter_TransOpcode13Template(Action<W3FilterPreprocStart> action)
+        static private W3FilterAddReqHeader IISFilterFilterAddReqHeaderTemplate(Action<W3FilterAddReqHeader> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterPreprocStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
+            return new W3FilterAddReqHeader(action, 10085, 3, "IISFilter", IISFilterGuid, 32, "FILTER_ADD_REQ_HEADER", ProviderGuid, ProviderName);
         }
-        static private W3FilterPreprocEnd IIS_Filter_TransOpcode14Template(Action<W3FilterPreprocEnd> action)
+        static private W3FilterAddRespHeader IISFilterFilterAddRespHeaderTemplate(Action<W3FilterAddRespHeader> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterPreprocEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
+            return new W3FilterAddRespHeader(action, 10087, 3, "IISFilter", IISFilterGuid, 34, "FILTER_ADD_RESP_HEADER", ProviderGuid, ProviderName);
         }
-        static private W3FilterURLMapStart IIS_Filter_TransOpcode15Template(Action<W3FilterURLMapStart> action)
+        static private W3FilterAuthCompleteEnd IISFilterFilterAuthCompleteEndTemplate(Action<W3FilterAuthCompleteEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterURLMapStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
+            return new W3FilterAuthCompleteEnd(action, 10073, 3, "IISFilter", IISFilterGuid, 20, "FILTER_AUTH_COMPLETE_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterURLMapEnd IIS_Filter_TransOpcode16Template(Action<W3FilterURLMapEnd> action)
+        static private W3FilterAuthCompleteStart IISFilterFilterAuthCompleteStartTemplate(Action<W3FilterAuthCompleteStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterURLMapEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 16, "Opcode16", ProviderGuid, ProviderName);
+            return new W3FilterAuthCompleteStart(action, 10072, 3, "IISFilter", IISFilterGuid, 19, "FILTER_AUTH_COMPLETE_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterAuthenticationStart IIS_Filter_TransOpcode17Template(Action<W3FilterAuthenticationStart> action)
+        static private W3FilterAuthenticationEnd IISFilterFilterAuthenticationEndTemplate(Action<W3FilterAuthenticationEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAuthenticationStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 17, "Opcode17", ProviderGuid, ProviderName);
+            return new W3FilterAuthenticationEnd(action, 10071, 3, "IISFilter", IISFilterGuid, 18, "FILTER_AUTHENTICATION_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterAuthenticationEnd IIS_Filter_TransOpcode18Template(Action<W3FilterAuthenticationEnd> action)
+        static private W3FilterAuthenticationStart IISFilterFilterAuthenticationStartTemplate(Action<W3FilterAuthenticationStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAuthenticationEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 18, "Opcode18", ProviderGuid, ProviderName);
+            return new W3FilterAuthenticationStart(action, 10070, 3, "IISFilter", IISFilterGuid, 17, "FILTER_AUTHENTICATION_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterAuthCompleteStart IIS_Filter_TransOpcode19Template(Action<W3FilterAuthCompleteStart> action)
+        static private W3FilterEnd IISFilterFilterEndTemplate(Action<W3FilterEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAuthCompleteStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 19, "Opcode19", ProviderGuid, ProviderName);
+            return new W3FilterEnd(action, 10064, 3, "IISFilter", IISFilterGuid, 2, "FILTER_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterAuthCompleteEnd IIS_Filter_TransOpcode20Template(Action<W3FilterAuthCompleteEnd> action)
+        static private W3FilterEndOfRequestEnd IISFilterFilterEndOfRequestEndTemplate(Action<W3FilterEndOfRequestEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAuthCompleteEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 20, "Opcode20", ProviderGuid, ProviderName);
+            return new W3FilterEndOfRequestEnd(action, 10077, 3, "IISFilter", IISFilterGuid, 24, "FILTER_END_OF_REQUEST_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterSendResponseStart IIS_Filter_TransOpcode21Template(Action<W3FilterSendResponseStart> action)
+        static private W3FilterEndOfRequestStart IISFilterFilterEndOfRequestStartTemplate(Action<W3FilterEndOfRequestStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterSendResponseStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 21, "Opcode21", ProviderGuid, ProviderName);
+            return new W3FilterEndOfRequestStart(action, 10076, 3, "IISFilter", IISFilterGuid, 23, "FILTER_END_OF_REQUEST_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterSendResponseEnd IIS_Filter_TransOpcode22Template(Action<W3FilterSendResponseEnd> action)
+        static private W3FilterError IISFilterFilterErrorTemplate(Action<W3FilterError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterSendResponseEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 22, "Opcode22", ProviderGuid, ProviderName);
+            return new W3FilterError(action, 10065, 3, "IISFilter", IISFilterGuid, 12, "FILTER_ERROR", ProviderGuid, ProviderName);
         }
-        static private W3FilterEndOfRequestStart IIS_Filter_TransOpcode23Template(Action<W3FilterEndOfRequestStart> action)
+        static private W3FilterLogEnd IISFilterFilterLogEndTemplate(Action<W3FilterLogEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterEndOfRequestStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 23, "Opcode23", ProviderGuid, ProviderName);
+            return new W3FilterLogEnd(action, 10079, 3, "IISFilter", IISFilterGuid, 26, "FILTER_LOG_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterEndOfRequestEnd IIS_Filter_TransOpcode24Template(Action<W3FilterEndOfRequestEnd> action)
+        static private W3FilterLogStart IISFilterFilterLogStartTemplate(Action<W3FilterLogStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterEndOfRequestEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 24, "Opcode24", ProviderGuid, ProviderName);
+            return new W3FilterLogStart(action, 10078, 3, "IISFilter", IISFilterGuid, 25, "FILTER_LOG_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterLogStart IIS_Filter_TransOpcode25Template(Action<W3FilterLogStart> action)
+        static private W3FilterPreprocEnd IISFilterFilterPreprocHeadersEndTemplate(Action<W3FilterPreprocEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterLogStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 25, "Opcode25", ProviderGuid, ProviderName);
+            return new W3FilterPreprocEnd(action, 10067, 3, "IISFilter", IISFilterGuid, 14, "FILTER_PREPROC_HEADERS_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterLogEnd IIS_Filter_TransOpcode26Template(Action<W3FilterLogEnd> action)
+        static private W3FilterPreprocStart IISFilterFilterPreprocHeadersStartTemplate(Action<W3FilterPreprocStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterLogEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 26, "Opcode26", ProviderGuid, ProviderName);
+            return new W3FilterPreprocStart(action, 10066, 3, "IISFilter", IISFilterGuid, 13, "FILTER_PREPROC_HEADERS_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterSendRawDataStart IIS_Filter_TransOpcode27Template(Action<W3FilterSendRawDataStart> action)
+        static private W3FilterSendRawDataEnd IISFilterFilterSendRawDataEndTemplate(Action<W3FilterSendRawDataEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterSendRawDataStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 27, "Opcode27", ProviderGuid, ProviderName);
+            return new W3FilterSendRawDataEnd(action, 10081, 3, "IISFilter", IISFilterGuid, 28, "FILTER_SEND_RAW_DATA_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterSendRawDataEnd IIS_Filter_TransOpcode28Template(Action<W3FilterSendRawDataEnd> action)
+        static private W3FilterSendRawDataStart IISFilterFilterSendRawDataStartTemplate(Action<W3FilterSendRawDataStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterSendRawDataEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 28, "Opcode28", ProviderGuid, ProviderName);
+            return new W3FilterSendRawDataStart(action, 10080, 3, "IISFilter", IISFilterGuid, 27, "FILTER_SEND_RAW_DATA_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterAccessDeniedStart IIS_Filter_TransOpcode29Template(Action<W3FilterAccessDeniedStart> action)
+        static private W3FilterSendResponseEnd IISFilterFilterSendResponseEndTemplate(Action<W3FilterSendResponseEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAccessDeniedStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 29, "Opcode29", ProviderGuid, ProviderName);
+            return new W3FilterSendResponseEnd(action, 10075, 3, "IISFilter", IISFilterGuid, 22, "FILTER_SEND_RESPONSE_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterAccessDeniedEnd IIS_Filter_TransOpcode30Template(Action<W3FilterAccessDeniedEnd> action)
+        static private W3FilterSendResponseStart IISFilterFilterSendResponseStartTemplate(Action<W3FilterSendResponseStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAccessDeniedEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 30, "Opcode30", ProviderGuid, ProviderName);
+            return new W3FilterSendResponseStart(action, 10074, 3, "IISFilter", IISFilterGuid, 21, "FILTER_SEND_RESPONSE_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterSetReqHeader IIS_Filter_TransOpcode31Template(Action<W3FilterSetReqHeader> action)
+        static private W3FilterSetReqHeader IISFilterFilterSetReqHeaderTemplate(Action<W3FilterSetReqHeader> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterSetReqHeader(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 31, "Opcode31", ProviderGuid, ProviderName);
+            return new W3FilterSetReqHeader(action, 10084, 3, "IISFilter", IISFilterGuid, 31, "FILTER_SET_REQ_HEADER", ProviderGuid, ProviderName);
         }
-        static private W3FilterAddReqHeader IIS_Filter_TransOpcode32Template(Action<W3FilterAddReqHeader> action)
+        static private W3FilterSetRespHeader IISFilterFilterSetRespHeaderTemplate(Action<W3FilterSetRespHeader> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAddReqHeader(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 32, "Opcode32", ProviderGuid, ProviderName);
+            return new W3FilterSetRespHeader(action, 10086, 3, "IISFilter", IISFilterGuid, 33, "FILTER_SET_RESP_HEADER", ProviderGuid, ProviderName);
         }
-        static private W3FilterSetRespHeader IIS_Filter_TransOpcode33Template(Action<W3FilterSetRespHeader> action)
+        static private W3FilterStart IISFilterFilterStartTemplate(Action<W3FilterStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterSetRespHeader(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 33, "Opcode33", ProviderGuid, ProviderName);
+            return new W3FilterStart(action, 10063, 3, "IISFilter", IISFilterGuid, 1, "FILTER_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterAddRespHeader IIS_Filter_TransOpcode34Template(Action<W3FilterAddRespHeader> action)
+        static private W3FilterURLMapEnd IISFilterFilterUrlMapEndTemplate(Action<W3FilterURLMapEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterAddRespHeader(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 34, "Opcode34", ProviderGuid, ProviderName);
+            return new W3FilterURLMapEnd(action, 10069, 3, "IISFilter", IISFilterGuid, 16, "FILTER_URL_MAP_END", ProviderGuid, ProviderName);
         }
-        static private W3FilterStart IIS_Filter_TransStartTemplate(Action<W3FilterStart> action)
+        static private W3FilterURLMapStart IISFilterFilterUrlMapStartTemplate(Action<W3FilterURLMapStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterStart(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 1, "Start", ProviderGuid, ProviderName);
+            return new W3FilterURLMapStart(action, 10068, 3, "IISFilter", IISFilterGuid, 15, "FILTER_URL_MAP_START", ProviderGuid, ProviderName);
         }
-        static private W3FilterEnd IIS_Filter_TransStopTemplate(Action<W3FilterEnd> action)
+        static private IISGeneralConfigChangeNotification IISGeneralConfigChangeNotificationTemplate(Action<IISGeneralConfigChangeNotification> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3FilterEnd(action, 10003, 3, "IIS_Filter_Trans", IISFilterTransGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new IISGeneralConfigChangeNotification(action, 10020, 0, "IISGeneral", IISGeneralGuid, 40, "CONFIG_CHANGE_NOTIFICATION", ProviderGuid, ProviderName);
         }
-        static private W3SecIllegalShortFilename IIS_Security_TransOpcode10Template(Action<W3SecIllegalShortFilename> action)
+        static private IISGeneralFileChangeNotification IISGeneralFileChangeNotificationTemplate(Action<IISGeneralFileChangeNotification> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecIllegalShortFilename(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
+            return new IISGeneralFileChangeNotification(action, 10019, 0, "IISGeneral", IISGeneralGuid, 39, "FILE_CHANGE_NOTIFICATION", ProviderGuid, ProviderName);
         }
-        static private W3SecRejectedIP IIS_Security_TransOpcode11Template(Action<W3SecRejectedIP> action)
+        static private W3GeneralCGIHandler IISGeneralGeneralCgiHandlerTemplate(Action<W3GeneralCGIHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecRejectedIP(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
+            return new W3GeneralCGIHandler(action, 10003, 0, "IISGeneral", IISGeneralGuid, 11, "GENERAL_CGI_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3SecRejectedHostname IIS_Security_TransOpcode12Template(Action<W3SecRejectedHostname> action)
+        static private W3GeneralChildRequestEnd IISGeneralGeneralChildRequestEndTemplate(Action<W3GeneralChildRequestEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecRejectedHostname(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
+            return new W3GeneralChildRequestEnd(action, 10012, 0, "IISGeneral", IISGeneralGuid, 32, "GENERAL_CHILD_REQUEST_END", ProviderGuid, ProviderName);
         }
-        static private W3SecRequireSSL128 IIS_Security_TransOpcode13Template(Action<W3SecRequireSSL128> action)
+        static private W3GeneralChildRequestStart IISGeneralGeneralChildRequestStartTemplate(Action<W3GeneralChildRequestStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecRequireSSL128(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
+            return new W3GeneralChildRequestStart(action, 10011, 0, "IISGeneral", IISGeneralGuid, 31, "GENERAL_CHILD_REQUEST_START", ProviderGuid, ProviderName);
         }
-        static private W3SecFileAccessDenied IIS_Security_TransOpcode14Template(Action<W3SecFileAccessDenied> action)
+        static private W3GeneralDavHandler IISGeneralGeneralDavHandlerTemplate(Action<W3GeneralDavHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecFileAccessDenied(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
+            return new W3GeneralDavHandler(action, 10007, 0, "IISGeneral", IISGeneralGuid, 15, "GENERAL_DAV_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3SecDeniedByMimemap IIS_Security_TransOpcode15Template(Action<W3SecDeniedByMimemap> action)
+        static private W3GeneralEndpointInformation IISGeneralGeneralEndpointInformationTemplate(Action<W3GeneralEndpointInformation> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecDeniedByMimemap(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
+            return new W3GeneralEndpointInformation(action, 10035, 0, "IISGeneral", IISGeneralGuid, 55, "GENERAL_ENDPOINT_INFORMATION", ProviderGuid, ProviderName);
         }
-        static private W3SecDeniedByISAPIRestriction IIS_Security_TransOpcode16Template(Action<W3SecDeniedByISAPIRestriction> action)
+        static private W3GeneralFlushResponseEnd IISGeneralGeneralFlushResponseEndTemplate(Action<W3GeneralFlushResponseEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecDeniedByISAPIRestriction(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 16, "Opcode16", ProviderGuid, ProviderName);
+            return new W3GeneralFlushResponseEnd(action, 10016, 0, "IISGeneral", IISGeneralGuid, 36, "GENERAL_FLUSH_RESPONSE_END", ProviderGuid, ProviderName);
         }
-        static private W3SecDeniedByCGIRestriction IIS_Security_TransOpcode17Template(Action<W3SecDeniedByCGIRestriction> action)
+        static private W3GeneralFlushResponseStart IISGeneralGeneralFlushResponseStartTemplate(Action<W3GeneralFlushResponseStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecDeniedByCGIRestriction(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 17, "Opcode17", ProviderGuid, ProviderName);
+            return new W3GeneralFlushResponseStart(action, 10015, 0, "IISGeneral", IISGeneralGuid, 35, "GENERAL_FLUSH_RESPONSE_START", ProviderGuid, ProviderName);
         }
-        static private W3SecDeniedByAccessFlags IIS_Security_TransOpcode18Template(Action<W3SecDeniedByAccessFlags> action)
+        static private W3GeneralGetURLMetadata IISGeneralGeneralGetUrlMetadataTemplate(Action<W3GeneralGetURLMetadata> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SecDeniedByAccessFlags(action, 10002, 2, "IIS_Security_Trans", IISSecurityTransGuid, 18, "Opcode18", ProviderGuid, ProviderName);
+            return new W3GeneralGetURLMetadata(action, 10010, 0, "IISGeneral", IISGeneralGuid, 30, "GENERAL_GET_URL_METADATA", ProviderGuid, ProviderName);
         }
-        static private W3GeneralStaticFileHandler IIS_TransOpcode10Template(Action<W3GeneralStaticFileHandler> action)
+        static private W3GeneralISAPIHandler IISGeneralGeneralIsapiHandlerTemplate(Action<W3GeneralISAPIHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralStaticFileHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
+            return new W3GeneralISAPIHandler(action, 10004, 0, "IISGeneral", IISGeneralGuid, 12, "GENERAL_ISAPI_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3GeneralCGIHandler IIS_TransOpcode11Template(Action<W3GeneralCGIHandler> action)
+        static private W3GeneralMapHandler IISGeneralGeneralMapHandlerTemplate(Action<W3GeneralMapHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralCGIHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
+            return new W3GeneralMapHandler(action, 10014, 0, "IISGeneral", IISGeneralGuid, 34, "GENERAL_MAP_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3GeneralISAPIHandler IIS_TransOpcode12Template(Action<W3GeneralISAPIHandler> action)
+        static private W3GeneralModuleFactoryFailed IISGeneralGeneralModuleFactoryFailedTemplate(Action<W3GeneralModuleFactoryFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralISAPIHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
+            return new W3GeneralModuleFactoryFailed(action, 10034, 0, "IISGeneral", IISGeneralGuid, 54, "GENERAL_MODULE_FACTORY_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3GeneralOopISAPIHandler IIS_TransOpcode13Template(Action<W3GeneralOopISAPIHandler> action)
+        static private W3GeneralNotSendCustomError IISGeneralGeneralNotSendCustomErrorTemplate(Action<W3GeneralNotSendCustomError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralOopISAPIHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
+            return new W3GeneralNotSendCustomError(action, 10032, 0, "IISGeneral", IISGeneralGuid, 52, "GENERAL_NOT_SEND_CUSTOM_ERROR", ProviderGuid, ProviderName);
         }
-        static private W3GeneralRedirectionHandler IIS_TransOpcode14Template(Action<W3GeneralRedirectionHandler> action)
+        static private W3GeneralOopISAPIHandler IISGeneralGeneralOopIsapiHandlerTemplate(Action<W3GeneralOopISAPIHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralRedirectionHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
+            return new W3GeneralOopISAPIHandler(action, 10005, 0, "IISGeneral", IISGeneralGuid, 13, "GENERAL_OOP_ISAPI_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3GeneralDavHandler IIS_TransOpcode15Template(Action<W3GeneralDavHandler> action)
+        static private W3GeneralOptionsHandler IISGeneralGeneralOptionsHandlerTemplate(Action<W3GeneralOptionsHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralDavHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
+            return new W3GeneralOptionsHandler(action, 10008, 0, "IISGeneral", IISGeneralGuid, 16, "GENERAL_OPTIONS_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3GeneralOptionsHandler IIS_TransOpcode16Template(Action<W3GeneralOptionsHandler> action)
+        static private W3GeneralReadEntityEnd IISGeneralGeneralReadEntityEndTemplate(Action<W3GeneralReadEntityEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralOptionsHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 16, "Opcode16", ProviderGuid, ProviderName);
+            return new W3GeneralReadEntityEnd(action, 10018, 0, "IISGeneral", IISGeneralGuid, 38, "GENERAL_READ_ENTITY_END", ProviderGuid, ProviderName);
         }
-        static private W3GeneralTraceHandler IIS_TransOpcode17Template(Action<W3GeneralTraceHandler> action)
+        static private W3GeneralReadEntityStart IISGeneralGeneralReadEntityStartTemplate(Action<W3GeneralReadEntityStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralTraceHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 17, "Opcode17", ProviderGuid, ProviderName);
+            return new W3GeneralReadEntityStart(action, 10017, 0, "IISGeneral", IISGeneralGuid, 37, "GENERAL_READ_ENTITY_START", ProviderGuid, ProviderName);
         }
-        static private W3SendResponse IIS_TransOpcode18Template(Action<W3SendResponse> action)
+        static private W3GeneralRedirectionHandler IISGeneralGeneralRedirectionHandlerTemplate(Action<W3GeneralRedirectionHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SendResponse(action, 10000, 0, "IIS_Trans", IISTransGuid, 18, "Opcode18", ProviderGuid, ProviderName);
+            return new W3GeneralRedirectionHandler(action, 10006, 0, "IISGeneral", IISGeneralGuid, 14, "GENERAL_REDIRECTION_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3SendResponse IIS_TransOpcode19Template(Action<W3SendResponse> action)
+        static private W3GeneralEndNewRequest IISGeneralGeneralRequestEndTemplate(Action<W3GeneralEndNewRequest> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SendResponse(action, 10000, 0, "IIS_Trans", IISTransGuid, 19, "Opcode19", ProviderGuid, ProviderName);
+            return new W3GeneralEndNewRequest(action, 10001, 0, "IISGeneral", IISGeneralGuid, 2, "GENERAL_REQUEST_END", ProviderGuid, ProviderName);
         }
-        static private W3SendResponse IIS_TransOpcode20Template(Action<W3SendResponse> action)
+        static private W3GeneralRequestEntity IISGeneralGeneralRequestEntityTemplate(Action<W3GeneralRequestEntity> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SendResponse(action, 10000, 0, "IIS_Trans", IISTransGuid, 20, "Opcode20", ProviderGuid, ProviderName);
+            return new W3GeneralRequestEntity(action, 10031, 0, "IISGeneral", IISGeneralGuid, 51, "GENERAL_REQUEST_ENTITY", ProviderGuid, ProviderName);
         }
-        static private W3SendResponse IIS_TransOpcode21Template(Action<W3SendResponse> action)
+        static private W3GeneralRequestHeaders IISGeneralGeneralRequestHeadersTemplate(Action<W3GeneralRequestHeaders> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SendResponse(action, 10000, 0, "IIS_Trans", IISTransGuid, 21, "Opcode21", ProviderGuid, ProviderName);
+            return new W3GeneralRequestHeaders(action, 10030, 0, "IISGeneral", IISGeneralGuid, 50, "GENERAL_REQUEST_HEADERS", ProviderGuid, ProviderName);
         }
-        static private W3SendResponse IIS_TransOpcode22Template(Action<W3SendResponse> action)
+        static private W3GeneralStartNewRequest IISGeneralGeneralRequestStartTemplate(Action<W3GeneralStartNewRequest> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SendResponse(action, 10000, 0, "IIS_Trans", IISTransGuid, 22, "Opcode22", ProviderGuid, ProviderName);
+            return new W3GeneralStartNewRequest(action, 10000, 0, "IISGeneral", IISGeneralGuid, 1, "GENERAL_REQUEST_START", ProviderGuid, ProviderName);
         }
-        static private W3SendResponse IIS_TransOpcode23Template(Action<W3SendResponse> action)
+        static private W3GeneralResponseEntityBuffer IISGeneralGeneralResponseEntityBufferTemplate(Action<W3GeneralResponseEntityBuffer> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SendResponse(action, 10000, 0, "IIS_Trans", IISTransGuid, 23, "Opcode23", ProviderGuid, ProviderName);
+            return new W3GeneralResponseEntityBuffer(action, 10029, 0, "IISGeneral", IISGeneralGuid, 49, "GENERAL_RESPONSE_ENTITY_BUFFER", ProviderGuid, ProviderName);
         }
-        static private W3SendResponse IIS_TransOpcode24Template(Action<W3SendResponse> action)
+        static private W3GeneralResponseEntityFile IISGeneralGeneralResponseEntityFileTemplate(Action<W3GeneralResponseEntityFile> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3SendResponse(action, 10000, 0, "IIS_Trans", IISTransGuid, 24, "Opcode24", ProviderGuid, ProviderName);
+            return new W3GeneralResponseEntityFile(action, 10028, 0, "IISGeneral", IISGeneralGuid, 48, "GENERAL_RESPONSE_ENTITY_FILE", ProviderGuid, ProviderName);
         }
-        static private W3GeneralGetURLMetadata IIS_TransOpcode30Template(Action<W3GeneralGetURLMetadata> action)
+        static private W3GeneralResponseHeaders IISGeneralGeneralResponseHeadersTemplate(Action<W3GeneralResponseHeaders> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralGetURLMetadata(action, 10000, 0, "IIS_Trans", IISTransGuid, 30, "Opcode30", ProviderGuid, ProviderName);
+            return new W3GeneralResponseHeaders(action, 10027, 0, "IISGeneral", IISGeneralGuid, 47, "GENERAL_RESPONSE_HEADERS", ProviderGuid, ProviderName);
         }
-        static private W3GeneralChildRequestStart IIS_TransOpcode31Template(Action<W3GeneralChildRequestStart> action)
+        static private W3GeneralSendCustomError IISGeneralGeneralSendCustomErrorTemplate(Action<W3GeneralSendCustomError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralChildRequestStart(action, 10000, 0, "IIS_Trans", IISTransGuid, 31, "Opcode31", ProviderGuid, ProviderName);
+            return new W3GeneralSendCustomError(action, 10013, 0, "IISGeneral", IISGeneralGuid, 33, "GENERAL_SEND_CUSTOM_ERROR", ProviderGuid, ProviderName);
         }
-        static private W3GeneralChildRequestEnd IIS_TransOpcode32Template(Action<W3GeneralChildRequestEnd> action)
+        static private W3GeneralSetRequestHeader IISGeneralGeneralSetRequestHeaderTemplate(Action<W3GeneralSetRequestHeader> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralChildRequestEnd(action, 10000, 0, "IIS_Trans", IISTransGuid, 32, "Opcode32", ProviderGuid, ProviderName);
+            return new W3GeneralSetRequestHeader(action, 10033, 0, "IISGeneral", IISGeneralGuid, 53, "GENERAL_SET_REQUEST_HEADER", ProviderGuid, ProviderName);
         }
-        static private W3GeneralSendCustomError IIS_TransOpcode33Template(Action<W3GeneralSendCustomError> action)
+        static private W3GeneralStaticFileHandler IISGeneralGeneralStaticFileHandlerTemplate(Action<W3GeneralStaticFileHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralSendCustomError(action, 10000, 0, "IIS_Trans", IISTransGuid, 33, "Opcode33", ProviderGuid, ProviderName);
+            return new W3GeneralStaticFileHandler(action, 10002, 0, "IISGeneral", IISGeneralGuid, 10, "GENERAL_STATIC_FILE_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3GeneralMapHandler IIS_TransOpcode34Template(Action<W3GeneralMapHandler> action)
+        static private W3GeneralTraceHandler IISGeneralGeneralTraceHandlerTemplate(Action<W3GeneralTraceHandler> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralMapHandler(action, 10000, 0, "IIS_Trans", IISTransGuid, 34, "Opcode34", ProviderGuid, ProviderName);
+            return new W3GeneralTraceHandler(action, 10009, 0, "IISGeneral", IISGeneralGuid, 17, "GENERAL_TRACE_HANDLER", ProviderGuid, ProviderName);
         }
-        static private W3GeneralFlushResponseStart IIS_TransOpcode35Template(Action<W3GeneralFlushResponseStart> action)
+        static private IISGeneralHandlerChanged IISGeneralHandlerChangedTemplate(Action<IISGeneralHandlerChanged> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralFlushResponseStart(action, 10000, 0, "IIS_Trans", IISTransGuid, 35, "Opcode35", ProviderGuid, ProviderName);
+            return new IISGeneralHandlerChanged(action, 10023, 0, "IISGeneral", IISGeneralGuid, 43, "HANDLER_CHANGED", ProviderGuid, ProviderName);
         }
-        static private W3GeneralFlushResponseEnd IIS_TransOpcode36Template(Action<W3GeneralFlushResponseEnd> action)
+        static private IISGeneralHandlerPreconditionNotMatch IISGeneralHandlerPreconditionNotMatchTemplate(Action<IISGeneralHandlerPreconditionNotMatch> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralFlushResponseEnd(action, 10000, 0, "IIS_Trans", IISTransGuid, 36, "Opcode36", ProviderGuid, ProviderName);
+            return new IISGeneralHandlerPreconditionNotMatch(action, 10026, 0, "IISGeneral", IISGeneralGuid, 46, "HANDLER_PRECONDITION_NOT_MATCH", ProviderGuid, ProviderName);
         }
-        static private W3GeneralReadEntityStart IIS_TransOpcode37Template(Action<W3GeneralReadEntityStart> action)
+        static private IISGeneralModulePreconditionNotMatch IISGeneralModulePreconditionNotMatchTemplate(Action<IISGeneralModulePreconditionNotMatch> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralReadEntityStart(action, 10000, 0, "IIS_Trans", IISTransGuid, 37, "Opcode37", ProviderGuid, ProviderName);
+            return new IISGeneralModulePreconditionNotMatch(action, 10025, 0, "IISGeneral", IISGeneralGuid, 45, "MODULE_PRECONDITION_NOT_MATCH", ProviderGuid, ProviderName);
         }
-        static private W3GeneralReadEntityEnd IIS_TransOpcode38Template(Action<W3GeneralReadEntityEnd> action)
+        static private IISGeneralUrlChanged IISGeneralUrlChangedTemplate(Action<IISGeneralUrlChanged> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralReadEntityEnd(action, 10000, 0, "IIS_Trans", IISTransGuid, 38, "Opcode38", ProviderGuid, ProviderName);
+            return new IISGeneralUrlChanged(action, 10022, 0, "IISGeneral", IISGeneralGuid, 42, "URL_CHANGED", ProviderGuid, ProviderName);
         }
-        static private IISGeneralFileChangeNotification IIS_TransOpcode39Template(Action<IISGeneralFileChangeNotification> action)
+        static private IISGeneralUserSet IISGeneralUserSetTemplate(Action<IISGeneralUserSet> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralFileChangeNotification(action, 10000, 0, "IIS_Trans", IISTransGuid, 39, "Opcode39", ProviderGuid, ProviderName);
+            return new IISGeneralUserSet(action, 10024, 0, "IISGeneral", IISGeneralGuid, 44, "USER_SET", ProviderGuid, ProviderName);
         }
-        static private IISGeneralConfigChangeNotification IIS_TransOpcode40Template(Action<IISGeneralConfigChangeNotification> action)
+        static private IISGeneralVirtualModuleUnresolved IISGeneralVirtualModuleUnresolvedTemplate(Action<IISGeneralVirtualModuleUnresolved> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralConfigChangeNotification(action, 10000, 0, "IIS_Trans", IISTransGuid, 40, "Opcode40", ProviderGuid, ProviderName);
+            return new IISGeneralVirtualModuleUnresolved(action, 10021, 0, "IISGeneral", IISGeneralGuid, 41, "VIRTUAL_MODULE_UNRESOLVED", ProviderGuid, ProviderName);
         }
-        static private IISGeneralVirtualModuleUnresolved IIS_TransOpcode41Template(Action<IISGeneralVirtualModuleUnresolved> action)
+        static private W3ISAPIEnd IISISAPIIsapiEndTemplate(Action<W3ISAPIEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralVirtualModuleUnresolved(action, 10000, 0, "IIS_Trans", IISTransGuid, 41, "Opcode41", ProviderGuid, ProviderName);
+            return new W3ISAPIEnd(action, 10089, 5, "IISISAPI", IISISAPIGuid, 2, "ISAPI_END", ProviderGuid, ProviderName);
         }
-        static private IISGeneralUrlChanged IIS_TransOpcode42Template(Action<IISGeneralUrlChanged> action)
+        static private W3ISAPIStart IISISAPIIsapiStartTemplate(Action<W3ISAPIStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralUrlChanged(action, 10000, 0, "IIS_Trans", IISTransGuid, 42, "Opcode42", ProviderGuid, ProviderName);
+            return new W3ISAPIStart(action, 10088, 5, "IISISAPI", IISISAPIGuid, 1, "ISAPI_START", ProviderGuid, ProviderName);
         }
-        static private IISGeneralHandlerChanged IIS_TransOpcode43Template(Action<IISGeneralHandlerChanged> action)
+        static private IISModuleEventsModuleCriticalError IISModuleModuleCriticalErrorTemplate(Action<IISModuleEventsModuleCriticalError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralHandlerChanged(action, 10000, 0, "IIS_Trans", IISTransGuid, 43, "Opcode43", ProviderGuid, ProviderName);
+            return new IISModuleEventsModuleCriticalError(action, 10168, 12, "IISModule", IISModuleGuid, 3, "MODULE_CRITICAL_ERROR", ProviderGuid, ProviderName);
         }
-        static private IISGeneralUserSet IIS_TransOpcode44Template(Action<IISGeneralUserSet> action)
+        static private IISModuleEventsModuleEnd IISModuleModuleEndTemplate(Action<IISModuleEventsModuleEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralUserSet(action, 10000, 0, "IIS_Trans", IISTransGuid, 44, "Opcode44", ProviderGuid, ProviderName);
+            return new IISModuleEventsModuleEnd(action, 10167, 12, "IISModule", IISModuleGuid, 2, "MODULE_END", ProviderGuid, ProviderName);
         }
-        static private IISGeneralModulePreconditionNotMatch IIS_TransOpcode45Template(Action<IISGeneralModulePreconditionNotMatch> action)
+        static private IISModuleEventsModuleError IISModuleModuleErrorTemplate(Action<IISModuleEventsModuleError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralModulePreconditionNotMatch(action, 10000, 0, "IIS_Trans", IISTransGuid, 45, "Opcode45", ProviderGuid, ProviderName);
+            return new IISModuleEventsModuleError(action, 10169, 12, "IISModule", IISModuleGuid, 4, "MODULE_ERROR", ProviderGuid, ProviderName);
         }
-        static private IISGeneralHandlerPreconditionNotMatch IIS_TransOpcode46Template(Action<IISGeneralHandlerPreconditionNotMatch> action)
+        static private IISModuleEventsModuleInformation IISModuleModuleInformationTemplate(Action<IISModuleEventsModuleInformation> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISGeneralHandlerPreconditionNotMatch(action, 10000, 0, "IIS_Trans", IISTransGuid, 46, "Opcode46", ProviderGuid, ProviderName);
+            return new IISModuleEventsModuleInformation(action, 10171, 12, "IISModule", IISModuleGuid, 6, "MODULE_INFORMATION", ProviderGuid, ProviderName);
         }
-        static private W3GeneralResponseHeaders IIS_TransOpcode47Template(Action<W3GeneralResponseHeaders> action)
+        static private IISModuleEventsModuleStart IISModuleModuleStartTemplate(Action<IISModuleEventsModuleStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralResponseHeaders(action, 10000, 0, "IIS_Trans", IISTransGuid, 47, "Opcode47", ProviderGuid, ProviderName);
+            return new IISModuleEventsModuleStart(action, 10166, 12, "IISModule", IISModuleGuid, 1, "MODULE_START", ProviderGuid, ProviderName);
         }
-        static private W3GeneralResponseEntityFile IIS_TransOpcode48Template(Action<W3GeneralResponseEntityFile> action)
+        static private IISModuleEventsModuleVerbose IISModuleModuleVerboseTemplate(Action<IISModuleEventsModuleVerbose> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralResponseEntityFile(action, 10000, 0, "IIS_Trans", IISTransGuid, 48, "Opcode48", ProviderGuid, ProviderName);
+            return new IISModuleEventsModuleVerbose(action, 10172, 12, "IISModule", IISModuleGuid, 7, "MODULE_VERBOSE", ProviderGuid, ProviderName);
         }
-        static private W3GeneralResponseEntityBuffer IIS_TransOpcode49Template(Action<W3GeneralResponseEntityBuffer> action)
+        static private IISModuleEventsModuleWarning IISModuleModuleWarningTemplate(Action<IISModuleEventsModuleWarning> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralResponseEntityBuffer(action, 10000, 0, "IIS_Trans", IISTransGuid, 49, "Opcode49", ProviderGuid, ProviderName);
+            return new IISModuleEventsModuleWarning(action, 10170, 12, "IISModule", IISModuleGuid, 5, "MODULE_WARNING", ProviderGuid, ProviderName);
         }
-        static private W3GeneralRequestHeaders IIS_TransOpcode50Template(Action<W3GeneralRequestHeaders> action)
+        static private IISRequestNotificationEventsResponseErrorStatus IISRequestNotificationModuleSetResponseErrorStatusTemplate(Action<IISRequestNotificationEventsResponseErrorStatus> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralRequestHeaders(action, 10000, 0, "IIS_Trans", IISTransGuid, 50, "Opcode50", ProviderGuid, ProviderName);
+            return new IISRequestNotificationEventsResponseErrorStatus(action, 10163, 11, "IISRequestNotification", IISRequestNotificationGuid, 16, "MODULE_SET_RESPONSE_ERROR_STATUS", ProviderGuid, ProviderName);
         }
-        static private W3GeneralRequestEntity IIS_TransOpcode51Template(Action<W3GeneralRequestEntity> action)
+        static private IISRequestNotificationEventsResponseSuccessStatus IISRequestNotificationModuleSetResponseSuccessStatusTemplate(Action<IISRequestNotificationEventsResponseSuccessStatus> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralRequestEntity(action, 10000, 0, "IIS_Trans", IISTransGuid, 51, "Opcode51", ProviderGuid, ProviderName);
+            return new IISRequestNotificationEventsResponseSuccessStatus(action, 10164, 11, "IISRequestNotification", IISRequestNotificationGuid, 17, "MODULE_SET_RESPONSE_SUCCESS_STATUS", ProviderGuid, ProviderName);
         }
-        static private W3GeneralNotSendCustomError IIS_TransOpcode52Template(Action<W3GeneralNotSendCustomError> action)
+        static private IISRequestNotificationEventsCompletion IISRequestNotificationNotifyModuleCompletionTemplate(Action<IISRequestNotificationEventsCompletion> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralNotSendCustomError(action, 10000, 0, "IIS_Trans", IISTransGuid, 52, "Opcode52", ProviderGuid, ProviderName);
+            return new IISRequestNotificationEventsCompletion(action, 10159, 11, "IISRequestNotification", IISRequestNotificationGuid, 3, "NOTIFY_MODULE_COMPLETION", ProviderGuid, ProviderName);
         }
-        static private W3GeneralSetRequestHeader IIS_TransOpcode53Template(Action<W3GeneralSetRequestHeader> action)
+        static private IISRequestNotificationEventsEnd IISRequestNotificationNotifyModuleEndTemplate(Action<IISRequestNotificationEventsEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralSetRequestHeader(action, 10000, 0, "IIS_Trans", IISTransGuid, 53, "Opcode53", ProviderGuid, ProviderName);
+            return new IISRequestNotificationEventsEnd(action, 10158, 11, "IISRequestNotification", IISRequestNotificationGuid, 2, "NOTIFY_MODULE_END", ProviderGuid, ProviderName);
         }
-        static private W3GeneralModuleFactoryFailed IIS_TransOpcode54Template(Action<W3GeneralModuleFactoryFailed> action)
+        static private IISRequestNotificationEventsStart IISRequestNotificationNotifyModuleStartTemplate(Action<IISRequestNotificationEventsStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralModuleFactoryFailed(action, 10000, 0, "IIS_Trans", IISTransGuid, 54, "Opcode54", ProviderGuid, ProviderName);
+            return new IISRequestNotificationEventsStart(action, 10157, 11, "IISRequestNotification", IISRequestNotificationGuid, 1, "NOTIFY_MODULE_START", ProviderGuid, ProviderName);
         }
-        static private W3GeneralEndpointInformation IIS_TransOpcode55Template(Action<W3GeneralEndpointInformation> action)
+        static private IISRequestNotificationPreBeginEnd IISRequestNotificationPreBeginRequestEndTemplate(Action<IISRequestNotificationPreBeginEnd> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralEndpointInformation(action, 10000, 0, "IIS_Trans", IISTransGuid, 55, "Opcode55", ProviderGuid, ProviderName);
+            return new IISRequestNotificationPreBeginEnd(action, 10161, 11, "IISRequestNotification", IISRequestNotificationGuid, 5, "PRE_BEGIN_REQUEST_END", ProviderGuid, ProviderName);
         }
-        static private W3GeneralSetResponseHeader IIS_TransOpcode56Template(Action<W3GeneralSetResponseHeader> action)
+        static private IISRequestNotificationPreBeginStart IISRequestNotificationPreBeginRequestStartTemplate(Action<IISRequestNotificationPreBeginStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralSetResponseHeader(action, 10000, 0, "IIS_Trans", IISTransGuid, 56, "Opcode56", ProviderGuid, ProviderName);
+            return new IISRequestNotificationPreBeginStart(action, 10160, 11, "IISRequestNotification", IISRequestNotificationGuid, 4, "PRE_BEGIN_REQUEST_START", ProviderGuid, ProviderName);
         }
-        static private W3GeneralStartNewRequest IIS_TransStartTemplate(Action<W3GeneralStartNewRequest> action)
+        static private IISRequestNotificationEventsError IISRequestNotificationRequestProcessingErrorTemplate(Action<IISRequestNotificationEventsError> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralStartNewRequest(action, 10000, 0, "IIS_Trans", IISTransGuid, 1, "Start", ProviderGuid, ProviderName);
+            return new IISRequestNotificationEventsError(action, 10162, 11, "IISRequestNotification", IISRequestNotificationGuid, 15, "REQUEST_PROCESSING_ERROR", ProviderGuid, ProviderName);
         }
-        static private W3GeneralEndNewRequest IIS_TransStopTemplate(Action<W3GeneralEndNewRequest> action)
+        static private IISRequestNotificationEventsResponseErrorDescription IISRequestNotificationSetResponseErrorDescriptionTemplate(Action<IISRequestNotificationEventsResponseErrorDescription> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3GeneralEndNewRequest(action, 10000, 0, "IIS_Trans", IISTransGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new IISRequestNotificationEventsResponseErrorDescription(action, 10165, 11, "IISRequestNotification", IISRequestNotificationGuid, 18, "SET_RESPONSE_ERROR_DESCRIPTION", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketEndSuccess IIS_WebSocket_TransDC_StartTemplate(Action<W3WebSocketEndSuccess> action)
+        static private W3SecDeniedByAccessFlags IISSecuritySecurityDeniedByAccessFlagsTemplate(Action<W3SecDeniedByAccessFlags> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketEndSuccess(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 3, "DC_Start", ProviderGuid, ProviderName);
+            return new W3SecDeniedByAccessFlags(action, 10062, 2, "IISSecurity", IISSecurityGuid, 18, "SECURITY_DENIED_BY_ACCESS_FLAGS", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketEndFailure IIS_WebSocket_TransDC_StopTemplate(Action<W3WebSocketEndFailure> action)
+        static private W3SecDeniedByCGIRestriction IISSecuritySecurityDeniedByCgiRestrictionTemplate(Action<W3SecDeniedByCGIRestriction> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketEndFailure(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 4, "DC_Stop", ProviderGuid, ProviderName);
+            return new W3SecDeniedByCGIRestriction(action, 10061, 2, "IISSecurity", IISSecurityGuid, 17, "SECURITY_DENIED_BY_CGI_RESTRICTION", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketReadFragmentStart IIS_WebSocket_TransExtensionTemplate(Action<W3WebSocketReadFragmentStart> action)
+        static private W3SecDeniedByISAPIRestriction IISSecuritySecurityDeniedByIsapiRestrictionTemplate(Action<W3SecDeniedByISAPIRestriction> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketReadFragmentStart(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 5, "Extension", ProviderGuid, ProviderName);
+            return new W3SecDeniedByISAPIRestriction(action, 10060, 2, "IISSecurity", IISSecurityGuid, 16, "SECURITY_DENIED_BY_ISAPI_RESTRICTION", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketWriteFragmentEndPending IIS_WebSocket_TransOpcode10Template(Action<W3WebSocketWriteFragmentEndPending> action)
+        static private W3SecDeniedByMimemap IISSecuritySecurityDeniedByMimemapTemplate(Action<W3SecDeniedByMimemap> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketWriteFragmentEndPending(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
+            return new W3SecDeniedByMimemap(action, 10059, 2, "IISSecurity", IISSecurityGuid, 15, "SECURITY_DENIED_BY_MIMEMAP", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketWriteFragmentEndSuccess IIS_WebSocket_TransOpcode11Template(Action<W3WebSocketWriteFragmentEndSuccess> action)
+        static private W3SecFileAccessDenied IISSecuritySecurityFileAccessDeniedTemplate(Action<W3SecFileAccessDenied> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketWriteFragmentEndSuccess(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
+            return new W3SecFileAccessDenied(action, 10058, 2, "IISSecurity", IISSecurityGuid, 14, "SECURITY_FILE_ACCESS_DENIED", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketWriteFragmentEndFailure IIS_WebSocket_TransOpcode12Template(Action<W3WebSocketWriteFragmentEndFailure> action)
+        static private W3SecIllegalShortFilename IISSecuritySecurityIllegalShortFilenameTemplate(Action<W3SecIllegalShortFilename> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketWriteFragmentEndFailure(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
+            return new W3SecIllegalShortFilename(action, 10054, 2, "IISSecurity", IISSecurityGuid, 10, "SECURITY_ILLEGAL_SHORT_FILENAME", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketApplicationCloseConnection IIS_WebSocket_TransOpcode13Template(Action<W3WebSocketApplicationCloseConnection> action)
+        static private W3SecRejectedHostname IISSecuritySecurityRejectedHostnameTemplate(Action<W3SecRejectedHostname> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketApplicationCloseConnection(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
+            return new W3SecRejectedHostname(action, 10056, 2, "IISSecurity", IISSecurityGuid, 12, "SECURITY_REJECTED_HOSTNAME", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketModuleCloseConnection IIS_WebSocket_TransOpcode14Template(Action<W3WebSocketModuleCloseConnection> action)
+        static private W3SecRejectedIP IISSecuritySecurityRejectedIpTemplate(Action<W3SecRejectedIP> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketModuleCloseConnection(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
+            return new W3SecRejectedIP(action, 10055, 2, "IISSecurity", IISSecurityGuid, 11, "SECURITY_REJECTED_IP", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketReadIoFailed IIS_WebSocket_TransOpcode15Template(Action<W3WebSocketReadIoFailed> action)
+        static private W3SecRequireSSL128 IISSecuritySecurityRejectedRequireSsl128Template(Action<W3SecRequireSSL128> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketReadIoFailed(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
+            return new W3SecRequireSSL128(action, 10057, 2, "IISSecurity", IISSecurityGuid, 13, "SECURITY_REJECTED_REQUIRE_SSL_128", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketWriteIoFailed IIS_WebSocket_TransOpcode16Template(Action<W3WebSocketWriteIoFailed> action)
+        static private W3WebSocketApplicationCloseConnection IISWebSocketWebsocketApplicationCloseConnectionTemplate(Action<W3WebSocketApplicationCloseConnection> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketWriteIoFailed(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 16, "Opcode16", ProviderGuid, ProviderName);
+            return new W3WebSocketApplicationCloseConnection(action, 10128, 8, "IISWebSocket", IISWebSocketGuid, 13, "WEBSOCKET_APPLICATION_CLOSE_CONNECTION", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketCloseReceived IIS_WebSocket_TransOpcode17Template(Action<W3WebSocketCloseReceived> action)
+        static private W3WebSocketEndFailure IISWebSocketWebsocketHandshakeNotSuccessTemplate(Action<W3WebSocketEndFailure> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketCloseReceived(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 17, "Opcode17", ProviderGuid, ProviderName);
+            return new W3WebSocketEndFailure(action, 10119, 8, "IISWebSocket", IISWebSocketGuid, 4, "WEBSOCKET_HANDSHAKE_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketCloseSendStart IIS_WebSocket_TransOpcode18Template(Action<W3WebSocketCloseSendStart> action)
+        static private W3WebSocketStart IISWebSocketWebsocketHandshakeStartTemplate(Action<W3WebSocketStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketCloseSendStart(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 18, "Opcode18", ProviderGuid, ProviderName);
+            return new W3WebSocketStart(action, 10117, 8, "IISWebSocket", IISWebSocketGuid, 2, "WEBSOCKET_HANDSHAKE_START", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketCloseSendSuccess IIS_WebSocket_TransOpcode19Template(Action<W3WebSocketCloseSendSuccess> action)
+        static private W3WebSocketEndSuccess IISWebSocketWebsocketHandshakeSuccessTemplate(Action<W3WebSocketEndSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketCloseSendSuccess(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 19, "Opcode19", ProviderGuid, ProviderName);
+            return new W3WebSocketEndSuccess(action, 10118, 8, "IISWebSocket", IISWebSocketGuid, 3, "WEBSOCKET_HANDSHAKE_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketCloseSendFailure IIS_WebSocket_TransOpcode20Template(Action<W3WebSocketCloseSendFailure> action)
+        static private W3WebSocketInitializeNotSuccess IISWebSocketWebsocketInitializeFailedTemplate(Action<W3WebSocketInitializeNotSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketCloseSendFailure(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 20, "Opcode20", ProviderGuid, ProviderName);
+            return new W3WebSocketInitializeNotSuccess(action, 10116, 8, "IISWebSocket", IISWebSocketGuid, 1, "WEBSOCKET_INITIALIZE_FAILED", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketReadFragmentEndPending IIS_WebSocket_TransReplyTemplate(Action<W3WebSocketReadFragmentEndPending> action)
+        static private W3WebSocketModuleCloseConnection IISWebSocketWebsocketModuleCloseConnectionTemplate(Action<W3WebSocketModuleCloseConnection> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketReadFragmentEndPending(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 6, "Reply", ProviderGuid, ProviderName);
+            return new W3WebSocketModuleCloseConnection(action, 10129, 8, "IISWebSocket", IISWebSocketGuid, 14, "WEBSOCKET_MODULE_CLOSE_CONNECTION", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketReadFragmentEndSuccess IIS_WebSocket_TransResumeTemplate(Action<W3WebSocketReadFragmentEndSuccess> action)
+        static private W3WebSocketReadFragmentEndFailure IISWebSocketWebsocketReadFragmentEndNotSuccessTemplate(Action<W3WebSocketReadFragmentEndFailure> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketReadFragmentEndSuccess(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 7, "Resume", ProviderGuid, ProviderName);
+            return new W3WebSocketReadFragmentEndFailure(action, 10123, 8, "IISWebSocket", IISWebSocketGuid, 8, "WEBSOCKET_READ_FRAGMENT_END_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketWriteFragmentStart IIS_WebSocket_TransSendTemplate(Action<W3WebSocketWriteFragmentStart> action)
+        static private W3WebSocketReadFragmentEndPending IISWebSocketWebsocketReadFragmentEndPendingTemplate(Action<W3WebSocketReadFragmentEndPending> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketWriteFragmentStart(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 9, "Send", ProviderGuid, ProviderName);
+            return new W3WebSocketReadFragmentEndPending(action, 10121, 8, "IISWebSocket", IISWebSocketGuid, 6, "WEBSOCKET_READ_FRAGMENT_END_PENDING", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketInitializeNotSuccess IIS_WebSocket_TransStartTemplate(Action<W3WebSocketInitializeNotSuccess> action)
+        static private W3WebSocketReadFragmentEndSuccess IISWebSocketWebsocketReadFragmentEndSuccessTemplate(Action<W3WebSocketReadFragmentEndSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketInitializeNotSuccess(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 1, "Start", ProviderGuid, ProviderName);
+            return new W3WebSocketReadFragmentEndSuccess(action, 10122, 8, "IISWebSocket", IISWebSocketGuid, 7, "WEBSOCKET_READ_FRAGMENT_END_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketStart IIS_WebSocket_TransStopTemplate(Action<W3WebSocketStart> action)
+        static private W3WebSocketReadFragmentStart IISWebSocketWebsocketReadFragmentStartTemplate(Action<W3WebSocketReadFragmentStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketStart(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new W3WebSocketReadFragmentStart(action, 10120, 8, "IISWebSocket", IISWebSocketGuid, 5, "WEBSOCKET_READ_FRAGMENT_START", ProviderGuid, ProviderName);
         }
-        static private W3WebSocketReadFragmentEndFailure IIS_WebSocket_TransSuspendTemplate(Action<W3WebSocketReadFragmentEndFailure> action)
+        static private W3WebSocketReadIoFailed IISWebSocketWebsocketReadIoNotSuccessTemplate(Action<W3WebSocketReadIoFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3WebSocketReadFragmentEndFailure(action, 10007, 8, "IIS_WebSocket_Trans", IISWebSocketTransGuid, 8, "Suspend", ProviderGuid, ProviderName);
+            return new W3WebSocketReadIoFailed(action, 10130, 8, "IISWebSocket", IISWebSocketGuid, 15, "WEBSOCKET_READ_IO_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private IISModuleEventsModuleCriticalError IISModuleEventsDC_StartTemplate(Action<IISModuleEventsModuleCriticalError> action)
+        static private W3WebSocketCloseReceived IISWebSocketWebsocketReceivedCloseTemplate(Action<W3WebSocketCloseReceived> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISModuleEventsModuleCriticalError(action, 10011, 12, "IISModuleEvents", IISModuleEventsGuid, 3, "DC_Start", ProviderGuid, ProviderName);
+            return new W3WebSocketCloseReceived(action, 10132, 8, "IISWebSocket", IISWebSocketGuid, 17, "WEBSOCKET_RECEIVED_CLOSE", ProviderGuid, ProviderName);
         }
-        static private IISModuleEventsModuleError IISModuleEventsDC_StopTemplate(Action<IISModuleEventsModuleError> action)
+        static private W3WebSocketCloseSendFailure IISWebSocketWebsocketSendCloseEndNotSuccessTemplate(Action<W3WebSocketCloseSendFailure> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISModuleEventsModuleError(action, 10011, 12, "IISModuleEvents", IISModuleEventsGuid, 4, "DC_Stop", ProviderGuid, ProviderName);
+            return new W3WebSocketCloseSendFailure(action, 10135, 8, "IISWebSocket", IISWebSocketGuid, 20, "WEBSOCKET_SEND_CLOSE_END_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private IISModuleEventsModuleWarning IISModuleEventsExtensionTemplate(Action<IISModuleEventsModuleWarning> action)
+        static private W3WebSocketCloseSendSuccess IISWebSocketWebsocketSendCloseEndSuccessTemplate(Action<W3WebSocketCloseSendSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISModuleEventsModuleWarning(action, 10011, 12, "IISModuleEvents", IISModuleEventsGuid, 5, "Extension", ProviderGuid, ProviderName);
+            return new W3WebSocketCloseSendSuccess(action, 10134, 8, "IISWebSocket", IISWebSocketGuid, 19, "WEBSOCKET_SEND_CLOSE_END_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private IISModuleEventsModuleInformation IISModuleEventsReplyTemplate(Action<IISModuleEventsModuleInformation> action)
+        static private W3WebSocketCloseSendStart IISWebSocketWebsocketSendCloseStartTemplate(Action<W3WebSocketCloseSendStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISModuleEventsModuleInformation(action, 10011, 12, "IISModuleEvents", IISModuleEventsGuid, 6, "Reply", ProviderGuid, ProviderName);
+            return new W3WebSocketCloseSendStart(action, 10133, 8, "IISWebSocket", IISWebSocketGuid, 18, "WEBSOCKET_SEND_CLOSE_START", ProviderGuid, ProviderName);
         }
-        static private IISModuleEventsModuleVerbose IISModuleEventsResumeTemplate(Action<IISModuleEventsModuleVerbose> action)
+        static private W3WebSocketWriteFragmentEndFailure IISWebSocketWebsocketWriteFragmentEndNotSuccessTemplate(Action<W3WebSocketWriteFragmentEndFailure> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISModuleEventsModuleVerbose(action, 10011, 12, "IISModuleEvents", IISModuleEventsGuid, 7, "Resume", ProviderGuid, ProviderName);
+            return new W3WebSocketWriteFragmentEndFailure(action, 10127, 8, "IISWebSocket", IISWebSocketGuid, 12, "WEBSOCKET_WRITE_FRAGMENT_END_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private IISModuleEventsModuleStart IISModuleEventsStartTemplate(Action<IISModuleEventsModuleStart> action)
+        static private W3WebSocketWriteFragmentEndPending IISWebSocketWebsocketWriteFragmentEndPendingTemplate(Action<W3WebSocketWriteFragmentEndPending> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISModuleEventsModuleStart(action, 10011, 12, "IISModuleEvents", IISModuleEventsGuid, 1, "Start", ProviderGuid, ProviderName);
+            return new W3WebSocketWriteFragmentEndPending(action, 10125, 8, "IISWebSocket", IISWebSocketGuid, 10, "WEBSOCKET_WRITE_FRAGMENT_END_PENDING", ProviderGuid, ProviderName);
         }
-        static private IISModuleEventsModuleEnd IISModuleEventsStopTemplate(Action<IISModuleEventsModuleEnd> action)
+        static private W3WebSocketWriteFragmentEndSuccess IISWebSocketWebsocketWriteFragmentEndSuccessTemplate(Action<W3WebSocketWriteFragmentEndSuccess> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISModuleEventsModuleEnd(action, 10011, 12, "IISModuleEvents", IISModuleEventsGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new W3WebSocketWriteFragmentEndSuccess(action, 10126, 8, "IISWebSocket", IISWebSocketGuid, 11, "WEBSOCKET_WRITE_FRAGMENT_END_SUCCESS", ProviderGuid, ProviderName);
         }
-        static private IISRequestNotificationEventsCompletion IISRequestNotificationEventsDC_StartTemplate(Action<IISRequestNotificationEventsCompletion> action)
+        static private W3WebSocketWriteFragmentStart IISWebSocketWebsocketWriteFragmentStartTemplate(Action<W3WebSocketWriteFragmentStart> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationEventsCompletion(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 3, "DC_Start", ProviderGuid, ProviderName);
+            return new W3WebSocketWriteFragmentStart(action, 10124, 8, "IISWebSocket", IISWebSocketGuid, 9, "WEBSOCKET_WRITE_FRAGMENT_START", ProviderGuid, ProviderName);
         }
-        static private IISRequestNotificationPreBeginStart IISRequestNotificationEventsDC_StopTemplate(Action<IISRequestNotificationPreBeginStart> action)
+        static private W3WebSocketWriteIoFailed IISWebSocketWebsocketWriteIoNotSuccessTemplate(Action<W3WebSocketWriteIoFailed> action)
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationPreBeginStart(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 4, "DC_Stop", ProviderGuid, ProviderName);
-        }
-        static private IISRequestNotificationPreBeginEnd IISRequestNotificationEventsExtensionTemplate(Action<IISRequestNotificationPreBeginEnd> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationPreBeginEnd(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 5, "Extension", ProviderGuid, ProviderName);
-        }
-        static private IISRequestNotificationEventsError IISRequestNotificationEventsOpcode15Template(Action<IISRequestNotificationEventsError> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationEventsError(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 15, "Opcode15", ProviderGuid, ProviderName);
-        }
-        static private IISRequestNotificationEventsResponseErrorStatus IISRequestNotificationEventsOpcode16Template(Action<IISRequestNotificationEventsResponseErrorStatus> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationEventsResponseErrorStatus(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 16, "Opcode16", ProviderGuid, ProviderName);
-        }
-        static private IISRequestNotificationEventsResponseSuccessStatus IISRequestNotificationEventsOpcode17Template(Action<IISRequestNotificationEventsResponseSuccessStatus> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationEventsResponseSuccessStatus(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 17, "Opcode17", ProviderGuid, ProviderName);
-        }
-        static private IISRequestNotificationEventsResponseErrorDescription IISRequestNotificationEventsOpcode18Template(Action<IISRequestNotificationEventsResponseErrorDescription> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationEventsResponseErrorDescription(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 18, "Opcode18", ProviderGuid, ProviderName);
-        }
-        static private IISRequestNotificationEventsStart IISRequestNotificationEventsStartTemplate(Action<IISRequestNotificationEventsStart> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationEventsStart(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 1, "Start", ProviderGuid, ProviderName);
-        }
-        static private IISRequestNotificationEventsEnd IISRequestNotificationEventsStopTemplate(Action<IISRequestNotificationEventsEnd> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IISRequestNotificationEventsEnd(action, 10010, 11, "IISRequestNotificationEvents", IISRequestNotificationEventsGuid, 2, "Stop", ProviderGuid, ProviderName);
-        }
-        static private IsapiDeleteContext Isapi_TransOpcode10Template(Action<IsapiDeleteContext> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IsapiDeleteContext(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 10, "Opcode10", ProviderGuid, ProviderName);
-        }
-        static private IsapiDeleteContext Isapi_TransOpcode11Template(Action<IsapiDeleteContext> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IsapiDeleteContext(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 11, "Opcode11", ProviderGuid, ProviderName);
-        }
-        static private IsapiDeleteContext Isapi_TransOpcode12Template(Action<IsapiDeleteContext> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IsapiDeleteContext(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 12, "Opcode12", ProviderGuid, ProviderName);
-        }
-        static private IsapiDeleteContext Isapi_TransOpcode13Template(Action<IsapiDeleteContext> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IsapiDeleteContext(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 13, "Opcode13", ProviderGuid, ProviderName);
-        }
-        static private IsapiDeleteContext Isapi_TransOpcode14Template(Action<IsapiDeleteContext> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IsapiDeleteContext(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 14, "Opcode14", ProviderGuid, ProviderName);
-        }
-        static private IsapiDeleteContext Isapi_TransOpcode15Template(Action<IsapiDeleteContext> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new IsapiDeleteContext(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 15, "Opcode15", ProviderGuid, ProviderName);
-        }
-        static private W3ISAPIStart Isapi_TransStartTemplate(Action<W3ISAPIStart> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3ISAPIStart(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 1, "Start", ProviderGuid, ProviderName);
-        }
-        static private W3ISAPIEnd Isapi_TransStopTemplate(Action<W3ISAPIEnd> action)
-        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-            return new W3ISAPIEnd(action, 10004, 5, "Isapi_Trans", IsapiTransGuid, 2, "Stop", ProviderGuid, ProviderName);
+            return new W3WebSocketWriteIoFailed(action, 10131, 8, "IISWebSocket", IISWebSocketGuid, 16, "WEBSOCKET_WRITE_IO_NOT_SUCCESS", ProviderGuid, ProviderName);
         }
 
         static private volatile TraceEvent[] s_templates;
@@ -2886,209 +2659,180 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[202];
-                templates[0] = IIS_TransStartTemplate(null);
-                templates[1] = IIS_TransStopTemplate(null);
-                templates[2] = IIS_TransOpcode10Template(null);
-                templates[3] = IIS_TransOpcode11Template(null);
-                templates[4] = IIS_TransOpcode12Template(null);
-                templates[5] = IIS_TransOpcode13Template(null);
-                templates[6] = IIS_TransOpcode14Template(null);
-                templates[7] = IIS_TransOpcode15Template(null);
-                templates[8] = IIS_TransOpcode16Template(null);
-                templates[9] = IIS_TransOpcode17Template(null);
-                templates[10] = IIS_TransOpcode30Template(null);
-                templates[11] = IIS_TransOpcode31Template(null);
-                templates[12] = IIS_TransOpcode32Template(null);
-                templates[13] = IIS_TransOpcode33Template(null);
-                templates[14] = IIS_TransOpcode34Template(null);
-                templates[15] = IIS_TransOpcode35Template(null);
-                templates[16] = IIS_TransOpcode36Template(null);
-                templates[17] = IIS_TransOpcode37Template(null);
-                templates[18] = IIS_TransOpcode38Template(null);
-                templates[19] = IIS_TransOpcode39Template(null);
-                templates[20] = IIS_TransOpcode40Template(null);
-                templates[21] = IIS_TransOpcode41Template(null);
-                templates[22] = IIS_TransOpcode42Template(null);
-                templates[23] = IIS_TransOpcode43Template(null);
-                templates[24] = IIS_TransOpcode44Template(null);
-                templates[25] = IIS_TransOpcode45Template(null);
-                templates[26] = IIS_TransOpcode46Template(null);
-                templates[27] = IIS_TransOpcode47Template(null);
-                templates[28] = IIS_TransOpcode48Template(null);
-                templates[29] = IIS_TransOpcode49Template(null);
-                templates[30] = IIS_TransOpcode50Template(null);
-                templates[31] = IIS_TransOpcode51Template(null);
-                templates[32] = IIS_TransOpcode52Template(null);
-                templates[33] = IIS_TransOpcode53Template(null);
-                templates[34] = IIS_TransOpcode54Template(null);
-                templates[35] = IIS_TransOpcode55Template(null);
-                templates[36] = IIS_TransOpcode56Template(null);
-                templates[37] = IIS_Authentication_TransOpcode10Template(null);
-                templates[38] = IIS_Authentication_TransOpcode11Template(null);
-                templates[39] = IIS_Authentication_TransOpcode12Template(null);
-                templates[40] = IIS_Authentication_TransOpcode13Template(null);
-                templates[41] = IIS_Authentication_TransOpcode14Template(null);
-                templates[42] = IIS_Authentication_TransOpcode15Template(null);
-                templates[43] = IIS_Authentication_TransOpcode16Template(null);
-                templates[44] = IIS_Authentication_TransOpcode17Template(null);
-                templates[45] = IIS_Authentication_TransOpcode18Template(null);
-                templates[46] = IIS_Authentication_TransOpcode19Template(null);
-                templates[47] = IIS_Authentication_TransOpcode20Template(null);
-                templates[48] = IIS_Authentication_TransOpcode21Template(null);
-                templates[49] = IIS_Authentication_TransOpcode22Template(null);
-                templates[50] = IIS_Authentication_TransOpcode23Template(null);
-                templates[51] = IIS_Authentication_TransOpcode55Template(null);
-                templates[52] = IIS_Authentication_TransOpcode24Template(null);
-                templates[53] = IIS_Authentication_TransOpcode27Template(null);
-                templates[54] = IIS_Authentication_TransOpcode28Template(null);
-                templates[55] = IIS_Security_TransOpcode10Template(null);
-                templates[56] = IIS_Security_TransOpcode11Template(null);
-                templates[57] = IIS_Security_TransOpcode12Template(null);
-                templates[58] = IIS_Security_TransOpcode13Template(null);
-                templates[59] = IIS_Security_TransOpcode14Template(null);
-                templates[60] = IIS_Security_TransOpcode15Template(null);
-                templates[61] = IIS_Security_TransOpcode16Template(null);
-                templates[62] = IIS_Security_TransOpcode17Template(null);
-                templates[63] = IIS_Security_TransOpcode18Template(null);
-                templates[64] = IIS_Filter_TransStartTemplate(null);
-                templates[65] = IIS_Filter_TransStopTemplate(null);
-                templates[66] = IIS_Filter_TransOpcode12Template(null);
-                templates[67] = IIS_Filter_TransOpcode13Template(null);
-                templates[68] = IIS_Filter_TransOpcode14Template(null);
-                templates[69] = IIS_Filter_TransOpcode15Template(null);
-                templates[70] = IIS_Filter_TransOpcode16Template(null);
-                templates[71] = IIS_Filter_TransOpcode17Template(null);
-                templates[72] = IIS_Filter_TransOpcode18Template(null);
-                templates[73] = IIS_Filter_TransOpcode19Template(null);
-                templates[74] = IIS_Filter_TransOpcode20Template(null);
-                templates[75] = IIS_Filter_TransOpcode21Template(null);
-                templates[76] = IIS_Filter_TransOpcode22Template(null);
-                templates[77] = IIS_Filter_TransOpcode23Template(null);
-                templates[78] = IIS_Filter_TransOpcode24Template(null);
-                templates[79] = IIS_Filter_TransOpcode25Template(null);
-                templates[80] = IIS_Filter_TransOpcode26Template(null);
-                templates[81] = IIS_Filter_TransOpcode27Template(null);
-                templates[82] = IIS_Filter_TransOpcode28Template(null);
-                templates[83] = IIS_Filter_TransOpcode29Template(null);
-                templates[84] = IIS_Filter_TransOpcode30Template(null);
-                templates[85] = IIS_Filter_TransOpcode31Template(null);
-                templates[86] = IIS_Filter_TransOpcode32Template(null);
-                templates[87] = IIS_Filter_TransOpcode33Template(null);
-                templates[88] = IIS_Filter_TransOpcode34Template(null);
-                templates[89] = Isapi_TransStartTemplate(null);
-                templates[90] = Isapi_TransStopTemplate(null);
-                templates[91] = IIS_Cgi_TransStartTemplate(null);
-                templates[92] = IIS_Cgi_TransStopTemplate(null);
-                templates[93] = IIS_Cgi_TransDC_StartTemplate(null);
-                templates[94] = IIS_Cgi_TransDC_StopTemplate(null);
-                templates[95] = IIS_Cgi_TransExtensionTemplate(null);
-                templates[96] = IIS_Cgi_TransReplyTemplate(null);
-                templates[97] = IIS_Cgi_TransResumeTemplate(null);
-                templates[98] = IIS_FastCgi_TransStartTemplate(null);
-                templates[99] = IIS_FastCgi_TransStopTemplate(null);
-                templates[100] = IIS_FastCgi_TransDC_StartTemplate(null);
-                templates[101] = IIS_FastCgi_TransDC_StopTemplate(null);
-                templates[102] = IIS_FastCgi_TransExtensionTemplate(null);
-                templates[103] = IIS_FastCgi_TransReplyTemplate(null);
-                templates[104] = IIS_FastCgi_TransResumeTemplate(null);
-                templates[105] = IIS_FastCgi_TransSuspendTemplate(null);
-                templates[106] = IIS_FastCgi_TransSendTemplate(null);
-                templates[107] = IIS_FastCgi_TransOpcode10Template(null);
-                templates[108] = IIS_FastCgi_TransOpcode11Template(null);
-                templates[109] = IIS_FastCgi_TransOpcode12Template(null);
-                templates[110] = IIS_FastCgi_TransOpcode13Template(null);
-                templates[111] = IIS_FastCgi_TransOpcode14Template(null);
-                templates[112] = IIS_FastCgi_TransOpcode15Template(null);
-                templates[113] = IIS_FastCgi_TransOpcode16Template(null);
-                templates[114] = IIS_FastCgi_TransOpcode17Template(null);
-                templates[115] = IIS_FastCgi_TransOpcode18Template(null);
-                templates[116] = IIS_FastCgi_TransOpcode19Template(null);
-                templates[117] = IIS_WebSocket_TransStartTemplate(null);
-                templates[118] = IIS_WebSocket_TransStopTemplate(null);
-                templates[119] = IIS_WebSocket_TransDC_StartTemplate(null);
-                templates[120] = IIS_WebSocket_TransDC_StopTemplate(null);
-                templates[121] = IIS_WebSocket_TransExtensionTemplate(null);
-                templates[122] = IIS_WebSocket_TransReplyTemplate(null);
-                templates[123] = IIS_WebSocket_TransResumeTemplate(null);
-                templates[124] = IIS_WebSocket_TransSuspendTemplate(null);
-                templates[125] = IIS_WebSocket_TransSendTemplate(null);
-                templates[126] = IIS_WebSocket_TransOpcode10Template(null);
-                templates[127] = IIS_WebSocket_TransOpcode11Template(null);
-                templates[128] = IIS_WebSocket_TransOpcode12Template(null);
-                templates[129] = IIS_WebSocket_TransOpcode13Template(null);
-                templates[130] = IIS_WebSocket_TransOpcode14Template(null);
-                templates[131] = IIS_WebSocket_TransOpcode15Template(null);
-                templates[132] = IIS_WebSocket_TransOpcode16Template(null);
-                templates[133] = IIS_WebSocket_TransOpcode17Template(null);
-                templates[134] = IIS_WebSocket_TransOpcode18Template(null);
-                templates[135] = IIS_WebSocket_TransOpcode19Template(null);
-                templates[136] = IIS_WebSocket_TransOpcode20Template(null);
-                templates[137] = IIS_Compression_TransStartTemplate(null);
-                templates[138] = IIS_Compression_TransStopTemplate(null);
-                templates[139] = IIS_Compression_TransDC_StartTemplate(null);
-                templates[140] = IIS_Compression_TransDC_StopTemplate(null);
-                templates[141] = IIS_Compression_TransExtensionTemplate(null);
-                templates[142] = IIS_Compression_TransReplyTemplate(null);
-                templates[143] = IIS_Compression_TransResumeTemplate(null);
-                templates[144] = IIS_Compression_TransSuspendTemplate(null);
-                templates[145] = IIS_Compression_TransSendTemplate(null);
-                templates[146] = IIS_Compression_TransOpcode10Template(null);
-                templates[147] = IIS_Compression_TransOpcode11Template(null);
-                templates[148] = IIS_Cache_TransOpcode10Template(null);
-                templates[149] = IIS_Cache_TransOpcode11Template(null);
-                templates[150] = IIS_Cache_TransOpcode12Template(null);
-                templates[151] = IIS_Cache_TransOpcode13Template(null);
-                templates[152] = IIS_Cache_TransOpcode14Template(null);
-                templates[153] = IIS_Cache_TransOpcode15Template(null);
-                templates[154] = IIS_Cache_TransOpcode16Template(null);
-                templates[155] = IIS_Cache_TransOpcode17Template(null);
-                templates[156] = IIS_Cache_TransOpcode18Template(null);
-                templates[157] = IIS_Cache_TransOpcode19Template(null);
-                templates[158] = IIS_Cache_TransOpcode20Template(null);
-                templates[159] = IISRequestNotificationEventsStartTemplate(null);
-                templates[160] = IISRequestNotificationEventsStopTemplate(null);
-                templates[161] = IISRequestNotificationEventsDC_StartTemplate(null);
-                templates[162] = IISRequestNotificationEventsDC_StopTemplate(null);
-                templates[163] = IISRequestNotificationEventsExtensionTemplate(null);
-                templates[164] = IISRequestNotificationEventsOpcode15Template(null);
-                templates[165] = IISRequestNotificationEventsOpcode16Template(null);
-                templates[166] = IISRequestNotificationEventsOpcode17Template(null);
-                templates[167] = IISRequestNotificationEventsOpcode18Template(null);
-                templates[168] = IISModuleEventsStartTemplate(null);
-                templates[169] = IISModuleEventsStopTemplate(null);
-                templates[170] = IISModuleEventsDC_StartTemplate(null);
-                templates[171] = IISModuleEventsDC_StopTemplate(null);
-                templates[172] = IISModuleEventsExtensionTemplate(null);
-                templates[173] = IISModuleEventsReplyTemplate(null);
-                templates[174] = IISModuleEventsResumeTemplate(null);
-                templates[175] = IIS_TransStartTemplate(null);
-                templates[176] = IIS_TransStopTemplate(null);
-                templates[177] = IIS_TransOpcode16Template(null);
-                templates[178] = IIS_TransOpcode17Template(null);
-                templates[179] = IIS_TransOpcode18Template(null);
-                templates[180] = IIS_TransOpcode19Template(null);
-                templates[181] = IIS_TransOpcode20Template(null);
-                templates[182] = IIS_TransOpcode21Template(null);
-                templates[183] = IIS_TransOpcode22Template(null);
-                templates[184] = IIS_TransOpcode23Template(null);
-                templates[185] = IIS_TransOpcode24Template(null);
-                templates[186] = IIS_TransOpcode10Template(null);
-                templates[187] = IIS_TransOpcode11Template(null);
-                templates[188] = IIS_TransOpcode12Template(null);
-                templates[189] = IIS_TransOpcode13Template(null);
-                templates[190] = IIS_Filter_TransStartTemplate(null);
-                templates[191] = IIS_Filter_TransStopTemplate(null);
-                templates[192] = IIS_Cgi_TransStartTemplate(null);
-                templates[193] = IIS_Cgi_TransStopTemplate(null);
-                templates[194] = Isapi_TransStartTemplate(null);
-                templates[195] = Isapi_TransStopTemplate(null);
-                templates[196] = Isapi_TransOpcode10Template(null);
-                templates[197] = Isapi_TransOpcode11Template(null);
-                templates[198] = Isapi_TransOpcode12Template(null);
-                templates[199] = Isapi_TransOpcode13Template(null);
-                templates[200] = Isapi_TransOpcode14Template(null);
-                templates[201] = Isapi_TransOpcode15Template(null);
+                var templates = new TraceEvent[173];
+                templates[0] = IISGeneralGeneralRequestStartTemplate(null);
+                templates[1] = IISGeneralGeneralRequestEndTemplate(null);
+                templates[2] = IISGeneralGeneralStaticFileHandlerTemplate(null);
+                templates[3] = IISGeneralGeneralCgiHandlerTemplate(null);
+                templates[4] = IISGeneralGeneralIsapiHandlerTemplate(null);
+                templates[5] = IISGeneralGeneralOopIsapiHandlerTemplate(null);
+                templates[6] = IISGeneralGeneralRedirectionHandlerTemplate(null);
+                templates[7] = IISGeneralGeneralDavHandlerTemplate(null);
+                templates[8] = IISGeneralGeneralOptionsHandlerTemplate(null);
+                templates[9] = IISGeneralGeneralTraceHandlerTemplate(null);
+                templates[10] = IISGeneralGeneralGetUrlMetadataTemplate(null);
+                templates[11] = IISGeneralGeneralChildRequestStartTemplate(null);
+                templates[12] = IISGeneralGeneralChildRequestEndTemplate(null);
+                templates[13] = IISGeneralGeneralSendCustomErrorTemplate(null);
+                templates[14] = IISGeneralGeneralMapHandlerTemplate(null);
+                templates[15] = IISGeneralGeneralFlushResponseStartTemplate(null);
+                templates[16] = IISGeneralGeneralFlushResponseEndTemplate(null);
+                templates[17] = IISGeneralGeneralReadEntityStartTemplate(null);
+                templates[18] = IISGeneralGeneralReadEntityEndTemplate(null);
+                templates[19] = IISGeneralFileChangeNotificationTemplate(null);
+                templates[20] = IISGeneralConfigChangeNotificationTemplate(null);
+                templates[21] = IISGeneralVirtualModuleUnresolvedTemplate(null);
+                templates[22] = IISGeneralUrlChangedTemplate(null);
+                templates[23] = IISGeneralHandlerChangedTemplate(null);
+                templates[24] = IISGeneralUserSetTemplate(null);
+                templates[25] = IISGeneralModulePreconditionNotMatchTemplate(null);
+                templates[26] = IISGeneralHandlerPreconditionNotMatchTemplate(null);
+                templates[27] = IISGeneralGeneralResponseHeadersTemplate(null);
+                templates[28] = IISGeneralGeneralResponseEntityFileTemplate(null);
+                templates[29] = IISGeneralGeneralResponseEntityBufferTemplate(null);
+                templates[30] = IISGeneralGeneralRequestHeadersTemplate(null);
+                templates[31] = IISGeneralGeneralRequestEntityTemplate(null);
+                templates[32] = IISGeneralGeneralNotSendCustomErrorTemplate(null);
+                templates[33] = IISGeneralGeneralSetRequestHeaderTemplate(null);
+                templates[34] = IISGeneralGeneralModuleFactoryFailedTemplate(null);
+                templates[35] = IISGeneralGeneralEndpointInformationTemplate(null);
+                templates[36] = IISAuthenticationAuthStartTemplate(null);
+                templates[37] = IISAuthenticationAuthSucceededTemplate(null);
+                templates[38] = IISAuthenticationAuthTypeNotSupportedTemplate(null);
+                templates[39] = IISAuthenticationAuthInvalidAnonAccountTemplate(null);
+                templates[40] = IISAuthenticationAuthPasswdChangeNeededTemplate(null);
+                templates[41] = IISAuthenticationAuthPasswdChangeDisabledTemplate(null);
+                templates[42] = IISAuthenticationAuthBadBasicHeaderTemplate(null);
+                templates[43] = IISAuthenticationAuthBasicLogonFailedTemplate(null);
+                templates[44] = IISAuthenticationAuthWdigestLogonFailedTemplate(null);
+                templates[45] = IISAuthenticationAuthIisdigestLogonFailedTemplate(null);
+                templates[46] = IISAuthenticationAuthPassportLogonFailedTemplate(null);
+                templates[47] = IISAuthenticationAuthSspiLogonFailedTemplate(null);
+                templates[48] = IISAuthenticationAuthNtlmNullSessionTemplate(null);
+                templates[49] = IISAuthenticationAuthSspiContinueNeededTemplate(null);
+                templates[50] = IISAuthenticationAuthKerberosFailedTemplate(null);
+                templates[51] = IISAuthenticationAuthAnonPasswdChangeNeededTemplate(null);
+                templates[52] = IISAuthenticationAuthRequestAuthTypeTemplate(null);
+                templates[53] = IISAuthenticationAuthEndTemplate(null);
+                templates[54] = IISSecuritySecurityIllegalShortFilenameTemplate(null);
+                templates[55] = IISSecuritySecurityRejectedIpTemplate(null);
+                templates[56] = IISSecuritySecurityRejectedHostnameTemplate(null);
+                templates[57] = IISSecuritySecurityRejectedRequireSsl128Template(null);
+                templates[58] = IISSecuritySecurityFileAccessDeniedTemplate(null);
+                templates[59] = IISSecuritySecurityDeniedByMimemapTemplate(null);
+                templates[60] = IISSecuritySecurityDeniedByIsapiRestrictionTemplate(null);
+                templates[61] = IISSecuritySecurityDeniedByCgiRestrictionTemplate(null);
+                templates[62] = IISSecuritySecurityDeniedByAccessFlagsTemplate(null);
+                templates[63] = IISFilterFilterStartTemplate(null);
+                templates[64] = IISFilterFilterEndTemplate(null);
+                templates[65] = IISFilterFilterErrorTemplate(null);
+                templates[66] = IISFilterFilterPreprocHeadersStartTemplate(null);
+                templates[67] = IISFilterFilterPreprocHeadersEndTemplate(null);
+                templates[68] = IISFilterFilterUrlMapStartTemplate(null);
+                templates[69] = IISFilterFilterUrlMapEndTemplate(null);
+                templates[70] = IISFilterFilterAuthenticationStartTemplate(null);
+                templates[71] = IISFilterFilterAuthenticationEndTemplate(null);
+                templates[72] = IISFilterFilterAuthCompleteStartTemplate(null);
+                templates[73] = IISFilterFilterAuthCompleteEndTemplate(null);
+                templates[74] = IISFilterFilterSendResponseStartTemplate(null);
+                templates[75] = IISFilterFilterSendResponseEndTemplate(null);
+                templates[76] = IISFilterFilterEndOfRequestStartTemplate(null);
+                templates[77] = IISFilterFilterEndOfRequestEndTemplate(null);
+                templates[78] = IISFilterFilterLogStartTemplate(null);
+                templates[79] = IISFilterFilterLogEndTemplate(null);
+                templates[80] = IISFilterFilterSendRawDataStartTemplate(null);
+                templates[81] = IISFilterFilterSendRawDataEndTemplate(null);
+                templates[82] = IISFilterFilterAccessDeniedStartTemplate(null);
+                templates[83] = IISFilterFilterAccessDeniedEndTemplate(null);
+                templates[84] = IISFilterFilterSetReqHeaderTemplate(null);
+                templates[85] = IISFilterFilterAddReqHeaderTemplate(null);
+                templates[86] = IISFilterFilterSetRespHeaderTemplate(null);
+                templates[87] = IISFilterFilterAddRespHeaderTemplate(null);
+                templates[88] = IISISAPIIsapiStartTemplate(null);
+                templates[89] = IISISAPIIsapiEndTemplate(null);
+                templates[90] = IISCGICgiStartTemplate(null);
+                templates[91] = IISCGICgiEndTemplate(null);
+                templates[92] = IISCGICgiLaunchTemplate(null);
+                templates[93] = IISCGICgiTimeoutTemplate(null);
+                templates[94] = IISCGICgiPrematureTerminationTemplate(null);
+                templates[95] = IISCGICgiRequestEntitySentTemplate(null);
+                templates[96] = IISCGICgiHeadersReceivedTemplate(null);
+                templates[97] = IISFastCGIFastcgiActivityTimeoutTemplate(null);
+                templates[98] = IISFastCGIFastcgiRequestTimeoutTemplate(null);
+                templates[99] = IISFastCGIFastcgiUnexpectedExitTemplate(null);
+                templates[100] = IISFastCGIFastcgiRapidFailureProtectionTemplate(null);
+                templates[101] = IISFastCGIFastcgiPathNotFoundTemplate(null);
+                templates[102] = IISFastCGIFastcgiScriptProcessorMissingTemplate(null);
+                templates[103] = IISFastCGIFastcgiAddJobobjectFailTemplate(null);
+                templates[104] = IISFastCGIFastcgiApplicationManagerShutdownTemplate(null);
+                templates[105] = IISFastCGIFastcgiQueueFullTemplate(null);
+                templates[106] = IISFastCGIFastcgiUnknownErrorTemplate(null);
+                templates[107] = IISFastCGIFastcgiResponseWrittenTemplate(null);
+                templates[108] = IISFastCGIFastcgiWaitingForResponseTemplate(null);
+                templates[109] = IISFastCGIFastcgiStderrTraceErrorTemplate(null);
+                templates[110] = IISFastCGIFastcgiStderrTraceWarningTemplate(null);
+                templates[111] = IISFastCGIFastcgiStderrTraceInfoTemplate(null);
+                templates[112] = IISFastCGIFastcgiQueueRequestTemplate(null);
+                templates[113] = IISFastCGIFastcgiAssignProcessTemplate(null);
+                templates[114] = IISFastCGIFastcgiStartTemplate(null);
+                templates[115] = IISFastCGIFastcgiEndTemplate(null);
+                templates[116] = IISWebSocketWebsocketInitializeFailedTemplate(null);
+                templates[117] = IISWebSocketWebsocketHandshakeStartTemplate(null);
+                templates[118] = IISWebSocketWebsocketHandshakeSuccessTemplate(null);
+                templates[119] = IISWebSocketWebsocketHandshakeNotSuccessTemplate(null);
+                templates[120] = IISWebSocketWebsocketReadFragmentStartTemplate(null);
+                templates[121] = IISWebSocketWebsocketReadFragmentEndPendingTemplate(null);
+                templates[122] = IISWebSocketWebsocketReadFragmentEndSuccessTemplate(null);
+                templates[123] = IISWebSocketWebsocketReadFragmentEndNotSuccessTemplate(null);
+                templates[124] = IISWebSocketWebsocketWriteFragmentStartTemplate(null);
+                templates[125] = IISWebSocketWebsocketWriteFragmentEndPendingTemplate(null);
+                templates[126] = IISWebSocketWebsocketWriteFragmentEndSuccessTemplate(null);
+                templates[127] = IISWebSocketWebsocketWriteFragmentEndNotSuccessTemplate(null);
+                templates[128] = IISWebSocketWebsocketApplicationCloseConnectionTemplate(null);
+                templates[129] = IISWebSocketWebsocketModuleCloseConnectionTemplate(null);
+                templates[130] = IISWebSocketWebsocketReadIoNotSuccessTemplate(null);
+                templates[131] = IISWebSocketWebsocketWriteIoNotSuccessTemplate(null);
+                templates[132] = IISWebSocketWebsocketReceivedCloseTemplate(null);
+                templates[133] = IISWebSocketWebsocketSendCloseStartTemplate(null);
+                templates[134] = IISWebSocketWebsocketSendCloseEndSuccessTemplate(null);
+                templates[135] = IISWebSocketWebsocketSendCloseEndNotSuccessTemplate(null);
+                templates[136] = IISCompressionStaticCompressionStartTemplate(null);
+                templates[137] = IISCompressionStaticCompressionSuccessTemplate(null);
+                templates[138] = IISCompressionStaticCompressionNotSuccessTemplate(null);
+                templates[139] = IISCompressionStaticCompressionCreateStartTemplate(null);
+                templates[140] = IISCompressionStaticCompressionCreateEndTemplate(null);
+                templates[141] = IISCompressionDynamicCompressionStartTemplate(null);
+                templates[142] = IISCompressionDynamicCompressionSuccessTemplate(null);
+                templates[143] = IISCompressionDynamicCompressionNotSuccessTemplate(null);
+                templates[144] = IISCompressionDynamicCompressionDoTemplate(null);
+                templates[145] = IISCompressionDynamicCompressionEndTemplate(null);
+                templates[146] = IISCompressionStaticCompressionEndTemplate(null);
+                templates[147] = IISCacheFileCacheAccessStartTemplate(null);
+                templates[148] = IISCacheFileCacheAccessEndTemplate(null);
+                templates[149] = IISCacheUrlCacheAccessStartTemplate(null);
+                templates[150] = IISCacheUrlCacheAccessEndTemplate(null);
+                templates[151] = IISCacheHttpsysCacheableTemplate(null);
+                templates[152] = IISCacheOutputCacheLookupStartTemplate(null);
+                templates[153] = IISCacheOutputCacheLookupEndTemplate(null);
+                templates[154] = IISCacheOutputCacheUpdateStartTemplate(null);
+                templates[155] = IISCacheOutputCacheUpdateEndTemplate(null);
+                templates[156] = IISCacheOutputCacheDisabledTemplate(null);
+                templates[157] = IISRequestNotificationNotifyModuleStartTemplate(null);
+                templates[158] = IISRequestNotificationNotifyModuleEndTemplate(null);
+                templates[159] = IISRequestNotificationNotifyModuleCompletionTemplate(null);
+                templates[160] = IISRequestNotificationPreBeginRequestStartTemplate(null);
+                templates[161] = IISRequestNotificationPreBeginRequestEndTemplate(null);
+                templates[162] = IISRequestNotificationRequestProcessingErrorTemplate(null);
+                templates[163] = IISRequestNotificationModuleSetResponseErrorStatusTemplate(null);
+                templates[164] = IISRequestNotificationModuleSetResponseSuccessStatusTemplate(null);
+                templates[165] = IISRequestNotificationSetResponseErrorDescriptionTemplate(null);
+                templates[166] = IISModuleModuleStartTemplate(null);
+                templates[167] = IISModuleModuleEndTemplate(null);
+                templates[168] = IISModuleModuleCriticalErrorTemplate(null);
+                templates[169] = IISModuleModuleErrorTemplate(null);
+                templates[170] = IISModuleModuleWarningTemplate(null);
+                templates[171] = IISModuleModuleInformationTemplate(null);
+                templates[172] = IISModuleModuleVerboseTemplate(null);
                 s_templates = templates;
             }
             foreach (var template in s_templates)
@@ -3102,6 +2846,852 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
 namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
 {
+    public sealed class W3AuthAnonPasswdChangeNeeded : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3AuthAnonPasswdChangeNeeded(Action<W3AuthAnonPasswdChangeNeeded> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthAnonPasswdChangeNeeded>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthAnonPasswdChangeNeeded> m_target;
+        #endregion
+    }
+    public sealed class W3AuthBadBasicHeader : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3AuthBadBasicHeader(Action<W3AuthBadBasicHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthBadBasicHeader>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthBadBasicHeader> m_target;
+        #endregion
+    }
+    public sealed class W3AuthBasicLogonFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3AuthBasicLogonFailed(Action<W3AuthBasicLogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthBasicLogonFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthBasicLogonFailed> m_target;
+        #endregion
+    }
+    public sealed class W3AuthEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3AuthEnd(Action<W3AuthEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthEnd> m_target;
+        #endregion
+    }
+    public sealed class W3AuthIISDigestLogonFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3AuthIISDigestLogonFailed(Action<W3AuthIISDigestLogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthIISDigestLogonFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthIISDigestLogonFailed> m_target;
+        #endregion
+    }
+    public sealed class W3AuthInvalidAnonAccount : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3AuthInvalidAnonAccount(Action<W3AuthInvalidAnonAccount> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthInvalidAnonAccount>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthInvalidAnonAccount> m_target;
+        #endregion
+    }
+    public sealed class W3AuthKerberosFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public bool KMUsed { get { return GetInt32At(16) != 0; } }
+        public string APUserName { get { return GetUnicodeStringAt(20); } }
+        public string SPNName { get { return GetUnicodeStringAt(SkipUnicodeString(20)); } }
+        public bool ADConfigIsOK { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(20))) != 0; } }
+        public string KerberosInfo { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(20)) + 4); } }
+
+        #region Private
+        internal W3AuthKerberosFailed(Action<W3AuthKerberosFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(20)) + 4)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(20)) + 4)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthKerberosFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "KMUsed", KMUsed);
+            XmlAttrib(sb, "APUserName", APUserName);
+            XmlAttrib(sb, "SPNName", SPNName);
+            XmlAttrib(sb, "ADConfigIsOK", ADConfigIsOK);
+            XmlAttrib(sb, "KerberosInfo", KerberosInfo);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "KMUsed", "APUserName", "SPNName", "ADConfigIsOK", "KerberosInfo" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return KMUsed;
+                case 2:
+                    return APUserName;
+                case 3:
+                    return SPNName;
+                case 4:
+                    return ADConfigIsOK;
+                case 5:
+                    return KerberosInfo;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthKerberosFailed> m_target;
+        #endregion
+    }
+    public sealed class W3AuthNTLMNullSession : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3AuthNTLMNullSession(Action<W3AuthNTLMNullSession> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthNTLMNullSession>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthNTLMNullSession> m_target;
+        #endregion
+    }
+    public sealed class W3AuthPassportLogonFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3AuthPassportLogonFailed(Action<W3AuthPassportLogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthPassportLogonFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthPassportLogonFailed> m_target;
+        #endregion
+    }
+    public sealed class W3AuthPasswdChangeDisabled : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3AuthPasswdChangeDisabled(Action<W3AuthPasswdChangeDisabled> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthPasswdChangeDisabled>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthPasswdChangeDisabled> m_target;
+        #endregion
+    }
+    public sealed class W3AuthPasswdChangeNeeded : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3AuthPasswdChangeNeeded(Action<W3AuthPasswdChangeNeeded> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthPasswdChangeNeeded>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthPasswdChangeNeeded> m_target;
+        #endregion
+    }
+    public sealed class W3AuthRequestAuthType : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int RequestAuthType { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3AuthRequestAuthType(Action<W3AuthRequestAuthType> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthRequestAuthType>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "RequestAuthType", RequestAuthType);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "RequestAuthType" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return RequestAuthType;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthRequestAuthType> m_target;
+        #endregion
+    }
+    public sealed class W3AuthSSPIContinueNeeded : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string PackageName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3AuthSSPIContinueNeeded(Action<W3AuthSSPIContinueNeeded> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthSSPIContinueNeeded>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "PackageName", PackageName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "PackageName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return PackageName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthSSPIContinueNeeded> m_target;
+        #endregion
+    }
+    public sealed class W3AuthSSPILogonFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3AuthSSPILogonFailed(Action<W3AuthSSPILogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3AuthSSPILogonFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3AuthSSPILogonFailed> m_target;
+        #endregion
+    }
     public sealed class W3AuthStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
@@ -3297,299 +3887,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3AuthTypeNotSupported> m_target;
         #endregion
     }
-    public sealed class W3AuthInvalidAnonAccount : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3AuthInvalidAnonAccount(Action<W3AuthInvalidAnonAccount> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthInvalidAnonAccount>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthInvalidAnonAccount> m_target;
-        #endregion
-    }
-    public sealed class W3AuthPasswdChangeNeeded : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3AuthPasswdChangeNeeded(Action<W3AuthPasswdChangeNeeded> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthPasswdChangeNeeded>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthPasswdChangeNeeded> m_target;
-        #endregion
-    }
-    public sealed class W3AuthPasswdChangeDisabled : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3AuthPasswdChangeDisabled(Action<W3AuthPasswdChangeDisabled> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthPasswdChangeDisabled>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthPasswdChangeDisabled> m_target;
-        #endregion
-    }
-    public sealed class W3AuthBadBasicHeader : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3AuthBadBasicHeader(Action<W3AuthBadBasicHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthBadBasicHeader>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthBadBasicHeader> m_target;
-        #endregion
-    }
-    public sealed class W3AuthBasicLogonFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3AuthBasicLogonFailed(Action<W3AuthBasicLogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthBasicLogonFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthBasicLogonFailed> m_target;
-        #endregion
-    }
     public sealed class W3AuthWDigestLogonFailed : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
@@ -3649,628 +3946,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
 
         private event Action<W3AuthWDigestLogonFailed> m_target;
-        #endregion
-    }
-    public sealed class W3AuthIISDigestLogonFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3AuthIISDigestLogonFailed(Action<W3AuthIISDigestLogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthIISDigestLogonFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthIISDigestLogonFailed> m_target;
-        #endregion
-    }
-    public sealed class W3AuthPassportLogonFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3AuthPassportLogonFailed(Action<W3AuthPassportLogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthPassportLogonFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthPassportLogonFailed> m_target;
-        #endregion
-    }
-    public sealed class W3AuthSSPILogonFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3AuthSSPILogonFailed(Action<W3AuthSSPILogonFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthSSPILogonFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthSSPILogonFailed> m_target;
-        #endregion
-    }
-    public sealed class W3AuthNTLMNullSession : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3AuthNTLMNullSession(Action<W3AuthNTLMNullSession> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthNTLMNullSession>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthNTLMNullSession> m_target;
-        #endregion
-    }
-    public sealed class W3AuthSSPIContinueNeeded : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string PackageName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3AuthSSPIContinueNeeded(Action<W3AuthSSPIContinueNeeded> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthSSPIContinueNeeded>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "PackageName", PackageName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "PackageName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return PackageName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthSSPIContinueNeeded> m_target;
-        #endregion
-    }
-    public sealed class W3AuthAnonPasswdChangeNeeded : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3AuthAnonPasswdChangeNeeded(Action<W3AuthAnonPasswdChangeNeeded> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthAnonPasswdChangeNeeded>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthAnonPasswdChangeNeeded> m_target;
-        #endregion
-    }
-    public sealed class W3AuthRequestAuthType : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int RequestAuthType { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3AuthRequestAuthType(Action<W3AuthRequestAuthType> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthRequestAuthType>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestAuthType", RequestAuthType);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestAuthType" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RequestAuthType;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthRequestAuthType> m_target;
-        #endregion
-    }
-    public sealed class W3AuthEnd : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3AuthEnd(Action<W3AuthEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthEnd> m_target;
-        #endregion
-    }
-    public sealed class W3AuthKerberosFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public bool KMUsed { get { return GetInt32At(16) != 0; } }
-        public string APUserName { get { return GetUnicodeStringAt(20); } }
-        public string SPNName { get { return GetUnicodeStringAt(SkipUnicodeString(20)); } }
-        public bool ADConfigIsOK { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(20))) != 0; } }
-        public string KerberosInfo { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(20)) + 4); } }
-
-        #region Private
-        internal W3AuthKerberosFailed(Action<W3AuthKerberosFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(20)) + 4)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(20)) + 4)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3AuthKerberosFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "KMUsed", KMUsed);
-            XmlAttrib(sb, "APUserName", APUserName);
-            XmlAttrib(sb, "SPNName", SPNName);
-            XmlAttrib(sb, "ADConfigIsOK", ADConfigIsOK);
-            XmlAttrib(sb, "KerberosInfo", KerberosInfo);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "KMUsed", "APUserName", "SPNName", "ADConfigIsOK", "KerberosInfo" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return KMUsed;
-                case 2:
-                    return APUserName;
-                case 3:
-                    return SPNName;
-                case 4:
-                    return ADConfigIsOK;
-                case 5:
-                    return KerberosInfo;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3AuthKerberosFailed> m_target;
-        #endregion
-    }
-    public sealed class W3CacheFileCacheAccessStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FileName { get { return GetUnicodeStringAt(16); } }
-        public string UserName { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-        public string DomainName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
-
-        #region Private
-        internal W3CacheFileCacheAccessStart(Action<W3CacheFileCacheAccessStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CacheFileCacheAccessStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
-            XmlAttrib(sb, "UserName", UserName);
-            XmlAttrib(sb, "DomainName", DomainName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName", "UserName", "DomainName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return FileName;
-                case 2:
-                    return UserName;
-                case 3:
-                    return DomainName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CacheFileCacheAccessStart> m_target;
         #endregion
     }
     public sealed class W3CacheFileCacheAccessEnd : TraceEvent
@@ -4358,13 +4033,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3CacheFileCacheAccessEnd> m_target;
         #endregion
     }
-    public sealed class W3CacheURLCacheAccessStart : TraceEvent
+    public sealed class W3CacheFileCacheAccessStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string RequestURL { get { return GetUnicodeStringAt(16); } }
+        public string FileName { get { return GetUnicodeStringAt(16); } }
+        public string UserName { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+        public string DomainName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
 
         #region Private
-        internal W3CacheURLCacheAccessStart(Action<W3CacheURLCacheAccessStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CacheFileCacheAccessStart(Action<W3CacheFileCacheAccessStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -4375,19 +4052,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CacheURLCacheAccessStart>)value; }
+            set { m_target = (Action<W3CacheFileCacheAccessStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestURL", RequestURL);
+            XmlAttrib(sb, "FileName", FileName);
+            XmlAttrib(sb, "UserName", UserName);
+            XmlAttrib(sb, "DomainName", DomainName);
             sb.Append("/>");
             return sb;
         }
@@ -4397,7 +4076,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestURL" };
+                    payloadNames = new string[] { "ContextId", "FileName", "UserName", "DomainName" };
                 return payloadNames;
             }
         }
@@ -4409,87 +4088,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return RequestURL;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CacheURLCacheAccessStart> m_target;
-        #endregion
-    }
-    public sealed class W3CacheURLCacheAccessEnd : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string PhysicalPath { get { return GetUnicodeStringAt(16); } }
-        public bool URLInfoFromCache { get { return GetInt32At(SkipUnicodeString(16)) != 0; } }
-        public bool URLInfoAddedToCache { get { return GetInt32At(SkipUnicodeString(16) + 4) != 0; } }
-        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16) + 8); } }
-
-        #region Private
-        internal W3CacheURLCacheAccessEnd(Action<W3CacheURLCacheAccessEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 12));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 12));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CacheURLCacheAccessEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "PhysicalPath", PhysicalPath);
-            XmlAttrib(sb, "URLInfoFromCache", URLInfoFromCache);
-            XmlAttrib(sb, "URLInfoAddedToCache", URLInfoAddedToCache);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "PhysicalPath", "URLInfoFromCache", "URLInfoAddedToCache", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return PhysicalPath;
+                    return FileName;
                 case 2:
-                    return URLInfoFromCache;
+                    return UserName;
                 case 3:
-                    return URLInfoAddedToCache;
-                case 4:
-                    return ErrorCode;
+                    return DomainName;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3CacheURLCacheAccessEnd> m_target;
+        private event Action<W3CacheFileCacheAccessStart> m_target;
         #endregion
     }
     public sealed class W3CacheHttpsysCacheable : TraceEvent
@@ -4565,12 +4175,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3CacheHttpsysCacheable> m_target;
         #endregion
     }
-    public sealed class W3OutputCacheLookupStart : TraceEvent
+    public sealed class W3OutputCacheDisabled : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3OutputCacheLookupStart(Action<W3OutputCacheLookupStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3OutputCacheDisabled(Action<W3OutputCacheDisabled> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -4587,7 +4197,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3OutputCacheLookupStart>)value; }
+            set { m_target = (Action<W3OutputCacheDisabled>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -4619,7 +4229,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3OutputCacheLookupStart> m_target;
+        private event Action<W3OutputCacheDisabled> m_target;
         #endregion
     }
     public sealed class W3OutputCacheLookupEnd : TraceEvent
@@ -4681,6 +4291,124 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
 
         private event Action<W3OutputCacheLookupEnd> m_target;
+        #endregion
+    }
+    public sealed class W3OutputCacheLookupStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3OutputCacheLookupStart(Action<W3OutputCacheLookupStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3OutputCacheLookupStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3OutputCacheLookupStart> m_target;
+        #endregion
+    }
+    public sealed class W3OutputCacheUpdateEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int Result { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3OutputCacheUpdateEnd(Action<W3OutputCacheUpdateEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3OutputCacheUpdateEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Result", Result);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Result" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Result;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3OutputCacheUpdateEnd> m_target;
         #endregion
     }
     public sealed class W3OutputCacheUpdateStart : TraceEvent
@@ -4748,13 +4476,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3OutputCacheUpdateStart> m_target;
         #endregion
     }
-    public sealed class W3OutputCacheUpdateEnd : TraceEvent
+    public sealed class W3CacheURLCacheAccessEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public int Result { get { return GetInt32At(16); } }
+        public string PhysicalPath { get { return GetUnicodeStringAt(16); } }
+        public bool URLInfoFromCache { get { return GetInt32At(SkipUnicodeString(16)) != 0; } }
+        public bool URLInfoAddedToCache { get { return GetInt32At(SkipUnicodeString(16) + 4) != 0; } }
+        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16) + 8); } }
 
         #region Private
-        internal W3OutputCacheUpdateEnd(Action<W3OutputCacheUpdateEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CacheURLCacheAccessEnd(Action<W3CacheURLCacheAccessEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -4765,19 +4496,22 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 12));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 12));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3OutputCacheUpdateEnd>)value; }
+            set { m_target = (Action<W3CacheURLCacheAccessEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Result", Result);
+            XmlAttrib(sb, "PhysicalPath", PhysicalPath);
+            XmlAttrib(sb, "URLInfoFromCache", URLInfoFromCache);
+            XmlAttrib(sb, "URLInfoAddedToCache", URLInfoAddedToCache);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
             sb.Append("/>");
             return sb;
         }
@@ -4787,7 +4521,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Result" };
+                    payloadNames = new string[] { "ContextId", "PhysicalPath", "URLInfoFromCache", "URLInfoAddedToCache", "ErrorCode" };
                 return payloadNames;
             }
         }
@@ -4799,22 +4533,89 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return Result;
+                    return PhysicalPath;
+                case 2:
+                    return URLInfoFromCache;
+                case 3:
+                    return URLInfoAddedToCache;
+                case 4:
+                    return ErrorCode;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3OutputCacheUpdateEnd> m_target;
+        private event Action<W3CacheURLCacheAccessEnd> m_target;
         #endregion
     }
-    public sealed class W3OutputCacheDisabled : TraceEvent
+    public sealed class W3CacheURLCacheAccessStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string RequestURL { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3CacheURLCacheAccessStart(Action<W3CacheURLCacheAccessStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CacheURLCacheAccessStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "RequestURL", RequestURL);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "RequestURL" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return RequestURL;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CacheURLCacheAccessStart> m_target;
+        #endregion
+    }
+    public sealed class W3CGIEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3OutputCacheDisabled(Action<W3OutputCacheDisabled> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIEnd(Action<W3CGIEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -4831,7 +4632,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3OutputCacheDisabled>)value; }
+            set { m_target = (Action<W3CGIEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -4863,18 +4664,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3OutputCacheDisabled> m_target;
+        private event Action<W3CGIEnd> m_target;
         #endregion
     }
-    public sealed class W3CacheFileCacheCreateFile : TraceEvent
+    public sealed class W3CGIHeadersReceived : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FileName { get { return GetUnicodeStringAt(16); } }
-        public string UserName { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-        public string DomainName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
 
         #region Private
-        internal W3CacheFileCacheCreateFile(Action<W3CacheFileCacheCreateFile> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIHeadersReceived(Action<W3CGIHeadersReceived> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -4885,21 +4683,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CacheFileCacheCreateFile>)value; }
+            set { m_target = (Action<W3CGIHeadersReceived>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
-            XmlAttrib(sb, "UserName", UserName);
-            XmlAttrib(sb, "DomainName", DomainName);
             sb.Append("/>");
             return sb;
         }
@@ -4909,7 +4704,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName", "UserName", "DomainName" };
+                    payloadNames = new string[] { "ContextId" };
                 return payloadNames;
             }
         }
@@ -4920,19 +4715,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             {
                 case 0:
                     return ContextId;
-                case 1:
-                    return FileName;
-                case 2:
-                    return UserName;
-                case 3:
-                    return DomainName;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3CacheFileCacheCreateFile> m_target;
+        private event Action<W3CGIHeadersReceived> m_target;
         #endregion
     }
     public sealed class W3CGILaunch : TraceEvent
@@ -5002,67 +4791,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
 
         private event Action<W3CGILaunch> m_target;
-        #endregion
-    }
-    public sealed class W3CGITimeout : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Headers { get { return GetUTF8StringAt(16); } }
-
-        #region Private
-        internal W3CGITimeout(Action<W3CGITimeout> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGITimeout>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Headers", Headers);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Headers" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Headers;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGITimeout> m_target;
         #endregion
     }
     public sealed class W3CGIPrematureTermination : TraceEvent
@@ -5183,12 +4911,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3CGIRequestEntitySent> m_target;
         #endregion
     }
-    public sealed class W3CGIHeadersReceived : TraceEvent
+    public sealed class W3CGIStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3CGIHeadersReceived(Action<W3CGIHeadersReceived> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIStart(Action<W3CGIStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -5205,7 +4933,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIHeadersReceived>)value; }
+            set { m_target = (Action<W3CGIStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -5237,78 +4965,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3CGIHeadersReceived> m_target;
-        #endregion
-    }
-    public sealed class W3CGIStart : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
-
-        #region Private
-        internal W3CGIStart(Action<W3CGIStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != 8));
-            Debug.Assert(!(Version > 0 && EventDataLength < 8));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RequestId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
         private event Action<W3CGIStart> m_target;
         #endregion
     }
-    public sealed class W3CGIEnd : TraceEvent
+    public sealed class W3CGITimeout : TraceEvent
     {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Headers { get { return GetUTF8StringAt(16); } }
 
         #region Private
-        internal W3CGIEnd(Action<W3CGIEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGITimeout(Action<W3CGITimeout> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -5319,20 +4985,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != 8));
-            Debug.Assert(!(Version > 0 && EventDataLength < 8));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIEnd>)value; }
+            set { m_target = (Action<W3CGITimeout>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
+            XmlAttrib(sb, "Headers", Headers);
             sb.Append("/>");
             return sb;
         }
@@ -5342,7 +5007,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId" };
+                    payloadNames = new string[] { "ContextId", "Headers" };
                 return payloadNames;
             }
         }
@@ -5354,23 +5019,24 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return RequestId;
+                    return Headers;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3CGIEnd> m_target;
+        private event Action<W3CGITimeout> m_target;
         #endregion
     }
-    public sealed class W3StaticCompressionNotSuccess : TraceEvent
+    public sealed class W3DynamicCompressionDo : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public int Reason { get { return GetInt32At(16); } }
+        public int OriginalSize { get { return GetInt32At(16); } }
+        public int CompressedSize { get { return GetInt32At(20); } }
 
         #region Private
-        internal W3StaticCompressionNotSuccess(Action<W3StaticCompressionNotSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3DynamicCompressionDo(Action<W3DynamicCompressionDo> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -5381,19 +5047,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+            Debug.Assert(!(Version == 1 && EventDataLength != 24));
+            Debug.Assert(!(Version > 1 && EventDataLength < 24));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3StaticCompressionNotSuccess>)value; }
+            set { m_target = (Action<W3DynamicCompressionDo>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Reason", Reason);
+            XmlAttrib(sb, "OriginalSize", OriginalSize);
+            XmlAttrib(sb, "CompressedSize", CompressedSize);
             sb.Append("/>");
             return sb;
         }
@@ -5403,7 +5070,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Reason" };
+                    payloadNames = new string[] { "ContextId", "OriginalSize", "CompressedSize" };
                 return payloadNames;
             }
         }
@@ -5415,152 +5082,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return Reason;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3StaticCompressionNotSuccess> m_target;
-        #endregion
-    }
-    public sealed class W3StaticCompressionCreateStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string OriginalFileName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3StaticCompressionCreateStart(Action<W3StaticCompressionCreateStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3StaticCompressionCreateStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "OriginalFileName", OriginalFileName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "OriginalFileName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return OriginalFileName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3StaticCompressionCreateStart> m_target;
-        #endregion
-    }
-    public sealed class W3StaticCompressionCreateEnd : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-        public string OriginalFileName { get { return GetUnicodeStringAt(20); } }
-        public int OriginalFileSize { get { return GetInt32At(SkipUnicodeString(20)); } }
-        public string CompressedFileName { get { return GetUnicodeStringAt(SkipUnicodeString(20) + 4); } }
-        public int CompressedFileSize { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(20) + 4)); } }
-
-        #region Private
-        internal W3StaticCompressionCreateEnd(Action<W3StaticCompressionCreateEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(20) + 4) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(20) + 4) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3StaticCompressionCreateEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            XmlAttrib(sb, "OriginalFileName", OriginalFileName);
-            XmlAttrib(sb, "OriginalFileSize", OriginalFileSize);
-            XmlAttrib(sb, "CompressedFileName", CompressedFileName);
-            XmlAttrib(sb, "CompressedFileSize", CompressedFileSize);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode", "OriginalFileName", "OriginalFileSize", "CompressedFileName", "CompressedFileSize" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
+                    return OriginalSize;
                 case 2:
-                    return OriginalFileName;
-                case 3:
-                    return OriginalFileSize;
-                case 4:
-                    return CompressedFileName;
-                case 5:
-                    return CompressedFileSize;
+                    return CompressedSize;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3StaticCompressionCreateEnd> m_target;
+        private event Action<W3DynamicCompressionDo> m_target;
         #endregion
     }
     public sealed class W3DynamicCompressionEnd : TraceEvent
@@ -5620,12 +5151,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3DynamicCompressionEnd> m_target;
         #endregion
     }
-    public sealed class W3StaticCompressionEnd : TraceEvent
+    public sealed class W3DynamicCompressionNotSuccess : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
+        public int Reason { get { return GetInt32At(16); } }
 
         #region Private
-        internal W3StaticCompressionEnd(Action<W3StaticCompressionEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3DynamicCompressionNotSuccess(Action<W3DynamicCompressionNotSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -5636,18 +5168,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3StaticCompressionEnd>)value; }
+            set { m_target = (Action<W3DynamicCompressionNotSuccess>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Reason", Reason);
             sb.Append("/>");
             return sb;
         }
@@ -5657,7 +5190,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
+                    payloadNames = new string[] { "ContextId", "Reason" };
                 return payloadNames;
             }
         }
@@ -5668,13 +5201,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             {
                 case 0:
                     return ContextId;
+                case 1:
+                    return Reason;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3StaticCompressionEnd> m_target;
+        private event Action<W3DynamicCompressionNotSuccess> m_target;
         #endregion
     }
     public sealed class W3DynamicCompressionStart : TraceEvent
@@ -5791,14 +5326,17 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3DynamicCompressionSuccess> m_target;
         #endregion
     }
-    public sealed class W3DynamicCompressionDo : TraceEvent
+    public sealed class W3StaticCompressionCreateEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public int OriginalSize { get { return GetInt32At(16); } }
-        public int CompressedSize { get { return GetInt32At(20); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+        public string OriginalFileName { get { return GetUnicodeStringAt(20); } }
+        public int OriginalFileSize { get { return GetInt32At(SkipUnicodeString(20)); } }
+        public string CompressedFileName { get { return GetUnicodeStringAt(SkipUnicodeString(20) + 4); } }
+        public int CompressedFileSize { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(20) + 4)); } }
 
         #region Private
-        internal W3DynamicCompressionDo(Action<W3DynamicCompressionDo> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3StaticCompressionCreateEnd(Action<W3StaticCompressionCreateEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -5809,20 +5347,23 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 24));
-            Debug.Assert(!(Version > 1 && EventDataLength < 24));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(20) + 4) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(20) + 4) + 4));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3DynamicCompressionDo>)value; }
+            set { m_target = (Action<W3StaticCompressionCreateEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "OriginalSize", OriginalSize);
-            XmlAttrib(sb, "CompressedSize", CompressedSize);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            XmlAttrib(sb, "OriginalFileName", OriginalFileName);
+            XmlAttrib(sb, "OriginalFileSize", OriginalFileSize);
+            XmlAttrib(sb, "CompressedFileName", CompressedFileName);
+            XmlAttrib(sb, "CompressedFileSize", CompressedFileSize);
             sb.Append("/>");
             return sb;
         }
@@ -5832,7 +5373,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "OriginalSize", "CompressedSize" };
+                    payloadNames = new string[] { "ContextId", "ErrorCode", "OriginalFileName", "OriginalFileSize", "CompressedFileName", "CompressedFileSize" };
                 return payloadNames;
             }
         }
@@ -5844,16 +5385,201 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return OriginalSize;
+                    return ErrorCode;
                 case 2:
-                    return CompressedSize;
+                    return OriginalFileName;
+                case 3:
+                    return OriginalFileSize;
+                case 4:
+                    return CompressedFileName;
+                case 5:
+                    return CompressedFileSize;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3DynamicCompressionDo> m_target;
+        private event Action<W3StaticCompressionCreateEnd> m_target;
+        #endregion
+    }
+    public sealed class W3StaticCompressionCreateStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string OriginalFileName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3StaticCompressionCreateStart(Action<W3StaticCompressionCreateStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3StaticCompressionCreateStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "OriginalFileName", OriginalFileName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "OriginalFileName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return OriginalFileName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3StaticCompressionCreateStart> m_target;
+        #endregion
+    }
+    public sealed class W3StaticCompressionEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3StaticCompressionEnd(Action<W3StaticCompressionEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3StaticCompressionEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3StaticCompressionEnd> m_target;
+        #endregion
+    }
+    public sealed class W3StaticCompressionNotSuccess : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int Reason { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3StaticCompressionNotSuccess(Action<W3StaticCompressionNotSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3StaticCompressionNotSuccess>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Reason", Reason);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Reason" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Reason;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3StaticCompressionNotSuccess> m_target;
         #endregion
     }
     public sealed class W3StaticCompressionStart : TraceEvent
@@ -5970,73 +5696,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3StaticCompressionSuccess> m_target;
         #endregion
     }
-    public sealed class W3DynamicCompressionNotSuccess : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int Reason { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3DynamicCompressionNotSuccess(Action<W3DynamicCompressionNotSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3DynamicCompressionNotSuccess>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Reason", Reason);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Reason" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Reason;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3DynamicCompressionNotSuccess> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFUnexpectedExit : TraceEvent
+    public sealed class W3CGIFActivityTimeout : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3CGIFUnexpectedExit(Action<W3CGIFUnexpectedExit> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFActivityTimeout(Action<W3CGIFActivityTimeout> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -6053,7 +5718,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIFUnexpectedExit>)value; }
+            set { m_target = (Action<W3CGIFActivityTimeout>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -6085,15 +5750,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3CGIFUnexpectedExit> m_target;
+        private event Action<W3CGIFActivityTimeout> m_target;
         #endregion
     }
-    public sealed class W3CGIFRapidFailureProtection : TraceEvent
+    public sealed class W3CGIFAddJobObjectFail : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3CGIFRapidFailureProtection(Action<W3CGIFRapidFailureProtection> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFAddJobObjectFail(Action<W3CGIFAddJobObjectFail> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -6110,7 +5775,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIFRapidFailureProtection>)value; }
+            set { m_target = (Action<W3CGIFAddJobObjectFail>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -6142,15 +5807,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3CGIFRapidFailureProtection> m_target;
+        private event Action<W3CGIFAddJobObjectFail> m_target;
         #endregion
     }
-    public sealed class W3CGIFPathNotFound : TraceEvent
+    public sealed class W3CGIFAppMgrShutdown : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3CGIFPathNotFound(Action<W3CGIFPathNotFound> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFAppMgrShutdown(Action<W3CGIFAppMgrShutdown> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -6167,7 +5832,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIFPathNotFound>)value; }
+            set { m_target = (Action<W3CGIFAppMgrShutdown>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -6199,430 +5864,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3CGIFPathNotFound> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFUnknownError : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3CGIFUnknownError(Action<W3CGIFUnknownError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFUnknownError>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFUnknownError> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFResponseWritten : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3CGIFResponseWritten(Action<W3CGIFResponseWritten> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFResponseWritten>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFResponseWritten> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFWaitingForResponse : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3CGIFWaitingForResponse(Action<W3CGIFWaitingForResponse> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFWaitingForResponse>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFWaitingForResponse> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFTraceError : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Message { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3CGIFTraceError(Action<W3CGIFTraceError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFTraceError>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Message", Message);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Message" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Message;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFTraceError> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFTraceWarning : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Message { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3CGIFTraceWarning(Action<W3CGIFTraceWarning> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFTraceWarning>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Message", Message);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Message" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Message;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFTraceWarning> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFTraceInfo : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Message { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3CGIFTraceInfo(Action<W3CGIFTraceInfo> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFTraceInfo>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Message", Message);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Message" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Message;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFTraceInfo> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFQueueRequest : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int PositionInQueue { get { return GetInt32At(16); } }
-        public int MaxInstances { get { return GetInt32At(20); } }
-
-        #region Private
-        internal W3CGIFQueueRequest(Action<W3CGIFQueueRequest> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 24));
-            Debug.Assert(!(Version > 1 && EventDataLength < 24));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFQueueRequest>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "PositionInQueue", PositionInQueue);
-            XmlAttrib(sb, "MaxInstances", MaxInstances);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "PositionInQueue", "MaxInstances" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return PositionInQueue;
-                case 2:
-                    return MaxInstances;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFQueueRequest> m_target;
+        private event Action<W3CGIFAppMgrShutdown> m_target;
         #endregion
     }
     public sealed class W3CGIFAssignProcess : TraceEvent
@@ -6698,63 +5940,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3CGIFAssignProcess> m_target;
         #endregion
     }
-    public sealed class W3CGIFStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3CGIFStart(Action<W3CGIFStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFStart> m_target;
-        #endregion
-    }
     public sealed class W3CGIFEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
@@ -6812,12 +5997,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3CGIFEnd> m_target;
         #endregion
     }
-    public sealed class W3CGIFScriptProcessorMissing : TraceEvent
+    public sealed class W3CGIFPathNotFound : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3CGIFScriptProcessorMissing(Action<W3CGIFScriptProcessorMissing> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFPathNotFound(Action<W3CGIFPathNotFound> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -6834,7 +6019,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIFScriptProcessorMissing>)value; }
+            set { m_target = (Action<W3CGIFPathNotFound>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -6866,64 +6051,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3CGIFScriptProcessorMissing> m_target;
-        #endregion
-    }
-    public sealed class W3CGIFAddJobObjectFail : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3CGIFAddJobObjectFail(Action<W3CGIFAddJobObjectFail> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3CGIFAddJobObjectFail>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3CGIFAddJobObjectFail> m_target;
+        private event Action<W3CGIFPathNotFound> m_target;
         #endregion
     }
     public sealed class W3CGIFQueueFull : TraceEvent
@@ -6983,12 +6111,77 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3CGIFQueueFull> m_target;
         #endregion
     }
-    public sealed class W3CGIFActivityTimeout : TraceEvent
+    public sealed class W3CGIFQueueRequest : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int PositionInQueue { get { return GetInt32At(16); } }
+        public int MaxInstances { get { return GetInt32At(20); } }
+
+        #region Private
+        internal W3CGIFQueueRequest(Action<W3CGIFQueueRequest> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 24));
+            Debug.Assert(!(Version > 1 && EventDataLength < 24));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CGIFQueueRequest>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "PositionInQueue", PositionInQueue);
+            XmlAttrib(sb, "MaxInstances", MaxInstances);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "PositionInQueue", "MaxInstances" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return PositionInQueue;
+                case 2:
+                    return MaxInstances;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CGIFQueueRequest> m_target;
+        #endregion
+    }
+    public sealed class W3CGIFRapidFailureProtection : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3CGIFActivityTimeout(Action<W3CGIFActivityTimeout> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFRapidFailureProtection(Action<W3CGIFRapidFailureProtection> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7005,7 +6198,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIFActivityTimeout>)value; }
+            set { m_target = (Action<W3CGIFRapidFailureProtection>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -7037,7 +6230,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3CGIFActivityTimeout> m_target;
+        private event Action<W3CGIFRapidFailureProtection> m_target;
         #endregion
     }
     public sealed class W3CGIFRequestTimeout : TraceEvent
@@ -7097,12 +6290,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3CGIFRequestTimeout> m_target;
         #endregion
     }
-    public sealed class W3CGIFAppMgrShutdown : TraceEvent
+    public sealed class W3CGIFResponseWritten : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3CGIFAppMgrShutdown(Action<W3CGIFAppMgrShutdown> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFResponseWritten(Action<W3CGIFResponseWritten> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7119,7 +6312,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3CGIFAppMgrShutdown>)value; }
+            set { m_target = (Action<W3CGIFResponseWritten>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -7151,16 +6344,370 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3CGIFAppMgrShutdown> m_target;
+        private event Action<W3CGIFResponseWritten> m_target;
         #endregion
     }
-    public sealed class W3FilterError : TraceEvent
+    public sealed class W3CGIFScriptProcessorMissing : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3CGIFScriptProcessorMissing(Action<W3CGIFScriptProcessorMissing> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CGIFScriptProcessorMissing>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CGIFScriptProcessorMissing> m_target;
+        #endregion
+    }
+    public sealed class W3CGIFStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3CGIFStart(Action<W3CGIFStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CGIFStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CGIFStart> m_target;
+        #endregion
+    }
+    public sealed class W3CGIFTraceError : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Message { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3CGIFTraceError(Action<W3CGIFTraceError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CGIFTraceError>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Message", Message);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Message" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Message;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CGIFTraceError> m_target;
+        #endregion
+    }
+    public sealed class W3CGIFTraceInfo : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Message { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3CGIFTraceInfo(Action<W3CGIFTraceInfo> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CGIFTraceInfo>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Message", Message);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Message" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Message;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CGIFTraceInfo> m_target;
+        #endregion
+    }
+    public sealed class W3CGIFTraceWarning : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Message { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3CGIFTraceWarning(Action<W3CGIFTraceWarning> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CGIFTraceWarning>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Message", Message);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Message" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Message;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CGIFTraceWarning> m_target;
+        #endregion
+    }
+    public sealed class W3CGIFUnexpectedExit : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3CGIFUnexpectedExit(Action<W3CGIFUnexpectedExit> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3CGIFUnexpectedExit>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3CGIFUnexpectedExit> m_target;
+        #endregion
+    }
+    public sealed class W3CGIFUnknownError : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
         public int ErrorCode { get { return GetInt32At(16); } }
 
         #region Private
-        internal W3FilterError(Action<W3FilterError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFUnknownError(Action<W3CGIFUnknownError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7177,7 +6724,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterError>)value; }
+            set { m_target = (Action<W3CGIFUnknownError>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -7212,15 +6759,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3FilterError> m_target;
+        private event Action<W3CGIFUnknownError> m_target;
         #endregion
     }
-    public sealed class W3FilterPreprocStart : TraceEvent
+    public sealed class W3CGIFWaitingForResponse : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3FilterPreprocStart(Action<W3FilterPreprocStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3CGIFWaitingForResponse(Action<W3CGIFWaitingForResponse> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7237,7 +6784,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterPreprocStart>)value; }
+            set { m_target = (Action<W3CGIFWaitingForResponse>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -7269,15 +6816,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3FilterPreprocStart> m_target;
+        private event Action<W3CGIFWaitingForResponse> m_target;
         #endregion
     }
-    public sealed class W3FilterPreprocEnd : TraceEvent
+    public sealed class W3FilterAccessDeniedEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3FilterPreprocEnd(Action<W3FilterPreprocEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterAccessDeniedEnd(Action<W3FilterAccessDeniedEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7294,7 +6841,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterPreprocEnd>)value; }
+            set { m_target = (Action<W3FilterAccessDeniedEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -7326,21 +6873,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3FilterPreprocEnd> m_target;
+        private event Action<W3FilterAccessDeniedEnd> m_target;
         #endregion
     }
-    public sealed class W3FilterURLMapStart : TraceEvent
+    public sealed class W3FilterAccessDeniedStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string OrigURL { get { return GetUTF8StringAt(16); } }
-        public string OrigPath { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-        public int AccessPerms { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))); } }
-        public int MatchingPath { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 4); } }
-        public int MatchingURL { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 8); } }
-        public string ScriptMapEntry { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16)) + 12); } }
+        public string RequestedURL { get { return GetUTF8StringAt(16); } }
+        public string PhysicalPath { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
+        public int DenialReason { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))); } }
 
         #region Private
-        internal W3FilterURLMapStart(Action<W3FilterURLMapStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterAccessDeniedStart(Action<W3FilterAccessDeniedStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7351,24 +6895,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16)) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16)) + 4));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterURLMapStart>)value; }
+            set { m_target = (Action<W3FilterAccessDeniedStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "OrigURL", OrigURL);
-            XmlAttrib(sb, "OrigPath", OrigPath);
-            XmlAttrib(sb, "AccessPerms", AccessPerms);
-            XmlAttrib(sb, "MatchingPath", MatchingPath);
-            XmlAttrib(sb, "MatchingURL", MatchingURL);
-            XmlAttrib(sb, "ScriptMapEntry", ScriptMapEntry);
+            XmlAttrib(sb, "RequestedURL", RequestedURL);
+            XmlAttrib(sb, "PhysicalPath", PhysicalPath);
+            XmlAttrib(sb, "DenialReason", DenialReason);
             sb.Append("/>");
             return sb;
         }
@@ -7378,7 +6919,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "OrigURL", "OrigPath", "AccessPerms", "MatchingPath", "MatchingURL", "ScriptMapEntry" };
+                    payloadNames = new string[] { "ContextId", "RequestedURL", "PhysicalPath", "DenialReason" };
                 return payloadNames;
             }
         }
@@ -7390,38 +6931,28 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return OrigURL;
+                    return RequestedURL;
                 case 2:
-                    return OrigPath;
+                    return PhysicalPath;
                 case 3:
-                    return AccessPerms;
-                case 4:
-                    return MatchingPath;
-                case 5:
-                    return MatchingURL;
-                case 6:
-                    return ScriptMapEntry;
+                    return DenialReason;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3FilterURLMapStart> m_target;
+        private event Action<W3FilterAccessDeniedStart> m_target;
         #endregion
     }
-    public sealed class W3FilterURLMapEnd : TraceEvent
+    public sealed class W3FilterAddReqHeader : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FinalURL { get { return GetUTF8StringAt(16); } }
-        public string FinalPath { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-        public int AccessPerms { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))); } }
-        public int MatchingPath { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 4); } }
-        public int MatchingURL { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 8); } }
-        public string ScriptMapEntry { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16)) + 12); } }
+        public string HeaderName { get { return GetUTF8StringAt(16); } }
+        public string HeaderValue { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
 
         #region Private
-        internal W3FilterURLMapEnd(Action<W3FilterURLMapEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterAddReqHeader(Action<W3FilterAddReqHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7432,24 +6963,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16))));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterURLMapEnd>)value; }
+            set { m_target = (Action<W3FilterAddReqHeader>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FinalURL", FinalURL);
-            XmlAttrib(sb, "FinalPath", FinalPath);
-            XmlAttrib(sb, "AccessPerms", AccessPerms);
-            XmlAttrib(sb, "MatchingPath", MatchingPath);
-            XmlAttrib(sb, "MatchingURL", MatchingURL);
-            XmlAttrib(sb, "ScriptMapEntry", ScriptMapEntry);
+            XmlAttrib(sb, "HeaderName", HeaderName);
+            XmlAttrib(sb, "HeaderValue", HeaderValue);
             sb.Append("/>");
             return sb;
         }
@@ -7459,7 +6986,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FinalURL", "FinalPath", "AccessPerms", "MatchingPath", "MatchingURL", "ScriptMapEntry" };
+                    payloadNames = new string[] { "ContextId", "HeaderName", "HeaderValue" };
                 return payloadNames;
             }
         }
@@ -7471,33 +6998,26 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return FinalURL;
+                    return HeaderName;
                 case 2:
-                    return FinalPath;
-                case 3:
-                    return AccessPerms;
-                case 4:
-                    return MatchingPath;
-                case 5:
-                    return MatchingURL;
-                case 6:
-                    return ScriptMapEntry;
+                    return HeaderValue;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3FilterURLMapEnd> m_target;
+        private event Action<W3FilterAddReqHeader> m_target;
         #endregion
     }
-    public sealed class W3FilterAuthenticationStart : TraceEvent
+    public sealed class W3FilterAddRespHeader : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string OrigUserName { get { return GetUTF8StringAt(16); } }
+        public string HeaderName { get { return GetUTF8StringAt(16); } }
+        public string HeaderValue { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
 
         #region Private
-        internal W3FilterAuthenticationStart(Action<W3FilterAuthenticationStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterAddRespHeader(Action<W3FilterAddRespHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7508,19 +7028,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16))));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterAuthenticationStart>)value; }
+            set { m_target = (Action<W3FilterAddRespHeader>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "OrigUserName", OrigUserName);
+            XmlAttrib(sb, "HeaderName", HeaderName);
+            XmlAttrib(sb, "HeaderValue", HeaderValue);
             sb.Append("/>");
             return sb;
         }
@@ -7530,7 +7051,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "OrigUserName" };
+                    payloadNames = new string[] { "ContextId", "HeaderName", "HeaderValue" };
                 return payloadNames;
             }
         }
@@ -7542,14 +7063,130 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return OrigUserName;
+                    return HeaderName;
+                case 2:
+                    return HeaderValue;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3FilterAuthenticationStart> m_target;
+        private event Action<W3FilterAddRespHeader> m_target;
+        #endregion
+    }
+    public sealed class W3FilterAuthCompleteEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3FilterAuthCompleteEnd(Action<W3FilterAuthCompleteEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterAuthCompleteEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterAuthCompleteEnd> m_target;
+        #endregion
+    }
+    public sealed class W3FilterAuthCompleteStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3FilterAuthCompleteStart(Action<W3FilterAuthCompleteStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterAuthCompleteStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterAuthCompleteStart> m_target;
         #endregion
     }
     public sealed class W3FilterAuthenticationEnd : TraceEvent
@@ -7617,12 +7254,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3FilterAuthenticationEnd> m_target;
         #endregion
     }
-    public sealed class W3FilterAuthCompleteStart : TraceEvent
+    public sealed class W3FilterAuthenticationStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
+        public string OrigUserName { get { return GetUTF8StringAt(16); } }
 
         #region Private
-        internal W3FilterAuthCompleteStart(Action<W3FilterAuthCompleteStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterAuthenticationStart(Action<W3FilterAuthenticationStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7633,18 +7271,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterAuthCompleteStart>)value; }
+            set { m_target = (Action<W3FilterAuthenticationStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "OrigUserName", OrigUserName);
             sb.Append("/>");
             return sb;
         }
@@ -7654,7 +7293,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
+                    payloadNames = new string[] { "ContextId", "OrigUserName" };
                 return payloadNames;
             }
         }
@@ -7665,79 +7304,24 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             {
                 case 0:
                     return ContextId;
+                case 1:
+                    return OrigUserName;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3FilterAuthCompleteStart> m_target;
+        private event Action<W3FilterAuthenticationStart> m_target;
         #endregion
     }
-    public sealed class W3FilterAuthCompleteEnd : TraceEvent
+    public sealed class W3FilterEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
+        public int NotificationStatus { get { return GetInt32At(16); } }
 
         #region Private
-        internal W3FilterAuthCompleteEnd(Action<W3FilterAuthCompleteEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3FilterAuthCompleteEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3FilterAuthCompleteEnd> m_target;
-        #endregion
-    }
-    public sealed class W3FilterSendResponseStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int HttpStatus { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3FilterSendResponseStart(Action<W3FilterSendResponseStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterEnd(Action<W3FilterEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7754,13 +7338,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterSendResponseStart>)value; }
+            set { m_target = (Action<W3FilterEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "HttpStatus", HttpStatus);
+            XmlAttrib(sb, "NotificationStatus", NotificationStatus);
             sb.Append("/>");
             return sb;
         }
@@ -7770,7 +7354,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "HttpStatus" };
+                    payloadNames = new string[] { "ContextId", "NotificationStatus" };
                 return payloadNames;
             }
         }
@@ -7782,128 +7366,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return HttpStatus;
+                    return NotificationStatus;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3FilterSendResponseStart> m_target;
-        #endregion
-    }
-    public sealed class W3FilterSendResponseEnd : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3FilterSendResponseEnd(Action<W3FilterSendResponseEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3FilterSendResponseEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3FilterSendResponseEnd> m_target;
-        #endregion
-    }
-    public sealed class W3FilterEndOfRequestStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3FilterEndOfRequestStart(Action<W3FilterEndOfRequestStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3FilterEndOfRequestStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3FilterEndOfRequestStart> m_target;
+        private event Action<W3FilterEnd> m_target;
         #endregion
     }
     public sealed class W3FilterEndOfRequestEnd : TraceEvent
@@ -7963,20 +7433,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3FilterEndOfRequestEnd> m_target;
         #endregion
     }
-    public sealed class W3FilterLogStart : TraceEvent
+    public sealed class W3FilterEndOfRequestStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string OrigClientHostName { get { return GetUTF8StringAt(16); } }
-        public string OrigClientUserName { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-        public string OrigServerName { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16))); } }
-        public string OrigOperation { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))); } }
-        public string OrigTarget { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))); } }
-        public string OrigParameters { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))); } }
-        public int OrigHttpStatus { get { return GetInt32At(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))))); } }
-        public int OrigWin32Status { get { return GetInt32At(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))) + 4); } }
 
         #region Private
-        internal W3FilterLogStart(Action<W3FilterLogStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterEndOfRequestStart(Action<W3FilterEndOfRequestStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -7987,26 +7449,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))) + 8));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))) + 8));
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterLogStart>)value; }
+            set { m_target = (Action<W3FilterEndOfRequestStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "OrigClientHostName", OrigClientHostName);
-            XmlAttrib(sb, "OrigClientUserName", OrigClientUserName);
-            XmlAttrib(sb, "OrigServerName", OrigServerName);
-            XmlAttrib(sb, "OrigOperation", OrigOperation);
-            XmlAttrib(sb, "OrigTarget", OrigTarget);
-            XmlAttrib(sb, "OrigParameters", OrigParameters);
-            XmlAttrib(sb, "OrigHttpStatus", OrigHttpStatus);
-            XmlAttrib(sb, "OrigWin32Status", OrigWin32Status);
             sb.Append("/>");
             return sb;
         }
@@ -8016,7 +7470,66 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "OrigClientHostName", "OrigClientUserName", "OrigServerName", "OrigOperation", "OrigTarget", "OrigParameters", "OrigHttpStatus", "OrigWin32Status" };
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterEndOfRequestStart> m_target;
+        #endregion
+    }
+    public sealed class W3FilterError : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3FilterError(Action<W3FilterError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterError>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
                 return payloadNames;
             }
         }
@@ -8028,28 +7541,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return OrigClientHostName;
-                case 2:
-                    return OrigClientUserName;
-                case 3:
-                    return OrigServerName;
-                case 4:
-                    return OrigOperation;
-                case 5:
-                    return OrigTarget;
-                case 6:
-                    return OrigParameters;
-                case 7:
-                    return OrigHttpStatus;
-                case 8:
-                    return OrigWin32Status;
+                    return ErrorCode;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3FilterLogStart> m_target;
+        private event Action<W3FilterError> m_target;
         #endregion
     }
     public sealed class W3FilterLogEnd : TraceEvent
@@ -8141,12 +7640,101 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3FilterLogEnd> m_target;
         #endregion
     }
-    public sealed class W3FilterSendRawDataStart : TraceEvent
+    public sealed class W3FilterLogStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string OrigClientHostName { get { return GetUTF8StringAt(16); } }
+        public string OrigClientUserName { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
+        public string OrigServerName { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16))); } }
+        public string OrigOperation { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))); } }
+        public string OrigTarget { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))); } }
+        public string OrigParameters { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))); } }
+        public int OrigHttpStatus { get { return GetInt32At(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))))); } }
+        public int OrigWin32Status { get { return GetInt32At(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))) + 4); } }
+
+        #region Private
+        internal W3FilterLogStart(Action<W3FilterLogStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))) + 8));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))))) + 8));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterLogStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "OrigClientHostName", OrigClientHostName);
+            XmlAttrib(sb, "OrigClientUserName", OrigClientUserName);
+            XmlAttrib(sb, "OrigServerName", OrigServerName);
+            XmlAttrib(sb, "OrigOperation", OrigOperation);
+            XmlAttrib(sb, "OrigTarget", OrigTarget);
+            XmlAttrib(sb, "OrigParameters", OrigParameters);
+            XmlAttrib(sb, "OrigHttpStatus", OrigHttpStatus);
+            XmlAttrib(sb, "OrigWin32Status", OrigWin32Status);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "OrigClientHostName", "OrigClientUserName", "OrigServerName", "OrigOperation", "OrigTarget", "OrigParameters", "OrigHttpStatus", "OrigWin32Status" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return OrigClientHostName;
+                case 2:
+                    return OrigClientUserName;
+                case 3:
+                    return OrigServerName;
+                case 4:
+                    return OrigOperation;
+                case 5:
+                    return OrigTarget;
+                case 6:
+                    return OrigParameters;
+                case 7:
+                    return OrigHttpStatus;
+                case 8:
+                    return OrigWin32Status;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterLogStart> m_target;
+        #endregion
+    }
+    public sealed class W3FilterPreprocEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3FilterSendRawDataStart(Action<W3FilterSendRawDataStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterPreprocEnd(Action<W3FilterPreprocEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -8163,7 +7751,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterSendRawDataStart>)value; }
+            set { m_target = (Action<W3FilterPreprocEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -8195,7 +7783,64 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3FilterSendRawDataStart> m_target;
+        private event Action<W3FilterPreprocEnd> m_target;
+        #endregion
+    }
+    public sealed class W3FilterPreprocStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3FilterPreprocStart(Action<W3FilterPreprocStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterPreprocStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterPreprocStart> m_target;
         #endregion
     }
     public sealed class W3FilterSendRawDataEnd : TraceEvent
@@ -8255,81 +7900,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3FilterSendRawDataEnd> m_target;
         #endregion
     }
-    public sealed class W3FilterAccessDeniedStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string RequestedURL { get { return GetUTF8StringAt(16); } }
-        public string PhysicalPath { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-        public int DenialReason { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))); } }
-
-        #region Private
-        internal W3FilterAccessDeniedStart(Action<W3FilterAccessDeniedStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16)) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16)) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3FilterAccessDeniedStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestedURL", RequestedURL);
-            XmlAttrib(sb, "PhysicalPath", PhysicalPath);
-            XmlAttrib(sb, "DenialReason", DenialReason);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestedURL", "PhysicalPath", "DenialReason" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RequestedURL;
-                case 2:
-                    return PhysicalPath;
-                case 3:
-                    return DenialReason;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3FilterAccessDeniedStart> m_target;
-        #endregion
-    }
-    public sealed class W3FilterAccessDeniedEnd : TraceEvent
+    public sealed class W3FilterSendRawDataStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3FilterAccessDeniedEnd(Action<W3FilterAccessDeniedEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterSendRawDataStart(Action<W3FilterSendRawDataStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -8346,7 +7922,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterAccessDeniedEnd>)value; }
+            set { m_target = (Action<W3FilterSendRawDataStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -8378,7 +7954,125 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3FilterAccessDeniedEnd> m_target;
+        private event Action<W3FilterSendRawDataStart> m_target;
+        #endregion
+    }
+    public sealed class W3FilterSendResponseEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3FilterSendResponseEnd(Action<W3FilterSendResponseEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterSendResponseEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterSendResponseEnd> m_target;
+        #endregion
+    }
+    public sealed class W3FilterSendResponseStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int HttpStatus { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3FilterSendResponseStart(Action<W3FilterSendResponseStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterSendResponseStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "HttpStatus", HttpStatus);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "HttpStatus" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return HttpStatus;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterSendResponseStart> m_target;
         #endregion
     }
     public sealed class W3FilterSetReqHeader : TraceEvent
@@ -8446,71 +8140,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3FilterSetReqHeader> m_target;
         #endregion
     }
-    public sealed class W3FilterAddReqHeader : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string HeaderName { get { return GetUTF8StringAt(16); } }
-        public string HeaderValue { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-
-        #region Private
-        internal W3FilterAddReqHeader(Action<W3FilterAddReqHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3FilterAddReqHeader>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "HeaderName", HeaderName);
-            XmlAttrib(sb, "HeaderValue", HeaderValue);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "HeaderName", "HeaderValue" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return HeaderName;
-                case 2:
-                    return HeaderValue;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3FilterAddReqHeader> m_target;
-        #endregion
-    }
     public sealed class W3FilterSetRespHeader : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
@@ -8576,76 +8205,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3FilterSetRespHeader> m_target;
         #endregion
     }
-    public sealed class W3FilterAddRespHeader : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string HeaderName { get { return GetUTF8StringAt(16); } }
-        public string HeaderValue { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-
-        #region Private
-        internal W3FilterAddRespHeader(Action<W3FilterAddRespHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3FilterAddRespHeader>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "HeaderName", HeaderName);
-            XmlAttrib(sb, "HeaderValue", HeaderValue);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "HeaderName", "HeaderValue" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return HeaderName;
-                case 2:
-                    return HeaderValue;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3FilterAddRespHeader> m_target;
-        #endregion
-    }
     public sealed class W3FilterStart : TraceEvent
     {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public string FilterName { get { if (Version >= 0) return GetUnicodeStringAt(8); return GetUnicodeStringAt(16); } }
-        public long RequestId { get { return GetInt64At(0); } }
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string FilterName { get { return GetUnicodeStringAt(16); } }
 
         #region Private
         internal W3FilterStart(Action<W3FilterStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -8660,8 +8223,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override void Validate()
         {
             Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(8)));
-            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(8)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
         }
         internal protected override Delegate Target
         {
@@ -8673,7 +8235,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
             XmlAttrib(sb, "FilterName", FilterName);
-            XmlAttrib(sb, "RequestId", RequestId);
             sb.Append("/>");
             return sb;
         }
@@ -8683,7 +8244,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FilterName", "RequestId" };
+                    payloadNames = new string[] { "ContextId", "FilterName" };
                 return payloadNames;
             }
         }
@@ -8696,8 +8257,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                     return ContextId;
                 case 1:
                     return FilterName;
-                case 2:
-                    return RequestId;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
@@ -8707,14 +8266,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3FilterStart> m_target;
         #endregion
     }
-    public sealed class W3FilterEnd : TraceEvent
+    public sealed class W3FilterURLMapEnd : TraceEvent
     {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public int NotificationStatus { get { if (Version >= 1) return GetInt32At(16); return 0; } }
-        public long RequestId { get { return GetInt64At(0); } }
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string FinalURL { get { return GetUTF8StringAt(16); } }
+        public string FinalPath { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
+        public int AccessPerms { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))); } }
+        public int MatchingPath { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 4); } }
+        public int MatchingURL { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 8); } }
+        public string ScriptMapEntry { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16)) + 12); } }
 
         #region Private
-        internal W3FilterEnd(Action<W3FilterEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterURLMapEnd(Action<W3FilterURLMapEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -8725,21 +8288,24 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version == 0 && EventDataLength != 8));
-            Debug.Assert(!(Version > 0 && EventDataLength < 8));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3FilterEnd>)value; }
+            set { m_target = (Action<W3FilterURLMapEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "NotificationStatus", NotificationStatus);
-            XmlAttrib(sb, "RequestId", RequestId);
+            XmlAttrib(sb, "FinalURL", FinalURL);
+            XmlAttrib(sb, "FinalPath", FinalPath);
+            XmlAttrib(sb, "AccessPerms", AccessPerms);
+            XmlAttrib(sb, "MatchingPath", MatchingPath);
+            XmlAttrib(sb, "MatchingURL", MatchingURL);
+            XmlAttrib(sb, "ScriptMapEntry", ScriptMapEntry);
             sb.Append("/>");
             return sb;
         }
@@ -8749,7 +8315,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "NotificationStatus", "RequestId" };
+                    payloadNames = new string[] { "ContextId", "FinalURL", "FinalPath", "AccessPerms", "MatchingPath", "MatchingURL", "ScriptMapEntry" };
                 return payloadNames;
             }
         }
@@ -8761,25 +8327,114 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return NotificationStatus;
+                    return FinalURL;
                 case 2:
-                    return RequestId;
+                    return FinalPath;
+                case 3:
+                    return AccessPerms;
+                case 4:
+                    return MatchingPath;
+                case 5:
+                    return MatchingURL;
+                case 6:
+                    return ScriptMapEntry;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3FilterEnd> m_target;
+        private event Action<W3FilterURLMapEnd> m_target;
         #endregion
     }
-    public sealed class W3SecIllegalShortFilename : TraceEvent
+    public sealed class W3FilterURLMapStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FileName { get { return GetUnicodeStringAt(16); } }
+        public string OrigURL { get { return GetUTF8StringAt(16); } }
+        public string OrigPath { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
+        public int AccessPerms { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))); } }
+        public int MatchingPath { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 4); } }
+        public int MatchingURL { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16)) + 8); } }
+        public string ScriptMapEntry { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16)) + 12); } }
 
         #region Private
-        internal W3SecIllegalShortFilename(Action<W3SecIllegalShortFilename> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3FilterURLMapStart(Action<W3FilterURLMapStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(16)) + 12)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3FilterURLMapStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "OrigURL", OrigURL);
+            XmlAttrib(sb, "OrigPath", OrigPath);
+            XmlAttrib(sb, "AccessPerms", AccessPerms);
+            XmlAttrib(sb, "MatchingPath", MatchingPath);
+            XmlAttrib(sb, "MatchingURL", MatchingURL);
+            XmlAttrib(sb, "ScriptMapEntry", ScriptMapEntry);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "OrigURL", "OrigPath", "AccessPerms", "MatchingPath", "MatchingURL", "ScriptMapEntry" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return OrigURL;
+                case 2:
+                    return OrigPath;
+                case 3:
+                    return AccessPerms;
+                case 4:
+                    return MatchingPath;
+                case 5:
+                    return MatchingURL;
+                case 6:
+                    return ScriptMapEntry;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3FilterURLMapStart> m_target;
+        #endregion
+    }
+    public sealed class IISGeneralConfigChangeNotification : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ConfigPath { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal IISGeneralConfigChangeNotification(Action<IISGeneralConfigChangeNotification> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -8796,13 +8451,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3SecIllegalShortFilename>)value; }
+            set { m_target = (Action<IISGeneralConfigChangeNotification>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
+            XmlAttrib(sb, "ConfigPath", ConfigPath);
             sb.Append("/>");
             return sb;
         }
@@ -8812,7 +8467,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName" };
+                    payloadNames = new string[] { "ContextId", "ConfigPath" };
                 return payloadNames;
             }
         }
@@ -8824,23 +8479,23 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return FileName;
+                    return ConfigPath;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3SecIllegalShortFilename> m_target;
+        private event Action<IISGeneralConfigChangeNotification> m_target;
         #endregion
     }
-    public sealed class W3SecRejectedIP : TraceEvent
+    public sealed class IISGeneralFileChangeNotification : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string IPAddress { get { return GetUnicodeStringAt(16); } }
+        public string FilePath { get { return GetUnicodeStringAt(16); } }
 
         #region Private
-        internal W3SecRejectedIP(Action<W3SecRejectedIP> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal IISGeneralFileChangeNotification(Action<IISGeneralFileChangeNotification> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -8857,13 +8512,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3SecRejectedIP>)value; }
+            set { m_target = (Action<IISGeneralFileChangeNotification>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "IPAddress", IPAddress);
+            XmlAttrib(sb, "FilePath", FilePath);
             sb.Append("/>");
             return sb;
         }
@@ -8873,7 +8528,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "IPAddress" };
+                    payloadNames = new string[] { "ContextId", "FilePath" };
                 return payloadNames;
             }
         }
@@ -8885,83 +8540,22 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return IPAddress;
+                    return FilePath;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3SecRejectedIP> m_target;
+        private event Action<IISGeneralFileChangeNotification> m_target;
         #endregion
     }
-    public sealed class W3SecRejectedHostname : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string HostName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3SecRejectedHostname(Action<W3SecRejectedHostname> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3SecRejectedHostname>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "HostName", HostName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "HostName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return HostName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3SecRejectedHostname> m_target;
-        #endregion
-    }
-    public sealed class W3SecRequireSSL128 : TraceEvent
+    public sealed class W3GeneralCGIHandler : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3SecRequireSSL128(Action<W3SecRequireSSL128> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3GeneralCGIHandler(Action<W3GeneralCGIHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -8978,7 +8572,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3SecRequireSSL128>)value; }
+            set { m_target = (Action<W3GeneralCGIHandler>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -9010,461 +8604,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3SecRequireSSL128> m_target;
-        #endregion
-    }
-    public sealed class W3SecFileAccessDenied : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FileName { get { return GetUnicodeStringAt(16); } }
-        public string AccountName { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-        public string DomainName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
-
-        #region Private
-        internal W3SecFileAccessDenied(Action<W3SecFileAccessDenied> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3SecFileAccessDenied>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
-            XmlAttrib(sb, "AccountName", AccountName);
-            XmlAttrib(sb, "DomainName", DomainName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName", "AccountName", "DomainName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return FileName;
-                case 2:
-                    return AccountName;
-                case 3:
-                    return DomainName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3SecFileAccessDenied> m_target;
-        #endregion
-    }
-    public sealed class W3SecDeniedByMimemap : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FileName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3SecDeniedByMimemap(Action<W3SecDeniedByMimemap> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3SecDeniedByMimemap>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return FileName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3SecDeniedByMimemap> m_target;
-        #endregion
-    }
-    public sealed class W3SecDeniedByISAPIRestriction : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ImageName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3SecDeniedByISAPIRestriction(Action<W3SecDeniedByISAPIRestriction> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3SecDeniedByISAPIRestriction>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ImageName", ImageName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ImageName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ImageName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3SecDeniedByISAPIRestriction> m_target;
-        #endregion
-    }
-    public sealed class W3SecDeniedByCGIRestriction : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ImageName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3SecDeniedByCGIRestriction(Action<W3SecDeniedByCGIRestriction> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3SecDeniedByCGIRestriction>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ImageName", ImageName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ImageName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ImageName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3SecDeniedByCGIRestriction> m_target;
-        #endregion
-    }
-    public sealed class W3SecDeniedByAccessFlags : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int CurrentFlags { get { return GetInt32At(16); } }
-        public int NeededFlags { get { return GetInt32At(20); } }
-
-        #region Private
-        internal W3SecDeniedByAccessFlags(Action<W3SecDeniedByAccessFlags> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 24));
-            Debug.Assert(!(Version > 1 && EventDataLength < 24));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3SecDeniedByAccessFlags>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "CurrentFlags", CurrentFlags);
-            XmlAttrib(sb, "NeededFlags", NeededFlags);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "CurrentFlags", "NeededFlags" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return CurrentFlags;
-                case 2:
-                    return NeededFlags;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3SecDeniedByAccessFlags> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralStaticFileHandler : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public string FileName { get { if (Version >= 0) return GetUnicodeStringAt(8); return GetUnicodeStringAt(16); } }
-        public long RequestId { get { return GetInt64At(0); } }
-
-        #region Private
-        internal W3GeneralStaticFileHandler(Action<W3GeneralStaticFileHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(8)));
-            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(8)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralStaticFileHandler>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
-            XmlAttrib(sb, "RequestId", RequestId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName", "RequestId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return FileName;
-                case 2:
-                    return RequestId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralStaticFileHandler> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralCGIHandler : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
-
-        #region Private
-        internal W3GeneralCGIHandler(Action<W3GeneralCGIHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != 8));
-            Debug.Assert(!(Version > 0 && EventDataLength < 8));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralCGIHandler>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RequestId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
         private event Action<W3GeneralCGIHandler> m_target;
         #endregion
     }
-    public sealed class W3GeneralISAPIHandler : TraceEvent
+    public sealed class W3GeneralChildRequestEnd : TraceEvent
     {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int BytesSent { get { return GetInt32At(16); } }
+        public int HttpStatus { get { return GetInt32At(20); } }
+        public int HttpSubStatus { get { return GetInt16At(24); } }
 
         #region Private
-        internal W3GeneralISAPIHandler(Action<W3GeneralISAPIHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3GeneralChildRequestEnd(Action<W3GeneralChildRequestEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -9475,20 +8626,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != 8));
-            Debug.Assert(!(Version > 0 && EventDataLength < 8));
+            Debug.Assert(!(Version == 1 && EventDataLength != 26));
+            Debug.Assert(!(Version > 1 && EventDataLength < 26));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3GeneralISAPIHandler>)value; }
+            set { m_target = (Action<W3GeneralChildRequestEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
+            XmlAttrib(sb, "BytesSent", BytesSent);
+            XmlAttrib(sb, "HttpStatus", HttpStatus);
+            XmlAttrib(sb, "HttpSubStatus", HttpSubStatus);
             sb.Append("/>");
             return sb;
         }
@@ -9498,7 +8650,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId" };
+                    payloadNames = new string[] { "ContextId", "BytesSent", "HttpStatus", "HttpSubStatus" };
                 return payloadNames;
             }
         }
@@ -9510,468 +8662,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return RequestId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralISAPIHandler> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralOopISAPIHandler : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public int ProcessId { get { if (Version >= 0) return GetInt32At(8); return GetInt32At(16); } }
-        public int TotalReqs { get { if (Version >= 0) return GetInt32At(12); return GetInt32At(20); } }
-        public int CurrentReqs { get { if (Version >= 0) return GetInt32At(16); return GetInt32At(24); } }
-        public long RequestId { get { return GetInt64At(0); } }
-
-        #region Private
-        internal W3GeneralOopISAPIHandler(Action<W3GeneralOopISAPIHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 28));
-            Debug.Assert(!(Version == 0 && EventDataLength != 20));
-            Debug.Assert(!(Version > 0 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralOopISAPIHandler>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ProcessId", ProcessId);
-            XmlAttrib(sb, "TotalReqs", TotalReqs);
-            XmlAttrib(sb, "CurrentReqs", CurrentReqs);
-            XmlAttrib(sb, "RequestId", RequestId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ProcessId", "TotalReqs", "CurrentReqs", "RequestId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ProcessId;
+                    return BytesSent;
                 case 2:
-                    return TotalReqs;
+                    return HttpStatus;
                 case 3:
-                    return CurrentReqs;
-                case 4:
-                    return RequestId;
+                    return HttpSubStatus;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3GeneralOopISAPIHandler> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralRedirectionHandler : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string RedirectedURL { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3GeneralRedirectionHandler(Action<W3GeneralRedirectionHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralRedirectionHandler>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RedirectedURL", RedirectedURL);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RedirectedURL" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RedirectedURL;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralRedirectionHandler> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralDavHandler : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FileName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal W3GeneralDavHandler(Action<W3GeneralDavHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralDavHandler>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return FileName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralDavHandler> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralOptionsHandler : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
-        public int BytesSent { get { return GetInt32At(8); } }
-
-        #region Private
-        internal W3GeneralOptionsHandler(Action<W3GeneralOptionsHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != 12));
-            Debug.Assert(!(Version > 0 && EventDataLength < 12));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralOptionsHandler>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
-            XmlAttrib(sb, "BytesSent", BytesSent);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId", "BytesSent" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RequestId;
-                case 2:
-                    return BytesSent;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralOptionsHandler> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralTraceHandler : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
-        public int BytesSent { get { return GetInt32At(8); } }
-
-        #region Private
-        internal W3GeneralTraceHandler(Action<W3GeneralTraceHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != 12));
-            Debug.Assert(!(Version > 0 && EventDataLength < 12));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralTraceHandler>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
-            XmlAttrib(sb, "BytesSent", BytesSent);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId", "BytesSent" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RequestId;
-                case 2:
-                    return BytesSent;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralTraceHandler> m_target;
-        #endregion
-    }
-    public sealed class W3SendResponse : TraceEvent
-    {
-        public long RequestId { get { return GetInt64At(0); } }
-        public int BytesSent { get { return GetInt32At(8); } }
-
-        #region Private
-        internal W3SendResponse(Action<W3SendResponse> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 0 && EventDataLength != 12));
-            Debug.Assert(!(Version > 0 && EventDataLength < 12));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3SendResponse>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "RequestId", RequestId);
-            XmlAttrib(sb, "BytesSent", BytesSent);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "RequestId", "BytesSent" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return RequestId;
-                case 1:
-                    return BytesSent;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3SendResponse> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralGetURLMetadata : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string PhysicalPath { get { return GetUnicodeStringAt(16); } }
-        public int AccessPerms { get { return GetInt32At(SkipUnicodeString(16)); } }
-
-        #region Private
-        internal W3GeneralGetURLMetadata(Action<W3GeneralGetURLMetadata> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralGetURLMetadata>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "PhysicalPath", PhysicalPath);
-            XmlAttrib(sb, "AccessPerms", AccessPerms);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "PhysicalPath", "AccessPerms" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return PhysicalPath;
-                case 2:
-                    return AccessPerms;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralGetURLMetadata> m_target;
+        private event Action<W3GeneralChildRequestEnd> m_target;
         #endregion
     }
     public sealed class W3GeneralChildRequestStart : TraceEvent
@@ -10047,15 +8749,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3GeneralChildRequestStart> m_target;
         #endregion
     }
-    public sealed class W3GeneralChildRequestEnd : TraceEvent
+    public sealed class W3GeneralDavHandler : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public int BytesSent { get { return GetInt32At(16); } }
-        public int HttpStatus { get { return GetInt32At(20); } }
-        public int HttpSubStatus { get { return GetInt16At(24); } }
+        public string FileName { get { return GetUnicodeStringAt(16); } }
 
         #region Private
-        internal W3GeneralChildRequestEnd(Action<W3GeneralChildRequestEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3GeneralDavHandler(Action<W3GeneralDavHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -10066,21 +8766,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 26));
-            Debug.Assert(!(Version > 1 && EventDataLength < 26));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3GeneralChildRequestEnd>)value; }
+            set { m_target = (Action<W3GeneralDavHandler>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "BytesSent", BytesSent);
-            XmlAttrib(sb, "HttpStatus", HttpStatus);
-            XmlAttrib(sb, "HttpSubStatus", HttpSubStatus);
+            XmlAttrib(sb, "FileName", FileName);
             sb.Append("/>");
             return sb;
         }
@@ -10090,7 +8788,143 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "BytesSent", "HttpStatus", "HttpSubStatus" };
+                    payloadNames = new string[] { "ContextId", "FileName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return FileName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralDavHandler> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralEndpointInformation : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string RemoteAddress { get { return GetUTF8StringAt(16); } }
+        public string RemotePort { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
+        public string LocalAddress { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16))); } }
+        public string LocalPort { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))); } }
+
+        #region Private
+        internal W3GeneralEndpointInformation(Action<W3GeneralEndpointInformation> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralEndpointInformation>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "RemoteAddress", RemoteAddress);
+            XmlAttrib(sb, "RemotePort", RemotePort);
+            XmlAttrib(sb, "LocalAddress", LocalAddress);
+            XmlAttrib(sb, "LocalPort", LocalPort);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "RemoteAddress", "RemotePort", "LocalAddress", "LocalPort" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return RemoteAddress;
+                case 2:
+                    return RemotePort;
+                case 3:
+                    return LocalAddress;
+                case 4:
+                    return LocalPort;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralEndpointInformation> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralFlushResponseEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int BytesSent { get { return GetInt32At(16); } }
+        public int ErrorCode { get { return GetInt32At(20); } }
+
+        #region Private
+        internal W3GeneralFlushResponseEnd(Action<W3GeneralFlushResponseEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 24));
+            Debug.Assert(!(Version > 1 && EventDataLength < 24));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralFlushResponseEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "BytesSent", BytesSent);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "BytesSent", "ErrorCode" };
                 return payloadNames;
             }
         }
@@ -10104,8 +8938,750 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 1:
                     return BytesSent;
                 case 2:
-                    return HttpStatus;
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralFlushResponseEnd> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralFlushResponseStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3GeneralFlushResponseStart(Action<W3GeneralFlushResponseStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralFlushResponseStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralFlushResponseStart> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralGetURLMetadata : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string PhysicalPath { get { return GetUnicodeStringAt(16); } }
+        public int AccessPerms { get { return GetInt32At(SkipUnicodeString(16)); } }
+
+        #region Private
+        internal W3GeneralGetURLMetadata(Action<W3GeneralGetURLMetadata> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 4));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralGetURLMetadata>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "PhysicalPath", PhysicalPath);
+            XmlAttrib(sb, "AccessPerms", AccessPerms);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "PhysicalPath", "AccessPerms" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return PhysicalPath;
+                case 2:
+                    return AccessPerms;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralGetURLMetadata> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralISAPIHandler : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3GeneralISAPIHandler(Action<W3GeneralISAPIHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralISAPIHandler>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralISAPIHandler> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralMapHandler : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3GeneralMapHandler(Action<W3GeneralMapHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralMapHandler>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralMapHandler> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralModuleFactoryFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ModuleName { get { return GetUnicodeStringAt(16); } }
+        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16)); } }
+
+        #region Private
+        internal W3GeneralModuleFactoryFailed(Action<W3GeneralModuleFactoryFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 4));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralModuleFactoryFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ModuleName", ModuleName);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ModuleName", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ModuleName;
+                case 2:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralModuleFactoryFailed> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralNotSendCustomError : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int Reason { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3GeneralNotSendCustomError(Action<W3GeneralNotSendCustomError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralNotSendCustomError>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Reason", Reason);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Reason" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Reason;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralNotSendCustomError> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralOopISAPIHandler : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ProcessId { get { return GetInt32At(16); } }
+        public int TotalReqs { get { return GetInt32At(20); } }
+        public int CurrentReqs { get { return GetInt32At(24); } }
+
+        #region Private
+        internal W3GeneralOopISAPIHandler(Action<W3GeneralOopISAPIHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 28));
+            Debug.Assert(!(Version > 1 && EventDataLength < 28));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralOopISAPIHandler>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ProcessId", ProcessId);
+            XmlAttrib(sb, "TotalReqs", TotalReqs);
+            XmlAttrib(sb, "CurrentReqs", CurrentReqs);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ProcessId", "TotalReqs", "CurrentReqs" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ProcessId;
+                case 2:
+                    return TotalReqs;
                 case 3:
+                    return CurrentReqs;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralOopISAPIHandler> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralOptionsHandler : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3GeneralOptionsHandler(Action<W3GeneralOptionsHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralOptionsHandler>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralOptionsHandler> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralReadEntityEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int BytesReceived { get { return GetInt32At(16); } }
+        public int ErrorCode { get { return GetInt32At(20); } }
+
+        #region Private
+        internal W3GeneralReadEntityEnd(Action<W3GeneralReadEntityEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 24));
+            Debug.Assert(!(Version > 1 && EventDataLength < 24));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralReadEntityEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "BytesReceived", BytesReceived);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "BytesReceived", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return BytesReceived;
+                case 2:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralReadEntityEnd> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralReadEntityStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3GeneralReadEntityStart(Action<W3GeneralReadEntityStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralReadEntityStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralReadEntityStart> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralRedirectionHandler : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string RedirectedURL { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3GeneralRedirectionHandler(Action<W3GeneralRedirectionHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralRedirectionHandler>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "RedirectedURL", RedirectedURL);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "RedirectedURL" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return RedirectedURL;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralRedirectionHandler> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralEndNewRequest : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int BytesSent { get { return GetInt32At(16); } }
+        public int BytesReceived { get { return GetInt32At(20); } }
+        public int HttpStatus { get { return GetInt32At(24); } }
+        public int HttpSubStatus { get { return GetInt16At(28); } }
+
+        #region Private
+        internal W3GeneralEndNewRequest(Action<W3GeneralEndNewRequest> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 30));
+            Debug.Assert(!(Version > 1 && EventDataLength < 30));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralEndNewRequest>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "BytesSent", BytesSent);
+            XmlAttrib(sb, "BytesReceived", BytesReceived);
+            XmlAttrib(sb, "HttpStatus", HttpStatus);
+            XmlAttrib(sb, "HttpSubStatus", HttpSubStatus);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "BytesSent", "BytesReceived", "HttpStatus", "HttpSubStatus" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return BytesSent;
+                case 2:
+                    return BytesReceived;
+                case 3:
+                    return HttpStatus;
+                case 4:
                     return HttpSubStatus;
                 default:
                     Debug.Assert(false, "Bad field index");
@@ -10113,7 +9689,401 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3GeneralChildRequestEnd> m_target;
+        private event Action<W3GeneralEndNewRequest> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralRequestEntity : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Buffer { get { return GetUTF8StringAt(16); } }
+
+        #region Private
+        internal W3GeneralRequestEntity(Action<W3GeneralRequestEntity> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralRequestEntity>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Buffer", Buffer);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Buffer" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Buffer;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralRequestEntity> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralRequestHeaders : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Headers { get { return GetUTF8StringAt(16); } }
+
+        #region Private
+        internal W3GeneralRequestHeaders(Action<W3GeneralRequestHeaders> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralRequestHeaders>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Headers", Headers);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Headers" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Headers;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralRequestHeaders> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralStartNewRequest : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int SiteId { get { return GetInt32At(16); } }
+        public string AppPoolId { get { return GetUnicodeStringAt(20); } }
+        public long ConnId { get { return GetInt64At(SkipUnicodeString(20)); } }
+        public long RawConnId { get { return GetInt64At(SkipUnicodeString(20) + 8); } }
+        public string RequestURL { get { return GetUnicodeStringAt(SkipUnicodeString(20) + 16); } }
+        public string RequestVerb { get { return GetUTF8StringAt(SkipUnicodeString(SkipUnicodeString(20) + 16)); } }
+
+        #region Private
+        internal W3GeneralStartNewRequest(Action<W3GeneralStartNewRequest> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUnicodeString(SkipUnicodeString(20) + 16))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUnicodeString(SkipUnicodeString(20) + 16))));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralStartNewRequest>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "SiteId", SiteId);
+            XmlAttrib(sb, "AppPoolId", AppPoolId);
+            XmlAttrib(sb, "ConnId", ConnId);
+            XmlAttrib(sb, "RawConnId", RawConnId);
+            XmlAttrib(sb, "RequestURL", RequestURL);
+            XmlAttrib(sb, "RequestVerb", RequestVerb);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "SiteId", "AppPoolId", "ConnId", "RawConnId", "RequestURL", "RequestVerb" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return SiteId;
+                case 2:
+                    return AppPoolId;
+                case 3:
+                    return ConnId;
+                case 4:
+                    return RawConnId;
+                case 5:
+                    return RequestURL;
+                case 6:
+                    return RequestVerb;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralStartNewRequest> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralResponseEntityBuffer : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Buffer { get { return GetUTF8StringAt(16); } }
+
+        #region Private
+        internal W3GeneralResponseEntityBuffer(Action<W3GeneralResponseEntityBuffer> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralResponseEntityBuffer>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Buffer", Buffer);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Buffer" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Buffer;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralResponseEntityBuffer> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralResponseEntityFile : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string FileName { get { return GetUnicodeStringAt(16); } }
+        public long Offset { get { return GetInt64At(SkipUnicodeString(16)); } }
+        public long Size { get { return GetInt64At(SkipUnicodeString(16) + 8); } }
+
+        #region Private
+        internal W3GeneralResponseEntityFile(Action<W3GeneralResponseEntityFile> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralResponseEntityFile>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "FileName", FileName);
+            XmlAttrib(sb, "Offset", Offset);
+            XmlAttrib(sb, "Size", Size);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "FileName", "Offset", "Size" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return FileName;
+                case 2:
+                    return Offset;
+                case 3:
+                    return Size;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralResponseEntityFile> m_target;
+        #endregion
+    }
+    public sealed class W3GeneralResponseHeaders : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Headers { get { return GetUTF8StringAt(16); } }
+
+        #region Private
+        internal W3GeneralResponseHeaders(Action<W3GeneralResponseHeaders> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3GeneralResponseHeaders>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Headers", Headers);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Headers" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Headers;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3GeneralResponseHeaders> m_target;
         #endregion
     }
     public sealed class W3GeneralSendCustomError : TraceEvent
@@ -10185,12 +10155,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<W3GeneralSendCustomError> m_target;
         #endregion
     }
-    public sealed class W3GeneralMapHandler : TraceEvent
+    public sealed class W3GeneralSetRequestHeader : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
+        public string HeaderName { get { return GetUTF8StringAt(16); } }
+        public string HeaderValue { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
+        public bool Replace { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))) != 0; } }
 
         #region Private
-        internal W3GeneralMapHandler(Action<W3GeneralMapHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3GeneralSetRequestHeader(Action<W3GeneralSetRequestHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -10201,18 +10174,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16)) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16)) + 4));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3GeneralMapHandler>)value; }
+            set { m_target = (Action<W3GeneralSetRequestHeader>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "HeaderName", HeaderName);
+            XmlAttrib(sb, "HeaderValue", HeaderValue);
+            XmlAttrib(sb, "Replace", Replace);
             sb.Append("/>");
             return sb;
         }
@@ -10222,125 +10198,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralMapHandler> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralFlushResponseStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3GeneralFlushResponseStart(Action<W3GeneralFlushResponseStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralFlushResponseStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralFlushResponseStart> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralFlushResponseEnd : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int BytesSent { get { return GetInt32At(16); } }
-        public int ErrorCode { get { return GetInt32At(20); } }
-
-        #region Private
-        internal W3GeneralFlushResponseEnd(Action<W3GeneralFlushResponseEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 24));
-            Debug.Assert(!(Version > 1 && EventDataLength < 24));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralFlushResponseEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "BytesSent", BytesSent);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "BytesSent", "ErrorCode" };
+                    payloadNames = new string[] { "ContextId", "HeaderName", "HeaderValue", "Replace" };
                 return payloadNames;
             }
         }
@@ -10352,147 +10210,27 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return BytesSent;
+                    return HeaderName;
                 case 2:
-                    return ErrorCode;
+                    return HeaderValue;
+                case 3:
+                    return Replace;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3GeneralFlushResponseEnd> m_target;
+        private event Action<W3GeneralSetRequestHeader> m_target;
         #endregion
     }
-    public sealed class W3GeneralReadEntityStart : TraceEvent
+    public sealed class W3GeneralStaticFileHandler : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
+        public string FileName { get { return GetUnicodeStringAt(16); } }
 
         #region Private
-        internal W3GeneralReadEntityStart(Action<W3GeneralReadEntityStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralReadEntityStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralReadEntityStart> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralReadEntityEnd : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int BytesReceived { get { return GetInt32At(16); } }
-        public int ErrorCode { get { return GetInt32At(20); } }
-
-        #region Private
-        internal W3GeneralReadEntityEnd(Action<W3GeneralReadEntityEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 24));
-            Debug.Assert(!(Version > 1 && EventDataLength < 24));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralReadEntityEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "BytesReceived", BytesReceived);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "BytesReceived", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return BytesReceived;
-                case 2:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralReadEntityEnd> m_target;
-        #endregion
-    }
-    public sealed class IISGeneralFileChangeNotification : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FilePath { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal IISGeneralFileChangeNotification(Action<IISGeneralFileChangeNotification> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3GeneralStaticFileHandler(Action<W3GeneralStaticFileHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -10509,13 +10247,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<IISGeneralFileChangeNotification>)value; }
+            set { m_target = (Action<W3GeneralStaticFileHandler>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FilePath", FilePath);
+            XmlAttrib(sb, "FileName", FileName);
             sb.Append("/>");
             return sb;
         }
@@ -10525,7 +10263,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FilePath" };
+                    payloadNames = new string[] { "ContextId", "FileName" };
                 return payloadNames;
             }
         }
@@ -10537,23 +10275,22 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return FilePath;
+                    return FileName;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<IISGeneralFileChangeNotification> m_target;
+        private event Action<W3GeneralStaticFileHandler> m_target;
         #endregion
     }
-    public sealed class IISGeneralConfigChangeNotification : TraceEvent
+    public sealed class W3GeneralTraceHandler : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ConfigPath { get { return GetUnicodeStringAt(16); } }
 
         #region Private
-        internal IISGeneralConfigChangeNotification(Action<IISGeneralConfigChangeNotification> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3GeneralTraceHandler(Action<W3GeneralTraceHandler> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -10564,19 +10301,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<IISGeneralConfigChangeNotification>)value; }
+            set { m_target = (Action<W3GeneralTraceHandler>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ConfigPath", ConfigPath);
             sb.Append("/>");
             return sb;
         }
@@ -10586,7 +10322,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ConfigPath" };
+                    payloadNames = new string[] { "ContextId" };
                 return payloadNames;
             }
         }
@@ -10597,145 +10333,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             {
                 case 0:
                     return ContextId;
-                case 1:
-                    return ConfigPath;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<IISGeneralConfigChangeNotification> m_target;
-        #endregion
-    }
-    public sealed class IISGeneralVirtualModuleUnresolved : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Name { get { return GetUnicodeStringAt(16); } }
-        public string Type { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-
-        #region Private
-        internal IISGeneralVirtualModuleUnresolved(Action<IISGeneralVirtualModuleUnresolved> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(16))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(16))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISGeneralVirtualModuleUnresolved>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Name", Name);
-            XmlAttrib(sb, "Type", Type);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Name", "Type" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Name;
-                case 2:
-                    return Type;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISGeneralVirtualModuleUnresolved> m_target;
-        #endregion
-    }
-    public sealed class IISGeneralUrlChanged : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string OldUrl { get { return GetUnicodeStringAt(16); } }
-        public string NewUrl { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-
-        #region Private
-        internal IISGeneralUrlChanged(Action<IISGeneralUrlChanged> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(16))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(16))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISGeneralUrlChanged>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "OldUrl", OldUrl);
-            XmlAttrib(sb, "NewUrl", NewUrl);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "OldUrl", "NewUrl" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return OldUrl;
-                case 2:
-                    return NewUrl;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISGeneralUrlChanged> m_target;
+        private event Action<W3GeneralTraceHandler> m_target;
         #endregion
     }
     public sealed class IISGeneralHandlerChanged : TraceEvent
@@ -10815,6 +10419,201 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<IISGeneralHandlerChanged> m_target;
         #endregion
     }
+    public sealed class IISGeneralHandlerPreconditionNotMatch : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Name { get { return GetUnicodeStringAt(16); } }
+        public string Precondition { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+
+        #region Private
+        internal IISGeneralHandlerPreconditionNotMatch(Action<IISGeneralHandlerPreconditionNotMatch> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(16))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(16))));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<IISGeneralHandlerPreconditionNotMatch>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Name", Name);
+            XmlAttrib(sb, "Precondition", Precondition);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Name", "Precondition" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Name;
+                case 2:
+                    return Precondition;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<IISGeneralHandlerPreconditionNotMatch> m_target;
+        #endregion
+    }
+    public sealed class IISGeneralModulePreconditionNotMatch : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string Name { get { return GetUnicodeStringAt(16); } }
+        public string Precondition { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+
+        #region Private
+        internal IISGeneralModulePreconditionNotMatch(Action<IISGeneralModulePreconditionNotMatch> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(16))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(16))));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<IISGeneralModulePreconditionNotMatch>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Name", Name);
+            XmlAttrib(sb, "Precondition", Precondition);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Name", "Precondition" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Name;
+                case 2:
+                    return Precondition;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<IISGeneralModulePreconditionNotMatch> m_target;
+        #endregion
+    }
+    public sealed class IISGeneralUrlChanged : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string OldUrl { get { return GetUnicodeStringAt(16); } }
+        public string NewUrl { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+
+        #region Private
+        internal IISGeneralUrlChanged(Action<IISGeneralUrlChanged> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(16))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(16))));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<IISGeneralUrlChanged>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "OldUrl", OldUrl);
+            XmlAttrib(sb, "NewUrl", NewUrl);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "OldUrl", "NewUrl" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return OldUrl;
+                case 2:
+                    return NewUrl;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<IISGeneralUrlChanged> m_target;
+        #endregion
+    }
     public sealed class IISGeneralUserSet : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
@@ -10884,14 +10683,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<IISGeneralUserSet> m_target;
         #endregion
     }
-    public sealed class IISGeneralModulePreconditionNotMatch : TraceEvent
+    public sealed class IISGeneralVirtualModuleUnresolved : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
         public string Name { get { return GetUnicodeStringAt(16); } }
-        public string Precondition { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+        public string Type { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
 
         #region Private
-        internal IISGeneralModulePreconditionNotMatch(Action<IISGeneralModulePreconditionNotMatch> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal IISGeneralVirtualModuleUnresolved(Action<IISGeneralVirtualModuleUnresolved> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -10908,14 +10707,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<IISGeneralModulePreconditionNotMatch>)value; }
+            set { m_target = (Action<IISGeneralVirtualModuleUnresolved>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
             XmlAttrib(sb, "Name", Name);
-            XmlAttrib(sb, "Precondition", Precondition);
+            XmlAttrib(sb, "Type", Type);
             sb.Append("/>");
             return sb;
         }
@@ -10925,7 +10724,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Name", "Precondition" };
+                    payloadNames = new string[] { "ContextId", "Name", "Type" };
                 return payloadNames;
             }
         }
@@ -10939,906 +10738,22 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 1:
                     return Name;
                 case 2:
-                    return Precondition;
+                    return Type;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<IISGeneralModulePreconditionNotMatch> m_target;
+        private event Action<IISGeneralVirtualModuleUnresolved> m_target;
         #endregion
     }
-    public sealed class IISGeneralHandlerPreconditionNotMatch : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Name { get { return GetUnicodeStringAt(16); } }
-        public string Precondition { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-
-        #region Private
-        internal IISGeneralHandlerPreconditionNotMatch(Action<IISGeneralHandlerPreconditionNotMatch> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(16))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(16))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISGeneralHandlerPreconditionNotMatch>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Name", Name);
-            XmlAttrib(sb, "Precondition", Precondition);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Name", "Precondition" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Name;
-                case 2:
-                    return Precondition;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISGeneralHandlerPreconditionNotMatch> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralResponseHeaders : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Headers { get { return GetUTF8StringAt(16); } }
-
-        #region Private
-        internal W3GeneralResponseHeaders(Action<W3GeneralResponseHeaders> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralResponseHeaders>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Headers", Headers);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Headers" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Headers;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralResponseHeaders> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralResponseEntityFile : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string FileName { get { return GetUnicodeStringAt(16); } }
-        public long Offset { get { return GetInt64At(SkipUnicodeString(16)); } }
-        public long Size { get { return GetInt64At(SkipUnicodeString(16) + 8); } }
-
-        #region Private
-        internal W3GeneralResponseEntityFile(Action<W3GeneralResponseEntityFile> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralResponseEntityFile>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "FileName", FileName);
-            XmlAttrib(sb, "Offset", Offset);
-            XmlAttrib(sb, "Size", Size);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "FileName", "Offset", "Size" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return FileName;
-                case 2:
-                    return Offset;
-                case 3:
-                    return Size;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralResponseEntityFile> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralResponseEntityBuffer : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Buffer { get { return GetUTF8StringAt(16); } }
-
-        #region Private
-        internal W3GeneralResponseEntityBuffer(Action<W3GeneralResponseEntityBuffer> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralResponseEntityBuffer>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Buffer", Buffer);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Buffer" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Buffer;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralResponseEntityBuffer> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralRequestHeaders : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Headers { get { return GetUTF8StringAt(16); } }
-
-        #region Private
-        internal W3GeneralRequestHeaders(Action<W3GeneralRequestHeaders> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralRequestHeaders>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Headers", Headers);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Headers" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Headers;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralRequestHeaders> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralRequestEntity : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string Buffer { get { return GetUTF8StringAt(16); } }
-
-        #region Private
-        internal W3GeneralRequestEntity(Action<W3GeneralRequestEntity> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralRequestEntity>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Buffer", Buffer);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Buffer" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Buffer;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralRequestEntity> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralNotSendCustomError : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int Reason { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3GeneralNotSendCustomError(Action<W3GeneralNotSendCustomError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralNotSendCustomError>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Reason", Reason);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Reason" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Reason;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralNotSendCustomError> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralSetRequestHeader : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string HeaderName { get { return GetUTF8StringAt(16); } }
-        public string HeaderValue { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-        public bool Replace { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))) != 0; } }
-
-        #region Private
-        internal W3GeneralSetRequestHeader(Action<W3GeneralSetRequestHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16)) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16)) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralSetRequestHeader>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "HeaderName", HeaderName);
-            XmlAttrib(sb, "HeaderValue", HeaderValue);
-            XmlAttrib(sb, "Replace", Replace);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "HeaderName", "HeaderValue", "Replace" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return HeaderName;
-                case 2:
-                    return HeaderValue;
-                case 3:
-                    return Replace;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralSetRequestHeader> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralModuleFactoryFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ModuleName { get { return GetUnicodeStringAt(16); } }
-        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16)); } }
-
-        #region Private
-        internal W3GeneralModuleFactoryFailed(Action<W3GeneralModuleFactoryFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralModuleFactoryFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ModuleName", ModuleName);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ModuleName;
-                case 2:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralModuleFactoryFailed> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralEndpointInformation : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string RemoteAddress { get { return GetUTF8StringAt(16); } }
-        public string RemotePort { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-        public string LocalAddress { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(16))); } }
-        public string LocalPort { get { return GetUTF8StringAt(SkipUTF8String(SkipUTF8String(SkipUTF8String(16)))); } }
-
-        #region Private
-        internal W3GeneralEndpointInformation(Action<W3GeneralEndpointInformation> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(SkipUTF8String(SkipUTF8String(16))))));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralEndpointInformation>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RemoteAddress", RemoteAddress);
-            XmlAttrib(sb, "RemotePort", RemotePort);
-            XmlAttrib(sb, "LocalAddress", LocalAddress);
-            XmlAttrib(sb, "LocalPort", LocalPort);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RemoteAddress", "RemotePort", "LocalAddress", "LocalPort" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return RemoteAddress;
-                case 2:
-                    return RemotePort;
-                case 3:
-                    return LocalAddress;
-                case 4:
-                    return LocalPort;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralEndpointInformation> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralSetResponseHeader : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string HeaderName { get { return GetUTF8StringAt(16); } }
-        public string HeaderValue { get { return GetUTF8StringAt(SkipUTF8String(16)); } }
-        public bool Replace { get { return GetInt32At(SkipUTF8String(SkipUTF8String(16))) != 0; } }
-
-        #region Private
-        internal W3GeneralSetResponseHeader(Action<W3GeneralSetResponseHeader> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUTF8String(16)) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(SkipUTF8String(16)) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralSetResponseHeader>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "HeaderName", HeaderName);
-            XmlAttrib(sb, "HeaderValue", HeaderValue);
-            XmlAttrib(sb, "Replace", Replace);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "HeaderName", "HeaderValue", "Replace" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return HeaderName;
-                case 2:
-                    return HeaderValue;
-                case 3:
-                    return Replace;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralSetResponseHeader> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralStartNewRequest : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public int SiteId { get { if (Version >= 1) return GetInt32At(16); return 0; } }
-        public string AppPoolId { get { if (Version >= 1) return GetUnicodeStringAt(20); return ""; } }
-        public long ConnId { get { if (Version >= 1) return GetInt64At(SkipUnicodeString(20)); return 0; } }
-        public long RawConnId { get { if (Version >= 1) return GetInt64At(SkipUnicodeString(20) + 8); return 0; } }
-        public string RequestURL { get { if (Version >= 1) return GetUnicodeStringAt(SkipUnicodeString(20) + 16); return ""; } }
-        public string RequestVerb { get { if (Version >= 1) return GetUTF8StringAt(SkipUnicodeString(SkipUnicodeString(20) + 16)); return ""; } }
-        public long RequestId { get { return GetInt64At(0); } }
-        public int BytesReceived { get { return GetInt32At(8); } }
-
-        #region Private
-        internal W3GeneralStartNewRequest(Action<W3GeneralStartNewRequest> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(SkipUnicodeString(SkipUnicodeString(20) + 16))));
-            Debug.Assert(!(Version == 0 && EventDataLength != 12));
-            Debug.Assert(!(Version > 0 && EventDataLength < 12));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralStartNewRequest>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "SiteId", SiteId);
-            XmlAttrib(sb, "AppPoolId", AppPoolId);
-            XmlAttrib(sb, "ConnId", ConnId);
-            XmlAttrib(sb, "RawConnId", RawConnId);
-            XmlAttrib(sb, "RequestURL", RequestURL);
-            XmlAttrib(sb, "RequestVerb", RequestVerb);
-            XmlAttrib(sb, "RequestId", RequestId);
-            XmlAttrib(sb, "BytesReceived", BytesReceived);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "SiteId", "AppPoolId", "ConnId", "RawConnId", "RequestURL", "RequestVerb", "RequestId", "BytesReceived" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return SiteId;
-                case 2:
-                    return AppPoolId;
-                case 3:
-                    return ConnId;
-                case 4:
-                    return RawConnId;
-                case 5:
-                    return RequestURL;
-                case 6:
-                    return RequestVerb;
-                case 7:
-                    return RequestId;
-                case 8:
-                    return BytesReceived;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralStartNewRequest> m_target;
-        #endregion
-    }
-    public sealed class W3GeneralEndNewRequest : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        //public int BytesSent { get { if (Version >= 0) return GetInt32At(8); return GetInt32At(16); } }
-        public int BytesSent { get { if (Version >= 1) return GetInt32At(16); return 0; } }
-        public int BytesReceived { get { if (Version >= 1) return GetInt32At(20); return 0; } }
-        public int HttpStatus { get { if (Version >= 1) return GetInt32At(24); return 0; } }
-        public int HttpSubStatus { get { if (Version >= 1) return GetInt16At(28); return 0; } }
-        public long RequestId { get { return GetInt64At(0); } }
-
-        #region Private
-        internal W3GeneralEndNewRequest(Action<W3GeneralEndNewRequest> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 30));
-            Debug.Assert(!(Version == 0 && EventDataLength != 12));
-            Debug.Assert(!(Version > 0 && EventDataLength < 12));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3GeneralEndNewRequest>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "BytesSent", BytesSent);
-            XmlAttrib(sb, "BytesReceived", BytesReceived);
-            XmlAttrib(sb, "HttpStatus", HttpStatus);
-            XmlAttrib(sb, "HttpSubStatus", HttpSubStatus);
-            XmlAttrib(sb, "RequestId", RequestId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "BytesSent", "BytesReceived", "HttpStatus", "HttpSubStatus", "RequestId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return BytesSent;
-                case 2:
-                    return BytesReceived;
-                case 3:
-                    return HttpStatus;
-                case 4:
-                    return HttpSubStatus;
-                case 5:
-                    return RequestId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3GeneralEndNewRequest> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketEndSuccess : TraceEvent
+    public sealed class W3ISAPIEnd : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3WebSocketEndSuccess(Action<W3WebSocketEndSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3ISAPIEnd(Action<W3ISAPIEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -11855,7 +10770,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3WebSocketEndSuccess>)value; }
+            set { m_target = (Action<W3ISAPIEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -11887,137 +10802,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3WebSocketEndSuccess> m_target;
+        private event Action<W3ISAPIEnd> m_target;
         #endregion
     }
-    public sealed class W3WebSocketEndFailure : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketEndFailure(Action<W3WebSocketEndFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketEndFailure>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketEndFailure> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketReadFragmentStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int BufferSize { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketReadFragmentStart(Action<W3WebSocketReadFragmentStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketReadFragmentStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "BufferSize", BufferSize);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "BufferSize" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return BufferSize;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketReadFragmentStart> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketWriteFragmentEndPending : TraceEvent
+    public sealed class W3ISAPIStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
 
         #region Private
-        internal W3WebSocketWriteFragmentEndPending(Action<W3WebSocketWriteFragmentEndPending> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal W3ISAPIStart(Action<W3ISAPIStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -12034,7 +10827,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3WebSocketWriteFragmentEndPending>)value; }
+            set { m_target = (Action<W3ISAPIStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -12066,979 +10859,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<W3WebSocketWriteFragmentEndPending> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketWriteFragmentEndSuccess : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int BytesSent { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketWriteFragmentEndSuccess(Action<W3WebSocketWriteFragmentEndSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketWriteFragmentEndSuccess>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "BytesSent", BytesSent);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "BytesSent" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return BytesSent;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketWriteFragmentEndSuccess> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketWriteFragmentEndFailure : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketWriteFragmentEndFailure(Action<W3WebSocketWriteFragmentEndFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketWriteFragmentEndFailure>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketWriteFragmentEndFailure> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketApplicationCloseConnection : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3WebSocketApplicationCloseConnection(Action<W3WebSocketApplicationCloseConnection> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketApplicationCloseConnection>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketApplicationCloseConnection> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketModuleCloseConnection : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int Reason { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketModuleCloseConnection(Action<W3WebSocketModuleCloseConnection> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketModuleCloseConnection>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Reason", Reason);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Reason" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Reason;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketModuleCloseConnection> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketReadIoFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketReadIoFailed(Action<W3WebSocketReadIoFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketReadIoFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketReadIoFailed> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketWriteIoFailed : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketWriteIoFailed(Action<W3WebSocketWriteIoFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketWriteIoFailed>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketWriteIoFailed> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketCloseReceived : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int Status { get { return GetInt32At(16); } }
-        public string Reason { get { return GetUnicodeStringAt(20); } }
-
-        #region Private
-        internal W3WebSocketCloseReceived(Action<W3WebSocketCloseReceived> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(20)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(20)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketCloseReceived>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Status", Status);
-            XmlAttrib(sb, "Reason", Reason);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Status", "Reason" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Status;
-                case 2:
-                    return Reason;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketCloseReceived> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketCloseSendStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int Status { get { return GetInt32At(16); } }
-        public string Reason { get { return GetUnicodeStringAt(20); } }
-
-        #region Private
-        internal W3WebSocketCloseSendStart(Action<W3WebSocketCloseSendStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(20)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(20)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketCloseSendStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "Status", Status);
-            XmlAttrib(sb, "Reason", Reason);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "Status", "Reason" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return Status;
-                case 2:
-                    return Reason;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketCloseSendStart> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketCloseSendSuccess : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3WebSocketCloseSendSuccess(Action<W3WebSocketCloseSendSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketCloseSendSuccess>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketCloseSendSuccess> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketCloseSendFailure : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketCloseSendFailure(Action<W3WebSocketCloseSendFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketCloseSendFailure>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketCloseSendFailure> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketReadFragmentEndPending : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3WebSocketReadFragmentEndPending(Action<W3WebSocketReadFragmentEndPending> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketReadFragmentEndPending>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketReadFragmentEndPending> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketReadFragmentEndSuccess : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int BytesReceived { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketReadFragmentEndSuccess(Action<W3WebSocketReadFragmentEndSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketReadFragmentEndSuccess>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "BytesReceived", BytesReceived);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "BytesReceived" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return BytesReceived;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketReadFragmentEndSuccess> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketWriteFragmentStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int DataType { get { return GetInt32At(16); } }
-        public int DataSize { get { return GetInt32At(20); } }
-
-        #region Private
-        internal W3WebSocketWriteFragmentStart(Action<W3WebSocketWriteFragmentStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 24));
-            Debug.Assert(!(Version > 1 && EventDataLength < 24));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketWriteFragmentStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "DataType", DataType);
-            XmlAttrib(sb, "DataSize", DataSize);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "DataType", "DataSize" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return DataType;
-                case 2:
-                    return DataSize;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketWriteFragmentStart> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketInitializeNotSuccess : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketInitializeNotSuccess(Action<W3WebSocketInitializeNotSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketInitializeNotSuccess>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketInitializeNotSuccess> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-
-        #region Private
-        internal W3WebSocketStart(Action<W3WebSocketStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < 16));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketStart> m_target;
-        #endregion
-    }
-    public sealed class W3WebSocketReadFragmentEndFailure : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public int ErrorCode { get { return GetInt32At(16); } }
-
-        #region Private
-        internal W3WebSocketReadFragmentEndFailure(Action<W3WebSocketReadFragmentEndFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 20));
-            Debug.Assert(!(Version > 1 && EventDataLength < 20));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3WebSocketReadFragmentEndFailure>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<W3WebSocketReadFragmentEndFailure> m_target;
+        private event Action<W3ISAPIStart> m_target;
         #endregion
     }
     public sealed class IISModuleEventsModuleCriticalError : TraceEvent
@@ -13114,6 +10935,79 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<IISModuleEventsModuleCriticalError> m_target;
         #endregion
     }
+    public sealed class IISModuleEventsModuleEnd : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ModuleName { get { return GetUnicodeStringAt(16); } }
+        public string Data1 { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+        public string Data2 { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
+        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))); } }
+
+        #region Private
+        internal IISModuleEventsModuleEnd(Action<IISModuleEventsModuleEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<IISModuleEventsModuleEnd>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ModuleName", ModuleName);
+            XmlAttrib(sb, "Data1", Data1);
+            XmlAttrib(sb, "Data2", Data2);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ModuleName", "Data1", "Data2", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ModuleName;
+                case 2:
+                    return Data1;
+                case 3:
+                    return Data2;
+                case 4:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<IISModuleEventsModuleEnd> m_target;
+        #endregion
+    }
     public sealed class IISModuleEventsModuleError : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
@@ -13185,79 +11079,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
 
         private event Action<IISModuleEventsModuleError> m_target;
-        #endregion
-    }
-    public sealed class IISModuleEventsModuleWarning : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ModuleName { get { return GetUnicodeStringAt(16); } }
-        public string Data1 { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-        public string Data2 { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
-        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))); } }
-
-        #region Private
-        internal IISModuleEventsModuleWarning(Action<IISModuleEventsModuleWarning> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISModuleEventsModuleWarning>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ModuleName", ModuleName);
-            XmlAttrib(sb, "Data1", Data1);
-            XmlAttrib(sb, "Data2", Data2);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName", "Data1", "Data2", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ModuleName;
-                case 2:
-                    return Data1;
-                case 3:
-                    return Data2;
-                case 4:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISModuleEventsModuleWarning> m_target;
         #endregion
     }
     public sealed class IISModuleEventsModuleInformation : TraceEvent
@@ -13333,79 +11154,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<IISModuleEventsModuleInformation> m_target;
         #endregion
     }
-    public sealed class IISModuleEventsModuleVerbose : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ModuleName { get { return GetUnicodeStringAt(16); } }
-        public string Data1 { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
-        public string Data2 { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
-        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))); } }
-
-        #region Private
-        internal IISModuleEventsModuleVerbose(Action<IISModuleEventsModuleVerbose> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISModuleEventsModuleVerbose>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ModuleName", ModuleName);
-            XmlAttrib(sb, "Data1", Data1);
-            XmlAttrib(sb, "Data2", Data2);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName", "Data1", "Data2", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ModuleName;
-                case 2:
-                    return Data1;
-                case 3:
-                    return Data2;
-                case 4:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISModuleEventsModuleVerbose> m_target;
-        #endregion
-    }
     public sealed class IISModuleEventsModuleStart : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
@@ -13479,7 +11227,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<IISModuleEventsModuleStart> m_target;
         #endregion
     }
-    public sealed class IISModuleEventsModuleEnd : TraceEvent
+    public sealed class IISModuleEventsModuleVerbose : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
         public string ModuleName { get { return GetUnicodeStringAt(16); } }
@@ -13488,7 +11236,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         public int ErrorCode { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))); } }
 
         #region Private
-        internal IISModuleEventsModuleEnd(Action<IISModuleEventsModuleEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal IISModuleEventsModuleVerbose(Action<IISModuleEventsModuleVerbose> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -13505,7 +11253,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<IISModuleEventsModuleEnd>)value; }
+            set { m_target = (Action<IISModuleEventsModuleVerbose>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -13549,20 +11297,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<IISModuleEventsModuleEnd> m_target;
+        private event Action<IISModuleEventsModuleVerbose> m_target;
         #endregion
     }
-    public sealed class IISRequestNotificationEventsCompletion : TraceEvent
+    public sealed class IISModuleEventsModuleWarning : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
         public string ModuleName { get { return GetUnicodeStringAt(16); } }
-        public int Notification { get { return GetInt32At(SkipUnicodeString(16)); } }
-        public bool fIsPostNotificationEvent { get { return GetInt32At(SkipUnicodeString(16) + 4) != 0; } }
-        public int CompletionBytes { get { return GetInt32At(SkipUnicodeString(16) + 8); } }
-        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16) + 12); } }
+        public string Data1 { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+        public string Data2 { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
+        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))); } }
 
         #region Private
-        internal IISRequestNotificationEventsCompletion(Action<IISRequestNotificationEventsCompletion> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal IISModuleEventsModuleWarning(Action<IISModuleEventsModuleWarning> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -13573,22 +11320,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 16));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 16));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16))) + 4));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<IISRequestNotificationEventsCompletion>)value; }
+            set { m_target = (Action<IISModuleEventsModuleWarning>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
             XmlAttrib(sb, "ModuleName", ModuleName);
-            XmlAttrib(sb, "Notification", Notification);
-            XmlAttrib(sb, "fIsPostNotificationEvent", fIsPostNotificationEvent);
-            XmlAttrib(sb, "CompletionBytes", CompletionBytes);
+            XmlAttrib(sb, "Data1", Data1);
+            XmlAttrib(sb, "Data2", Data2);
             XmlAttrib(sb, "ErrorCode", ErrorCode);
             sb.Append("/>");
             return sb;
@@ -13599,7 +11345,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName", "Notification", "fIsPostNotificationEvent", "CompletionBytes", "ErrorCode" };
+                    payloadNames = new string[] { "ContextId", "ModuleName", "Data1", "Data2", "ErrorCode" };
                 return payloadNames;
             }
         }
@@ -13613,12 +11359,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 1:
                     return ModuleName;
                 case 2:
-                    return Notification;
+                    return Data1;
                 case 3:
-                    return fIsPostNotificationEvent;
+                    return Data2;
                 case 4:
-                    return CompletionBytes;
-                case 5:
                     return ErrorCode;
                 default:
                     Debug.Assert(false, "Bad field index");
@@ -13626,202 +11370,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             }
         }
 
-        private event Action<IISRequestNotificationEventsCompletion> m_target;
-        #endregion
-    }
-    public sealed class IISRequestNotificationPreBeginStart : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ModuleName { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal IISRequestNotificationPreBeginStart(Action<IISRequestNotificationPreBeginStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISRequestNotificationPreBeginStart>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ModuleName", ModuleName);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ModuleName;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISRequestNotificationPreBeginStart> m_target;
-        #endregion
-    }
-    public sealed class IISRequestNotificationPreBeginEnd : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ModuleName { get { return GetUnicodeStringAt(16); } }
-        public int NotificationStatus { get { return GetInt32At(SkipUnicodeString(16)); } }
-
-        #region Private
-        internal IISRequestNotificationPreBeginEnd(Action<IISRequestNotificationPreBeginEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 4));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 4));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISRequestNotificationPreBeginEnd>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ModuleName", ModuleName);
-            XmlAttrib(sb, "NotificationStatus", NotificationStatus);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName", "NotificationStatus" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ModuleName;
-                case 2:
-                    return NotificationStatus;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISRequestNotificationPreBeginEnd> m_target;
-        #endregion
-    }
-    public sealed class IISRequestNotificationEventsError : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ModuleName { get { return GetUnicodeStringAt(16); } }
-        public int Notification { get { return GetInt32At(SkipUnicodeString(16)); } }
-        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16) + 4); } }
-
-        #region Private
-        internal IISRequestNotificationEventsError(Action<IISRequestNotificationEventsError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 8));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 8));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISRequestNotificationEventsError>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ModuleName", ModuleName);
-            XmlAttrib(sb, "Notification", Notification);
-            XmlAttrib(sb, "ErrorCode", ErrorCode);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName", "Notification", "ErrorCode" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ModuleName;
-                case 2:
-                    return Notification;
-                case 3:
-                    return ErrorCode;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISRequestNotificationEventsError> m_target;
+        private event Action<IISModuleEventsModuleWarning> m_target;
         #endregion
     }
     public sealed class IISRequestNotificationEventsResponseErrorStatus : TraceEvent
@@ -13982,76 +11531,17 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<IISRequestNotificationEventsResponseSuccessStatus> m_target;
         #endregion
     }
-    public sealed class IISRequestNotificationEventsResponseErrorDescription : TraceEvent
-    {
-        public Guid ContextId { get { return GetGuidAt(0); } }
-        public string ErrorDescription { get { return GetUnicodeStringAt(16); } }
-
-        #region Private
-        internal IISRequestNotificationEventsResponseErrorDescription(Action<IISRequestNotificationEventsResponseErrorDescription> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<IISRequestNotificationEventsResponseErrorDescription>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "ErrorDescription", ErrorDescription);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ErrorDescription" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ContextId;
-                case 1:
-                    return ErrorDescription;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IISRequestNotificationEventsResponseErrorDescription> m_target;
-        #endregion
-    }
-    public sealed class IISRequestNotificationEventsStart : TraceEvent
+    public sealed class IISRequestNotificationEventsCompletion : TraceEvent
     {
         public Guid ContextId { get { return GetGuidAt(0); } }
         public string ModuleName { get { return GetUnicodeStringAt(16); } }
         public int Notification { get { return GetInt32At(SkipUnicodeString(16)); } }
-        public bool fIsPostNotification { get { return GetInt32At(SkipUnicodeString(16) + 4) != 0; } }
+        public bool fIsPostNotificationEvent { get { return GetInt32At(SkipUnicodeString(16) + 4) != 0; } }
+        public int CompletionBytes { get { return GetInt32At(SkipUnicodeString(16) + 8); } }
+        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16) + 12); } }
 
         #region Private
-        internal IISRequestNotificationEventsStart(Action<IISRequestNotificationEventsStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal IISRequestNotificationEventsCompletion(Action<IISRequestNotificationEventsCompletion> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -14062,13 +11552,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 8));
-            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 8));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 16));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<IISRequestNotificationEventsStart>)value; }
+            set { m_target = (Action<IISRequestNotificationEventsCompletion>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -14076,7 +11566,9 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             XmlAttrib(sb, "ContextId", ContextId);
             XmlAttrib(sb, "ModuleName", ModuleName);
             XmlAttrib(sb, "Notification", Notification);
-            XmlAttrib(sb, "fIsPostNotification", fIsPostNotification);
+            XmlAttrib(sb, "fIsPostNotificationEvent", fIsPostNotificationEvent);
+            XmlAttrib(sb, "CompletionBytes", CompletionBytes);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
             sb.Append("/>");
             return sb;
         }
@@ -14086,7 +11578,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "ModuleName", "Notification", "fIsPostNotification" };
+                    payloadNames = new string[] { "ContextId", "ModuleName", "Notification", "fIsPostNotificationEvent", "CompletionBytes", "ErrorCode" };
                 return payloadNames;
             }
         }
@@ -14102,14 +11594,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 2:
                     return Notification;
                 case 3:
-                    return fIsPostNotification;
+                    return fIsPostNotificationEvent;
+                case 4:
+                    return CompletionBytes;
+                case 5:
+                    return ErrorCode;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<IISRequestNotificationEventsStart> m_target;
+        private event Action<IISRequestNotificationEventsCompletion> m_target;
         #endregion
     }
     public sealed class IISRequestNotificationEventsEnd : TraceEvent
@@ -14185,13 +11681,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         private event Action<IISRequestNotificationEventsEnd> m_target;
         #endregion
     }
-    public sealed class IsapiDeleteContext : TraceEvent
+    public sealed class IISRequestNotificationEventsStart : TraceEvent
     {
-        public long RequestId { get { return GetInt64At(0); } }
-        public Address connID { get { return GetAddressAt(8); } }
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ModuleName { get { return GetUnicodeStringAt(16); } }
+        public int Notification { get { return GetInt32At(SkipUnicodeString(16)); } }
+        public bool fIsPostNotification { get { return GetInt32At(SkipUnicodeString(16) + 4) != 0; } }
 
         #region Private
-        internal IsapiDeleteContext(Action<IsapiDeleteContext> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal IISRequestNotificationEventsStart(Action<IISRequestNotificationEventsStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -14202,85 +11700,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 0 && EventDataLength != HostOffset(12, 1)));
-            Debug.Assert(!(Version > 0 && EventDataLength < HostOffset(12, 1)));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 8));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 8));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<IsapiDeleteContext>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "RequestId", RequestId);
-            XmlAttribHex(sb, "connID", connID);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "RequestId", "connID" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return RequestId;
-                case 1:
-                    return connID;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        private event Action<IsapiDeleteContext> m_target;
-        #endregion
-    }
-    public sealed class W3ISAPIStart : TraceEvent
-    {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
-        public Address connID { get { return GetAddressAt(8); } }
-        public int fOop { get { return GetInt32At(HostOffset(12, 1)); } }
-
-        #region Private
-        internal W3ISAPIStart(Action<W3ISAPIStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            this.m_target = target;
-        }
-        internal protected override void Dispatch()
-        {
-            m_target(this);
-        }
-        internal protected override void Validate()
-        {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != HostOffset(16, 1)));
-            Debug.Assert(!(Version > 0 && EventDataLength < HostOffset(16, 1)));
-        }
-        internal protected override Delegate Target
-        {
-            get { return m_target; }
-            set { m_target = (Action<W3ISAPIStart>)value; }
+            set { m_target = (Action<IISRequestNotificationEventsStart>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
-            XmlAttribHex(sb, "connID", connID);
-            XmlAttrib(sb, "fOop", fOop);
+            XmlAttrib(sb, "ModuleName", ModuleName);
+            XmlAttrib(sb, "Notification", Notification);
+            XmlAttrib(sb, "fIsPostNotification", fIsPostNotification);
             sb.Append("/>");
             return sb;
         }
@@ -14290,7 +11724,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId", "connID", "fOop" };
+                    payloadNames = new string[] { "ContextId", "ModuleName", "Notification", "fIsPostNotification" };
                 return payloadNames;
             }
         }
@@ -14302,28 +11736,28 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return RequestId;
+                    return ModuleName;
                 case 2:
-                    return connID;
+                    return Notification;
                 case 3:
-                    return fOop;
+                    return fIsPostNotification;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3ISAPIStart> m_target;
+        private event Action<IISRequestNotificationEventsStart> m_target;
         #endregion
     }
-    public sealed class W3ISAPIEnd : TraceEvent
+    public sealed class IISRequestNotificationPreBeginEnd : TraceEvent
     {
-        public Guid ContextId { get { if (Version >= 1) return GetGuidAt(0); return Guid.Empty; } }
-        public long RequestId { get { return GetInt64At(0); } }
-        public Address connID { get { return GetAddressAt(8); } }
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ModuleName { get { return GetUnicodeStringAt(16); } }
+        public int NotificationStatus { get { return GetInt32At(SkipUnicodeString(16)); } }
 
         #region Private
-        internal W3ISAPIEnd(Action<W3ISAPIEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+        internal IISRequestNotificationPreBeginEnd(Action<IISRequestNotificationPreBeginEnd> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             this.m_target = target;
@@ -14334,21 +11768,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 1 && EventDataLength != 16));
-            Debug.Assert(!(Version == 0 && EventDataLength != HostOffset(12, 1)));
-            Debug.Assert(!(Version > 0 && EventDataLength < HostOffset(12, 1)));
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 4));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 4));
         }
         internal protected override Delegate Target
         {
             get { return m_target; }
-            set { m_target = (Action<W3ISAPIEnd>)value; }
+            set { m_target = (Action<IISRequestNotificationPreBeginEnd>)value; }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
             XmlAttrib(sb, "ContextId", ContextId);
-            XmlAttrib(sb, "RequestId", RequestId);
-            XmlAttribHex(sb, "connID", connID);
+            XmlAttrib(sb, "ModuleName", ModuleName);
+            XmlAttrib(sb, "NotificationStatus", NotificationStatus);
             sb.Append("/>");
             return sb;
         }
@@ -14358,7 +11791,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ContextId", "RequestId", "connID" };
+                    payloadNames = new string[] { "ContextId", "ModuleName", "NotificationStatus" };
                 return payloadNames;
             }
         }
@@ -14370,16 +11803,1972 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace
                 case 0:
                     return ContextId;
                 case 1:
-                    return RequestId;
+                    return ModuleName;
                 case 2:
-                    return connID;
+                    return NotificationStatus;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
             }
         }
 
-        private event Action<W3ISAPIEnd> m_target;
+        private event Action<IISRequestNotificationPreBeginEnd> m_target;
+        #endregion
+    }
+    public sealed class IISRequestNotificationPreBeginStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ModuleName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal IISRequestNotificationPreBeginStart(Action<IISRequestNotificationPreBeginStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<IISRequestNotificationPreBeginStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ModuleName", ModuleName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ModuleName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ModuleName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<IISRequestNotificationPreBeginStart> m_target;
+        #endregion
+    }
+    public sealed class IISRequestNotificationEventsError : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ModuleName { get { return GetUnicodeStringAt(16); } }
+        public int Notification { get { return GetInt32At(SkipUnicodeString(16)); } }
+        public int ErrorCode { get { return GetInt32At(SkipUnicodeString(16) + 4); } }
+
+        #region Private
+        internal IISRequestNotificationEventsError(Action<IISRequestNotificationEventsError> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16) + 8));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16) + 8));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<IISRequestNotificationEventsError>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ModuleName", ModuleName);
+            XmlAttrib(sb, "Notification", Notification);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ModuleName", "Notification", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ModuleName;
+                case 2:
+                    return Notification;
+                case 3:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<IISRequestNotificationEventsError> m_target;
+        #endregion
+    }
+    public sealed class IISRequestNotificationEventsResponseErrorDescription : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ErrorDescription { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal IISRequestNotificationEventsResponseErrorDescription(Action<IISRequestNotificationEventsResponseErrorDescription> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<IISRequestNotificationEventsResponseErrorDescription>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorDescription", ErrorDescription);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorDescription" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorDescription;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<IISRequestNotificationEventsResponseErrorDescription> m_target;
+        #endregion
+    }
+    public sealed class W3SecDeniedByAccessFlags : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int CurrentFlags { get { return GetInt32At(16); } }
+        public int NeededFlags { get { return GetInt32At(20); } }
+
+        #region Private
+        internal W3SecDeniedByAccessFlags(Action<W3SecDeniedByAccessFlags> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 24));
+            Debug.Assert(!(Version > 1 && EventDataLength < 24));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecDeniedByAccessFlags>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "CurrentFlags", CurrentFlags);
+            XmlAttrib(sb, "NeededFlags", NeededFlags);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "CurrentFlags", "NeededFlags" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return CurrentFlags;
+                case 2:
+                    return NeededFlags;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecDeniedByAccessFlags> m_target;
+        #endregion
+    }
+    public sealed class W3SecDeniedByCGIRestriction : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ImageName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3SecDeniedByCGIRestriction(Action<W3SecDeniedByCGIRestriction> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecDeniedByCGIRestriction>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ImageName", ImageName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ImageName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ImageName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecDeniedByCGIRestriction> m_target;
+        #endregion
+    }
+    public sealed class W3SecDeniedByISAPIRestriction : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string ImageName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3SecDeniedByISAPIRestriction(Action<W3SecDeniedByISAPIRestriction> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecDeniedByISAPIRestriction>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ImageName", ImageName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ImageName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ImageName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecDeniedByISAPIRestriction> m_target;
+        #endregion
+    }
+    public sealed class W3SecDeniedByMimemap : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string FileName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3SecDeniedByMimemap(Action<W3SecDeniedByMimemap> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecDeniedByMimemap>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "FileName", FileName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "FileName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return FileName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecDeniedByMimemap> m_target;
+        #endregion
+    }
+    public sealed class W3SecFileAccessDenied : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string FileName { get { return GetUnicodeStringAt(16); } }
+        public string AccountName { get { return GetUnicodeStringAt(SkipUnicodeString(16)); } }
+        public string DomainName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(16))); } }
+
+        #region Private
+        internal W3SecFileAccessDenied(Action<W3SecFileAccessDenied> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(16)))));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecFileAccessDenied>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "FileName", FileName);
+            XmlAttrib(sb, "AccountName", AccountName);
+            XmlAttrib(sb, "DomainName", DomainName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "FileName", "AccountName", "DomainName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return FileName;
+                case 2:
+                    return AccountName;
+                case 3:
+                    return DomainName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecFileAccessDenied> m_target;
+        #endregion
+    }
+    public sealed class W3SecIllegalShortFilename : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string FileName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3SecIllegalShortFilename(Action<W3SecIllegalShortFilename> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecIllegalShortFilename>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "FileName", FileName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "FileName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return FileName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecIllegalShortFilename> m_target;
+        #endregion
+    }
+    public sealed class W3SecRejectedHostname : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string HostName { get { return GetUnicodeStringAt(16); } }
+
+        #region Private
+        internal W3SecRejectedHostname(Action<W3SecRejectedHostname> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecRejectedHostname>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "HostName", HostName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "HostName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return HostName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecRejectedHostname> m_target;
+        #endregion
+    }
+    public sealed class W3SecRejectedIP : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public string IPAddress { get { return GetUTF8StringAt(16); } }
+
+        #region Private
+        internal W3SecRejectedIP(Action<W3SecRejectedIP> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUTF8String(16)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUTF8String(16)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecRejectedIP>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "IPAddress", IPAddress);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "IPAddress" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return IPAddress;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecRejectedIP> m_target;
+        #endregion
+    }
+    public sealed class W3SecRequireSSL128 : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3SecRequireSSL128(Action<W3SecRequireSSL128> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3SecRequireSSL128>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3SecRequireSSL128> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketApplicationCloseConnection : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3WebSocketApplicationCloseConnection(Action<W3WebSocketApplicationCloseConnection> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketApplicationCloseConnection>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketApplicationCloseConnection> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketEndFailure : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketEndFailure(Action<W3WebSocketEndFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketEndFailure>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketEndFailure> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3WebSocketStart(Action<W3WebSocketStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketStart> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketEndSuccess : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3WebSocketEndSuccess(Action<W3WebSocketEndSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketEndSuccess>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketEndSuccess> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketInitializeNotSuccess : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketInitializeNotSuccess(Action<W3WebSocketInitializeNotSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketInitializeNotSuccess>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketInitializeNotSuccess> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketModuleCloseConnection : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int Reason { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketModuleCloseConnection(Action<W3WebSocketModuleCloseConnection> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketModuleCloseConnection>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Reason", Reason);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Reason" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Reason;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketModuleCloseConnection> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketReadFragmentEndFailure : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketReadFragmentEndFailure(Action<W3WebSocketReadFragmentEndFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketReadFragmentEndFailure>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketReadFragmentEndFailure> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketReadFragmentEndPending : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3WebSocketReadFragmentEndPending(Action<W3WebSocketReadFragmentEndPending> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketReadFragmentEndPending>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketReadFragmentEndPending> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketReadFragmentEndSuccess : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int BytesReceived { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketReadFragmentEndSuccess(Action<W3WebSocketReadFragmentEndSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketReadFragmentEndSuccess>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "BytesReceived", BytesReceived);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "BytesReceived" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return BytesReceived;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketReadFragmentEndSuccess> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketReadFragmentStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int BufferSize { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketReadFragmentStart(Action<W3WebSocketReadFragmentStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketReadFragmentStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "BufferSize", BufferSize);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "BufferSize" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return BufferSize;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketReadFragmentStart> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketReadIoFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketReadIoFailed(Action<W3WebSocketReadIoFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketReadIoFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketReadIoFailed> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketCloseReceived : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int Status { get { return GetInt32At(16); } }
+        public string Reason { get { return GetUnicodeStringAt(20); } }
+
+        #region Private
+        internal W3WebSocketCloseReceived(Action<W3WebSocketCloseReceived> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(20)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(20)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketCloseReceived>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Status", Status);
+            XmlAttrib(sb, "Reason", Reason);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Status", "Reason" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Status;
+                case 2:
+                    return Reason;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketCloseReceived> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketCloseSendFailure : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketCloseSendFailure(Action<W3WebSocketCloseSendFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketCloseSendFailure>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketCloseSendFailure> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketCloseSendSuccess : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3WebSocketCloseSendSuccess(Action<W3WebSocketCloseSendSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketCloseSendSuccess>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketCloseSendSuccess> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketCloseSendStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int Status { get { return GetInt32At(16); } }
+        public string Reason { get { return GetUnicodeStringAt(20); } }
+
+        #region Private
+        internal W3WebSocketCloseSendStart(Action<W3WebSocketCloseSendStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != SkipUnicodeString(20)));
+            Debug.Assert(!(Version > 1 && EventDataLength < SkipUnicodeString(20)));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketCloseSendStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "Status", Status);
+            XmlAttrib(sb, "Reason", Reason);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "Status", "Reason" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return Status;
+                case 2:
+                    return Reason;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketCloseSendStart> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketWriteFragmentEndFailure : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketWriteFragmentEndFailure(Action<W3WebSocketWriteFragmentEndFailure> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketWriteFragmentEndFailure>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketWriteFragmentEndFailure> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketWriteFragmentEndPending : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+
+        #region Private
+        internal W3WebSocketWriteFragmentEndPending(Action<W3WebSocketWriteFragmentEndPending> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 16));
+            Debug.Assert(!(Version > 1 && EventDataLength < 16));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketWriteFragmentEndPending>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketWriteFragmentEndPending> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketWriteFragmentEndSuccess : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int BytesSent { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketWriteFragmentEndSuccess(Action<W3WebSocketWriteFragmentEndSuccess> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketWriteFragmentEndSuccess>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "BytesSent", BytesSent);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "BytesSent" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return BytesSent;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketWriteFragmentEndSuccess> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketWriteFragmentStart : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int DataType { get { return GetInt32At(16); } }
+        public int DataSize { get { return GetInt32At(20); } }
+
+        #region Private
+        internal W3WebSocketWriteFragmentStart(Action<W3WebSocketWriteFragmentStart> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 24));
+            Debug.Assert(!(Version > 1 && EventDataLength < 24));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketWriteFragmentStart>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "DataType", DataType);
+            XmlAttrib(sb, "DataSize", DataSize);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "DataType", "DataSize" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return DataType;
+                case 2:
+                    return DataSize;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketWriteFragmentStart> m_target;
+        #endregion
+    }
+    public sealed class W3WebSocketWriteIoFailed : TraceEvent
+    {
+        public Guid ContextId { get { return GetGuidAt(0); } }
+        public int ErrorCode { get { return GetInt32At(16); } }
+
+        #region Private
+        internal W3WebSocketWriteIoFailed(Action<W3WebSocketWriteIoFailed> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.m_target = target;
+        }
+        internal protected override void Dispatch()
+        {
+            m_target(this);
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 1 && EventDataLength != 20));
+            Debug.Assert(!(Version > 1 && EventDataLength < 20));
+        }
+        internal protected override Delegate Target
+        {
+            get { return m_target; }
+            set { m_target = (Action<W3WebSocketWriteIoFailed>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ContextId", ContextId);
+            XmlAttrib(sb, "ErrorCode", ErrorCode);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ContextId", "ErrorCode" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ContextId;
+                case 1:
+                    return ErrorCode;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<W3WebSocketWriteIoFailed> m_target;
         #endregion
     }
 }

--- a/src/TraceEvent/Parsers/w3core.man.xml
+++ b/src/TraceEvent/Parsers/w3core.man.xml
@@ -1,0 +1,1393 @@
+<instrumentationManifest xmlns="http://schemas.microsoft.com/win/2004/08/events">
+  <instrumentation xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events">
+    <events xmlns="http://schemas.microsoft.com/win/2004/08/events">
+      <provider name="IIS_Trace" guid="{3a2a4e84-4c21-4981-ae10-3fda0d9b0f83}">
+        <tasks>
+          <task name="IISGeneral"  value="0" eventGUID="{d42cf7ef-de92-473e-8b6c-621ea663113a}"/>
+        <opcodes>
+          <opcode name="GENERAL_REQUEST_START" symbol="IISGeneral_GENERAL_REQUEST_START" value="1"/>
+          <opcode name="GENERAL_REQUEST_END" symbol="IISGeneral_GENERAL_REQUEST_END" value="2"/>
+          <opcode name="GENERAL_STATIC_FILE_HANDLER" symbol="IISGeneral_GENERAL_STATIC_FILE_HANDLER" value="10"/>
+          <opcode name="GENERAL_CGI_HANDLER" symbol="IISGeneral_GENERAL_CGI_HANDLER" value="11"/>
+          <opcode name="GENERAL_ISAPI_HANDLER" symbol="IISGeneral_GENERAL_ISAPI_HANDLER" value="12"/>
+          <opcode name="GENERAL_OOP_ISAPI_HANDLER" symbol="IISGeneral_GENERAL_OOP_ISAPI_HANDLER" value="13"/>
+          <opcode name="GENERAL_REDIRECTION_HANDLER" symbol="IISGeneral_GENERAL_REDIRECTION_HANDLER" value="14"/>
+          <opcode name="GENERAL_DAV_HANDLER" symbol="IISGeneral_GENERAL_DAV_HANDLER" value="15"/>
+          <opcode name="GENERAL_OPTIONS_HANDLER" symbol="IISGeneral_GENERAL_OPTIONS_HANDLER" value="16"/>
+          <opcode name="GENERAL_TRACE_HANDLER" symbol="IISGeneral_GENERAL_TRACE_HANDLER" value="17"/>
+          <opcode name="GENERAL_GET_URL_METADATA" symbol="IISGeneral_GENERAL_GET_URL_METADATA" value="30"/>
+          <opcode name="GENERAL_CHILD_REQUEST_START" symbol="IISGeneral_GENERAL_CHILD_REQUEST_START" value="31"/>
+          <opcode name="GENERAL_CHILD_REQUEST_END" symbol="IISGeneral_GENERAL_CHILD_REQUEST_END" value="32"/>
+          <opcode name="GENERAL_SEND_CUSTOM_ERROR" symbol="IISGeneral_GENERAL_SEND_CUSTOM_ERROR" value="33"/>
+          <opcode name="GENERAL_MAP_HANDLER" symbol="IISGeneral_GENERAL_MAP_HANDLER" value="34"/>
+          <opcode name="GENERAL_FLUSH_RESPONSE_START" symbol="IISGeneral_GENERAL_FLUSH_RESPONSE_START" value="35"/>
+          <opcode name="GENERAL_FLUSH_RESPONSE_END" symbol="IISGeneral_GENERAL_FLUSH_RESPONSE_END" value="36"/>
+          <opcode name="GENERAL_READ_ENTITY_START" symbol="IISGeneral_GENERAL_READ_ENTITY_START" value="37"/>
+          <opcode name="GENERAL_READ_ENTITY_END" symbol="IISGeneral_GENERAL_READ_ENTITY_END" value="38"/>
+          <opcode name="FILE_CHANGE_NOTIFICATION" symbol="IISGeneral_FILE_CHANGE_NOTIFICATION" value="39"/>
+          <opcode name="CONFIG_CHANGE_NOTIFICATION" symbol="IISGeneral_CONFIG_CHANGE_NOTIFICATION" value="40"/>
+          <opcode name="VIRTUAL_MODULE_UNRESOLVED" symbol="IISGeneral_VIRTUAL_MODULE_UNRESOLVED" value="41"/>
+          <opcode name="URL_CHANGED" symbol="IISGeneral_URL_CHANGED" value="42"/>
+          <opcode name="HANDLER_CHANGED" symbol="IISGeneral_HANDLER_CHANGED" value="43"/>
+          <opcode name="USER_SET" symbol="IISGeneral_USER_SET" value="44"/>
+          <opcode name="MODULE_PRECONDITION_NOT_MATCH" symbol="IISGeneral_MODULE_PRECONDITION_NOT_MATCH" value="45"/>
+          <opcode name="HANDLER_PRECONDITION_NOT_MATCH" symbol="IISGeneral_HANDLER_PRECONDITION_NOT_MATCH" value="46"/>
+          <opcode name="GENERAL_RESPONSE_HEADERS" symbol="IISGeneral_GENERAL_RESPONSE_HEADERS" value="47"/>
+          <opcode name="GENERAL_RESPONSE_ENTITY_FILE" symbol="IISGeneral_GENERAL_RESPONSE_ENTITY_FILE" value="48"/>
+          <opcode name="GENERAL_RESPONSE_ENTITY_BUFFER" symbol="IISGeneral_GENERAL_RESPONSE_ENTITY_BUFFER" value="49"/>
+          <opcode name="GENERAL_REQUEST_HEADERS" symbol="IISGeneral_GENERAL_REQUEST_HEADERS" value="50"/>
+          <opcode name="GENERAL_REQUEST_ENTITY" symbol="IISGeneral_GENERAL_REQUEST_ENTITY" value="51"/>
+          <opcode name="GENERAL_NOT_SEND_CUSTOM_ERROR" symbol="IISGeneral_GENERAL_NOT_SEND_CUSTOM_ERROR" value="52"/>
+          <opcode name="GENERAL_SET_REQUEST_HEADER" symbol="IISGeneral_GENERAL_SET_REQUEST_HEADER" value="53"/>
+          <opcode name="GENERAL_MODULE_FACTORY_FAILED" symbol="IISGeneral_GENERAL_MODULE_FACTORY_FAILED" value="54"/>
+          <opcode name="GENERAL_ENDPOINT_INFORMATION" symbol="IISGeneral_GENERAL_ENDPOINT_INFORMATION" value="55"/>
+        </opcodes>
+          <task name="IISAuthentication"  value="1" eventGUID="{c33bbe8f-985b-4080-81e6-005f1a06b9e2}"/>
+        <opcodes>
+          <opcode name="AUTH_START" symbol="IISAuthentication_AUTH_START" value="10"/>
+          <opcode name="AUTH_SUCCEEDED" symbol="IISAuthentication_AUTH_SUCCEEDED" value="11"/>
+          <opcode name="AUTH_TYPE_NOT_SUPPORTED" symbol="IISAuthentication_AUTH_TYPE_NOT_SUPPORTED" value="12"/>
+          <opcode name="AUTH_INVALID_ANON_ACCOUNT" symbol="IISAuthentication_AUTH_INVALID_ANON_ACCOUNT" value="13"/>
+          <opcode name="AUTH_PASSWD_CHANGE_NEEDED" symbol="IISAuthentication_AUTH_PASSWD_CHANGE_NEEDED" value="14"/>
+          <opcode name="AUTH_PASSWD_CHANGE_DISABLED" symbol="IISAuthentication_AUTH_PASSWD_CHANGE_DISABLED" value="15"/>
+          <opcode name="AUTH_BAD_BASIC_HEADER" symbol="IISAuthentication_AUTH_BAD_BASIC_HEADER" value="16"/>
+          <opcode name="AUTH_BASIC_LOGON_FAILED" symbol="IISAuthentication_AUTH_BASIC_LOGON_FAILED" value="17"/>
+          <opcode name="AUTH_WDIGEST_LOGON_FAILED" symbol="IISAuthentication_AUTH_WDIGEST_LOGON_FAILED" value="18"/>
+          <opcode name="AUTH_IISDIGEST_LOGON_FAILED" symbol="IISAuthentication_AUTH_IISDIGEST_LOGON_FAILED" value="19"/>
+          <opcode name="AUTH_PASSPORT_LOGON_FAILED" symbol="IISAuthentication_AUTH_PASSPORT_LOGON_FAILED" value="20"/>
+          <opcode name="AUTH_SSPI_LOGON_FAILED" symbol="IISAuthentication_AUTH_SSPI_LOGON_FAILED" value="21"/>
+          <opcode name="AUTH_NTLM_NULL_SESSION" symbol="IISAuthentication_AUTH_NTLM_NULL_SESSION" value="22"/>
+          <opcode name="AUTH_SSPI_CONTINUE_NEEDED" symbol="IISAuthentication_AUTH_SSPI_CONTINUE_NEEDED" value="23"/>
+          <opcode name="AUTH_KERBEROS_FAILED" symbol="IISAuthentication_AUTH_KERBEROS_FAILED" value="55"/>
+          <opcode name="AUTH_ANON_PASSWD_CHANGE_NEEDED" symbol="IISAuthentication_AUTH_ANON_PASSWD_CHANGE_NEEDED" value="24"/>
+          <opcode name="AUTH_REQUEST_AUTH_TYPE" symbol="IISAuthentication_AUTH_REQUEST_AUTH_TYPE" value="27"/>
+          <opcode name="AUTH_END" symbol="IISAuthentication_AUTH_END" value="28"/>
+        </opcodes>
+          <task name="IISSecurity"  value="2" eventGUID="{29347ffb-ba48-41e6-bffd-469c5e543ca5}"/>
+        <opcodes>
+          <opcode name="SECURITY_ILLEGAL_SHORT_FILENAME" symbol="IISSecurity_SECURITY_ILLEGAL_SHORT_FILENAME" value="10"/>
+          <opcode name="SECURITY_REJECTED_IP" symbol="IISSecurity_SECURITY_REJECTED_IP" value="11"/>
+          <opcode name="SECURITY_REJECTED_HOSTNAME" symbol="IISSecurity_SECURITY_REJECTED_HOSTNAME" value="12"/>
+          <opcode name="SECURITY_REJECTED_REQUIRE_SSL_128" symbol="IISSecurity_SECURITY_REJECTED_REQUIRE_SSL_128" value="13"/>
+          <opcode name="SECURITY_FILE_ACCESS_DENIED" symbol="IISSecurity_SECURITY_FILE_ACCESS_DENIED" value="14"/>
+          <opcode name="SECURITY_DENIED_BY_MIMEMAP" symbol="IISSecurity_SECURITY_DENIED_BY_MIMEMAP" value="15"/>
+          <opcode name="SECURITY_DENIED_BY_ISAPI_RESTRICTION" symbol="IISSecurity_SECURITY_DENIED_BY_ISAPI_RESTRICTION" value="16"/>
+          <opcode name="SECURITY_DENIED_BY_CGI_RESTRICTION" symbol="IISSecurity_SECURITY_DENIED_BY_CGI_RESTRICTION" value="17"/>
+          <opcode name="SECURITY_DENIED_BY_ACCESS_FLAGS" symbol="IISSecurity_SECURITY_DENIED_BY_ACCESS_FLAGS" value="18"/>
+        </opcodes>
+          <task name="IISFilter"  value="3" eventGUID="{00237f0d-73eb-4bcf-a232-126693595847}"/>
+        <opcodes>
+          <opcode name="FILTER_START" symbol="IISFilter_FILTER_START" value="1"/>
+          <opcode name="FILTER_END" symbol="IISFilter_FILTER_END" value="2"/>
+          <opcode name="FILTER_ERROR" symbol="IISFilter_FILTER_ERROR" value="12"/>
+          <opcode name="FILTER_PREPROC_HEADERS_START" symbol="IISFilter_FILTER_PREPROC_HEADERS_START" value="13"/>
+          <opcode name="FILTER_PREPROC_HEADERS_END" symbol="IISFilter_FILTER_PREPROC_HEADERS_END" value="14"/>
+          <opcode name="FILTER_URL_MAP_START" symbol="IISFilter_FILTER_URL_MAP_START" value="15"/>
+          <opcode name="FILTER_URL_MAP_END" symbol="IISFilter_FILTER_URL_MAP_END" value="16"/>
+          <opcode name="FILTER_AUTHENTICATION_START" symbol="IISFilter_FILTER_AUTHENTICATION_START" value="17"/>
+          <opcode name="FILTER_AUTHENTICATION_END" symbol="IISFilter_FILTER_AUTHENTICATION_END" value="18"/>
+          <opcode name="FILTER_AUTH_COMPLETE_START" symbol="IISFilter_FILTER_AUTH_COMPLETE_START" value="19"/>
+          <opcode name="FILTER_AUTH_COMPLETE_END" symbol="IISFilter_FILTER_AUTH_COMPLETE_END" value="20"/>
+          <opcode name="FILTER_SEND_RESPONSE_START" symbol="IISFilter_FILTER_SEND_RESPONSE_START" value="21"/>
+          <opcode name="FILTER_SEND_RESPONSE_END" symbol="IISFilter_FILTER_SEND_RESPONSE_END" value="22"/>
+          <opcode name="FILTER_END_OF_REQUEST_START" symbol="IISFilter_FILTER_END_OF_REQUEST_START" value="23"/>
+          <opcode name="FILTER_END_OF_REQUEST_END" symbol="IISFilter_FILTER_END_OF_REQUEST_END" value="24"/>
+          <opcode name="FILTER_LOG_START" symbol="IISFilter_FILTER_LOG_START" value="25"/>
+          <opcode name="FILTER_LOG_END" symbol="IISFilter_FILTER_LOG_END" value="26"/>
+          <opcode name="FILTER_SEND_RAW_DATA_START" symbol="IISFilter_FILTER_SEND_RAW_DATA_START" value="27"/>
+          <opcode name="FILTER_SEND_RAW_DATA_END" symbol="IISFilter_FILTER_SEND_RAW_DATA_END" value="28"/>
+          <opcode name="FILTER_ACCESS_DENIED_START" symbol="IISFilter_FILTER_ACCESS_DENIED_START" value="29"/>
+          <opcode name="FILTER_ACCESS_DENIED_END" symbol="IISFilter_FILTER_ACCESS_DENIED_END" value="30"/>
+          <opcode name="FILTER_SET_REQ_HEADER" symbol="IISFilter_FILTER_SET_REQ_HEADER" value="31"/>
+          <opcode name="FILTER_ADD_REQ_HEADER" symbol="IISFilter_FILTER_ADD_REQ_HEADER" value="32"/>
+          <opcode name="FILTER_SET_RESP_HEADER" symbol="IISFilter_FILTER_SET_RESP_HEADER" value="33"/>
+          <opcode name="FILTER_ADD_RESP_HEADER" symbol="IISFilter_FILTER_ADD_RESP_HEADER" value="34"/>
+        </opcodes>
+          <task name="IISStaticFile"  value="4" eventGUID="{79b02104-0db9-4cda-a552-058d97c2ecfd}"/>
+        <opcodes>
+        </opcodes>
+          <task name="IISISAPI"  value="5" eventGUID="{2e94e6c7-eda0-4b73-9010-2529edce1c27}"/>
+        <opcodes>
+          <opcode name="ISAPI_START" symbol="IISISAPI_ISAPI_START" value="1"/>
+          <opcode name="ISAPI_END" symbol="IISISAPI_ISAPI_END" value="2"/>
+        </opcodes>
+          <task name="IISCGI"  value="6" eventGUID="{e2e55403-0d2e-4609-a470-be0da04013c0}"/>
+        <opcodes>
+          <opcode name="CGI_START" symbol="IISCGI_CGI_START" value="1"/>
+          <opcode name="CGI_END" symbol="IISCGI_CGI_END" value="2"/>
+          <opcode name="CGI_LAUNCH" symbol="IISCGI_CGI_LAUNCH" value="3"/>
+          <opcode name="CGI_TIMEOUT" symbol="IISCGI_CGI_TIMEOUT" value="4"/>
+          <opcode name="CGI_PREMATURE_TERMINATION" symbol="IISCGI_CGI_PREMATURE_TERMINATION" value="5"/>
+          <opcode name="CGI_REQUEST_ENTITY_SENT" symbol="IISCGI_CGI_REQUEST_ENTITY_SENT" value="6"/>
+          <opcode name="CGI_HEADERS_RECEIVED" symbol="IISCGI_CGI_HEADERS_RECEIVED" value="7"/>
+        </opcodes>
+          <task name="IISFastCGI"  value="7" eventGUID="{e3642acc-3627-42b0-8372-867baa033b07}"/>
+        <opcodes>
+          <opcode name="FASTCGI_ACTIVITY_TIMEOUT" symbol="IISFastCGI_FASTCGI_ACTIVITY_TIMEOUT" value="1"/>
+          <opcode name="FASTCGI_REQUEST_TIMEOUT" symbol="IISFastCGI_FASTCGI_REQUEST_TIMEOUT" value="2"/>
+          <opcode name="FASTCGI_UNEXPECTED_EXIT" symbol="IISFastCGI_FASTCGI_UNEXPECTED_EXIT" value="3"/>
+          <opcode name="FASTCGI_RAPID_FAILURE_PROTECTION" symbol="IISFastCGI_FASTCGI_RAPID_FAILURE_PROTECTION" value="4"/>
+          <opcode name="FASTCGI_PATH_NOT_FOUND" symbol="IISFastCGI_FASTCGI_PATH_NOT_FOUND" value="5"/>
+          <opcode name="FASTCGI_SCRIPT_PROCESSOR_MISSING" symbol="IISFastCGI_FASTCGI_SCRIPT_PROCESSOR_MISSING" value="6"/>
+          <opcode name="FASTCGI_ADD_JOBOBJECT_FAIL" symbol="IISFastCGI_FASTCGI_ADD_JOBOBJECT_FAIL" value="7"/>
+          <opcode name="FASTCGI_APPLICATION_MANAGER_SHUTDOWN" symbol="IISFastCGI_FASTCGI_APPLICATION_MANAGER_SHUTDOWN" value="8"/>
+          <opcode name="FASTCGI_QUEUE_FULL" symbol="IISFastCGI_FASTCGI_QUEUE_FULL" value="9"/>
+          <opcode name="FASTCGI_UNKNOWN_ERROR" symbol="IISFastCGI_FASTCGI_UNKNOWN_ERROR" value="10"/>
+          <opcode name="FASTCGI_RESPONSE_WRITTEN" symbol="IISFastCGI_FASTCGI_RESPONSE_WRITTEN" value="11"/>
+          <opcode name="FASTCGI_WAITING_FOR_RESPONSE" symbol="IISFastCGI_FASTCGI_WAITING_FOR_RESPONSE" value="12"/>
+          <opcode name="FASTCGI_STDERR_TRACE_ERROR" symbol="IISFastCGI_FASTCGI_STDERR_TRACE_ERROR" value="13"/>
+          <opcode name="FASTCGI_STDERR_TRACE_WARNING" symbol="IISFastCGI_FASTCGI_STDERR_TRACE_WARNING" value="14"/>
+          <opcode name="FASTCGI_STDERR_TRACE_INFO" symbol="IISFastCGI_FASTCGI_STDERR_TRACE_INFO" value="15"/>
+          <opcode name="FASTCGI_QUEUE_REQUEST" symbol="IISFastCGI_FASTCGI_QUEUE_REQUEST" value="16"/>
+          <opcode name="FASTCGI_ASSIGN_PROCESS" symbol="IISFastCGI_FASTCGI_ASSIGN_PROCESS" value="17"/>
+          <opcode name="FASTCGI_START" symbol="IISFastCGI_FASTCGI_START" value="18"/>
+          <opcode name="FASTCGI_END" symbol="IISFastCGI_FASTCGI_END" value="19"/>
+        </opcodes>
+          <task name="IISWebSocket"  value="8" eventGUID="{2ce74327-08be-425c-bfc5-1534fe7fefa6}"/>
+        <opcodes>
+          <opcode name="WEBSOCKET_INITIALIZE_FAILED" symbol="IISWebSocket_WEBSOCKET_INITIALIZE_FAILED" value="1"/>
+          <opcode name="WEBSOCKET_HANDSHAKE_START" symbol="IISWebSocket_WEBSOCKET_HANDSHAKE_START" value="2"/>
+          <opcode name="WEBSOCKET_HANDSHAKE_SUCCESS" symbol="IISWebSocket_WEBSOCKET_HANDSHAKE_SUCCESS" value="3"/>
+          <opcode name="WEBSOCKET_HANDSHAKE_NOT_SUCCESS" symbol="IISWebSocket_WEBSOCKET_HANDSHAKE_NOT_SUCCESS" value="4"/>
+          <opcode name="WEBSOCKET_READ_FRAGMENT_START" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_START" value="5"/>
+          <opcode name="WEBSOCKET_READ_FRAGMENT_END_PENDING" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_END_PENDING" value="6"/>
+          <opcode name="WEBSOCKET_READ_FRAGMENT_END_SUCCESS" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_END_SUCCESS" value="7"/>
+          <opcode name="WEBSOCKET_READ_FRAGMENT_END_NOT_SUCCESS" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_END_NOT_SUCCESS" value="8"/>
+          <opcode name="WEBSOCKET_WRITE_FRAGMENT_START" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_START" value="9"/>
+          <opcode name="WEBSOCKET_WRITE_FRAGMENT_END_PENDING" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_END_PENDING" value="10"/>
+          <opcode name="WEBSOCKET_WRITE_FRAGMENT_END_SUCCESS" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_END_SUCCESS" value="11"/>
+          <opcode name="WEBSOCKET_WRITE_FRAGMENT_END_NOT_SUCCESS" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_END_NOT_SUCCESS" value="12"/>
+          <opcode name="WEBSOCKET_APPLICATION_CLOSE_CONNECTION" symbol="IISWebSocket_WEBSOCKET_APPLICATION_CLOSE_CONNECTION" value="13"/>
+          <opcode name="WEBSOCKET_MODULE_CLOSE_CONNECTION" symbol="IISWebSocket_WEBSOCKET_MODULE_CLOSE_CONNECTION" value="14"/>
+          <opcode name="WEBSOCKET_READ_IO_NOT_SUCCESS" symbol="IISWebSocket_WEBSOCKET_READ_IO_NOT_SUCCESS" value="15"/>
+          <opcode name="WEBSOCKET_WRITE_IO_NOT_SUCCESS" symbol="IISWebSocket_WEBSOCKET_WRITE_IO_NOT_SUCCESS" value="16"/>
+          <opcode name="WEBSOCKET_RECEIVED_CLOSE" symbol="IISWebSocket_WEBSOCKET_RECEIVED_CLOSE" value="17"/>
+          <opcode name="WEBSOCKET_SEND_CLOSE_START" symbol="IISWebSocket_WEBSOCKET_SEND_CLOSE_START" value="18"/>
+          <opcode name="WEBSOCKET_SEND_CLOSE_END_SUCCESS" symbol="IISWebSocket_WEBSOCKET_SEND_CLOSE_END_SUCCESS" value="19"/>
+          <opcode name="WEBSOCKET_SEND_CLOSE_END_NOT_SUCCESS" symbol="IISWebSocket_WEBSOCKET_SEND_CLOSE_END_NOT_SUCCESS" value="20"/>
+        </opcodes>
+          <task name="IISCompression"  value="9" eventGUID="{e60cee96-4472-448d-a13c-2170b18220ec}"/>
+        <opcodes>
+          <opcode name="STATIC_COMPRESSION_START" symbol="IISCompression_STATIC_COMPRESSION_START" value="1"/>
+          <opcode name="STATIC_COMPRESSION_SUCCESS" symbol="IISCompression_STATIC_COMPRESSION_SUCCESS" value="2"/>
+          <opcode name="STATIC_COMPRESSION_NOT_SUCCESS" symbol="IISCompression_STATIC_COMPRESSION_NOT_SUCCESS" value="3"/>
+          <opcode name="STATIC_COMPRESSION_CREATE_START" symbol="IISCompression_STATIC_COMPRESSION_CREATE_START" value="4"/>
+          <opcode name="STATIC_COMPRESSION_CREATE_END" symbol="IISCompression_STATIC_COMPRESSION_CREATE_END" value="5"/>
+          <opcode name="DYNAMIC_COMPRESSION_START" symbol="IISCompression_DYNAMIC_COMPRESSION_START" value="6"/>
+          <opcode name="DYNAMIC_COMPRESSION_SUCCESS" symbol="IISCompression_DYNAMIC_COMPRESSION_SUCCESS" value="7"/>
+          <opcode name="DYNAMIC_COMPRESSION_NOT_SUCCESS" symbol="IISCompression_DYNAMIC_COMPRESSION_NOT_SUCCESS" value="8"/>
+          <opcode name="DYNAMIC_COMPRESSION_DO" symbol="IISCompression_DYNAMIC_COMPRESSION_DO" value="9"/>
+          <opcode name="DYNAMIC_COMPRESSION_END" symbol="IISCompression_DYNAMIC_COMPRESSION_END" value="10"/>
+          <opcode name="STATIC_COMPRESSION_END" symbol="IISCompression_STATIC_COMPRESSION_END" value="11"/>
+        </opcodes>
+          <task name="IISCache"  value="10" eventGUID="{ac1d69f1-bf33-4ca0-9313-bca13873e1dc}"/>
+        <opcodes>
+          <opcode name="FILE_CACHE_ACCESS_START" symbol="IISCache_FILE_CACHE_ACCESS_START" value="10"/>
+          <opcode name="FILE_CACHE_ACCESS_END" symbol="IISCache_FILE_CACHE_ACCESS_END" value="11"/>
+          <opcode name="URL_CACHE_ACCESS_START" symbol="IISCache_URL_CACHE_ACCESS_START" value="12"/>
+          <opcode name="URL_CACHE_ACCESS_END" symbol="IISCache_URL_CACHE_ACCESS_END" value="13"/>
+          <opcode name="HTTPSYS_CACHEABLE" symbol="IISCache_HTTPSYS_CACHEABLE" value="14"/>
+          <opcode name="OUTPUT_CACHE_LOOKUP_START" symbol="IISCache_OUTPUT_CACHE_LOOKUP_START" value="15"/>
+          <opcode name="OUTPUT_CACHE_LOOKUP_END" symbol="IISCache_OUTPUT_CACHE_LOOKUP_END" value="16"/>
+          <opcode name="OUTPUT_CACHE_UPDATE_START" symbol="IISCache_OUTPUT_CACHE_UPDATE_START" value="17"/>
+          <opcode name="OUTPUT_CACHE_UPDATE_END" symbol="IISCache_OUTPUT_CACHE_UPDATE_END" value="18"/>
+          <opcode name="OUTPUT_CACHE_DISABLED" symbol="IISCache_OUTPUT_CACHE_DISABLED" value="19"/>
+        </opcodes>
+          <task name="IISRequestNotification"  value="11" eventGUID="{002e91e3-e7ae-44ab-8e07-99230ffa6ade}"/>
+        <opcodes>
+          <opcode name="NOTIFY_MODULE_START" symbol="IISRequestNotification_NOTIFY_MODULE_START" value="1"/>
+          <opcode name="NOTIFY_MODULE_END" symbol="IISRequestNotification_NOTIFY_MODULE_END" value="2"/>
+          <opcode name="NOTIFY_MODULE_COMPLETION" symbol="IISRequestNotification_NOTIFY_MODULE_COMPLETION" value="3"/>
+          <opcode name="PRE_BEGIN_REQUEST_START" symbol="IISRequestNotification_PRE_BEGIN_REQUEST_START" value="4"/>
+          <opcode name="PRE_BEGIN_REQUEST_END" symbol="IISRequestNotification_PRE_BEGIN_REQUEST_END" value="5"/>
+          <opcode name="REQUEST_PROCESSING_ERROR" symbol="IISRequestNotification_REQUEST_PROCESSING_ERROR" value="15"/>
+          <opcode name="MODULE_SET_RESPONSE_ERROR_STATUS" symbol="IISRequestNotification_MODULE_SET_RESPONSE_ERROR_STATUS" value="16"/>
+          <opcode name="MODULE_SET_RESPONSE_SUCCESS_STATUS" symbol="IISRequestNotification_MODULE_SET_RESPONSE_SUCCESS_STATUS" value="17"/>
+          <opcode name="SET_RESPONSE_ERROR_DESCRIPTION" symbol="IISRequestNotification_SET_RESPONSE_ERROR_DESCRIPTION" value="18"/>
+        </opcodes>
+          <task name="IISModule"  value="12" eventGUID="{d79a948e-95f1-417b-a731-b7a79dec7ae5}"/>
+        <opcodes>
+          <opcode name="MODULE_START" symbol="IISModule_MODULE_START" value="1"/>
+          <opcode name="MODULE_END" symbol="IISModule_MODULE_END" value="2"/>
+          <opcode name="MODULE_CRITICAL_ERROR" symbol="IISModule_MODULE_CRITICAL_ERROR" value="3"/>
+          <opcode name="MODULE_ERROR" symbol="IISModule_MODULE_ERROR" value="4"/>
+          <opcode name="MODULE_WARNING" symbol="IISModule_MODULE_WARNING" value="5"/>
+          <opcode name="MODULE_INFORMATION" symbol="IISModule_MODULE_INFORMATION" value="6"/>
+          <opcode name="MODULE_VERBOSE" symbol="IISModule_MODULE_VERBOSE" value="7"/>
+        </opcodes>
+        </tasks>
+        <templates>
+          <template tid="W3GeneralStartNewRequest">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="SiteId" inType="win:UInt32"/>
+            <data name="AppPoolId" inType="win:UnicodeString"/>
+            <data name="ConnId" inType="win:UInt64"/>
+            <data name="RawConnId" inType="win:UInt64"/>
+            <data name="RequestURL" inType="win:UnicodeString"/>
+            <data name="RequestVerb" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3GeneralEndNewRequest">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="BytesSent" inType="win:UInt32"/>
+            <data name="BytesReceived" inType="win:UInt32"/>
+            <data name="HttpStatus" inType="win:UInt32"/>
+            <data name="HttpSubStatus" inType="win:UInt16"/>
+          </template>
+          <template tid="W3GeneralStaticFileHandler">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3GeneralCGIHandler">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3GeneralISAPIHandler">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3GeneralOopISAPIHandler">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ProcessId" inType="win:UInt32"/>
+            <data name="TotalReqs" inType="win:UInt32"/>
+            <data name="CurrentReqs" inType="win:UInt32"/>
+          </template>
+          <template tid="W3GeneralRedirectionHandler">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="RedirectedURL" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3GeneralDavHandler">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3GeneralOptionsHandler">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3GeneralTraceHandler">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3GeneralGetURLMetadata">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="PhysicalPath" inType="win:UnicodeString"/>
+            <data name="AccessPerms" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3GeneralChildRequestStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="SiteId" inType="win:UInt32"/>
+            <data name="RequestURL" inType="win:UnicodeString"/>
+            <data name="RequestVerb" inType="win:AnsiString"/>
+            <data name="RecursiveLevel" inType="win:UInt32"/>
+          </template>
+          <template tid="W3GeneralChildRequestEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="BytesSent" inType="win:UInt32"/>
+            <data name="HttpStatus" inType="win:UInt32"/>
+            <data name="HttpSubStatus" inType="win:UInt16"/>
+          </template>
+          <template tid="W3GeneralSendCustomError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HttpStatus" inType="win:UInt32"/>
+            <data name="HttpSubStatus" inType="win:UInt16"/>
+            <data name="FileNameOrURL" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3GeneralMapHandler">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3GeneralFlushResponseStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3GeneralFlushResponseEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="BytesSent" inType="win:UInt32"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3GeneralReadEntityStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3GeneralReadEntityEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="BytesReceived" inType="win:UInt32"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISGeneralFileChangeNotification">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FilePath" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISGeneralConfigChangeNotification">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ConfigPath" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISGeneralVirtualModuleUnresolved">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Name" inType="win:UnicodeString"/>
+            <data name="Type" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISGeneralUrlChanged">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="OldUrl" inType="win:UnicodeString"/>
+            <data name="NewUrl" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISGeneralHandlerChanged">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="OldHandlerName" inType="win:UnicodeString"/>
+            <data name="NewHandlerName" inType="win:UnicodeString"/>
+            <data name="NewHandlerModules" inType="win:UnicodeString"/>
+            <data name="NewHandlerScriptProcessor" inType="win:UnicodeString"/>
+            <data name="NewHandlerType" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISGeneralUserSet">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="AuthType" inType="win:UnicodeString"/>
+            <data name="UserName" inType="win:UnicodeString"/>
+            <data name="SupportsIsInRole" inType="win:Boolean"/>
+          </template>
+          <template tid="IISGeneralModulePreconditionNotMatch">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Name" inType="win:UnicodeString"/>
+            <data name="Precondition" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISGeneralHandlerPreconditionNotMatch">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Name" inType="win:UnicodeString"/>
+            <data name="Precondition" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3GeneralResponseHeaders">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Headers" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3GeneralResponseEntityFile">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+            <data name="Offset" inType="win:UInt64"/>
+            <data name="Size" inType="win:UInt64"/>
+          </template>
+          <template tid="W3GeneralResponseEntityBuffer">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Buffer" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3GeneralRequestHeaders">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Headers" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3GeneralRequestEntity">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Buffer" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3GeneralNotSendCustomError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Reason" inType="win:UInt32"/>
+          </template>
+          <template tid="W3GeneralSetRequestHeader">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HeaderName" inType="win:AnsiString"/>
+            <data name="HeaderValue" inType="win:AnsiString"/>
+            <data name="Replace" inType="win:Boolean"/>
+          </template>
+          <template tid="W3GeneralModuleFactoryFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3GeneralEndpointInformation">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="RemoteAddress" inType="win:AnsiString"/>
+            <data name="RemotePort" inType="win:AnsiString"/>
+            <data name="LocalAddress" inType="win:AnsiString"/>
+            <data name="LocalPort" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3AuthStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="AuthTypeSupported" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthSucceeded">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="AuthType" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="NTLMUsed" inType="win:Boolean"/>
+            <data name="RemoteUserName" inType="win:UnicodeString"/>
+            <data name="AuthUserName" inType="win:UnicodeString"/>
+            <data name="TokenImpersonationLevel" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthTypeNotSupported">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3AuthInvalidAnonAccount">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthPasswdChangeNeeded">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3AuthPasswdChangeDisabled">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3AuthBadBasicHeader">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3AuthBasicLogonFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthWDigestLogonFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthIISDigestLogonFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthPassportLogonFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthSSPILogonFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthNTLMNullSession">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3AuthSSPIContinueNeeded">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="PackageName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3AuthKerberosFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="KMUsed" inType="win:Boolean"/>
+            <data name="APUserName" inType="win:UnicodeString"/>
+            <data name="SPNName" inType="win:UnicodeString"/>
+            <data name="ADConfigIsOK" inType="win:Boolean"/>
+            <data name="KerberosInfo" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3AuthAnonPasswdChangeNeeded">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3AuthRequestAuthType">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="RequestAuthType" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3AuthEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3SecIllegalShortFilename">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3SecRejectedIP">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="IPAddress" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3SecRejectedHostname">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HostName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3SecRequireSSL128">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3SecFileAccessDenied">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+            <data name="AccountName" inType="win:UnicodeString"/>
+            <data name="DomainName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3SecDeniedByMimemap">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3SecDeniedByISAPIRestriction">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ImageName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3SecDeniedByCGIRestriction">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ImageName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3SecDeniedByAccessFlags">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="CurrentFlags" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="NeededFlags" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3FilterStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FilterName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3FilterEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="NotificationStatus" inType="win:UInt32"/>
+          </template>
+          <template tid="W3FilterError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3FilterPreprocStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterPreprocEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterURLMapStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="OrigURL" inType="win:AnsiString"/>
+            <data name="OrigPath" inType="win:AnsiString"/>
+            <data name="AccessPerms" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="MatchingPath" inType="win:UInt32"/>
+            <data name="MatchingURL" inType="win:UInt32"/>
+            <data name="ScriptMapEntry" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3FilterURLMapEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FinalURL" inType="win:AnsiString"/>
+            <data name="FinalPath" inType="win:AnsiString"/>
+            <data name="AccessPerms" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="MatchingPath" inType="win:UInt32"/>
+            <data name="MatchingURL" inType="win:UInt32"/>
+            <data name="ScriptMapEntry" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3FilterAuthenticationStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="OrigUserName" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3FilterAuthenticationEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FinalUserName" inType="win:AnsiString"/>
+            <data name="PasswordChanged" inType="win:Boolean"/>
+          </template>
+          <template tid="W3FilterAuthCompleteStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterAuthCompleteEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterSendResponseStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HttpStatus" inType="win:UInt32"/>
+          </template>
+          <template tid="W3FilterSendResponseEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterEndOfRequestStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterEndOfRequestEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterLogStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="OrigClientHostName" inType="win:AnsiString"/>
+            <data name="OrigClientUserName" inType="win:AnsiString"/>
+            <data name="OrigServerName" inType="win:AnsiString"/>
+            <data name="OrigOperation" inType="win:AnsiString"/>
+            <data name="OrigTarget" inType="win:AnsiString"/>
+            <data name="OrigParameters" inType="win:AnsiString"/>
+            <data name="OrigHttpStatus" inType="win:UInt32"/>
+            <data name="OrigWin32Status" inType="win:UInt32"/>
+          </template>
+          <template tid="W3FilterLogEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FinalClientHostName" inType="win:AnsiString"/>
+            <data name="FinalClientUserName" inType="win:AnsiString"/>
+            <data name="FinalServerName" inType="win:AnsiString"/>
+            <data name="FinalOperation" inType="win:AnsiString"/>
+            <data name="FinalTarget" inType="win:AnsiString"/>
+            <data name="FinalParameters" inType="win:AnsiString"/>
+            <data name="FinalHttpStatus" inType="win:UInt32"/>
+            <data name="FinalWin32Status" inType="win:UInt32"/>
+          </template>
+          <template tid="W3FilterSendRawDataStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterSendRawDataEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterAccessDeniedStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="RequestedURL" inType="win:AnsiString"/>
+            <data name="PhysicalPath" inType="win:AnsiString"/>
+            <data name="DenialReason" inType="win:UInt32"/>
+          </template>
+          <template tid="W3FilterAccessDeniedEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3FilterSetReqHeader">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HeaderName" inType="win:AnsiString"/>
+            <data name="HeaderValue" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3FilterAddReqHeader">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HeaderName" inType="win:AnsiString"/>
+            <data name="HeaderValue" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3FilterSetRespHeader">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HeaderName" inType="win:AnsiString"/>
+            <data name="HeaderValue" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3FilterAddRespHeader">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HeaderName" inType="win:AnsiString"/>
+            <data name="HeaderValue" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3ISAPIStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3ISAPIEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGILaunch">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="CommandLine" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="ProcessId" inType="win:UInt32"/>
+          </template>
+          <template tid="W3CGITimeout">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Headers" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3CGIPrematureTermination">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Headers" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3CGIRequestEntitySent">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIHeadersReceived">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFActivityTimeout">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFRequestTimeout">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFUnexpectedExit">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFRapidFailureProtection">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFPathNotFound">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFScriptProcessorMissing">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFAddJobObjectFail">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFAppMgrShutdown">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFQueueFull">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFUnknownError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3CGIFResponseWritten">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFWaitingForResponse">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFTraceError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Message" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3CGIFTraceWarning">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Message" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3CGIFTraceInfo">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Message" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3CGIFQueueRequest">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="PositionInQueue" inType="win:UInt32"/>
+            <data name="MaxInstances" inType="win:UInt32"/>
+          </template>
+          <template tid="W3CGIFAssignProcess">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="CommandLine" inType="win:UnicodeString"/>
+            <data name="IsNewProcess" inType="win:Boolean"/>
+            <data name="ProcessId" inType="win:UInt32"/>
+            <data name="RequestNumber" inType="win:UInt32"/>
+          </template>
+          <template tid="W3CGIFStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CGIFEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3WebSocketInitializeNotSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3WebSocketEndSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3WebSocketEndFailure">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketReadFragmentStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="BufferSize" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketReadFragmentEndPending">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3WebSocketReadFragmentEndSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="BytesReceived" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketReadFragmentEndFailure">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketWriteFragmentStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="DataType" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="DataSize" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketWriteFragmentEndPending">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3WebSocketWriteFragmentEndSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="BytesSent" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketWriteFragmentEndFailure">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketApplicationCloseConnection">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3WebSocketModuleCloseConnection">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Reason" inType="win:UInt32"/>
+          </template>
+          <template tid="W3WebSocketReadIoFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketWriteIoFailed">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3WebSocketCloseReceived">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Status" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="Reason" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3WebSocketCloseSendStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Status" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="Reason" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3WebSocketCloseSendSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3WebSocketCloseSendFailure">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3StaticCompressionStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3StaticCompressionSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3StaticCompressionNotSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Reason" inType="win:UInt32"/>
+          </template>
+          <template tid="W3StaticCompressionCreateStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="OriginalFileName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3StaticCompressionCreateEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="OriginalFileName" inType="win:UnicodeString"/>
+            <data name="OriginalFileSize" inType="win:UInt32"/>
+            <data name="CompressedFileName" inType="win:UnicodeString"/>
+            <data name="CompressedFileSize" inType="win:UInt32"/>
+          </template>
+          <template tid="W3DynamicCompressionStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3DynamicCompressionSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3DynamicCompressionNotSuccess">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Reason" inType="win:UInt32"/>
+          </template>
+          <template tid="W3DynamicCompressionDo">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="OriginalSize" inType="win:UInt32"/>
+            <data name="CompressedSize" inType="win:UInt32"/>
+          </template>
+          <template tid="W3DynamicCompressionEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3StaticCompressionEnd">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3CacheFileCacheAccessStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+            <data name="UserName" inType="win:UnicodeString"/>
+            <data name="DomainName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3CacheFileCacheAccessEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Successful" inType="win:Boolean"/>
+            <data name="FileFromCache" inType="win:Boolean"/>
+            <data name="FileAddedToCache" inType="win:Boolean"/>
+            <data name="FileDirmoned" inType="win:Boolean"/>
+            <data name="LastModCheckErrorIgnored" inType="win:Boolean"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="LastModifiedTime" inType="win:AnsiString"/>
+          </template>
+          <template tid="W3CacheURLCacheAccessStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="RequestURL" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3CacheURLCacheAccessEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="PhysicalPath" inType="win:UnicodeString"/>
+            <data name="URLInfoFromCache" inType="win:Boolean"/>
+            <data name="URLInfoAddedToCache" inType="win:Boolean"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3CacheHttpsysCacheable">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="HttpsysCacheable" inType="win:Boolean"/>
+            <data name="Reason" inType="win:UInt32"/>
+            <data name="CachePolicy" inType="win:UInt32"/>
+            <data name="TimeToLive" inType="win:UInt32"/>
+          </template>
+          <template tid="W3OutputCacheLookupStart">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="W3OutputCacheLookupEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Result" inType="win:UInt32"/>
+          </template>
+          <template tid="W3OutputCacheUpdateStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="CachePolicy" inType="win:UInt32"/>
+            <data name="TimeToLive" inType="win:UInt32"/>
+          </template>
+          <template tid="W3OutputCacheUpdateEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="Result" inType="win:UInt32"/>
+          </template>
+          <template tid="W3OutputCacheDisabled">
+            <data name="ContextId" inType="win:GUID"/>
+          </template>
+          <template tid="IISRequestNotificationEventsStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Notification" inType="win:UInt32"/>
+            <data name="fIsPostNotification" inType="win:Boolean"/>
+          </template>
+          <template tid="IISRequestNotificationEventsEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Notification" inType="win:UInt32"/>
+            <data name="fIsPostNotificationEvent" inType="win:Boolean"/>
+            <data name="NotificationStatus" inType="win:UInt32"/>
+          </template>
+          <template tid="IISRequestNotificationEventsCompletion">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Notification" inType="win:UInt32"/>
+            <data name="fIsPostNotificationEvent" inType="win:Boolean"/>
+            <data name="CompletionBytes" inType="win:UInt32"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISRequestNotificationPreBeginStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISRequestNotificationPreBeginEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="NotificationStatus" inType="win:UInt32"/>
+          </template>
+          <template tid="IISRequestNotificationEventsError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Notification" inType="win:UInt32"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISRequestNotificationEventsResponseErrorStatus">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Notification" inType="win:UInt32"/>
+            <data name="HttpStatus" inType="win:UInt32"/>
+            <data name="HttpReason" inType="win:AnsiString"/>
+            <data name="HttpSubStatus" inType="win:UInt16"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+            <data name="ConfigExceptionInfo" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISRequestNotificationEventsResponseSuccessStatus">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Notification" inType="win:UInt32"/>
+            <data name="HttpStatus" inType="win:UInt32"/>
+            <data name="HttpReason" inType="win:AnsiString"/>
+          </template>
+          <template tid="IISRequestNotificationEventsResponseErrorDescription">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ErrorDescription" inType="win:UnicodeString"/>
+          </template>
+          <template tid="IISModuleEventsModuleStart">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Data1" inType="win:UnicodeString"/>
+            <data name="Data2" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISModuleEventsModuleEnd">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Data1" inType="win:UnicodeString"/>
+            <data name="Data2" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISModuleEventsModuleCriticalError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Data1" inType="win:UnicodeString"/>
+            <data name="Data2" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISModuleEventsModuleError">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Data1" inType="win:UnicodeString"/>
+            <data name="Data2" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISModuleEventsModuleWarning">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Data1" inType="win:UnicodeString"/>
+            <data name="Data2" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISModuleEventsModuleInformation">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Data1" inType="win:UnicodeString"/>
+            <data name="Data2" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="IISModuleEventsModuleVerbose">
+            <data name="ContextId" inType="win:GUID"/>
+            <data name="ModuleName" inType="win:UnicodeString"/>
+            <data name="Data1" inType="win:UnicodeString"/>
+            <data name="Data2" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3ReceiveNewRequest">
+            <data name="RequestId" inType="win:UInt64"/>
+            <data name="BytesReceived" inType="win:UInt32"/>
+          </template>
+          <template tid="W3SendResponse">
+            <data name="RequestId" inType="win:UInt64"/>
+            <data name="BytesSent" inType="win:UInt32"/>
+          </template>
+          <template tid="W3FileRequest">
+            <data name="RequestId" inType="win:UInt64"/>
+            <data name="FileName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3CGIRequest">
+            <data name="RequestId" inType="win:UInt64"/>
+          </template>
+          <template tid="W3IsapiRequest">
+            <data name="RequestId" inType="win:UInt64"/>
+          </template>
+          <template tid="W3OopRequest">
+            <data name="RequestId" inType="win:UInt64"/>
+            <data name="ProcessId" inType="win:UInt32"/>
+            <data name="TotalReqs" inType="win:UInt32"/>
+            <data name="CurrentReqs" inType="win:UInt32"/>
+          </template>
+          <template tid="W3FilterTransStart">
+            <data name="RequestId" inType="win:UInt64"/>
+            <data name="FilterName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3FilterTransEnd">
+            <data name="RequestId" inType="win:UInt64"/>
+          </template>
+          <template tid="W3CgiTrans">
+            <data name="RequestId" inType="win:UInt64"/>
+          </template>
+          <template tid="IsapiMapRequestId">
+            <data name="RequestId" inType="win:UInt64"/>
+            <data name="connID" inType="win:Pointer"/>
+            <data name="fOop" inType="win:UInt32"/>
+          </template>
+          <template tid="IsapiDeleteContext">
+            <data name="RequestId" inType="win:UInt64"/>
+            <data name="connID" inType="win:Pointer"/>
+          </template>
+        </templates>
+        <events>
+          <event value="10000" version="1" template="W3GeneralStartNewRequest" opcode="1" task="IISGeneral" symbol="IISGeneral_GENERAL_REQUEST_START"/>
+          <event value="10001" version="1" template="W3GeneralEndNewRequest" opcode="2" task="IISGeneral" symbol="IISGeneral_GENERAL_REQUEST_END"/>
+          <event value="10002" version="1" template="W3GeneralStaticFileHandler" opcode="10" task="IISGeneral" symbol="IISGeneral_GENERAL_STATIC_FILE_HANDLER"/>
+          <event value="10003" version="1" template="W3GeneralCGIHandler" opcode="11" task="IISGeneral" symbol="IISGeneral_GENERAL_CGI_HANDLER"/>
+          <event value="10004" version="1" template="W3GeneralISAPIHandler" opcode="12" task="IISGeneral" symbol="IISGeneral_GENERAL_ISAPI_HANDLER"/>
+          <event value="10005" version="1" template="W3GeneralOopISAPIHandler" opcode="13" task="IISGeneral" symbol="IISGeneral_GENERAL_OOP_ISAPI_HANDLER"/>
+          <event value="10006" version="1" template="W3GeneralRedirectionHandler" opcode="14" task="IISGeneral" symbol="IISGeneral_GENERAL_REDIRECTION_HANDLER"/>
+          <event value="10007" version="1" template="W3GeneralDavHandler" opcode="15" task="IISGeneral" symbol="IISGeneral_GENERAL_DAV_HANDLER"/>
+          <event value="10008" version="1" template="W3GeneralOptionsHandler" opcode="16" task="IISGeneral" symbol="IISGeneral_GENERAL_OPTIONS_HANDLER"/>
+          <event value="10009" version="1" template="W3GeneralTraceHandler" opcode="17" task="IISGeneral" symbol="IISGeneral_GENERAL_TRACE_HANDLER"/>
+          <event value="10010" version="1" template="W3GeneralGetURLMetadata" opcode="30" task="IISGeneral" symbol="IISGeneral_GENERAL_GET_URL_METADATA"/>
+          <event value="10011" version="1" template="W3GeneralChildRequestStart" opcode="31" task="IISGeneral" symbol="IISGeneral_GENERAL_CHILD_REQUEST_START"/>
+          <event value="10012" version="1" template="W3GeneralChildRequestEnd" opcode="32" task="IISGeneral" symbol="IISGeneral_GENERAL_CHILD_REQUEST_END"/>
+          <event value="10013" version="1" template="W3GeneralSendCustomError" opcode="33" task="IISGeneral" symbol="IISGeneral_GENERAL_SEND_CUSTOM_ERROR"/>
+          <event value="10014" version="1" template="W3GeneralMapHandler" opcode="34" task="IISGeneral" symbol="IISGeneral_GENERAL_MAP_HANDLER"/>
+          <event value="10015" version="1" template="W3GeneralFlushResponseStart" opcode="35" task="IISGeneral" symbol="IISGeneral_GENERAL_FLUSH_RESPONSE_START"/>
+          <event value="10016" version="1" template="W3GeneralFlushResponseEnd" opcode="36" task="IISGeneral" symbol="IISGeneral_GENERAL_FLUSH_RESPONSE_END"/>
+          <event value="10017" version="1" template="W3GeneralReadEntityStart" opcode="37" task="IISGeneral" symbol="IISGeneral_GENERAL_READ_ENTITY_START"/>
+          <event value="10018" version="1" template="W3GeneralReadEntityEnd" opcode="38" task="IISGeneral" symbol="IISGeneral_GENERAL_READ_ENTITY_END"/>
+          <event value="10019" version="1" template="IISGeneralFileChangeNotification" opcode="39" task="IISGeneral" symbol="IISGeneral_FILE_CHANGE_NOTIFICATION"/>
+          <event value="10020" version="1" template="IISGeneralConfigChangeNotification" opcode="40" task="IISGeneral" symbol="IISGeneral_CONFIG_CHANGE_NOTIFICATION"/>
+          <event value="10021" version="1" template="IISGeneralVirtualModuleUnresolved" opcode="41" task="IISGeneral" symbol="IISGeneral_VIRTUAL_MODULE_UNRESOLVED"/>
+          <event value="10022" version="1" template="IISGeneralUrlChanged" opcode="42" task="IISGeneral" symbol="IISGeneral_URL_CHANGED"/>
+          <event value="10023" version="1" template="IISGeneralHandlerChanged" opcode="43" task="IISGeneral" symbol="IISGeneral_HANDLER_CHANGED"/>
+          <event value="10024" version="1" template="IISGeneralUserSet" opcode="44" task="IISGeneral" symbol="IISGeneral_USER_SET"/>
+          <event value="10025" version="1" template="IISGeneralModulePreconditionNotMatch" opcode="45" task="IISGeneral" symbol="IISGeneral_MODULE_PRECONDITION_NOT_MATCH"/>
+          <event value="10026" version="1" template="IISGeneralHandlerPreconditionNotMatch" opcode="46" task="IISGeneral" symbol="IISGeneral_HANDLER_PRECONDITION_NOT_MATCH"/>
+          <event value="10027" version="1" template="W3GeneralResponseHeaders" opcode="47" task="IISGeneral" symbol="IISGeneral_GENERAL_RESPONSE_HEADERS"/>
+          <event value="10028" version="1" template="W3GeneralResponseEntityFile" opcode="48" task="IISGeneral" symbol="IISGeneral_GENERAL_RESPONSE_ENTITY_FILE"/>
+          <event value="10029" version="1" template="W3GeneralResponseEntityBuffer" opcode="49" task="IISGeneral" symbol="IISGeneral_GENERAL_RESPONSE_ENTITY_BUFFER"/>
+          <event value="10030" version="1" template="W3GeneralRequestHeaders" opcode="50" task="IISGeneral" symbol="IISGeneral_GENERAL_REQUEST_HEADERS"/>
+          <event value="10031" version="1" template="W3GeneralRequestEntity" opcode="51" task="IISGeneral" symbol="IISGeneral_GENERAL_REQUEST_ENTITY"/>
+          <event value="10032" version="1" template="W3GeneralNotSendCustomError" opcode="52" task="IISGeneral" symbol="IISGeneral_GENERAL_NOT_SEND_CUSTOM_ERROR"/>
+          <event value="10033" version="1" template="W3GeneralSetRequestHeader" opcode="53" task="IISGeneral" symbol="IISGeneral_GENERAL_SET_REQUEST_HEADER"/>
+          <event value="10034" version="1" template="W3GeneralModuleFactoryFailed" opcode="54" task="IISGeneral" symbol="IISGeneral_GENERAL_MODULE_FACTORY_FAILED"/>
+          <event value="10035" version="1" template="W3GeneralEndpointInformation" opcode="55" task="IISGeneral" symbol="IISGeneral_GENERAL_ENDPOINT_INFORMATION"/>
+          <event value="10036" version="1" template="W3AuthStart" opcode="10" task="IISAuthentication" symbol="IISAuthentication_AUTH_START"/>
+          <event value="10037" version="1" template="W3AuthSucceeded" opcode="11" task="IISAuthentication" symbol="IISAuthentication_AUTH_SUCCEEDED"/>
+          <event value="10038" version="1" template="W3AuthTypeNotSupported" opcode="12" task="IISAuthentication" symbol="IISAuthentication_AUTH_TYPE_NOT_SUPPORTED"/>
+          <event value="10039" version="1" template="W3AuthInvalidAnonAccount" opcode="13" task="IISAuthentication" symbol="IISAuthentication_AUTH_INVALID_ANON_ACCOUNT"/>
+          <event value="10040" version="1" template="W3AuthPasswdChangeNeeded" opcode="14" task="IISAuthentication" symbol="IISAuthentication_AUTH_PASSWD_CHANGE_NEEDED"/>
+          <event value="10041" version="1" template="W3AuthPasswdChangeDisabled" opcode="15" task="IISAuthentication" symbol="IISAuthentication_AUTH_PASSWD_CHANGE_DISABLED"/>
+          <event value="10042" version="1" template="W3AuthBadBasicHeader" opcode="16" task="IISAuthentication" symbol="IISAuthentication_AUTH_BAD_BASIC_HEADER"/>
+          <event value="10043" version="1" template="W3AuthBasicLogonFailed" opcode="17" task="IISAuthentication" symbol="IISAuthentication_AUTH_BASIC_LOGON_FAILED"/>
+          <event value="10044" version="1" template="W3AuthWDigestLogonFailed" opcode="18" task="IISAuthentication" symbol="IISAuthentication_AUTH_WDIGEST_LOGON_FAILED"/>
+          <event value="10045" version="1" template="W3AuthIISDigestLogonFailed" opcode="19" task="IISAuthentication" symbol="IISAuthentication_AUTH_IISDIGEST_LOGON_FAILED"/>
+          <event value="10046" version="1" template="W3AuthPassportLogonFailed" opcode="20" task="IISAuthentication" symbol="IISAuthentication_AUTH_PASSPORT_LOGON_FAILED"/>
+          <event value="10047" version="1" template="W3AuthSSPILogonFailed" opcode="21" task="IISAuthentication" symbol="IISAuthentication_AUTH_SSPI_LOGON_FAILED"/>
+          <event value="10048" version="1" template="W3AuthNTLMNullSession" opcode="22" task="IISAuthentication" symbol="IISAuthentication_AUTH_NTLM_NULL_SESSION"/>
+          <event value="10049" version="1" template="W3AuthSSPIContinueNeeded" opcode="23" task="IISAuthentication" symbol="IISAuthentication_AUTH_SSPI_CONTINUE_NEEDED"/>
+          <event value="10050" version="1" template="W3AuthKerberosFailed" opcode="55" task="IISAuthentication" symbol="IISAuthentication_AUTH_KERBEROS_FAILED"/>
+          <event value="10051" version="1" template="W3AuthAnonPasswdChangeNeeded" opcode="24" task="IISAuthentication" symbol="IISAuthentication_AUTH_ANON_PASSWD_CHANGE_NEEDED"/>
+          <event value="10052" version="1" template="W3AuthRequestAuthType" opcode="27" task="IISAuthentication" symbol="IISAuthentication_AUTH_REQUEST_AUTH_TYPE"/>
+          <event value="10053" version="1" template="W3AuthEnd" opcode="28" task="IISAuthentication" symbol="IISAuthentication_AUTH_END"/>
+          <event value="10054" version="1" template="W3SecIllegalShortFilename" opcode="10" task="IISSecurity" symbol="IISSecurity_SECURITY_ILLEGAL_SHORT_FILENAME"/>
+          <event value="10055" version="1" template="W3SecRejectedIP" opcode="11" task="IISSecurity" symbol="IISSecurity_SECURITY_REJECTED_IP"/>
+          <event value="10056" version="1" template="W3SecRejectedHostname" opcode="12" task="IISSecurity" symbol="IISSecurity_SECURITY_REJECTED_HOSTNAME"/>
+          <event value="10057" version="1" template="W3SecRequireSSL128" opcode="13" task="IISSecurity" symbol="IISSecurity_SECURITY_REJECTED_REQUIRE_SSL_128"/>
+          <event value="10058" version="1" template="W3SecFileAccessDenied" opcode="14" task="IISSecurity" symbol="IISSecurity_SECURITY_FILE_ACCESS_DENIED"/>
+          <event value="10059" version="1" template="W3SecDeniedByMimemap" opcode="15" task="IISSecurity" symbol="IISSecurity_SECURITY_DENIED_BY_MIMEMAP"/>
+          <event value="10060" version="1" template="W3SecDeniedByISAPIRestriction" opcode="16" task="IISSecurity" symbol="IISSecurity_SECURITY_DENIED_BY_ISAPI_RESTRICTION"/>
+          <event value="10061" version="1" template="W3SecDeniedByCGIRestriction" opcode="17" task="IISSecurity" symbol="IISSecurity_SECURITY_DENIED_BY_CGI_RESTRICTION"/>
+          <event value="10062" version="1" template="W3SecDeniedByAccessFlags" opcode="18" task="IISSecurity" symbol="IISSecurity_SECURITY_DENIED_BY_ACCESS_FLAGS"/>
+          <event value="10063" version="1" template="W3FilterStart" opcode="1" task="IISFilter" symbol="IISFilter_FILTER_START"/>
+          <event value="10064" version="1" template="W3FilterEnd" opcode="2" task="IISFilter" symbol="IISFilter_FILTER_END"/>
+          <event value="10065" version="1" template="W3FilterError" opcode="12" task="IISFilter" symbol="IISFilter_FILTER_ERROR"/>
+          <event value="10066" version="1" template="W3FilterPreprocStart" opcode="13" task="IISFilter" symbol="IISFilter_FILTER_PREPROC_HEADERS_START"/>
+          <event value="10067" version="1" template="W3FilterPreprocEnd" opcode="14" task="IISFilter" symbol="IISFilter_FILTER_PREPROC_HEADERS_END"/>
+          <event value="10068" version="1" template="W3FilterURLMapStart" opcode="15" task="IISFilter" symbol="IISFilter_FILTER_URL_MAP_START"/>
+          <event value="10069" version="1" template="W3FilterURLMapEnd" opcode="16" task="IISFilter" symbol="IISFilter_FILTER_URL_MAP_END"/>
+          <event value="10070" version="1" template="W3FilterAuthenticationStart" opcode="17" task="IISFilter" symbol="IISFilter_FILTER_AUTHENTICATION_START"/>
+          <event value="10071" version="1" template="W3FilterAuthenticationEnd" opcode="18" task="IISFilter" symbol="IISFilter_FILTER_AUTHENTICATION_END"/>
+          <event value="10072" version="1" template="W3FilterAuthCompleteStart" opcode="19" task="IISFilter" symbol="IISFilter_FILTER_AUTH_COMPLETE_START"/>
+          <event value="10073" version="1" template="W3FilterAuthCompleteEnd" opcode="20" task="IISFilter" symbol="IISFilter_FILTER_AUTH_COMPLETE_END"/>
+          <event value="10074" version="1" template="W3FilterSendResponseStart" opcode="21" task="IISFilter" symbol="IISFilter_FILTER_SEND_RESPONSE_START"/>
+          <event value="10075" version="1" template="W3FilterSendResponseEnd" opcode="22" task="IISFilter" symbol="IISFilter_FILTER_SEND_RESPONSE_END"/>
+          <event value="10076" version="1" template="W3FilterEndOfRequestStart" opcode="23" task="IISFilter" symbol="IISFilter_FILTER_END_OF_REQUEST_START"/>
+          <event value="10077" version="1" template="W3FilterEndOfRequestEnd" opcode="24" task="IISFilter" symbol="IISFilter_FILTER_END_OF_REQUEST_END"/>
+          <event value="10078" version="1" template="W3FilterLogStart" opcode="25" task="IISFilter" symbol="IISFilter_FILTER_LOG_START"/>
+          <event value="10079" version="1" template="W3FilterLogEnd" opcode="26" task="IISFilter" symbol="IISFilter_FILTER_LOG_END"/>
+          <event value="10080" version="1" template="W3FilterSendRawDataStart" opcode="27" task="IISFilter" symbol="IISFilter_FILTER_SEND_RAW_DATA_START"/>
+          <event value="10081" version="1" template="W3FilterSendRawDataEnd" opcode="28" task="IISFilter" symbol="IISFilter_FILTER_SEND_RAW_DATA_END"/>
+          <event value="10082" version="1" template="W3FilterAccessDeniedStart" opcode="29" task="IISFilter" symbol="IISFilter_FILTER_ACCESS_DENIED_START"/>
+          <event value="10083" version="1" template="W3FilterAccessDeniedEnd" opcode="30" task="IISFilter" symbol="IISFilter_FILTER_ACCESS_DENIED_END"/>
+          <event value="10084" version="1" template="W3FilterSetReqHeader" opcode="31" task="IISFilter" symbol="IISFilter_FILTER_SET_REQ_HEADER"/>
+          <event value="10085" version="1" template="W3FilterAddReqHeader" opcode="32" task="IISFilter" symbol="IISFilter_FILTER_ADD_REQ_HEADER"/>
+          <event value="10086" version="1" template="W3FilterSetRespHeader" opcode="33" task="IISFilter" symbol="IISFilter_FILTER_SET_RESP_HEADER"/>
+          <event value="10087" version="1" template="W3FilterAddRespHeader" opcode="34" task="IISFilter" symbol="IISFilter_FILTER_ADD_RESP_HEADER"/>
+          <event value="10088" version="1" template="W3ISAPIStart" opcode="1" task="IISISAPI" symbol="IISISAPI_ISAPI_START"/>
+          <event value="10089" version="1" template="W3ISAPIEnd" opcode="2" task="IISISAPI" symbol="IISISAPI_ISAPI_END"/>
+          <event value="10090" version="1" template="W3CGIStart" opcode="1" task="IISCGI" symbol="IISCGI_CGI_START"/>
+          <event value="10091" version="1" template="W3CGIEnd" opcode="2" task="IISCGI" symbol="IISCGI_CGI_END"/>
+          <event value="10092" version="1" template="W3CGILaunch" opcode="3" task="IISCGI" symbol="IISCGI_CGI_LAUNCH"/>
+          <event value="10093" version="1" template="W3CGITimeout" opcode="4" task="IISCGI" symbol="IISCGI_CGI_TIMEOUT"/>
+          <event value="10094" version="1" template="W3CGIPrematureTermination" opcode="5" task="IISCGI" symbol="IISCGI_CGI_PREMATURE_TERMINATION"/>
+          <event value="10095" version="1" template="W3CGIRequestEntitySent" opcode="6" task="IISCGI" symbol="IISCGI_CGI_REQUEST_ENTITY_SENT"/>
+          <event value="10096" version="1" template="W3CGIHeadersReceived" opcode="7" task="IISCGI" symbol="IISCGI_CGI_HEADERS_RECEIVED"/>
+          <event value="10097" version="1" template="W3CGIFActivityTimeout" opcode="1" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_ACTIVITY_TIMEOUT"/>
+          <event value="10098" version="1" template="W3CGIFRequestTimeout" opcode="2" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_REQUEST_TIMEOUT"/>
+          <event value="10099" version="1" template="W3CGIFUnexpectedExit" opcode="3" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_UNEXPECTED_EXIT"/>
+          <event value="10100" version="1" template="W3CGIFRapidFailureProtection" opcode="4" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_RAPID_FAILURE_PROTECTION"/>
+          <event value="10101" version="1" template="W3CGIFPathNotFound" opcode="5" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_PATH_NOT_FOUND"/>
+          <event value="10102" version="1" template="W3CGIFScriptProcessorMissing" opcode="6" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_SCRIPT_PROCESSOR_MISSING"/>
+          <event value="10103" version="1" template="W3CGIFAddJobObjectFail" opcode="7" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_ADD_JOBOBJECT_FAIL"/>
+          <event value="10104" version="1" template="W3CGIFAppMgrShutdown" opcode="8" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_APPLICATION_MANAGER_SHUTDOWN"/>
+          <event value="10105" version="1" template="W3CGIFQueueFull" opcode="9" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_QUEUE_FULL"/>
+          <event value="10106" version="1" template="W3CGIFUnknownError" opcode="10" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_UNKNOWN_ERROR"/>
+          <event value="10107" version="1" template="W3CGIFResponseWritten" opcode="11" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_RESPONSE_WRITTEN"/>
+          <event value="10108" version="1" template="W3CGIFWaitingForResponse" opcode="12" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_WAITING_FOR_RESPONSE"/>
+          <event value="10109" version="1" template="W3CGIFTraceError" opcode="13" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_STDERR_TRACE_ERROR"/>
+          <event value="10110" version="1" template="W3CGIFTraceWarning" opcode="14" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_STDERR_TRACE_WARNING"/>
+          <event value="10111" version="1" template="W3CGIFTraceInfo" opcode="15" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_STDERR_TRACE_INFO"/>
+          <event value="10112" version="1" template="W3CGIFQueueRequest" opcode="16" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_QUEUE_REQUEST"/>
+          <event value="10113" version="1" template="W3CGIFAssignProcess" opcode="17" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_ASSIGN_PROCESS"/>
+          <event value="10114" version="1" template="W3CGIFStart" opcode="18" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_START"/>
+          <event value="10115" version="1" template="W3CGIFEnd" opcode="19" task="IISFastCGI" symbol="IISFastCGI_FASTCGI_END"/>
+          <event value="10116" version="1" template="W3WebSocketInitializeNotSuccess" opcode="1" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_INITIALIZE_FAILED"/>
+          <event value="10117" version="1" template="W3WebSocketStart" opcode="2" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_HANDSHAKE_START"/>
+          <event value="10118" version="1" template="W3WebSocketEndSuccess" opcode="3" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_HANDSHAKE_SUCCESS"/>
+          <event value="10119" version="1" template="W3WebSocketEndFailure" opcode="4" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_HANDSHAKE_NOT_SUCCESS"/>
+          <event value="10120" version="1" template="W3WebSocketReadFragmentStart" opcode="5" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_START"/>
+          <event value="10121" version="1" template="W3WebSocketReadFragmentEndPending" opcode="6" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_END_PENDING"/>
+          <event value="10122" version="1" template="W3WebSocketReadFragmentEndSuccess" opcode="7" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_END_SUCCESS"/>
+          <event value="10123" version="1" template="W3WebSocketReadFragmentEndFailure" opcode="8" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_READ_FRAGMENT_END_NOT_SUCCESS"/>
+          <event value="10124" version="1" template="W3WebSocketWriteFragmentStart" opcode="9" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_START"/>
+          <event value="10125" version="1" template="W3WebSocketWriteFragmentEndPending" opcode="10" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_END_PENDING"/>
+          <event value="10126" version="1" template="W3WebSocketWriteFragmentEndSuccess" opcode="11" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_END_SUCCESS"/>
+          <event value="10127" version="1" template="W3WebSocketWriteFragmentEndFailure" opcode="12" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_WRITE_FRAGMENT_END_NOT_SUCCESS"/>
+          <event value="10128" version="1" template="W3WebSocketApplicationCloseConnection" opcode="13" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_APPLICATION_CLOSE_CONNECTION"/>
+          <event value="10129" version="1" template="W3WebSocketModuleCloseConnection" opcode="14" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_MODULE_CLOSE_CONNECTION"/>
+          <event value="10130" version="1" template="W3WebSocketReadIoFailed" opcode="15" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_READ_IO_NOT_SUCCESS"/>
+          <event value="10131" version="1" template="W3WebSocketWriteIoFailed" opcode="16" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_WRITE_IO_NOT_SUCCESS"/>
+          <event value="10132" version="1" template="W3WebSocketCloseReceived" opcode="17" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_RECEIVED_CLOSE"/>
+          <event value="10133" version="1" template="W3WebSocketCloseSendStart" opcode="18" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_SEND_CLOSE_START"/>
+          <event value="10134" version="1" template="W3WebSocketCloseSendSuccess" opcode="19" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_SEND_CLOSE_END_SUCCESS"/>
+          <event value="10135" version="1" template="W3WebSocketCloseSendFailure" opcode="20" task="IISWebSocket" symbol="IISWebSocket_WEBSOCKET_SEND_CLOSE_END_NOT_SUCCESS"/>
+          <event value="10136" version="1" template="W3StaticCompressionStart" opcode="1" task="IISCompression" symbol="IISCompression_STATIC_COMPRESSION_START"/>
+          <event value="10137" version="1" template="W3StaticCompressionSuccess" opcode="2" task="IISCompression" symbol="IISCompression_STATIC_COMPRESSION_SUCCESS"/>
+          <event value="10138" version="1" template="W3StaticCompressionNotSuccess" opcode="3" task="IISCompression" symbol="IISCompression_STATIC_COMPRESSION_NOT_SUCCESS"/>
+          <event value="10139" version="1" template="W3StaticCompressionCreateStart" opcode="4" task="IISCompression" symbol="IISCompression_STATIC_COMPRESSION_CREATE_START"/>
+          <event value="10140" version="1" template="W3StaticCompressionCreateEnd" opcode="5" task="IISCompression" symbol="IISCompression_STATIC_COMPRESSION_CREATE_END"/>
+          <event value="10141" version="1" template="W3DynamicCompressionStart" opcode="6" task="IISCompression" symbol="IISCompression_DYNAMIC_COMPRESSION_START"/>
+          <event value="10142" version="1" template="W3DynamicCompressionSuccess" opcode="7" task="IISCompression" symbol="IISCompression_DYNAMIC_COMPRESSION_SUCCESS"/>
+          <event value="10143" version="1" template="W3DynamicCompressionNotSuccess" opcode="8" task="IISCompression" symbol="IISCompression_DYNAMIC_COMPRESSION_NOT_SUCCESS"/>
+          <event value="10144" version="1" template="W3DynamicCompressionDo" opcode="9" task="IISCompression" symbol="IISCompression_DYNAMIC_COMPRESSION_DO"/>
+          <event value="10145" version="1" template="W3DynamicCompressionEnd" opcode="10" task="IISCompression" symbol="IISCompression_DYNAMIC_COMPRESSION_END"/>
+          <event value="10146" version="1" template="W3StaticCompressionEnd" opcode="11" task="IISCompression" symbol="IISCompression_STATIC_COMPRESSION_END"/>
+          <event value="10147" version="1" template="W3CacheFileCacheAccessStart" opcode="10" task="IISCache" symbol="IISCache_FILE_CACHE_ACCESS_START"/>
+          <event value="10148" version="1" template="W3CacheFileCacheAccessEnd" opcode="11" task="IISCache" symbol="IISCache_FILE_CACHE_ACCESS_END"/>
+          <event value="10149" version="1" template="W3CacheURLCacheAccessStart" opcode="12" task="IISCache" symbol="IISCache_URL_CACHE_ACCESS_START"/>
+          <event value="10150" version="1" template="W3CacheURLCacheAccessEnd" opcode="13" task="IISCache" symbol="IISCache_URL_CACHE_ACCESS_END"/>
+          <event value="10151" version="1" template="W3CacheHttpsysCacheable" opcode="14" task="IISCache" symbol="IISCache_HTTPSYS_CACHEABLE"/>
+          <event value="10152" version="1" template="W3OutputCacheLookupStart" opcode="15" task="IISCache" symbol="IISCache_OUTPUT_CACHE_LOOKUP_START"/>
+          <event value="10153" version="1" template="W3OutputCacheLookupEnd" opcode="16" task="IISCache" symbol="IISCache_OUTPUT_CACHE_LOOKUP_END"/>
+          <event value="10154" version="1" template="W3OutputCacheUpdateStart" opcode="17" task="IISCache" symbol="IISCache_OUTPUT_CACHE_UPDATE_START"/>
+          <event value="10155" version="1" template="W3OutputCacheUpdateEnd" opcode="18" task="IISCache" symbol="IISCache_OUTPUT_CACHE_UPDATE_END"/>
+          <event value="10156" version="1" template="W3OutputCacheDisabled" opcode="19" task="IISCache" symbol="IISCache_OUTPUT_CACHE_DISABLED"/>
+          <event value="10157" version="1" template="IISRequestNotificationEventsStart" opcode="1" task="IISRequestNotification" symbol="IISRequestNotification_NOTIFY_MODULE_START"/>
+          <event value="10158" version="1" template="IISRequestNotificationEventsEnd" opcode="2" task="IISRequestNotification" symbol="IISRequestNotification_NOTIFY_MODULE_END"/>
+          <event value="10159" version="1" template="IISRequestNotificationEventsCompletion" opcode="3" task="IISRequestNotification" symbol="IISRequestNotification_NOTIFY_MODULE_COMPLETION"/>
+          <event value="10160" version="1" template="IISRequestNotificationPreBeginStart" opcode="4" task="IISRequestNotification" symbol="IISRequestNotification_PRE_BEGIN_REQUEST_START"/>
+          <event value="10161" version="1" template="IISRequestNotificationPreBeginEnd" opcode="5" task="IISRequestNotification" symbol="IISRequestNotification_PRE_BEGIN_REQUEST_END"/>
+          <event value="10162" version="1" template="IISRequestNotificationEventsError" opcode="15" task="IISRequestNotification" symbol="IISRequestNotification_REQUEST_PROCESSING_ERROR"/>
+          <event value="10163" version="1" template="IISRequestNotificationEventsResponseErrorStatus" opcode="16" task="IISRequestNotification" symbol="IISRequestNotification_MODULE_SET_RESPONSE_ERROR_STATUS"/>
+          <event value="10164" version="1" template="IISRequestNotificationEventsResponseSuccessStatus" opcode="17" task="IISRequestNotification" symbol="IISRequestNotification_MODULE_SET_RESPONSE_SUCCESS_STATUS"/>
+          <event value="10165" version="1" template="IISRequestNotificationEventsResponseErrorDescription" opcode="18" task="IISRequestNotification" symbol="IISRequestNotification_SET_RESPONSE_ERROR_DESCRIPTION"/>
+          <event value="10166" version="1" template="IISModuleEventsModuleStart" opcode="1" task="IISModule" symbol="IISModule_MODULE_START"/>
+          <event value="10167" version="1" template="IISModuleEventsModuleEnd" opcode="2" task="IISModule" symbol="IISModule_MODULE_END"/>
+          <event value="10168" version="1" template="IISModuleEventsModuleCriticalError" opcode="3" task="IISModule" symbol="IISModule_MODULE_CRITICAL_ERROR"/>
+          <event value="10169" version="1" template="IISModuleEventsModuleError" opcode="4" task="IISModule" symbol="IISModule_MODULE_ERROR"/>
+          <event value="10170" version="1" template="IISModuleEventsModuleWarning" opcode="5" task="IISModule" symbol="IISModule_MODULE_WARNING"/>
+          <event value="10171" version="1" template="IISModuleEventsModuleInformation" opcode="6" task="IISModule" symbol="IISModule_MODULE_INFORMATION"/>
+          <event value="10172" version="1" template="IISModuleEventsModuleVerbose" opcode="7" task="IISModule" symbol="IISModule_MODULE_VERBOSE"/>
+        </events>
+      </provider>
+      <provider name="IIS_Global_Trace" guid="{d55d3bc9-cba9-44df-827e-132d3a4596c2}">
+        <tasks>
+          <task name="IISStartup"  value="0" eventGUID="{35646e78-fe59-47e9-a617-eef5fc640816}"/>
+        <opcodes>
+          <opcode name="GLOBAL_PROCESS_START_INFO" symbol="IISStartup_GLOBAL_PROCESS_START_INFO" value="10"/>
+          <opcode name="GLOBAL_W3_SERVER_START" symbol="IISStartup_GLOBAL_W3_SERVER_START" value="11"/>
+          <opcode name="GLOBAL_RESOURCE_DLL_START" symbol="IISStartup_GLOBAL_RESOURCE_DLL_START" value="12"/>
+          <opcode name="GLOBAL_IISUTIL_START" symbol="IISStartup_GLOBAL_IISUTIL_START" value="13"/>
+          <opcode name="GLOBAL_WINSOCK_START" symbol="IISStartup_GLOBAL_WINSOCK_START" value="14"/>
+          <opcode name="GLOBAL_METABASE_START" symbol="IISStartup_GLOBAL_METABASE_START" value="15"/>
+          <opcode name="GLOBAL_MB_LISTENER_START" symbol="IISStartup_GLOBAL_MB_LISTENER_START" value="16"/>
+          <opcode name="GLOBAL_W3_SITE_START" symbol="IISStartup_GLOBAL_W3_SITE_START" value="17"/>
+          <opcode name="GLOBAL_ULATQ_START" symbol="IISStartup_GLOBAL_ULATQ_START" value="18"/>
+          <opcode name="GLOBAL_FILTER_START" symbol="IISStartup_GLOBAL_FILTER_START" value="19"/>
+          <opcode name="GLOBAL_SITE_LIST_START" symbol="IISStartup_GLOBAL_SITE_LIST_START" value="20"/>
+          <opcode name="GLOBAL_CACHE_START" symbol="IISStartup_GLOBAL_CACHE_START" value="21"/>
+          <opcode name="GLOBAL_W3_CONNECTION_START" symbol="IISStartup_GLOBAL_W3_CONNECTION_START" value="22"/>
+          <opcode name="GLOBAL_W3_CONTEXT_START" symbol="IISStartup_GLOBAL_W3_CONTEXT_START" value="23"/>
+          <opcode name="GLOBAL_W3_REQUEST_START" symbol="IISStartup_GLOBAL_W3_REQUEST_START" value="24"/>
+          <opcode name="GLOBAL_W3_RESPONSE_START" symbol="IISStartup_GLOBAL_W3_RESPONSE_START" value="25"/>
+          <opcode name="GLOBAL_SERVER_VARIABLE_START" symbol="IISStartup_GLOBAL_SERVER_VARIABLE_START" value="26"/>
+          <opcode name="GLOBAL_MIME_MAP_START" symbol="IISStartup_GLOBAL_MIME_MAP_START" value="27"/>
+          <opcode name="GLOBAL_LOGGING_START" symbol="IISStartup_GLOBAL_LOGGING_START" value="28"/>
+          <opcode name="GLOBAL_RAW_CONNECTION_START" symbol="IISStartup_GLOBAL_RAW_CONNECTION_START" value="29"/>
+          <opcode name="GLOBAL_CERTIFICATE_START" symbol="IISStartup_GLOBAL_CERTIFICATE_START" value="30"/>
+          <opcode name="GLOBAL_ISAPI_RESTRICTION_LIST_START" symbol="IISStartup_GLOBAL_ISAPI_RESTRICTION_LIST_START" value="31"/>
+          <opcode name="GLOBAL_CGI_RESTRICTION_LIST_START" symbol="IISStartup_GLOBAL_CGI_RESTRICTION_LIST_START" value="32"/>
+          <opcode name="GLOBAL_COMPRESSION_START" symbol="IISStartup_GLOBAL_COMPRESSION_START" value="33"/>
+          <opcode name="GLOBAL_W3_SERVER_END" symbol="IISStartup_GLOBAL_W3_SERVER_END" value="34"/>
+          <opcode name="GLOBAL_W3_SERVER_INIT_ERROR" symbol="IISStartup_GLOBAL_W3_SERVER_INIT_ERROR" value="35"/>
+          <opcode name="FILTER_LOAD_START" symbol="IISStartup_FILTER_LOAD_START" value="36"/>
+          <opcode name="FILTER_LOAD_END" symbol="IISStartup_FILTER_LOAD_END" value="37"/>
+          <opcode name="GLOBAL_ULATQ_START_LISTENING" symbol="IISStartup_GLOBAL_ULATQ_START_LISTENING" value="38"/>
+        </opcodes>
+          <task name="IISShutdown"  value="1" eventGUID="{e1af7c2a-7bbe-4bec-b5e0-ba064e1d77da}"/>
+        <opcodes>
+          <opcode name="GLOBAL_PROCESS_SHUTDOWN_MODE" symbol="IISShutdown_GLOBAL_PROCESS_SHUTDOWN_MODE" value="10"/>
+          <opcode name="GLOBAL_W3_SERVER_SHUTDOWN_START" symbol="IISShutdown_GLOBAL_W3_SERVER_SHUTDOWN_START" value="11"/>
+          <opcode name="GLOBAL_W3_SERVER_SHUTDOWN_END" symbol="IISShutdown_GLOBAL_W3_SERVER_SHUTDOWN_END" value="12"/>
+          <opcode name="FILTER_UNLOAD_START" symbol="IISShutdown_FILTER_UNLOAD_START" value="13"/>
+          <opcode name="FILTER_UNLOAD_END" symbol="IISShutdown_FILTER_UNLOAD_END" value="14"/>
+        </opcodes>
+          <task name="IISGlobalCache"  value="2" eventGUID="{c4ccfe5b-639e-42d9-a9af-a5dee1688f35}"/>
+        <opcodes>
+        </opcodes>
+        </tasks>
+        <templates>
+          <template tid="W3StartupProcessStartInfo">
+            <data name="CommandLineArgs" inType="win:UnicodeString"/>
+            <data name="IIS5CompatMode" inType="win:Boolean"/>
+            <data name="UserName" inType="win:UnicodeString"/>
+            <data name="ProcessAffinityMask" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3StartupW3serverStart">
+          </template>
+          <template tid="W3StartupResourceDllStart">
+          </template>
+          <template tid="W3StartupIISUtilStart">
+          </template>
+          <template tid="W3StartupWinsockStart">
+          </template>
+          <template tid="W3StartupMetabaseStart">
+          </template>
+          <template tid="W3StartupMblistenerStart">
+          </template>
+          <template tid="W3StartupW3siteStart">
+          </template>
+          <template tid="W3StartupUlatqStart">
+          </template>
+          <template tid="W3StartupGlobalFilterStart">
+          </template>
+          <template tid="W3StartupSiteListStart">
+          </template>
+          <template tid="W3StartupCacheStart">
+          </template>
+          <template tid="W3StartupW3connectionStart">
+          </template>
+          <template tid="W3StartupW3contextStart">
+          </template>
+          <template tid="W3StartupW3requestStart">
+          </template>
+          <template tid="W3StartupW3responseStart">
+          </template>
+          <template tid="W3StartupServerVariableStart">
+          </template>
+          <template tid="W3StartupMimeMapStart">
+          </template>
+          <template tid="W3StartupLoggingStart">
+          </template>
+          <template tid="W3StartupRawConnectionStart">
+          </template>
+          <template tid="W3StartupCertificateStart">
+          </template>
+          <template tid="W3StartupISAPIRestrictionListStart">
+          </template>
+          <template tid="W3StartupCGIRestrictionListStart">
+          </template>
+          <template tid="W3StartupCompressionStart">
+          </template>
+          <template tid="W3StartupW3serverEnd">
+          </template>
+          <template tid="W3StartupW3serverInitError">
+            <data name="InitStatus" inType="win:UInt32"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3StartupFilterLoadStart">
+            <data name="FilterName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3StartupFilterLoadEnd">
+            <data name="FilterName" inType="win:UnicodeString"/>
+            <data name="ErrorCode" inType="win:UInt32" outType="win:hexInt32"/>
+          </template>
+          <template tid="W3StartupUlatqStartListening">
+          </template>
+          <template tid="W3ShutdownProcessMode">
+            <data name="ShutdownImmediate" inType="win:Boolean"/>
+            <data name="AllCGIKilled" inType="win:Boolean"/>
+          </template>
+          <template tid="W3ShutdownW3serverShutdownStart">
+          </template>
+          <template tid="W3ShutdownW3serverShutdownEnd">
+          </template>
+          <template tid="W3ShutdownFilterUnloadStart">
+            <data name="FilterName" inType="win:UnicodeString"/>
+          </template>
+          <template tid="W3ShutdownFilterUnloadEnd">
+            <data name="FilterName" inType="win:UnicodeString"/>
+          </template>
+        </templates>
+        <events>
+          <event value="10000" version="1" template="W3StartupProcessStartInfo" opcode="10" task="IISStartup" symbol="IISStartup_GLOBAL_PROCESS_START_INFO"/>
+          <event value="10001" version="1" template="W3StartupW3serverStart" opcode="11" task="IISStartup" symbol="IISStartup_GLOBAL_W3_SERVER_START"/>
+          <event value="10002" version="1" template="W3StartupResourceDllStart" opcode="12" task="IISStartup" symbol="IISStartup_GLOBAL_RESOURCE_DLL_START"/>
+          <event value="10003" version="1" template="W3StartupIISUtilStart" opcode="13" task="IISStartup" symbol="IISStartup_GLOBAL_IISUTIL_START"/>
+          <event value="10004" version="1" template="W3StartupWinsockStart" opcode="14" task="IISStartup" symbol="IISStartup_GLOBAL_WINSOCK_START"/>
+          <event value="10005" version="1" template="W3StartupMetabaseStart" opcode="15" task="IISStartup" symbol="IISStartup_GLOBAL_METABASE_START"/>
+          <event value="10006" version="1" template="W3StartupMblistenerStart" opcode="16" task="IISStartup" symbol="IISStartup_GLOBAL_MB_LISTENER_START"/>
+          <event value="10007" version="1" template="W3StartupW3siteStart" opcode="17" task="IISStartup" symbol="IISStartup_GLOBAL_W3_SITE_START"/>
+          <event value="10008" version="1" template="W3StartupUlatqStart" opcode="18" task="IISStartup" symbol="IISStartup_GLOBAL_ULATQ_START"/>
+          <event value="10009" version="1" template="W3StartupGlobalFilterStart" opcode="19" task="IISStartup" symbol="IISStartup_GLOBAL_FILTER_START"/>
+          <event value="10010" version="1" template="W3StartupSiteListStart" opcode="20" task="IISStartup" symbol="IISStartup_GLOBAL_SITE_LIST_START"/>
+          <event value="10011" version="1" template="W3StartupCacheStart" opcode="21" task="IISStartup" symbol="IISStartup_GLOBAL_CACHE_START"/>
+          <event value="10012" version="1" template="W3StartupW3connectionStart" opcode="22" task="IISStartup" symbol="IISStartup_GLOBAL_W3_CONNECTION_START"/>
+          <event value="10013" version="1" template="W3StartupW3contextStart" opcode="23" task="IISStartup" symbol="IISStartup_GLOBAL_W3_CONTEXT_START"/>
+          <event value="10014" version="1" template="W3StartupW3requestStart" opcode="24" task="IISStartup" symbol="IISStartup_GLOBAL_W3_REQUEST_START"/>
+          <event value="10015" version="1" template="W3StartupW3responseStart" opcode="25" task="IISStartup" symbol="IISStartup_GLOBAL_W3_RESPONSE_START"/>
+          <event value="10016" version="1" template="W3StartupServerVariableStart" opcode="26" task="IISStartup" symbol="IISStartup_GLOBAL_SERVER_VARIABLE_START"/>
+          <event value="10017" version="1" template="W3StartupMimeMapStart" opcode="27" task="IISStartup" symbol="IISStartup_GLOBAL_MIME_MAP_START"/>
+          <event value="10018" version="1" template="W3StartupLoggingStart" opcode="28" task="IISStartup" symbol="IISStartup_GLOBAL_LOGGING_START"/>
+          <event value="10019" version="1" template="W3StartupRawConnectionStart" opcode="29" task="IISStartup" symbol="IISStartup_GLOBAL_RAW_CONNECTION_START"/>
+          <event value="10020" version="1" template="W3StartupCertificateStart" opcode="30" task="IISStartup" symbol="IISStartup_GLOBAL_CERTIFICATE_START"/>
+          <event value="10021" version="1" template="W3StartupISAPIRestrictionListStart" opcode="31" task="IISStartup" symbol="IISStartup_GLOBAL_ISAPI_RESTRICTION_LIST_START"/>
+          <event value="10022" version="1" template="W3StartupCGIRestrictionListStart" opcode="32" task="IISStartup" symbol="IISStartup_GLOBAL_CGI_RESTRICTION_LIST_START"/>
+          <event value="10023" version="1" template="W3StartupCompressionStart" opcode="33" task="IISStartup" symbol="IISStartup_GLOBAL_COMPRESSION_START"/>
+          <event value="10024" version="1" template="W3StartupW3serverEnd" opcode="34" task="IISStartup" symbol="IISStartup_GLOBAL_W3_SERVER_END"/>
+          <event value="10025" version="1" template="W3StartupW3serverInitError" opcode="35" task="IISStartup" symbol="IISStartup_GLOBAL_W3_SERVER_INIT_ERROR"/>
+          <event value="10026" version="1" template="W3StartupFilterLoadStart" opcode="36" task="IISStartup" symbol="IISStartup_FILTER_LOAD_START"/>
+          <event value="10027" version="1" template="W3StartupFilterLoadEnd" opcode="37" task="IISStartup" symbol="IISStartup_FILTER_LOAD_END"/>
+          <event value="10028" version="1" template="W3StartupUlatqStartListening" opcode="38" task="IISStartup" symbol="IISStartup_GLOBAL_ULATQ_START_LISTENING"/>
+          <event value="10029" version="1" template="W3ShutdownProcessMode" opcode="10" task="IISShutdown" symbol="IISShutdown_GLOBAL_PROCESS_SHUTDOWN_MODE"/>
+          <event value="10030" version="1" template="W3ShutdownW3serverShutdownStart" opcode="11" task="IISShutdown" symbol="IISShutdown_GLOBAL_W3_SERVER_SHUTDOWN_START"/>
+          <event value="10031" version="1" template="W3ShutdownW3serverShutdownEnd" opcode="12" task="IISShutdown" symbol="IISShutdown_GLOBAL_W3_SERVER_SHUTDOWN_END"/>
+          <event value="10032" version="1" template="W3ShutdownFilterUnloadStart" opcode="13" task="IISShutdown" symbol="IISShutdown_FILTER_UNLOAD_START"/>
+          <event value="10033" version="1" template="W3ShutdownFilterUnloadEnd" opcode="14" task="IISShutdown" symbol="IISShutdown_FILTER_UNLOAD_END"/>
+        </events>
+      </provider>
+    </events>
+  </instrumentation>
+</instrumentationManifest>

--- a/src/TraceEvent/Parsers/w3core.mof
+++ b/src/TraceEvent/Parsers/w3core.mof
@@ -1,0 +1,6217 @@
+#pragma classflags("forceupdate")  
+#pragma namespace ("\\\\.\\Root\\WMI")  
+#pragma autorecover  
+[Dynamic,  
+  Description("IIS: WWW Server"),  
+  Guid("{3a2a4e84-4c21-4981-ae10-3fda0d9b0f83}"),  
+  locale("MS\\0x409")]  
+class IIS_Trace:EventTrace  
+{  
+    [Description ("Enable Flags") : amended,  
+        ValueDescriptions{  
+            "Allow tracing only selected requests",  
+            "IIS authentication events",  
+            "IIS security events",  
+            "IIS filter events",  
+            "IIS static file events",  
+            "IIS CGI events",  
+            "IIS compression events",  
+            "IIS cache events",  
+            "IIS request notifications events",  
+            "IIS module events",  
+            "IIS FastCGI events",  
+            "IIS ISAPI events",  
+            "IIS WebSocket events",  
+            "IIS general events",  
+            "IIS all events" } : amended,  
+         DefineValues{  
+            "ETW_IIS_PER_URL",  
+            "ETW_IIS_AUTHENTICATION",      
+            "ETW_IIS_SECURITY",            
+            "ETW_IIS_FILTER",              
+            "ETW_IIS_STATIC_FILE",         
+            "ETW_IIS_CGI",                 
+            "ETW_IIS_COMPRESSION",  
+            "ETW_IIS_CACHE",  
+            "ETW_IIS_REQUEST_NOTIFICATION",  
+            "ETW_IIS_MODULE",  
+            "ETW_IIS_FASTCGI",  
+            "ETW_IIS_ISAPI",  
+            "ETW_IIS_WEBSOCKET",  
+            "ETW_IIS_GENERAL",  
+            "ETW_IIS_ALL" },  
+        Values{  
+            "UseUrlFilter",  
+            "IISAuthentication",  
+            "IISSecurity",  
+            "IISFilter",  
+            "IISStaticFile",  
+            "IISCGI",  
+            "IISCompression",  
+            "IISCache",  
+            "IISRequestNotification",  
+            "IISModule",  
+            "IISFastCGI",  
+            "IISISAPI",  
+            "IISWebSocket",  
+            "IISGeneral",  
+            "IISAll"},  
+        ValueMap{  
+            "0x0001",  
+            "0x0002",  
+            "0x0004",  
+            "0x0008",  
+            "0x0010",  
+            "0x0020",  
+            "0x0040",  
+            "0x0080",  
+            "0x0100",  
+            "0x0200",  
+            "0x1000", 
+            "0x2000",  
+            "0x4000",  
+            "0x0000",  
+            "0x4FFE"}  
+    ]  
+    uint32 Flags;  
+  
+    [Description ("Levels") : amended,  
+        ValueDescriptions{  
+            "Abnormal exit or termination",  
+            "Severe errors",  
+            "Warnings",  
+            "Information",  
+            "Detailed information" } : amended,  
+         DefineValues{  
+            "TRACE_LEVEL_FATAL",  
+            "TRACE_LEVEL_ERROR",   
+            "TRACE_LEVEL_WARNING",  
+            "TRACE_LEVEL_INFORMATION",             
+            "TRACE_LEVEL_VERBOSE" },                     
+        Values{  
+            "Fatal",  
+            "Error",  
+            "Warning",  
+            "Information",  
+            "Verbose" },  
+        ValueMap{  
+            "0x1",  
+            "0x2",  
+            "0x3",  
+            "0x4",  
+            "0x5" },  
+        ValueType("index")  
+    ]  
+    uint32 Level;  
+};  
+
+[Dynamic,  
+ Description("IIS general events") : amended,  
+ Guid("{d42cf7ef-de92-473e-8b6c-621ea663113a}"),  
+ EventVersion(1),  
+ DisplayName("IISGeneral"),  
+ EventHttpRequest,  
+ locale("MS\\0x409")  
+]  
+class IIS_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS starts processing a new request") : amended,  
+ EventType(1),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_REQUEST_START") : amended  
+]  
+class W3GeneralStartNewRequest:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Site ID") : amended,  
+     read]  
+     uint32  SiteId;  
+    [WmiDataId(3),  
+     Description("Application Pool ID") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  AppPoolId;  
+    [WmiDataId(4),  
+     Description("Connection ID") : amended,  
+     read]  
+     uint64  ConnId;  
+    [WmiDataId(5),  
+     Description("HttpFilter - Raw Connection ID") : amended,  
+     read]  
+     uint64  RawConnId;  
+    [WmiDataId(6),  
+     Description("Request URL") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  RequestURL;  
+    [WmiDataId(7),  
+     Description("Request Verb") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  RequestVerb;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends processing a request") : amended,  
+ EventType(2),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_REQUEST_END") : amended  
+]  
+class W3GeneralEndNewRequest:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Bytes Sent") : amended,  
+     read]  
+     uint32 BytesSent;  
+    [WmiDataId(3),  
+     Description("Bytes received") : amended,  
+     read]  
+     uint32 BytesReceived;  
+    [WmiDataId(4),  
+     Description("Response status code") : amended,  
+     read]  
+     uint32 HttpStatus;  
+    [WmiDataId(5),  
+     Description("Response substatus code") : amended,  
+     read]  
+     uint16 HttpSubStatus;  
+};  
+  
+[Dynamic,  
+ Description("IIS processes a static file request") : amended,  
+ EventType(10),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_STATIC_FILE_HANDLER") : amended  
+]  
+class W3GeneralStaticFileHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Static file name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FileName;  
+};  
+  
+[Dynamic,  
+ Description("IIS processes a CGI request") : amended,  
+ EventType(11),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_CGI_HANDLER") : amended  
+]  
+class W3GeneralCGIHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS processes an in-proc ISAPI request") : amended,  
+ EventType(12),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_ISAPI_HANDLER") : amended  
+]  
+class W3GeneralISAPIHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS processes an out-of-proc ISAPI request") : amended,  
+ EventType(13),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_OOP_ISAPI_HANDLER") : amended  
+]  
+class W3GeneralOopISAPIHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Process ID") : amended,  
+     read]  
+     uint32 ProcessId;  
+    [WmiDataId(3),  
+     Description("Total Requests") : amended,  
+     read]  
+     uint32 TotalReqs;  
+    [WmiDataId(4),  
+     Description("Current Requests") : amended,  
+     read]  
+     uint32 CurrentReqs;  
+  
+};  
+  
+[Dynamic,  
+ Description("IIS redirects a request") : amended,  
+ EventType(14),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_REDIRECTION_HANDLER") : amended  
+]  
+class W3GeneralRedirectionHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Redirected URL") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string RedirectedURL;  
+};  
+  
+[Dynamic,  
+ Description("IIS processes a DAV request") : amended,  
+ EventType(15),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_DAV_HANDLER") : amended  
+]  
+class W3GeneralDavHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("File name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FileName;  
+};  
+  
+[Dynamic,  
+ Description("IIS processes an OPTIONS request") : amended,  
+ EventType(16),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_OPTIONS_HANDLER") : amended  
+]  
+class W3GeneralOptionsHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS processes a TRACE request") : amended,  
+ EventType(17),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_TRACE_HANDLER") : amended  
+]  
+class W3GeneralTraceHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS gets URL metadata") : amended,  
+ EventType(30),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_GET_URL_METADATA") : amended  
+]  
+class W3GeneralGetURLMetadata:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Request Physical Path") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  PhysicalPath;  
+    [WmiDataId(3),  
+     Description("Request Access Permissions") : amended,  
+     ValueDescriptions{  
+           "Allow for Read",  
+           "Allow for Write",  
+           "Allow for Execute",  
+           "Apply access mask to source",  
+           "Allow for Script execution",  
+           "Local host access only",  
+           "Local host access only",  
+           "Local host access only",  
+           "Local host access only",  
+           "VR maps to no physical path",  
+           "Require SSL",  
+           "Allow Client Certificates",  
+           "Require Client Certificates",  
+           "Map SSL cert to NT account",  
+           "Require 128 bit SSL"} : amended,  
+     DefineValues{  
+           "MD_ACCESS_READ",  
+           "MD_ACCESS_WRITE",  
+           "MD_ACCESS_EXECUTE",  
+           "MD_ACCESS_SOURCE",  
+           "MD_ACCESS_SCRIPT",  
+           "MD_ACCESS_NO_REMOTE_WRITE",  
+           "MD_ACCESS_NO_REMOTE_READ",  
+           "MD_ACCESS_NO_REMOTE_EXECUTE",  
+           "MD_ACCESS_NO_REMOTE_SCRIPT",  
+           "MD_ACCESS_NO_PHYSICAL_DIR",  
+           "MD_ACCESS_SSL",  
+           "MD_ACCESS_NEGO_CERT",  
+           "MD_ACCESS_REQUIRE_CERT",  
+           "MD_ACCESS_MAP_CERT",  
+           "MD_ACCESS_SSL128"},  
+     Values{  
+            "Read",  
+            "Write",  
+            "Exec",  
+            "Source",  
+            "Script",  
+            "NoRemoteWrite",  
+            "NoRemoteRead",  
+            "NoRemoteExec",  
+            "NoRemoteScript",  
+            "NoPhysicalDir",  
+            "SSL",  
+            "CliCert",  
+            "ReqCliCert",  
+            "MapCliCert",  
+            "SSL128"},  
+     ValueMap{  
+            "0x00001",  
+            "0x00002",  
+            "0x00004",  
+            "0x00010",  
+            "0x00200",  
+            "0x00400",  
+            "0x01000",  
+            "0x02000",  
+            "0x04000",  
+            "0x08000",  
+            "0x00008",  
+            "0x00020",  
+            "0x00040",  
+            "0x00080",  
+            "0x00100" },  
+     format("x"),  
+     read]  
+     uint32  AccessPerms;  
+};  
+  
+[Dynamic,  
+ Description("IIS starts processing a child request") : amended,  
+ EventType(31),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_CHILD_REQUEST_START") : amended  
+]  
+class W3GeneralChildRequestStart:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Site ID") : amended,  
+     read]  
+     uint32  SiteId;  
+    [WmiDataId(3),  
+     Description("Request URL") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  RequestURL;  
+    [WmiDataId(4),  
+     Description("Request Verb") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  RequestVerb;  
+    [WmiDataId(5),  
+     Description("Current recursive level") : amended,  
+     read]  
+     uint32  RecursiveLevel;       
+};  
+  
+[Dynamic,  
+ Description("IIS ends processing a child request") : amended,  
+ EventType(32),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_CHILD_REQUEST_END") : amended  
+]  
+class W3GeneralChildRequestEnd:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Bytes Sent") : amended,  
+     read]  
+     uint32 BytesSent;  
+    [WmiDataId(3),  
+     Description("Response status code") : amended,  
+     read]  
+     uint32 HttpStatus;  
+    [WmiDataId(4),  
+     Description("Response substatus code") : amended,  
+     read]  
+     uint16 HttpSubStatus;  
+};  
+  
+[Dynamic,  
+ Description("IIS sends back a custom error") : amended,  
+ EventType(33),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_SEND_CUSTOM_ERROR") : amended  
+]  
+class W3GeneralSendCustomError:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Response status code") : amended,  
+     read]  
+     uint32 HttpStatus;  
+    [WmiDataId(3),  
+     Description("Response substatus code") : amended,  
+     read]  
+     uint16 HttpSubStatus;  
+    [WmiDataId(4),  
+     Description("Custom error file name or URL") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  FileNameOrURL;  
+};  
+  
+[Dynamic,  
+ Description("IIS processes a MAP request") : amended,  
+ EventType(34),  
+ EventLevel(0),  
+ EventTypeName("GENERAL_MAP_HANDLER") : amended  
+]  
+class W3GeneralMapHandler:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+  
+[Dynamic,  
+ Description("IIS begins flushing response data to client") : amended,  
+ EventType(35),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_FLUSH_RESPONSE_START") : amended  
+]  
+class W3GeneralFlushResponseStart:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS finishes flushing response data to client") : amended,  
+ EventType(36),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_FLUSH_RESPONSE_END") : amended  
+]  
+class W3GeneralFlushResponseEnd:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Bytes sent") : amended,  
+     read]  
+     uint32  BytesSent;  
+    [WmiDataId(3),  
+     Description("Error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("IIS starts reading request data from client") : amended,  
+ EventType(37),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_READ_ENTITY_START") : amended  
+]  
+class W3GeneralReadEntityStart:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS finishes reading request data from client") : amended,  
+ EventType(38),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_READ_ENTITY_END") : amended  
+]  
+class W3GeneralReadEntityEnd:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Bytes received") : amended,  
+     read]  
+     uint32  BytesReceived;  
+    [WmiDataId(3),  
+     Description("Error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("File change notification fired") : amended,  
+ EventType(39),  
+ EventLevel(4),  
+ EventTypeName("FILE_CHANGE_NOTIFICATION") : amended  
+]  
+class IISGeneralFileChangeNotification:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("File path") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  FilePath;  
+};  
+  
+[Dynamic,  
+ Description("Config change notification fired") : amended,  
+ EventType(40),  
+ EventLevel(4),  
+ EventTypeName("CONFIG_CHANGE_NOTIFICATION") : amended  
+]  
+class IISGeneralConfigChangeNotification:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Config path") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ConfigPath;  
+};  
+  
+[Dynamic,  
+ Description("Virtual module unresolved") : amended,  
+ EventType(41),  
+ EventLevel(4),  
+ EventTypeName("VIRTUAL_MODULE_UNRESOLVED") : amended  
+]  
+class IISGeneralVirtualModuleUnresolved:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Module name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Name;  
+    [WmiDataId(3),  
+     Description("Module type") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Type;  
+};  
+  
+[Dynamic,  
+ Description("Url changed") : amended,  
+ EventType(42),  
+ EventLevel(4),  
+ EventTypeName("URL_CHANGED") : amended  
+]  
+class IISGeneralUrlChanged:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Old url") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  OldUrl;  
+    [WmiDataId(3),  
+     Description("New url") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  NewUrl;  
+};  
+  
+[Dynamic,  
+ Description("Handler changed") : amended,  
+ EventType(43),  
+ EventLevel(4),  
+ EventTypeName("HANDLER_CHANGED") : amended  
+]  
+class IISGeneralHandlerChanged:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Old handler name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  OldHandlerName;  
+    [WmiDataId(3),  
+     Description("New handler name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  NewHandlerName;  
+    [WmiDataId(4),  
+     Description("New handler modules") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  NewHandlerModules;  
+    [WmiDataId(5),  
+     Description("New handler scriptProcessor") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  NewHandlerScriptProcessor;  
+    [WmiDataId(6),  
+     Description("New handler type") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  NewHandlerType;  
+};  
+  
+[Dynamic,  
+ Description("User set") : amended,  
+ EventType(44),  
+ EventLevel(4),  
+ EventTypeName("USER_SET") : amended  
+]  
+class IISGeneralUserSet:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Auth type") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  AuthType;  
+    [WmiDataId(3),  
+     Description("User name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  UserName;  
+    [WmiDataId(4),  
+     Description("Supports IsInRole") : amended,  
+     read]  
+     boolean SupportsIsInRole;  
+};  
+  
+[Dynamic,  
+ Description("Module not run due to non matching precondition") : amended,  
+ EventType(45),  
+ EventLevel(4),  
+ EventTypeName("MODULE_PRECONDITION_NOT_MATCH") : amended  
+]  
+class IISGeneralModulePreconditionNotMatch:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Module name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Name;  
+    [WmiDataId(3),  
+     Description("Precondition") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Precondition;  
+};  
+  
+[Dynamic,  
+ Description("Handler not run due to non matching precondition") : amended,  
+ EventType(46),  
+ EventLevel(4),  
+ EventTypeName("HANDLER_PRECONDITION_NOT_MATCH") : amended  
+]  
+class IISGeneralHandlerPreconditionNotMatch:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Handler name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Name;  
+    [WmiDataId(3),  
+     Description("Precondition") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Precondition;  
+};  
+  
+[Dynamic,  
+ Description("Response headers") : amended,  
+ EventType(47),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_RESPONSE_HEADERS") : amended  
+]  
+class W3GeneralResponseHeaders:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Response headers") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  Headers;  
+};  
+  
+[Dynamic,  
+ Description("Response entity from file") : amended,  
+ EventType(48),  
+ EventLevel(5),  
+ EventTypeName("GENERAL_RESPONSE_ENTITY_FILE") : amended  
+]  
+class W3GeneralResponseEntityFile:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("File name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  FileName;  
+    [WmiDataId(3),  
+     Description("Offset") : amended,  
+     read]  
+     uint64  Offset;  
+    [WmiDataId(4),  
+     Description("Size") : amended,  
+     read]  
+     uint64  Size;  
+};  
+  
+[Dynamic,  
+ Description("Response entity from buffer") : amended,  
+ EventType(49),  
+ EventLevel(5),  
+ EventTypeName("GENERAL_RESPONSE_ENTITY_BUFFER") : amended  
+]  
+class W3GeneralResponseEntityBuffer:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Buffer") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  Buffer;  
+};  
+  
+[Dynamic,  
+ Description("Request headers") : amended,  
+ EventType(50),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_REQUEST_HEADERS") : amended  
+]  
+class W3GeneralRequestHeaders:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Request headers") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  Headers;  
+};  
+  
+[Dynamic,  
+ Description("Request entity") : amended,  
+ EventType(51),  
+ EventLevel(5),  
+ EventTypeName("GENERAL_REQUEST_ENTITY") : amended  
+]  
+class W3GeneralRequestEntity:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Buffer") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  Buffer;  
+};  
+  
+[Dynamic,  
+ Description("Custom errors will not be sent") : amended,  
+ EventType(52),  
+ EventLevel(5),  
+ EventTypeName("GENERAL_NOT_SEND_CUSTOM_ERROR") : amended  
+]  
+class W3GeneralNotSendCustomError:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Reason for custom errors not running") : amended,  
+     ValueDescriptions{  
+        "Unknown",  
+        "Successful request",  
+        "Module called SetStatus with fTrySkipCustomErrors",  
+        "Existing response passthrough",  
+        "Existing response auto" } : amended,  
+     DefineValues{  
+        "UNKNOWN",  
+        "SETSTATUS_SUCCESS",  
+        "SETSTATUS_TRYSKIP",  
+        "EXISTINGRESPONSE_PASSTHROUGH",  
+        "EXISTINGRESPONSE_AUTO" },  
+     Values{  
+        "UNKNOWN",  
+        "SETSTATUS_SUCCESS",  
+        "SETSTATUS_TRYSKIP",  
+        "EXISTINGRESPONSE_PASSTHROUGH",  
+        "EXISTINGRESPONSE_AUTO" },  
+     ValueMap{  
+        "0",  
+        "1",  
+        "2",  
+        "3",  
+        "4"},  
+     ValueType("index")]  
+     uint32  Reason;  
+};  
+  
+[Dynamic,  
+ Description("Module called IHttpRequest SetHeader or DeleteHeader") : amended,  
+ EventType(53),  
+ EventLevel(5),  
+ EventTypeName("GENERAL_SET_REQUEST_HEADER") : amended  
+]  
+class W3GeneralSetRequestHeader:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Header name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderName;  
+    [WmiDataId(3),  
+     Description("Header value") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderValue;  
+    [WmiDataId(4),  
+     Description("Replace header") : amended,  
+     read]  
+     boolean Replace;  
+};  
+  
+[Dynamic,  
+ Description("IHttpModuleFactory GetHttpModule Failed") : amended,  
+ EventType(54),  
+ EventLevel(2),  
+ EventTypeName("GENERAL_MODULE_FACTORY_FAILED") : amended  
+]  
+class W3GeneralModuleFactoryFailed:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Endpoint information") : amended,  
+ EventType(55),  
+ EventLevel(4),  
+ EventTypeName("GENERAL_ENDPOINT_INFORMATION") : amended  
+]  
+class W3GeneralEndpointInformation:IIS_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Remote address") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  RemoteAddress;  
+    [WmiDataId(3),  
+     Description("Remote port") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  RemotePort;  
+    [WmiDataId(4),  
+     Description("Local address") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  LocalAddress;  
+    [WmiDataId(5),  
+     Description("Local port") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  LocalPort;  
+};  
+  
+
+[Dynamic,  
+ Description("IIS authentication events") : amended,  
+ Guid("{c33bbe8f-985b-4080-81e6-005f1a06b9e2}"),  
+ EventVersion(1),  
+ DisplayName("IISAuthentication"),  
+ EventHttpRequest,  
+  
+ locale("MS\\0x409")  
+]  
+class IIS_Authentication_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS authentication starts") : amended,  
+ EventType(10),  
+ EventLevel(4),  
+ EventTypeName("AUTH_START") : amended  
+]  
+class W3AuthStart:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Auth type supported on the URL") : amended,  
+     ValueDescriptions{  
+        "Anonymous authentication",  
+        "Basic authentication",  
+        "Windows integrated authentication",  
+        "Digest authentication",  
+        "Passport authentication",  
+        "SSL Certificate mapping authentication"} : amended,  
+     DefineValues{  
+        "MD_AUTH_ANONYMOUS",  
+        "MD_AUTH_BASIC",   
+        "MD_AUTH_NT",  
+        "MD_AUTH_MD5",             
+        "MD_AUTH_PASSPORT",  
+        "MD_ACCESS_MAP_CERT"},                     
+     Values{  
+        "Anonymous",  
+        "Basic",  
+        "NT",  
+        "Digest",  
+        "Passport",  
+        "MapCliCert"},  
+     ValueMap{  
+        "0x1",  
+        "0x2",  
+        "0x4",  
+        "0x10",  
+        "0x40",  
+        "0x80"},  
+     format("x"),  
+     read]  
+     uint32  AuthTypeSupported;  
+};  
+  
+[Dynamic,  
+ Description("IIS authentication succeeds") : amended,  
+ EventType(11),  
+ EventLevel(4),  
+ EventTypeName("AUTH_SUCCEEDED") : amended  
+]  
+class W3AuthSucceeded:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Auth type actually used to authenticate the request") : amended,  
+     ValueDescriptions{  
+        "Anonymous authentication",  
+        "Basic authentication",  
+        "Windows integrated authentication",  
+        "Digest authenticaion",  
+        "Passport authentication",  
+        "SSL Certificate mapping authentication"} : amended,  
+     DefineValues{  
+        "MD_AUTH_ANONYMOUS",  
+        "MD_AUTH_BASIC",   
+        "MD_AUTH_NT",  
+        "MD_AUTH_MD5",             
+        "MD_AUTH_PASSPORT",  
+        "MD_ACCESS_MAP_CERT"},                     
+     Values{  
+        "Anonymous",  
+        "Basic",  
+        "NT",  
+        "Digest",  
+        "Passport",  
+        "CertMap"},  
+     ValueMap{  
+        "0x1",  
+        "0x2",  
+        "0x4",  
+        "0x10",  
+        "0x40",  
+        "0x80"},  
+     format("x"),  
+     read]  
+     uint32  AuthType;  
+    [WmiDataId(3),  
+     Description("NTLM is used during SSPI authentication") : amended,  
+     read]  
+     boolean NTLMUsed;  
+    [WmiDataId(4),  
+     Description("Remote user name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  RemoteUserName;  
+    [WmiDataId(5),  
+     Description("Authenticated user name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  AuthUserName;  
+    [WmiDataId(6),  
+     Description("The token impersonation level") : amended,  
+     ValueDescriptions{  
+        "Anonymous impersonation level",  
+        "Identify impersonation level",  
+        "Impersonate impersonation level",  
+        "Delegate impersonation level",  
+        "Unable to determine impersonation level"} : amended,  
+     DefineValues{  
+        "IMPERSONATION_LEVEL_ANONYMOUS",  
+        "IMPERSONATION_LEVEL_IDENTIFY",   
+        "IMPERSONATION_LEVEL_IMPERSONATE",  
+        "IMPERSONATION_LEVEL_DELEGATE",  
+        "IMPERSONATION_LEVEL_UNKNOWN"},                     
+     Values{  
+        "ImpersonationAnonymous",  
+        "ImpersonationIdentify",  
+        "ImpersonationImpersonate",  
+        "ImpersonationDelegate",  
+        "ImpersonationUnknown"} : amended,  
+     ValueMap{  
+        "0x0",  
+        "0x1",  
+        "0x2",  
+        "0x3",  
+        "0x4"},  
+     ValueType("index"),  
+     format("x"),  
+     read]  
+     uint32  TokenImpersonationLevel;  
+};  
+  
+[Dynamic,  
+ Description("The authentication type is not supported by configuration") : amended,  
+ EventType(12),  
+ EventLevel(3),  
+ EventTypeName("AUTH_TYPE_NOT_SUPPORTED") : amended  
+]  
+class W3AuthTypeNotSupported:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Invalid anonymous account on the request URL") : amended,  
+ EventType(13),  
+ EventLevel(2),  
+ EventTypeName("AUTH_INVALID_ANON_ACCOUNT") : amended  
+]  
+class W3AuthInvalidAnonAccount:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Logon error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("User password needs to be changed") : amended,  
+ EventType(14),  
+ EventLevel(3),  
+ EventTypeName("AUTH_PASSWD_CHANGE_NEEDED") : amended  
+]  
+class W3AuthPasswdChangeNeeded:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Password change disabled on the request URL") : amended,  
+ EventType(15),  
+ EventLevel(3),  
+ EventTypeName("AUTH_PASSWD_CHANGE_DISABLED") : amended  
+]  
+class W3AuthPasswdChangeDisabled:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Bad Basic header in the request") : amended,  
+ EventType(16),  
+ EventLevel(3),  
+ EventTypeName("AUTH_BAD_BASIC_HEADER") : amended  
+]  
+class W3AuthBadBasicHeader:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Basic logon failed") : amended,  
+ EventType(17),  
+ EventLevel(3),  
+ EventTypeName("AUTH_BASIC_LOGON_FAILED") : amended  
+]  
+class W3AuthBasicLogonFailed:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Logon error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Advanced digest logon failed") : amended,  
+ EventType(18),  
+ EventLevel(3),  
+ EventTypeName("AUTH_WDIGEST_LOGON_FAILED") : amended  
+]  
+class W3AuthWDigestLogonFailed:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Logon error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Legacy digest logon failed") : amended,  
+ EventType(19),  
+ EventLevel(3),  
+ EventTypeName("AUTH_IISDIGEST_LOGON_FAILED") : amended  
+]  
+class W3AuthIISDigestLogonFailed:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Logon error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Passport logon failed") : amended,  
+ EventType(20),  
+ EventLevel(3),  
+ EventTypeName("AUTH_PASSPORT_LOGON_FAILED") : amended  
+]  
+class W3AuthPassportLogonFailed:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Logon error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Integrated windows logon failed") : amended,  
+ EventType(21),  
+ EventLevel(3),  
+ EventTypeName("AUTH_SSPI_LOGON_FAILED") : amended  
+]  
+class W3AuthSSPILogonFailed:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Logon error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("NTLM null session detected") : amended,  
+ EventType(22),  
+ EventLevel(3),  
+ EventTypeName("AUTH_NTLM_NULL_SESSION") : amended  
+]  
+class W3AuthNTLMNullSession:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Integrated windows logon continue needed") : amended,  
+ EventType(23),  
+ EventLevel(4),  
+ EventTypeName("AUTH_SSPI_CONTINUE_NEEDED") : amended  
+]  
+class W3AuthSSPIContinueNeeded:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Package name used during SSPI authentication") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string PackageName;  
+};  
+  
+[Dynamic,  
+ Description("Unable to negotiate Kerberos authentication") : amended,  
+ EventType(55),  
+ EventLevel(3),  
+ EventTypeName("AUTH_KERBEROS_FAILED") : amended  
+]  
+class W3AuthKerberosFailed:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Kernel mode is used during SSPI authentication") : amended,  
+     read]  
+     boolean KMUsed;  
+    [WmiDataId(3),  
+     Description("App pool user name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  APUserName;  
+    [WmiDataId(4),  
+     Description("Service principal name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  SPNName;  
+    [WmiDataId(5),  
+     Description("Active directory configured properly") : amended,  
+     read]  
+     boolean ADConfigIsOK;  
+    [WmiDataId(6),  
+     Description("Kerberos configuration details") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  KerberosInfo;  
+};  
+  
+[Dynamic,  
+ Description("Anonymous account password needs to be changed") : amended,  
+ EventType(24),  
+ EventLevel(2),  
+ EventTypeName("AUTH_ANON_PASSWD_CHANGE_NEEDED") : amended  
+]  
+class W3AuthAnonPasswdChangeNeeded:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Authentication type in the request") : amended,  
+ EventType(27),  
+ EventLevel(4),  
+ EventTypeName("AUTH_REQUEST_AUTH_TYPE") : amended  
+]  
+class W3AuthRequestAuthType:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Auth type of the request") : amended,  
+     ValueDescriptions{  
+        "Anonymous authentication",  
+        "Basic authentication",  
+        "Windows integrated authentication",  
+        "Digest authenticaion",  
+        "Passport authentication",  
+        "SSL Certificate mapping authentication"} : amended,  
+     DefineValues{  
+        "MD_AUTH_ANONYMOUS",  
+        "MD_AUTH_BASIC",   
+        "MD_AUTH_NT",  
+        "MD_AUTH_MD5",             
+        "MD_AUTH_PASSPORT",  
+        "MD_ACCESS_MAP_CERT"},                     
+     Values{  
+        "Anonymous",  
+        "Basic",  
+        "NT",  
+        "Digest",  
+        "Passport",  
+        "CertMap"},  
+     ValueMap{  
+        "0x1",  
+        "0x2",  
+        "0x4",  
+        "0x10",  
+        "0x40",  
+        "0x80"},  
+      format("x"),  
+     read]  
+     uint32  RequestAuthType;  
+};  
+  
+[Dynamic,  
+ Description("IIS authentication ends") : amended,  
+ EventType(28),  
+ EventLevel(4),  
+ EventTypeName("AUTH_END") : amended  
+]  
+class W3AuthEnd:IIS_Authentication_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS security events") : amended,  
+ Guid("{29347ffb-ba48-41e6-bffd-469c5e543ca5}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISSecurity"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Security_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("Illegal short file name") : amended,  
+ EventType(10),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_ILLEGAL_SHORT_FILENAME") : amended  
+]  
+class W3SecIllegalShortFilename:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Illegal short file name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  FileName;  
+};  
+  
+[Dynamic,  
+ Description("Remote IP rejected") : amended,  
+ EventType(11),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_REJECTED_IP") : amended  
+]  
+class W3SecRejectedIP:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Rejected IP address") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  IPAddress;  
+};  
+  
+[Dynamic,  
+ Description("Hostname rejected") : amended,  
+ EventType(12),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_REJECTED_HOSTNAME") : amended  
+]  
+class W3SecRejectedHostname:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Rejected host name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  HostName;  
+};  
+  
+[Dynamic,  
+ Description("IIS requires 128bit SSL Encryption") : amended,  
+ EventType(13),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_REJECTED_REQUIRE_SSL_128") : amended  
+]  
+class W3SecRequireSSL128:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("File access is denied") : amended,  
+ EventType(14),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_FILE_ACCESS_DENIED") : amended  
+]  
+class W3SecFileAccessDenied:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The name of the file being accessed") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  FileName;  
+    [WmiDataId(3),  
+     Description("The account name used to access the file") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  AccountName;  
+    [WmiDataId(4),  
+     Description("The domain name of the account used to access the file") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  DomainName;  
+};  
+  
+[Dynamic,  
+ Description("File access is denied by mime map policy") : amended,  
+ EventType(15),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_DENIED_BY_MIMEMAP") : amended  
+]  
+class W3SecDeniedByMimemap:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The name of the file being denied by mime map") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  FileName;  
+};  
+  
+[Dynamic,  
+ Description("Access is denied by ISAPI restriction") : amended,  
+ EventType(16),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_DENIED_BY_ISAPI_RESTRICTION") : amended  
+]  
+class W3SecDeniedByISAPIRestriction:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The gateway image name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ImageName;  
+};  
+  
+[Dynamic,  
+ Description("Access is denied by CGI restriction") : amended,  
+ EventType(17),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_DENIED_BY_CGI_RESTRICTION") : amended  
+]  
+class W3SecDeniedByCGIRestriction:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The gateway image name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ImageName;  
+};  
+  
+[Dynamic,  
+ Description("Access is denied by access flags") : amended,  
+ EventType(18),  
+ EventLevel(3),  
+ EventTypeName("SECURITY_DENIED_BY_ACCESS_FLAGS") : amended  
+]  
+class W3SecDeniedByAccessFlags:IIS_Security_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Flags from configuration") : amended,  
+     format("x"),  
+     read]  
+     uint32  CurrentFlags;  
+    [WmiDataId(3),  
+     Description("Flags needed to continue") : amended,  
+     format("x"),  
+     read]  
+     uint32  NeededFlags;  
+};  
+  
+[Dynamic,  
+ Description("IIS filter events") : amended,  
+ Guid("{00237f0d-73eb-4bcf-a232-126693595847}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISFilter"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Filter_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 filter starts") : amended,  
+ EventType(1),  
+ EventLevel(0),  
+ EventTypeName("FILTER_START") : amended  
+]  
+class W3FilterStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Filter Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FilterName;  
+};  
+  
+[Dynamic,  
+ Description("W3 filter ends") : amended,  
+ EventType(2),  
+ EventLevel(0),  
+ EventTypeName("FILTER_END") : amended  
+]  
+class W3FilterEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+   [WmiDataId(2),  
+    Description("Notification Status") : amended,  
+    ValueDescriptions{  
+        "Request finished",  
+        "Request finished keep alive",  
+        "Continue notification",  
+        "Notification finished",  
+        "Error",  
+        "Read next data"  
+     } : amended,  
+     DefineValues{  
+        "SF_STATUS_REQ_FINISHED",  
+        "SF_STATUS_REQ_FINISHED_KEEP_CONN",  
+        "SF_STATUS_REQ_NEXT_NOTIFICATION",  
+        "SF_STATUS_REQ_HANDLED_NOTIFICATION",  
+        "SF_STATUS_REQ_ERROR",  
+        "SF_STATUS_REQ_READ_NEXT"  
+    },  
+    Values{  
+        "SF_STATUS_REQ_FINISHED",  
+        "SF_STATUS_REQ_FINISHED_KEEP_CONN",  
+        "SF_STATUS_REQ_NEXT_NOTIFICATION",  
+        "SF_STATUS_REQ_HANDLED_NOTIFICATION",  
+        "SF_STATUS_REQ_ERROR",  
+        "SF_STATUS_REQ_READ_NEXT"  
+    },  
+    ValueMap{  
+        "0x08000000",  
+        "0x08000001",  
+        "0x08000002",  
+        "0x08000003",  
+        "0x08000004",  
+        "0x08000005"  
+    },  
+    ValueType("index")]  
+    uint32  NotificationStatus;  
+};  
+  
+[Dynamic,  
+ Description("Filter error") : amended,  
+ EventType(12),  
+ EventLevel(2),  
+ EventTypeName("FILTER_ERROR") : amended  
+]  
+class W3FilterError:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Filter Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Filter starts PREPROC_HEADERS notification") : amended,  
+ EventType(13),  
+ EventLevel(4),  
+ EventTypeName("FILTER_PREPROC_HEADERS_START") : amended  
+]  
+class W3FilterPreprocStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Filter ends PREPROC_HEADERS notification") : amended,  
+ EventType(14),  
+ EventLevel(4),  
+ EventTypeName("FILTER_PREPROC_HEADERS_END") : amended  
+]  
+class W3FilterPreprocEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS starts URL_MAP notification") : amended,  
+ EventType(15),  
+ EventLevel(4),  
+ EventTypeName("FILTER_URL_MAP_START") : amended  
+]  
+class W3FilterURLMapStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Original URL") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigURL;  
+    [WmiDataId(3),  
+     Description("Original Path") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigPath;  
+    [WmiDataId(4),  
+     Description("The AccessPerm that applies to this URL") : amended,  
+     format("x"),  
+     read]  
+     uint32  AccessPerms;  
+    [WmiDataId(5),  
+     Description("Number of matching characters in physical path") : amended,  
+     read]  
+     uint32  MatchingPath;  
+    [WmiDataId(6),  
+     Description("Number of matching characters in the URL") : amended,  
+     read]  
+     uint32  MatchingURL;  
+    [WmiDataId(7),  
+     Description("The script mapped entry for this URL") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  ScriptMapEntry;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends URL_MAP notification") : amended,  
+ EventType(16),  
+ EventLevel(4),  
+ EventTypeName("FILTER_URL_MAP_END") : amended  
+]  
+class W3FilterURLMapEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Final URL") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalURL;  
+    [WmiDataId(3),  
+     Description("Final Path") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalPath;  
+    [WmiDataId(4),  
+     Description("The AccessPerm that applies to this URL") : amended,  
+     format("x"),  
+     read]  
+     uint32  AccessPerms;  
+    [WmiDataId(5),  
+     Description("Number of matching characters in physical path") : amended,  
+     read]  
+     uint32  MatchingPath;  
+    [WmiDataId(6),  
+     Description("Number of matching characters in the URL") : amended,  
+     read]  
+     uint32  MatchingURL;  
+    [WmiDataId(7),  
+     Description("The script mapped entry for this URL") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  ScriptMapEntry;  
+};  
+  
+[Dynamic,  
+ Description("IIS starts AUTHENTICATION notification") : amended,  
+ EventType(17),  
+ EventLevel(4),  
+ EventTypeName("FILTER_AUTHENTICATION_START") : amended  
+]  
+class W3FilterAuthenticationStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Original user name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigUserName;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends AUTHENTICATION notification") : amended,  
+ EventType(18),  
+ EventLevel(4),  
+ EventTypeName("FILTER_AUTHENTICATION_END") : amended  
+]  
+class W3FilterAuthenticationEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Final user name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalUserName;  
+    [WmiDataId(3),  
+     Description("Password changed or not") : amended,  
+     read]  
+     boolean PasswordChanged;  
+};  
+  
+[Dynamic,  
+ Description("IIS starts AUTH_COMPLETE notification") : amended,  
+ EventType(19),  
+ EventLevel(4),  
+ EventTypeName("FILTER_AUTH_COMPLETE_START") : amended  
+]  
+class W3FilterAuthCompleteStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS ends AUTH_COMPLETE notification") : amended,  
+ EventType(20),  
+ EventLevel(4),  
+ EventTypeName("FILTER_AUTH_COMPLETE_END") : amended  
+]  
+class W3FilterAuthCompleteEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS starts SEND_RESPONSE notification") : amended,  
+ EventType(21),  
+ EventLevel(4),  
+ EventTypeName("FILTER_SEND_RESPONSE_START") : amended  
+]  
+class W3FilterSendResponseStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The current HTTP status code") : amended,  
+     read]  
+     uint32  HttpStatus;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends SEND_RESPONSE notification") : amended,  
+ EventType(22),  
+ EventLevel(4),  
+ EventTypeName("FILTER_SEND_RESPONSE_END") : amended  
+]  
+class W3FilterSendResponseEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS starts END_OF_REQUEST notification") : amended,  
+ EventType(23),  
+ EventLevel(4),  
+ EventTypeName("FILTER_END_OF_REQUEST_START") : amended  
+]  
+class W3FilterEndOfRequestStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS ends END_OF_REQUEST notification") : amended,  
+ EventType(24),  
+ EventLevel(4),  
+ EventTypeName("FILTER_END_OF_REQUEST_END") : amended  
+]  
+class W3FilterEndOfRequestEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS starts LOG notification") : amended,  
+ EventType(25),  
+ EventLevel(4),  
+ EventTypeName("FILTER_LOG_START") : amended  
+]  
+class W3FilterLogStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Original client host name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigClientHostName;  
+    [WmiDataId(3),  
+     Description("Original client user name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigClientUserName;  
+    [WmiDataId(4),  
+     Description("Original server name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigServerName;  
+    [WmiDataId(5),  
+     Description("Original operation") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigOperation;  
+    [WmiDataId(6),  
+     Description("Original target") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigTarget;  
+    [WmiDataId(7),  
+     Description("Original parameters") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  OrigParameters;  
+    [WmiDataId(8),  
+     Description("Original HTTP status") : amended,  
+     read]  
+     uint32  OrigHttpStatus;  
+    [WmiDataId(9),  
+     Description("Original win32 status") : amended,  
+     read]  
+     uint32  OrigWin32Status;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends LOG notification") : amended,  
+ EventType(26),  
+ EventLevel(4),  
+ EventTypeName("FILTER_LOG_END") : amended  
+]  
+class W3FilterLogEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Final client host name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalClientHostName;  
+    [WmiDataId(3),  
+     Description("Final client user name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalClientUserName;  
+    [WmiDataId(4),  
+     Description("Final server name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalServerName;  
+    [WmiDataId(5),  
+     Description("Final operation") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalOperation;  
+    [WmiDataId(6),  
+     Description("Final target") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalTarget;  
+    [WmiDataId(7),  
+     Description("Final parameters") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  FinalParameters;  
+    [WmiDataId(8),  
+     Description("Final HTTP status") : amended,  
+     read]  
+     uint32  FinalHttpStatus;  
+    [WmiDataId(9),  
+     Description("Final win32 status") : amended,  
+     read]  
+     uint32  FinalWin32Status;  
+};  
+  
+[Dynamic,  
+ Description("IIS starts SEND_RAW_DATA notification") : amended,  
+ EventType(27),  
+ EventLevel(4),  
+ EventTypeName("FILTER_SEND_RAW_DATA_START") : amended  
+]  
+class W3FilterSendRawDataStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS ends SEND_RAW_DATA notification") : amended,  
+ EventType(28),  
+ EventLevel(4),  
+ EventTypeName("FILTER_SEND_RAW_DATA_END") : amended  
+]  
+class W3FilterSendRawDataEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS starts ACCESS_DENIED notification") : amended,  
+ EventType(29),  
+ EventLevel(4),  
+ EventTypeName("FILTER_ACCESS_DENIED_START") : amended  
+]  
+class W3FilterAccessDeniedStart:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The requested URL") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  RequestedURL;  
+    [WmiDataId(3),  
+     Description("The physical path of the sources") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  PhysicalPath;  
+    [WmiDataId(4),  
+     Description("Denial reason") : amended,  
+     read]  
+     uint32  DenialReason;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends ACCESS_DENIED notification") : amended,  
+ EventType(30),  
+ EventLevel(4),  
+ EventTypeName("FILTER_ACCESS_DENIED_END") : amended  
+]  
+class W3FilterAccessDeniedEnd:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS filter SET_REQ_HEADER") : amended,  
+ EventType(31),  
+ EventLevel(4),  
+ EventTypeName("FILTER_SET_REQ_HEADER") : amended  
+]  
+class W3FilterSetReqHeader:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The header name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderName;  
+    [WmiDataId(3),  
+     Description("The header value") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderValue;  
+};  
+  
+[Dynamic,  
+ Description("IIS filter ADD_REQ_HEADER") : amended,  
+ EventType(32),  
+ EventLevel(4),  
+ EventTypeName("FILTER_ADD_REQ_HEADER") : amended  
+]  
+class W3FilterAddReqHeader:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The header name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderName;  
+    [WmiDataId(3),  
+     Description("The header value") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderValue;  
+};  
+  
+[Dynamic,  
+ Description("IIS filter SET_RESP_HEADER") : amended,  
+ EventType(33),  
+ EventLevel(4),  
+ EventTypeName("FILTER_SET_RESP_HEADER") : amended  
+]  
+class W3FilterSetRespHeader:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The header name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderName;  
+    [WmiDataId(3),  
+     Description("The header value") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderValue;  
+};  
+  
+[Dynamic,  
+ Description("IIS filter ADD_RESP_HEADER") : amended,  
+ EventType(34),  
+ EventLevel(4),  
+ EventTypeName("FILTER_ADD_RESP_HEADER") : amended  
+]  
+class W3FilterAddRespHeader:IIS_Filter_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("The header name") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderName;  
+    [WmiDataId(3),  
+     Description("The header value") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  HeaderValue;  
+};  
+  
+[Dynamic,  
+ Description("IIS static file events") : amended,  
+ Guid("{79b02104-0db9-4cda-a552-058d97c2ecfd}"),  
+ EventVersion(1),  
+ DisplayName("IISStaticFile"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Static_File_Trans:IIS_Trace  
+{  
+};  
+  
+  
+[Dynamic,  
+ Description("IIS ISAPI events") : amended,  
+ Guid("{2e94e6c7-eda0-4b73-9010-2529edce1c27}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISISAPI"),  
+ locale("MS\\0x409")  
+]  
+class Isapi_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS starts processing an ISAPI Request") : amended,  
+ EventType{1},  
+ EventLevel(0),  
+ EventTypeName{"ISAPI_START"} : amended  
+]  
+class W3ISAPIStart:Isapi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS ends processing an ISAPI Request") : amended,  
+ EventType{2},  
+ EventLevel(0),  
+ EventTypeName{"ISAPI_END"} : amended  
+]  
+class W3ISAPIEnd:Isapi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+
+[Dynamic,  
+ Description("IIS CGI events") : amended,  
+ Guid("{e2e55403-0d2e-4609-a470-be0da04013c0}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISCGI"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Cgi_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS starts processing a CGI Request") : amended,  
+ EventType{1},  
+ EventLevel(0),  
+ EventTypeName{"CGI_START"} : amended  
+]  
+class W3CGIStart:IIS_Cgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS ends processing a CGI Request") : amended,  
+ EventType{2},  
+ EventLevel(0),  
+ EventTypeName{"CGI_END"} : amended  
+]  
+class W3CGIEnd:IIS_Cgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS launches a CGI") : amended,  
+ EventType{3},  
+ EventLevel(4),  
+ EventTypeName{"CGI_LAUNCH"} : amended  
+]  
+class W3CGILaunch:IIS_Cgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Command line") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  CommandLine;  
+    [WmiDataId(3),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+    [WmiDataId(4),  
+     Description("Process Id") : amended,  
+     read]  
+     uint32  ProcessId;  
+};  
+  
+[Dynamic,  
+ Description("IIS times out a CGI Request") : amended,  
+ EventType{4},  
+ EventLevel(4),  
+ EventTypeName{"CGI_TIMEOUT"} : amended  
+]  
+class W3CGITimeout:IIS_Cgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Headers received") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  Headers;  
+};  
+  
+[Dynamic,  
+ Description("CGI terminates before providing a complete set of headers") : amended,  
+ EventType{5},  
+ EventLevel(4),  
+ EventTypeName{"CGI_PREMATURE_TERMINATION"} : amended  
+]  
+class W3CGIPrematureTermination:IIS_Cgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Headers received") : amended,  
+     StringTermination("NullTerminated"),  
+     read]  
+     string  Headers;  
+};  
+  
+[Dynamic,  
+ Description("IIS has finished sending request entity to the CGI") : amended,  
+ EventType{6},  
+ EventLevel(4),  
+ EventTypeName{"CGI_REQUEST_ENTITY_SENT"} : amended  
+]  
+class W3CGIRequestEntitySent:IIS_Cgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS has received headers from the CGI") : amended,  
+ EventType{7},  
+ EventLevel(4),  
+ EventTypeName{"CGI_HEADERS_RECEIVED"} : amended  
+]  
+class W3CGIHeadersReceived:IIS_Cgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+
+  
+[Dynamic,  
+ Description("IIS FastCGI events") : amended,  
+ Guid("{e3642acc-3627-42b0-8372-867baa033b07}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISFastCGI"),  
+ locale("MS\\0x409")  
+]  
+class IIS_FastCgi_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("The FastCGI process exceeded activity timeout") : amended,  
+ EventType{1},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_ACTIVITY_TIMEOUT"} : amended  
+]  
+class W3CGIFActivityTimeout:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("The FastCGI process exceeded request timeout") : amended,  
+ EventType{2},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_REQUEST_TIMEOUT"} : amended  
+]  
+class W3CGIFRequestTimeout:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("The FastCGI process exited unexpectedly") : amended,  
+ EventType{3},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_UNEXPECTED_EXIT"} : amended  
+]  
+class W3CGIFUnexpectedExit:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("The FastCGI process has failed too frequently recently") : amended,  
+ EventType{4},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_RAPID_FAILURE_PROTECTION"} : amended  
+]  
+class W3CGIFRapidFailureProtection:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("The FastCGI process could not be found") : amended,  
+ EventType{5},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_PATH_NOT_FOUND"} : amended  
+]  
+class W3CGIFPathNotFound:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("The FastCGI script processor is not configured") : amended,  
+ EventType{6},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_SCRIPT_PROCESSOR_MISSING"} : amended  
+]  
+class W3CGIFScriptProcessorMissing:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("The FastCGI process could not be added to a JobObject") : amended,  
+ EventType{7},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_ADD_JOBOBJECT_FAIL"} : amended  
+]  
+class W3CGIFAddJobObjectFail:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Either the worker process is shutting down or a config change occurred") : amended,  
+ EventType{8},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_APPLICATION_MANAGER_SHUTDOWN"} : amended  
+]  
+class W3CGIFAppMgrShutdown:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("The FastCGI queue is full") : amended,  
+ EventType{9},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_QUEUE_FULL"} : amended  
+]  
+class W3CGIFQueueFull:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("An unknown FastCGI error occurred") : amended,  
+ EventType{10},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_UNKNOWN_ERROR"} : amended  
+]  
+class W3CGIFUnknownError:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("The FastCGI response has been written to IIS") : amended,  
+ EventType{11},  
+ EventLevel(4),  
+ EventTypeName{"FASTCGI_RESPONSE_WRITTEN"} : amended  
+]  
+class W3CGIFResponseWritten:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Waiting for FastCGI process to respond") : amended,  
+ EventType{12},  
+ EventLevel(5),  
+ EventTypeName{"FASTCGI_WAITING_FOR_RESPONSE"} : amended  
+]  
+class W3CGIFWaitingForResponse:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("FastCGI error trace on stderr stream") : amended,  
+ EventType{13},  
+ EventLevel(2),  
+ EventTypeName{"FASTCGI_STDERR_TRACE_ERROR"} : amended  
+]  
+class W3CGIFTraceError:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Message") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string Message;  
+};  
+  
+[Dynamic,  
+ Description("FastCGI warning trace on stderr stream") : amended,  
+ EventType{14},  
+ EventLevel(3),  
+ EventTypeName{"FASTCGI_STDERR_TRACE_WARNING"} : amended  
+]  
+class W3CGIFTraceWarning:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Message") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string Message;  
+};  
+  
+[Dynamic,  
+ Description("FastCGI info trace on stderr stream") : amended,  
+ EventType{15},  
+ EventLevel(5),  
+ EventTypeName{"FASTCGI_STDERR_TRACE_INFO"} : amended  
+]  
+class W3CGIFTraceInfo:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Message") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string Message;  
+};  
+  
+[Dynamic,  
+ Description("Adding request to wait queue because all processes are busy") : amended,  
+ EventType{16},  
+ EventLevel(0),  
+ EventTypeName{"FASTCGI_QUEUE_REQUEST"} : amended  
+]  
+class W3CGIFQueueRequest:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Position in queue") : amended,  
+     read]  
+     uint32  PositionInQueue;  
+    [WmiDataId(3),  
+     Description("Max fastcgi process allowed") : amended,  
+     read]  
+     uint32  MaxInstances;  
+};  
+  
+[Dynamic,  
+ Description("Fastcgi process assigned to this request") : amended,  
+ EventType{17},  
+ EventLevel(0),  
+ EventTypeName{"FASTCGI_ASSIGN_PROCESS"} : amended  
+]  
+class W3CGIFAssignProcess:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Command line") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  CommandLine;  
+    [WmiDataId(3),  
+     Description("Is a new process") : amended,  
+     read]  
+     boolean IsNewProcess;  
+    [WmiDataId(4),  
+     Description("Process Id") : amended,  
+     read]  
+     uint32  ProcessId;  
+    [WmiDataId(5),  
+     Description("Number of requests served by this process instance") : amended,  
+     read]  
+     uint32  RequestNumber;  
+};  
+  
+[Dynamic,  
+ Description("Request processing start") : amended,  
+ EventType{18},  
+ EventLevel(0),  
+ EventTypeName{"FASTCGI_START"} : amended  
+]  
+class W3CGIFStart:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Request processing end") : amended,  
+ EventType{19},  
+ EventLevel(0),  
+ EventTypeName{"FASTCGI_END"} : amended  
+]  
+class W3CGIFEnd:IIS_FastCgi_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+
+[Dynamic,  
+ Description("IIS Websocket events") : amended,  
+ Guid("{2ce74327-08be-425c-bfc5-1534fe7fefa6}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISWebSocket"),  
+ locale("MS\\0x409")  
+]  
+class IIS_WebSocket_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("Websocket request initialization failed") : amended,  
+ EventType{1},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_INITIALIZE_FAILED"} : amended  
+]  
+class W3WebSocketInitializeNotSuccess:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Websocket is beginning server handshake") : amended,  
+ EventType{2},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_HANDSHAKE_START"} : amended  
+]  
+class W3WebSocketStart:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Websocket completed server handshake successfully") : amended,  
+ EventType{3},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_HANDSHAKE_SUCCESS"} : amended  
+]  
+class W3WebSocketEndSuccess:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Websocket completed server handshake unsuccessfully") : amended,  
+ EventType{4},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_HANDSHAKE_NOT_SUCCESS"} : amended  
+]  
+class W3WebSocketEndFailure:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Websocket received a read request from application") : amended,  
+ EventType{5},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_READ_FRAGMENT_START"} : amended  
+]  
+class W3WebSocketReadFragmentStart:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Buffer Size") : amended,  
+     format("x"),  
+     read]  
+     uint32  BufferSize;  
+};  
+  
+[Dynamic,  
+ Description("Websocket returned Pending for an application read request") : amended,  
+ EventType{6},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_READ_FRAGMENT_END_PENDING"} : amended  
+]  
+class W3WebSocketReadFragmentEndPending:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Websocket completed the application read request successfully") : amended,  
+ EventType{7},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_READ_FRAGMENT_END_SUCCESS"} : amended  
+]  
+class W3WebSocketReadFragmentEndSuccess:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Bytes Received") : amended,  
+     format("x"),  
+     read]  
+     uint32  BytesReceived;  
+};  
+  
+[Dynamic,  
+ Description("Websocket failed to complete application read request") : amended,  
+ EventType{8},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_READ_FRAGMENT_END_NOT_SUCCESS"} : amended  
+]  
+class W3WebSocketReadFragmentEndFailure:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Websocket received a write request from application") : amended,  
+ EventType{9},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_WRITE_FRAGMENT_START"} : amended  
+]  
+class W3WebSocketWriteFragmentStart:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Data Type") : amended,  
+     format("x"),  
+     read]  
+     uint32  DataType;  
+  
+    [WmiDataId(3),  
+     Description("Data Size") : amended,  
+     format("x"),  
+     read]  
+     uint32  DataSize;  
+};  
+  
+[Dynamic,  
+ Description("Websocket returned Pending for an application write request") : amended,  
+ EventType{10},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_WRITE_FRAGMENT_END_PENDING"} : amended  
+]  
+class W3WebSocketWriteFragmentEndPending:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Websocket completed the application write request successfully") : amended,  
+ EventType{11},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_WRITE_FRAGMENT_END_SUCCESS"} : amended  
+]  
+class W3WebSocketWriteFragmentEndSuccess:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Bytes Sent") : amended,  
+     format("x"),  
+     read]  
+     uint32  BytesSent;  
+};  
+  
+[Dynamic,  
+ Description("Websocket failed to complete application write request") : amended,  
+ EventType{12},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_WRITE_FRAGMENT_END_NOT_SUCCESS"} : amended  
+]  
+class W3WebSocketWriteFragmentEndFailure:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Websocket received a close connection request from the application") : amended,  
+ EventType{13},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_APPLICATION_CLOSE_CONNECTION"} : amended  
+]  
+class W3WebSocketApplicationCloseConnection:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Websocket closed the tcp connection") : amended,  
+ EventType{14},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_MODULE_CLOSE_CONNECTION"} : amended  
+]  
+class W3WebSocketModuleCloseConnection:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Reason for closing connection") : amended,  
+        ValueDescriptions{  
+            "Ping timeout reached" } : amended,  
+        DefineValues{  
+            "PING_TIMEOUT" },  
+        Values{  
+            "PING_TIMEOUT" },  
+        ValueMap{  
+            "1"},  
+        ValueType("index")]  
+     uint32  Reason;  
+};  
+  
+[Dynamic,  
+ Description("Websocket read IO failed") : amended,  
+ EventType{15},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_READ_IO_NOT_SUCCESS"} : amended  
+]  
+class W3WebSocketReadIoFailed:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Websocket write IO failed ") : amended,  
+ EventType{16},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_WRITE_IO_NOT_SUCCESS"} : amended  
+]  
+class W3WebSocketWriteIoFailed:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Websocket received a close frame from the client") : amended,  
+ EventType{17},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_RECEIVED_CLOSE"} : amended  
+]  
+class W3WebSocketCloseReceived:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Close Status") : amended,  
+     format("x"),  
+     read]  
+     uint32  Status;  
+  
+    [WmiDataId(3),  
+     Description("Close Reason") : amended,  
+     format("w"),  
+     read]  
+     string Reason;  
+};  
+  
+[Dynamic,  
+ Description("Websocket received a request to send a close frame to the client") : amended,  
+ EventType{18},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_SEND_CLOSE_START"} : amended  
+]  
+class W3WebSocketCloseSendStart:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("Close Status") : amended,  
+     format("x"),  
+     read]  
+     uint32  Status;  
+  
+    [WmiDataId(3),  
+     Description("Close Reason") : amended,  
+     format("w"),  
+     read]  
+     string Reason;  
+};  
+  
+[Dynamic,  
+ Description("Websocket send a close frame successfully") : amended,  
+ EventType{19},  
+ EventLevel(5),  
+ EventTypeName{"WEBSOCKET_SEND_CLOSE_END_SUCCESS"} : amended  
+]  
+class W3WebSocketCloseSendSuccess:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Websocket failed to send a close frame") : amended,  
+ EventType{20},  
+ EventLevel(4),  
+ EventTypeName{"WEBSOCKET_SEND_CLOSE_END_NOT_SUCCESS"} : amended  
+]  
+class W3WebSocketCloseSendFailure:IIS_WebSocket_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+  
+    [WmiDataId(2),  
+     Description("ErrorCode") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+
+[Dynamic,  
+ Description("IIS compression event") : amended,  
+ Guid("{e60cee96-4472-448d-a13c-2170b18220ec}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISCompression"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Compression_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS is starting static compression") : amended,  
+ EventType{1},  
+ EventLevel(4),  
+ EventTypeName{"STATIC_COMPRESSION_START"} : amended  
+]  
+class W3StaticCompressionStart:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS has successfully served static compressed content") : amended,  
+ EventType{2},  
+ EventLevel(4),  
+ EventTypeName{"STATIC_COMPRESSION_SUCCESS"} : amended  
+]  
+class W3StaticCompressionSuccess:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS has been unsuccessful doing static compression") : amended,  
+ EventType{3},  
+ EventLevel(4),  
+ EventTypeName{"STATIC_COMPRESSION_NOT_SUCCESS"} : amended  
+]  
+class W3StaticCompressionNotSuccess:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Reason for not doing static compression") : amended,  
+        ValueDescriptions{  
+            "No Accept-Encoding sent by client",  
+            "compression is disabled because no suitable configuration was found",  
+            "Server not configured to compress 1.0 requests",  
+            "Server not configured to compress proxy requests",  
+            "No compression scheme matches for this extension/Accept-Encoding",  
+            "Unknown error",  
+            "Server not configured to compress range requests",  
+            "File smaller than compression threshold",  
+            "File encrypted",  
+            "Compressed copy does not exist",  
+            "Compressed copy out of date",  
+            "Server not configured to compress content-Type for this extension",  
+            "Document footer enabled for static files",  
+            "Url has not been requested frequently enough to justify compression",  
+            "Compressed copy could not be created" } : amended,  
+        DefineValues{  
+            "NO_ACCEPT_ENCODING",  
+            "COMPRESSION_DISABLED",  
+            "NO_COMPRESSION_10",  
+            "NO_COMPRESSION_PROXY",  
+            "NO_MATCHING_SCHEME",  
+            "UNKNOWN_ERROR",  
+            "NO_COMPRESSION_RANGE",  
+            "FILE_TOO_SMALL",  
+            "FILE_ENCRYPTED",  
+            "COMPRESS_FILE_NOT_FOUND",  
+            "COMPRESS_FILE_STALE",  
+            "NO_MATCHING_CONTENT_TYPE",  
+            "FOOTER_ENABLED",  
+            "NOT_FREQUENTLY_HIT",  
+            "FAIL_TO_COMPRESS" },  
+        Values{  
+            "NO_ACCEPT_ENCODING",  
+            "COMPRESSION_DISABLED",  
+            "NO_COMPRESSION_10",  
+            "NO_COMPRESSION_PROXY",  
+            "NO_MATCHING_SCHEME",  
+            "UNKNOWN_ERROR",  
+            "NO_COMPRESSION_RANGE",  
+            "FILE_TOO_SMALL",  
+            "FILE_ENCRYPTED",  
+            "COMPRESS_FILE_NOT_FOUND",  
+            "COMPRESS_FILE_STALE",  
+            "NO_MATCHING_CONTENT_TYPE",  
+            "FOOTER_ENABLED",  
+            "NOT_FREQUENTLY_HIT",  
+            "FAIL_TO_COMPRESS" },  
+        ValueMap{  
+            "1",  
+            "2",  
+            "3",  
+            "4",  
+            "5",  
+            "6",  
+            "7",  
+            "8",  
+            "9",  
+            "10",  
+            "11",  
+            "12",  
+            "13",  
+            "14",  
+            "15"},  
+        ValueType("index")]  
+     uint32  Reason;  
+};  
+  
+[Dynamic,  
+ Description("IIS is starting to create static compressed copy") : amended,  
+ EventType{4},  
+ EventLevel(4),  
+ EventTypeName{"STATIC_COMPRESSION_CREATE_START"} : amended  
+]  
+class W3StaticCompressionCreateStart:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Original File name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  OriginalFileName;  
+};  
+  
+[Dynamic,  
+ Description("IIS has finished trying to create static compressed copy") : amended,  
+ EventType{5},  
+ EventLevel(4),  
+ EventTypeName{"STATIC_COMPRESSION_CREATE_END"} : amended  
+]  
+class W3StaticCompressionCreateEnd:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+    [WmiDataId(3),  
+     Description("Original File name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  OriginalFileName;  
+    [WmiDataId(4),  
+     Description("Original file size") : amended,  
+     read]  
+     uint32  OriginalFileSize;  
+    [WmiDataId(5),  
+     Description("Compressed File name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  CompressedFileName;  
+    [WmiDataId(6),  
+     Description("Compressed file size") : amended,  
+     read]  
+     uint32  CompressedFileSize;  
+};  
+  
+[Dynamic,  
+ Description("IIS is starting dynamic compression") : amended,  
+ EventType{6},  
+ EventLevel(4),  
+ EventTypeName{"DYNAMIC_COMPRESSION_START"} : amended  
+]  
+class W3DynamicCompressionStart:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS is successfully doing dynamic compression") : amended,  
+ EventType{7},  
+ EventLevel(4),  
+ EventTypeName{"DYNAMIC_COMPRESSION_SUCCESS"} : amended  
+]  
+class W3DynamicCompressionSuccess:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("IIS has been unsuccessful doing dynamic compression") : amended,  
+ EventType{8},  
+ EventLevel(4),  
+ EventTypeName{"DYNAMIC_COMPRESSION_NOT_SUCCESS"} : amended  
+]  
+class W3DynamicCompressionNotSuccess:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Reason for not doing dynamic compression") : amended,  
+        ValueDescriptions{  
+            "No Accept-Encoding sent by client",  
+            "compression is disabled because no suitable configuration was found",  
+            "Server not configured to compress 1.0 requests",  
+            "Server not configured to compress proxy requests",  
+            "No compression scheme matches for this extension/Accept-Encoding",  
+            "Unknown Error",  
+            "Headers being sent twice for the same response",  
+            "No Headers sent before entity body send",  
+            "The response status code is not success",  
+            "There is a content-encoding already present in the response",  
+            "Server not configured to compress range requests",  
+            "Server not configured to compress this content-Type" } : amended,  
+        DefineValues{  
+            "NO_ACCEPT_ENCODING",  
+            "COMPRESSION_DISABLED",  
+            "NO_COMPRESSION_10",  
+            "NO_COMPRESSION_PROXY",  
+            "NO_MATCHING_SCHEME",  
+            "UNKNOWN_ERROR",  
+            "HEADERS_SENT_TWICE",  
+            "NO_HEADER_SENT",  
+            "NOT_SUCCESS_STATUS",  
+            "ALREADY_CONTENT_ENCODING",  
+            "NO_COMPRESSION_RANGE",  
+            "NO_MATCHING_CONTENT_TYPE" },  
+        Values{  
+            "NO_ACCEPT_ENCODING",  
+            "COMPRESSION_DISABLED",  
+            "NO_COMPRESSION_10",  
+            "NO_COMPRESSION_PROXY",  
+            "NO_MATCHING_SCHEME",  
+            "UNKNOWN_ERROR",  
+            "HEADERS_SENT_TWICE",  
+            "NO_HEADER_SENT",  
+            "NOT_SUCCESS_STATUS",  
+            "ALREADY_CONTENT_ENCODING",  
+            "NO_COMPRESSION_RANGE",  
+            "NO_MATCHING_CONTENT_TYPE" },  
+        ValueMap{  
+            "1",  
+            "2",  
+            "3",  
+            "4",  
+            "5",  
+            "6",  
+            "7",  
+            "8",  
+            "9",  
+            "10",  
+            "11",  
+            "12"},  
+        ValueType("index")]  
+     uint32  Reason;  
+};  
+  
+[Dynamic,  
+ Description("IIS has dynamically compressed some data") : amended,  
+ EventType{9},  
+ EventLevel(5),  
+ EventTypeName{"DYNAMIC_COMPRESSION_DO"} : amended  
+]  
+class W3DynamicCompressionDo:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Original size") : amended,  
+     read]  
+     uint32  OriginalSize;  
+    [WmiDataId(3),  
+     Description("Compressed size") : amended,  
+     read]  
+     uint32  CompressedSize;  
+};  
+  
+[Dynamic,  
+ Description("Dynamic compression has finished") : amended,  
+ EventType{10},  
+ EventLevel(4),  
+ EventTypeName{"DYNAMIC_COMPRESSION_END"} : amended  
+]  
+class W3DynamicCompressionEnd:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+[Dynamic,  
+ Description("Static compression has finished") : amended,  
+ EventType{11},  
+ EventLevel(4),  
+ EventTypeName{"STATIC_COMPRESSION_END"} : amended  
+]  
+class W3StaticCompressionEnd:IIS_Compression_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+};  
+  
+
+[Dynamic,  
+ Description("IIS cache events") : amended,  
+ Guid("{ac1d69f1-bf33-4ca0-9313-bca13873e1dc}"),  
+ EventVersion(1),  
+ DisplayName("IISCache"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Cache_Trans:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS starts accessing file cache") : amended,  
+ EventType(10),  
+ EventLevel(4),  
+ EventTypeName("FILE_CACHE_ACCESS_START") : amended  
+]  
+class W3CacheFileCacheAccessStart:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("File name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  FileName;  
+    [WmiDataId(3),  
+     Description("User name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  UserName;  
+    [WmiDataId(4),  
+     Description("Domain name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  DomainName;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends accessing file cache") : amended,  
+ EventType(11),  
+ EventLevel(4),  
+ EventTypeName("FILE_CACHE_ACCESS_END") : amended  
+]  
+class W3CacheFileCacheAccessEnd:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Successful") : amended,  
+     read]  
+     boolean Successful;  
+    [WmiDataId(3),  
+     Description("File from cache") : amended,  
+     read]  
+     boolean FileFromCache;  
+    [WmiDataId(4),  
+     Description("File added to cache") : amended,  
+     read]  
+     boolean FileAddedToCache;  
+    [WmiDataId(5),  
+     Description("File being dirmonitored") : amended,  
+     read]  
+     boolean FileDirmoned;  
+    [WmiDataId(6),  
+     Description("Last-modified check (if done) error ignored") : amended,  
+     read]  
+     boolean LastModCheckErrorIgnored;  
+    [WmiDataId(7),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+    [WmiDataId(8),  
+     Description("GMT last modified time") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  LastModifiedTime;  
+};  
+  
+[Dynamic,  
+ Description("IIS starts accessing URL cache to get metadata") : amended,  
+ EventType(12),  
+ EventLevel(4),  
+ EventTypeName("URL_CACHE_ACCESS_START") : amended  
+]  
+class W3CacheURLCacheAccessStart:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Request URL") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  RequestURL;  
+};  
+  
+[Dynamic,  
+ Description("IIS ends accessing URL cache") : amended,  
+ EventType(13),  
+ EventLevel(4),  
+ EventTypeName("URL_CACHE_ACCESS_END") : amended  
+]  
+class W3CacheURLCacheAccessEnd:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Request Physical Path") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  PhysicalPath;  
+    [WmiDataId(3),  
+     Description("URL info from cache") : amended,  
+     read]  
+     boolean URLInfoFromCache;  
+    [WmiDataId(4),  
+     Description("URL info added to cache") : amended,  
+     read]  
+     boolean URLInfoAddedToCache;  
+    [WmiDataId(5),  
+     Description("Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("IIS decides if the request is HTTP.SYS cacheable") : amended,  
+ EventType(14),  
+ EventLevel(4),  
+ EventHttpRequest,  
+ EventTypeName("HTTPSYS_CACHEABLE") : amended  
+]  
+class W3CacheHttpsysCacheable:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("HTTP.SYS cacheable") : amended,  
+     read]  
+     boolean HttpsysCacheable;  
+    [WmiDataId(3),  
+    Description("Reason for not HTTP.SYS cacheable") : amended,  
+        ValueDescriptions{  
+            "OK to cache the file",  
+            "No metadata",  
+            "HTTP.SYS cache disabled",  
+            "The file is compressible",  
+            "Footer is enabled",  
+            "Supress the entity",  
+            "URL is changed by filter",  
+            "HTTP status is not 200",  
+            "Child request",  
+            "The current handler is not HTTP.SYS friendly",  
+            "There are filters that are not cache aware",  
+            "Non anonymous auth was used",  
+            "IP restriction set on the URL",  
+            "Custom logging is enabled",  
+            "SSL restriction",  
+            "ISAPI did not specify caching for this response",  
+            "This static request contains a querystring",  
+            "There is more data remaining in this response",  
+            "This static file has not been cached in usermode",  
+            "This response is being sent using unparsed headers",  
+            "Dynamic compression enabled",  
+            "Nothing in the pipeline enabled HTTP.SYS caching",  
+            "HTTP verb must be GET for caching to occur",  
+            "Cache invalidator must be ready before caching",  
+            "Handler for the request was changed",  
+            "Request filter rule depends on headers" } : amended,  
+         DefineValues{  
+            "OK",  
+            "NO_METADATA",  
+            "HTTPSYS_CACHE_DISABLED",  
+            "FILE_COMPRESSIBLE",  
+            "FOOTER_ENABLED",  
+            "SUPRESSING_ENTITY",  
+            "URL_CHANGE_BY_FILTER",  
+            "HTTP_STATUS_NOT_OK",  
+            "CHILD_REQUEST",  
+            "HANDLER_HTTPSYS_UNFRIENDLY",  
+            "FILTER_CACHE_UNAWARE",  
+            "NON_ANONYMOUS_ACCESS",  
+            "IP_RESTRICTION_SET",  
+            "CUSTOM_LOGGING",  
+            "SSL_RESTRICTION",  
+            "ISAPI_NOT_CACHING",  
+            "STATIC_REQUEST_QUERYSTRING",  
+            "RESPONSE_MORE_DATA",  
+            "FILE_NOT_CACHED",  
+            "RESPONSE_SENDING_RAW_HEADERS",  
+            "DYNAMIC_COMPRESSION_ENABLED",  
+            "NO_PIPELINE_ENABLE",  
+            "VERB_NOT_GET",  
+            "NO_CACHE_INVALIDATOR",  
+            "HANDLER_CHANGED",  
+            "REQUEST_FILTER_RULE" },  
+        Values{  
+            "OK",  
+            "NO_METADATA",  
+            "HTTPSYS_CACHE_DISABLED",  
+            "FILE_COMPRESSIBLE",  
+            "FOOTER_ENABLED",  
+            "SUPRESSING_ENTITY",  
+            "URL_CHANGE_BY_FILTER",  
+            "HTTP_STATUS_NOT_OK",  
+            "CHILD_REQUEST",  
+            "HANDLER_HTTPSYS_UNFRIENDLY",  
+            "FILTER_CACHE_UNAWARE",  
+            "NON_ANONYMOUS_ACCESS",  
+            "IP_RESTRICTION_SET",  
+            "CUSTOM_LOGGING",  
+            "SSL_RESTRICTION",  
+            "ISAPI_NOT_CACHING",  
+            "STATIC_REQUEST_QUERYSTRING",  
+            "RESPONSE_MORE_DATA",  
+            "FILE_NOT_CACHED",  
+            "RESPONSE_SENDING_RAW_HEADERS",  
+            "DYNAMIC_COMPRESSION_ENABLED",  
+            "NO_PIPELINE_ENABLE",  
+            "VERB_NOT_GET",  
+            "NO_CACHE_INVALIDATOR",  
+            "HANDLER_CHANGED",  
+            "REQUEST_FILTER_RULE" },  
+        ValueMap{  
+            "0",  
+            "1",  
+            "2",  
+            "3",  
+            "4",  
+            "5",  
+            "6",  
+            "7",  
+            "8",  
+            "9",  
+            "10",  
+            "11",  
+            "12",  
+            "13",  
+            "14",  
+            "15",  
+            "16",  
+            "17",  
+            "18",  
+            "19",  
+            "20",  
+            "21",  
+            "22",  
+            "23",  
+            "24",  
+            "25"},  
+        ValueType("index")]  
+     uint32  Reason;  
+    [WmiDataId(4),  
+    Description("Cache policy") : amended,  
+        ValueDescriptions{  
+            "No cache",  
+            "User Invalidates",  
+            "Time to Live" } : amended,  
+        DefineValues{  
+            "NO_CACHE",  
+            "USER_INVALIDATES",  
+            "TIME_TO_LIVE" },  
+        Values{  
+            "NO_CACHE",  
+            "USER_INVALIDATES",  
+            "TIME_TO_LIVE" },  
+        ValueMap{  
+            "0",  
+            "1",  
+            "2"},  
+        ValueType("index")]  
+     uint32  CachePolicy;  
+   [WmiDataId(5),  
+     Description("Time to live") : amended,  
+     read]  
+     uint32  TimeToLive;  
+};  
+  
+[Dynamic,  
+ Description("Start lookup from output-cache") : amended,  
+ EventType(15),  
+ EventLevel(4),  
+ EventHttpRequest,  
+ EventTypeName("OUTPUT_CACHE_LOOKUP_START") : amended  
+]  
+class W3OutputCacheLookupStart:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;  
+};  
+  
+[Dynamic,  
+ Description("Finish lookup from output-cache") : amended,  
+ EventType(16),  
+ EventLevel(4),  
+ EventHttpRequest,  
+ EventTypeName("OUTPUT_CACHE_LOOKUP_END") : amended  
+]  
+class W3OutputCacheLookupEnd:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+    Description("Result of lookup") : amended,  
+        ValueDescriptions{  
+            "Not found",  
+            "Found and used",  
+            "Not used due to non-matching Accept header",  
+            "Not used due to non-matching Accept-Encoding header",  
+            "Caching disabled for this response",  
+            "Conditional headers Range/If-Match/If-Unmodified-Since present in the request" } : amended,  
+        DefineValues{  
+            "NOT_FOUND",  
+            "FOUND",  
+            "ACCEPT_NOT_MATCH",  
+            "ACCEPT_ENCODING_NOT_MATCH",  
+            "CACHING_DISABLED",  
+            "CONDITIONAL_HEADERS_PRESENT" },  
+        Values{  
+            "NOT_FOUND",  
+            "FOUND",  
+            "ACCEPT_NOT_MATCH",  
+            "ACCEPT_ENCODING_NOT_MATCH",  
+            "CACHING_DISABLED",  
+            "CONDITIONAL_HEADERS_PRESENT" },  
+        ValueMap{  
+            "0",  
+            "1",  
+            "2",  
+            "3",  
+            "4",  
+            "5"},  
+        ValueType("index")]  
+     uint32  Result;  
+};  
+  
+[Dynamic,  
+ Description("Start updating output-cache") : amended,  
+ EventType(17),  
+ EventLevel(4),  
+ EventHttpRequest,  
+ EventTypeName("OUTPUT_CACHE_UPDATE_START") : amended  
+]  
+class W3OutputCacheUpdateStart:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+    Description("Cache policy") : amended,  
+        ValueDescriptions{  
+            "No cache",  
+            "User Invalidates",  
+            "Time to Live" } : amended,  
+        DefineValues{  
+            "NO_CACHE",  
+            "USER_INVALIDATES",  
+            "TIME_TO_LIVE" },  
+        Values{  
+            "NO_CACHE",  
+            "USER_INVALIDATES",  
+            "TIME_TO_LIVE" },  
+        ValueMap{  
+            "0",  
+            "1",  
+            "2"},  
+        ValueType("index")]  
+     uint32  CachePolicy;  
+   [WmiDataId(3),  
+     Description("Time to live") : amended,  
+     read]  
+     uint32  TimeToLive;  
+};  
+  
+[Dynamic,  
+ Description("Finish updating output-cache") : amended,  
+ EventType(18),  
+ EventLevel(4),  
+ EventHttpRequest,  
+ EventTypeName("OUTPUT_CACHE_UPDATE_END") : amended  
+]  
+class W3OutputCacheUpdateEnd:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+    Description("Result of update") : amended,  
+        ValueDescriptions{  
+            "Added",  
+            "Unknown error",  
+            "Not frequently hit",  
+            "Headers already sent to client",  
+            "Headers suppressed",  
+            "Request verb is not GET",  
+            "Response status is not 200",  
+            "Caching disabled for this response",  
+            "Response size exceeded",  
+            "Cache size exceeded",  
+            "Non unique vary-by conditions",  
+            "Entry exists",  
+            "Already cached by another cache" } : amended,  
+        DefineValues{  
+            "ADDED",  
+            "UNKNOWN_ERROR",  
+            "NOT_FREQUENTLY_HIT",  
+            "HEADERS_FLUSHED",  
+            "HEADERS_SUPPRESSED",  
+            "VERB_NOT_GET",  
+            "STATUS_NOT_OK",  
+            "CACHING_DISABLED",  
+            "RESPONSE_TOO_BIG",  
+            "CACHE_FULL",  
+            "VARY_BY_NOT_MATCH",  
+            "ENTRY_EXISTS",  
+            "ALREADY_CACHED" },  
+        Values{  
+            "ADDED",  
+            "UNKNOWN_ERROR",  
+            "NOT_FREQUENTLY_HIT",  
+            "HEADERS_FLUSHED",  
+            "HEADERS_SUPPRESSED",  
+            "VERB_NOT_GET",  
+            "STATUS_NOT_OK",  
+            "CACHING_DISABLED",  
+            "RESPONSE_TOO_BIG",  
+            "CACHE_FULL",  
+            "VARY_BY_NOT_MATCH",  
+            "ENTRY_EXISTS",  
+            "ALREADY_CACHED" },  
+        ValueMap{  
+            "0",  
+            "1",  
+            "2",  
+            "3",  
+            "4",  
+            "5",  
+            "6",  
+            "7",  
+            "8",  
+            "9",  
+            "10",  
+            "11",  
+            "12"},  
+        ValueType("index")]  
+     uint32  Result;  
+};  
+  
+[Dynamic,  
+ Description("Output-cache disabled") : amended,  
+ EventType(19),  
+ EventLevel(4),  
+ EventHttpRequest,  
+ EventTypeName("OUTPUT_CACHE_DISABLED") : amended  
+]  
+class W3OutputCacheDisabled:IIS_Cache_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;  
+};  
+  
+ 
+  
+[Dynamic,  
+ Description("IIS core notifications") : amended,  
+ Guid("{002e91e3-e7ae-44ab-8e07-99230ffa6ade}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISRequestNotification"),  
+ locale("MS\\0x409")  
+]  
+class IISRequestNotificationEvents:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("Start notification for module") : amended,  
+ EventType(1),  
+ EventLevel(5),  
+ EventTypeName("NOTIFY_MODULE_START") : amended  
+]  
+class IISRequestNotificationEventsStart:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Notification") : amended,  
+        ValueDescriptions{  
+            "request is beginning",  
+            "request is being authenticated",  
+            "request is being authorized",  
+            "satisfy request from cache",  
+            "map handler for request",  
+            "acquire request state",  
+            "pre-execute handler",  
+            "execute handler",  
+            "release request state",  
+            "update cache",  
+            "log request",  
+            "end request",  
+            "custom notification",  
+            "send response",  
+            "read entity",  
+            "map a url to phys path" } : amended,  
+         DefineValues{  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",    
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",    
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        Values{  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",         
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",  
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        ValueMap{  
+            "0x00000001",  
+            "0x00000002",  
+            "0x00000004",  
+            "0x00000008",  
+            "0x00000010",  
+            "0x00000020",  
+            "0x00000040",  
+            "0x00000080",  
+            "0x00000100",  
+            "0x00000200",  
+            "0x00000400",  
+            "0x00000800",  
+            "0x10000000",  
+            "0x20000000", 
+            "0x40000000", 
+            "0x80000000"  
+        },  
+        ValueType("index")]  
+     uint32  Notification;  
+    [WmiDataId(4),  
+     Description("flag if this is a post notification event") : amended,  
+     read]  
+     boolean   fIsPostNotification;  
+};  
+  
+[Dynamic,  
+ Description("Finish notification for module") : amended,  
+ EventType(2),  
+ EventLevel(5),  
+ EventTypeName("NOTIFY_MODULE_END") : amended  
+]  
+class IISRequestNotificationEventsEnd:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Notification") : amended,  
+        ValueDescriptions{  
+            "request is beginning",  
+            "request is being authenticated",  
+            "request is being authorized",  
+            "satisfy request from cache",  
+            "map handler for request",  
+            "acquire request state",  
+            "pre-execute handler",  
+            "execute handler",  
+            "release request state",  
+            "update cache",  
+            "log request",  
+            "end request",  
+            "custom notification",  
+            "send response",  
+            "read entity",  
+            "map a url to phys path" } : amended,  
+         DefineValues{  
+  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",    
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",    
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        Values{  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",         
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",  
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        ValueMap{  
+            "0x00000001",  // request is beginning  
+            "0x00000002",  // request is being authenticated  
+            "0x00000004",  // request is being authorized  
+            "0x00000008",  // satisfy request from cache  
+            "0x00000010",  // map handler for request  
+            "0x00000020",  // acquire request state  
+            "0x00000040",  // pre-execute handler  
+            "0x00000080",  // execute handler  
+            "0x00000100",  // release request state  
+            "0x00000200",  // update cache  
+            "0x00000400",  // log request  
+            "0x00000800",  // end request  
+            "0x10000000",  // custom notification  
+            "0x20000000",  // send response  
+            "0x40000000",  // read entity  
+            "0x80000000"   // map a url to phys path  
+        },  
+        ValueType("index")]  
+        uint32  Notification;  
+   [WmiDataId(4),  
+    Description("flag if this is a post notification event") : amended,  
+    read]  
+     boolean   fIsPostNotificationEvent;  
+   [WmiDataId(5),  
+    Description("Notification Status") : amended,  
+    ValueDescriptions{  
+        "continue processing for notification",  
+        "finish request processing"  
+     } : amended,  
+     DefineValues{  
+        "NOTIFICATION_CONTINUE",  
+        "NOTIFICATION_FINISH_REQUEST"  
+    },  
+    Values{  
+        "NOTIFICATION_CONTINUE",  
+        "NOTIFICATION_FINISH_REQUEST"  
+    },  
+    ValueMap{  
+        "0",  
+        "2"  
+    },  
+    ValueType("index")]  
+    uint32  NotificationStatus;  
+};  
+  
+[Dynamic,  
+ Description("Completion notification for module") : amended,  
+ EventType(3),  
+ EventLevel(5),  
+ EventTypeName("NOTIFY_MODULE_COMPLETION") : amended  
+]  
+class IISRequestNotificationEventsCompletion:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Notification") : amended,  
+        ValueDescriptions{  
+            "request is beginning",  
+            "request is being authenticated",  
+            "request is being authorized",  
+            "satisfy request from cache",  
+            "map handler for request",  
+            "acquire request state",  
+            "pre-execute handler",  
+            "execute handler",  
+            "release request state",  
+            "update cache",  
+            "log request",  
+            "end request",  
+            "custom notification",  
+            "send response",  
+            "read entity",  
+            "map a url to phys path" } : amended,  
+         DefineValues{  
+  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",    
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",    
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        Values{  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",         
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",  
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        ValueMap{  
+            "0x00000001",  // request is beginning  
+            "0x00000002",  // request is being authenticated  
+            "0x00000004",  // request is being authorized  
+            "0x00000008",  // satisfy request from cache  
+            "0x00000010",  // map handler for request  
+            "0x00000020",  // acquire request state  
+            "0x00000040",  // pre-execute handler  
+            "0x00000080",  // execute handler  
+            "0x00000100",  // release request state  
+            "0x00000200",  // update cache  
+            "0x00000400",  // log request  
+            "0x00000800",  // end request  
+            "0x10000000",  // custom notification  
+            "0x20000000",  // send response  
+            "0x40000000",  // read entity  
+            "0x80000000"   // map a url to phys path  
+        },  
+        ValueType("index")]  
+        uint32  Notification;  
+    [WmiDataId(4),  
+     Description("flag if this is a post notification event") : amended,  
+     read]  
+     boolean   fIsPostNotificationEvent;  
+    [WmiDataId(5),  
+     Description("Bytes completed") : amended,  
+     read]  
+     uint32  CompletionBytes;  
+    [WmiDataId(6),  
+     Description("Error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Start notification for pre-begin request") : amended,  
+ EventType(4),  
+ EventLevel(5),  
+ EventTypeName("PRE_BEGIN_REQUEST_START") : amended  
+]  
+class IISRequestNotificationPreBeginStart:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,       
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+};  
+  
+[Dynamic,  
+ Description("Finish notification for pre-begin request") : amended,  
+ EventType(5),  
+ EventLevel(5),  
+ EventTypeName("PRE_BEGIN_REQUEST_END") : amended  
+]  
+class IISRequestNotificationPreBeginEnd:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+   [WmiDataId(3),  
+    Description("Notification Status") : amended,  
+    ValueDescriptions{  
+        "continue processing for notification",  
+        "finish request processing"  
+     } : amended,  
+     DefineValues{  
+        "NOTIFICATION_CONTINUE",  
+        "NOTIFICATION_HANDLED"  
+    },  
+    Values{  
+        "NOTIFICATION_CONTINUE",  
+        "NOTIFICATION_HANDLED"  
+    },  
+    ValueMap{  
+        "0",  
+        "1"  
+    },  
+    ValueType("index")]  
+    uint32  NotificationStatus;  
+};  
+  
+  
+  
+[Dynamic,  
+ Description("Request processing failure") : amended,  
+ EventType(15),  
+ EventLevel(2),  
+ EventTypeName("REQUEST_PROCESSING_ERROR") : amended  
+]  
+class IISRequestNotificationEventsError:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Notification") : amended,  
+        ValueDescriptions{  
+            "request is beginning",  
+            "request is being authenticated",  
+            "request is being authorized",  
+            "satisfy request from cache",  
+            "map handler for request",  
+            "acquire request state",  
+            "pre-execute handler",  
+            "execute handler",  
+            "release request state",  
+            "update cache",  
+            "log request",  
+            "end request",  
+            "custom notification",  
+            "send response",  
+            "read entity",  
+            "map a url to phys path" } : amended,  
+         DefineValues{  
+  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",    
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",    
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        Values{  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",         
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",  
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        ValueMap{  
+            "0x00000001",  // request is beginning  
+            "0x00000002",  // request is being authenticated  
+            "0x00000004",  // request is being authorized  
+            "0x00000008",  // satisfy request from cache  
+            "0x00000010",  // map handler for request  
+            "0x00000020",  // acquire request state  
+            "0x00000040",  // pre-execute handler  
+            "0x00000080",  // execute handler  
+            "0x00000100",  // release request state  
+            "0x00000200",  // update cache  
+            "0x00000400",  // log request  
+            "0x00000800",  // end request  
+            "0x10000000",  // custom notification  
+            "0x20000000",  // send response  
+            "0x40000000",  // read entity  
+            "0x80000000"   // map a url to phys path  
+        },  
+        ValueType("index")]  
+        uint32  Notification;  
+   [WmiDataId(4),  
+     Description("Error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Set response error status") : amended,  
+ EventType(16),  
+ EventLevel(3),  
+ EventTypeName("MODULE_SET_RESPONSE_ERROR_STATUS") : amended  
+]  
+class IISRequestNotificationEventsResponseErrorStatus:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Notification") : amended,  
+        ValueDescriptions{  
+            "before request is beginning",  
+            "request is beginning",  
+            "request is being authenticated",  
+            "request is being authorized",  
+            "satisfy request from cache",  
+            "map handler for request",  
+            "acquire request state",  
+            "pre-execute handler",  
+            "execute handler",  
+            "release request state",  
+            "update cache",  
+            "log request",  
+            "end request",  
+            "custom notification",  
+            "send response",  
+            "read entity",  
+            "map a url to phys path" } : amended,  
+         DefineValues{  
+            "PRE_BEGIN_REQUEST",  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",    
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",    
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        Values{  
+            "PRE_BEGIN_REQUEST",  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",         
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",  
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        ValueMap{  
+            "0x00000000",  
+            "0x00000001",  // request is beginning  
+            "0x00000002",  // request is being authenticated  
+            "0x00000004",  // request is being authorized  
+            "0x00000008",  // satisfy request from cache  
+            "0x00000010",  // map handler for request  
+            "0x00000020",  // acquire request state  
+            "0x00000040",  // pre-execute handler  
+            "0x00000080",  // execute handler  
+            "0x00000100",  // release request state  
+            "0x00000200",  // update cache  
+            "0x00000400",  // log request  
+            "0x00000800",  // end request  
+            "0x10000000",  // custom notification  
+            "0x20000000",  // send response  
+            "0x40000000",  // read entity  
+            "0x80000000"   // map a url to phys path  
+        },  
+        ValueType("index")]  
+        uint32  Notification;  
+    [WmiDataId(4),  
+     Description("Response status code") : amended,  
+     read]  
+     uint32 HttpStatus;  
+    [WmiDataId(5),  
+     Description("Reason") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  HttpReason;  
+    [WmiDataId(6),  
+     Description("Response substatus code") : amended,  
+     read]  
+     uint16 HttpSubStatus;  
+    [WmiDataId(7),  
+     Description("Error code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+    [WmiDataId(8),  
+     Description("Configuration Exception Details") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ConfigExceptionInfo;  
+};  
+  
+[Dynamic,  
+ Description("Set response status") : amended,  
+ EventType(17),  
+ EventLevel(4),  
+ EventTypeName("MODULE_SET_RESPONSE_SUCCESS_STATUS") : amended  
+]  
+class IISRequestNotificationEventsResponseSuccessStatus:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;   
+    [WmiDataId(2),  
+     Description("Module Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Notification") : amended,  
+        ValueDescriptions{  
+            "request is beginning",  
+            "request is being authenticated",  
+            "request is being authorized",  
+            "satisfy request from cache",  
+            "map handler for request",  
+            "acquire request state",  
+            "pre-execute handler",  
+            "execute handler",  
+            "release request state",  
+            "update cache",  
+            "log request",  
+            "end request",  
+            "custom notification",  
+            "send response",  
+            "read entity",  
+            "map a url to phys path" } : amended,  
+         DefineValues{  
+  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",    
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",    
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        Values{  
+            "BEGIN_REQUEST",  
+            "AUTHENTICATE_REQUEST",  
+            "AUTHORIZE_REQUEST",   
+            "RESOLVE_REQUEST_CACHE",  
+            "MAP_REQUEST_HANDLER",           
+            "REQUEST_ACQUIRE_STATE",         
+            "PRE_EXECUTE_REQUEST_HANDLER",  
+            "EXECUTE_REQUEST_HANDLER",       
+            "RELEASE_REQUEST_STATE",         
+            "UPDATE_REQUEST_CACHE",          
+            "LOG_REQUEST",                  
+            "END_REQUEST",  
+            "CUSTOM_NOTIFICATION",  
+            "SEND_RESPONSE",                 
+            "READ_ENTITY",                   
+            "MAP_PATH"  
+        },  
+        ValueMap{  
+            "0x00000001",  // request is beginning  
+            "0x00000002",  // request is being authenticated  
+            "0x00000004",  // request is being authorized  
+            "0x00000008",  // satisfy request from cache  
+            "0x00000010",  // map handler for request  
+            "0x00000020",  // acquire request state  
+            "0x00000040",  // pre-execute handler  
+            "0x00000080",  // execute handler  
+            "0x00000100",  // release request state  
+            "0x00000200",  // update cache  
+            "0x00000400",  // log request  
+            "0x00000800",  // end request  
+            "0x10000000",  // custom notification  
+            "0x20000000",  // send response  
+            "0x40000000",  // read entity  
+            "0x80000000"   // map a url to phys path  
+        },  
+        ValueType("index")]  
+        uint32  Notification;  
+    [WmiDataId(4),  
+     Description("Response status code") : amended,  
+     read]  
+     uint32 HttpStatus;  
+    [WmiDataId(5),  
+     Description("Reason") : amended,  
+     StringTermination("NullTerminated"),  
+     format("a"),  
+     read]  
+     string  HttpReason;  
+};  
+  
+[Dynamic,  
+ Description("Set response error description") : amended,  
+ EventType(18),  
+ EventLevel(3),  
+ EventTypeName("SET_RESPONSE_ERROR_DESCRIPTION") : amended  
+]  
+class IISRequestNotificationEventsResponseErrorDescription:IISRequestNotificationEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Error description") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ErrorDescription;  
+};  
+  
+//  
+// 11. Module events  
+//  
+  
+[Dynamic,  
+ Description("IIS Module Events") : amended,  
+ Guid("{d79a948e-95f1-417b-a731-b7a79dec7ae5}"),  
+ EventVersion(1),  
+ EventHttpRequest,  
+ DisplayName("IISModule"),  
+ locale("MS\\0x409")  
+]  
+class IISModuleEvents:IIS_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("Start of module events") : amended,  
+ EventType(1),  
+ EventLevel(4),  
+ EventTypeName("MODULE_START") : amended  
+]  
+class IISModuleEventsModuleStart:IISModuleEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Name of module raising event") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Module data 1") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data1;  
+    [WmiDataId(4),  
+     Description("Module Data 2") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data2;  
+    [WmiDataId(5),  
+     Description("Module Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("End of module events") : amended,  
+ EventType(2),  
+ EventLevel(4),  
+ EventTypeName("MODULE_END") : amended  
+]  
+class IISModuleEventsModuleEnd:IISModuleEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Name of module raising event") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Module data 1") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data1;  
+    [WmiDataId(4),  
+     Description("Module Data 2") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data2;  
+    [WmiDataId(5),  
+     Description("Module Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Module Critical Error") : amended,  
+ EventType(3),  
+ EventLevel(1),  
+ EventTypeName("MODULE_CRITICAL_ERROR") : amended  
+]  
+class IISModuleEventsModuleCriticalError:IISModuleEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Name of module raising event") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Module data 1") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data1;  
+    [WmiDataId(4),  
+     Description("Module Data 2") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data2;  
+    [WmiDataId(5),  
+     Description("Module Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Module Error") : amended,  
+ EventType(4),  
+ EventLevel(2),  
+ EventTypeName("MODULE_ERROR") : amended  
+]  
+class IISModuleEventsModuleError:IISModuleEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Name of module raising event") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Module data 1") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data1;  
+    [WmiDataId(4),  
+     Description("Module Data 2") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data2;  
+    [WmiDataId(5),  
+     Description("Module Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Module Warning") : amended,  
+ EventType(5),  
+ EventLevel(3),  
+ EventTypeName("MODULE_WARNING") : amended  
+]  
+class IISModuleEventsModuleWarning:IISModuleEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Name of module raising event") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Module data 1") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data1;  
+    [WmiDataId(4),  
+     Description("Module Data 2") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data2;  
+    [WmiDataId(5),  
+     Description("Module Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Module Information") : amended,  
+ EventType(6),  
+ EventLevel(4),  
+ EventTypeName("MODULE_INFORMATION") : amended  
+]  
+class IISModuleEventsModuleInformation:IISModuleEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Name of module raising event") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Module data 1") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data1;  
+    [WmiDataId(4),  
+     Description("Module Data 2") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data2;  
+    [WmiDataId(5),  
+     Description("Module Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("Module Verbose") : amended,  
+ EventType(7),  
+ EventLevel(5),  
+ EventTypeName("MODULE_VERBOSE") : amended  
+]  
+class IISModuleEventsModuleVerbose:IISModuleEvents  
+{  
+    [WmiDataId(1),  
+     Description("Context ID") : amended,  
+     extension("Guid"),  
+     ActivityID,  
+     read]  
+     object  ContextId;  
+    [WmiDataId(2),  
+     Description("Name of module raising event") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  ModuleName;  
+    [WmiDataId(3),  
+     Description("Module data 1") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data1;  
+    [WmiDataId(4),  
+     Description("Module Data 2") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  Data2;  
+    [WmiDataId(5),  
+     Description("Module Error Code") : amended,  
+     format("x"),  
+     read]  
+     uint32  ErrorCode;  
+};  
+  
+
+[Dynamic,  
+ Description("IIS User Request") : amended,  
+ Guid("{d42cf7ef-de92-473e-8b6c-621ea663113a}"),  
+ EventVersion(0),  
+ EventDeprecated,  
+ EventArea(0),  
+ DisplayName("W3Server"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Trans_V0:IIS_Trace  
+{  
+  
+};  
+  
+[Dynamic,  
+ Description("W3 Service Received a New Request") : amended,  
+ EventType(1),  
+ EventLevel(0),  
+ EventTypeName("Start") : amended  
+]  
+class W3ReceiveNewRequest:IIS_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+    [WmiDataId(2),  
+     Description("Bytes Received") : amended,  
+     read]  
+     uint32 BytesReceived;  
+};  
+  
+[Dynamic,  
+ Description("W3 Service Send Response") : amended,  
+ EventType{2, 16, 17, 18, 19, 20, 21, 22, 23, 24},  
+ EventLevel(0),  
+ EventTypeName{"End", "SndBody", "SndResp", "SndEnt", "SndFilt", "ErrSnd", "ErrEnt", "ErrCtx", "ErrVec", "VecSnd"} : amended  
+]  
+class W3SendResponse:IIS_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+    [WmiDataId(2),  
+     Description("Bytes Sent") : amended,  
+     read]  
+     uint32 BytesSent;  
+};  
+  
+  
+[Dynamic,  
+ Description("W3 StaticFile request") : amended,  
+ EventType(10),  
+ EventLevel(0),  
+ EventTypeName("FileReq") : amended  
+]  
+class W3FileRequest:IIS_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+    [WmiDataId(2),  
+     Description("File Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FileName;  
+};  
+  
+[Dynamic,  
+ Description("W3 CGI request") : amended,  
+ EventType(11),  
+ EventLevel(0),  
+ EventTypeName("CGIReq") : amended  
+]  
+class W3CGIRequest:IIS_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+};  
+  
+[Dynamic,  
+ Description("W3 ISAPI request") : amended,  
+ EventType(12),  
+ EventLevel(0),  
+ EventTypeName("IsapiReq") : amended  
+]  
+class W3IsapiRequest:IIS_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+};  
+  
+  
+[Dynamic,  
+ Description("W3 Service makes an OOP ISAPI request") : amended,  
+ EventType(13),  
+ EventLevel(0),  
+ EventTypeName("OopReq") : amended  
+]  
+class W3OopRequest:IIS_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+    [WmiDataId(2),  
+     Description("Process ID") : amended,  
+     read]  
+     uint32 ProcessId;  
+    [WmiDataId(3),  
+     Description("Total Requests") : amended,  
+     read]  
+     uint32 TotalReqs;  
+    [WmiDataId(4),  
+     Description("Current Requests") : amended,  
+     read]  
+     uint32 CurrentReqs;  
+  
+};  
+  
+[Dynamic,  
+ Description("IIS Filter Request") : amended,  
+ Guid("{00237f0d-73eb-4bcf-a232-126693595847}"),  
+ EventVersion(0),  
+ EventArea(0),  
+ EventDeprecated,  
+ DisplayName("W3Filter"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Filter_Trans_V0:IIS_Trace  
+{  
+  
+};  
+  
+[Dynamic,  
+ Description("W3 Filter Request") : amended,  
+ EventType(1),  
+ EventLevel(0),  
+ EventTypeName("Start") : amended  
+]  
+class W3FilterTransStart:IIS_Filter_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+    [WmiDataId(2),  
+     Description("Filter Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FilterName;  
+};  
+  
+[Dynamic,  
+ Description("W3 Filter Request") : amended,  
+ EventType(2),  
+ EventLevel(0),  
+ EventTypeName("End") : amended  
+]  
+class W3FilterTransEnd:IIS_Filter_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+};  
+  
+  
+[Dynamic,  
+ Description("IIS CGI Request") : amended,  
+ Guid("{e2e55403-0d2e-4609-a470-be0da04013c0}"),  
+ EventVersion(0),  
+ EventArea( 0 ),  
+ EventDeprecated,  
+ DisplayName("W3Cgi"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Cgi_Trans_V0:IIS_Trace  
+{  
+  
+};  
+  
+[Dynamic,  
+ Description("CGI Request") : amended,  
+ EventType{1, 2},  
+ EventLevel(0),  
+ EventTypeName{"Start", "End"} : amended  
+]  
+class W3CgiTrans:IIS_Cgi_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;  
+};  
+  
+  
+  
+[Dynamic,  
+ Description("IIS User Request") : amended,  
+ Guid("{2e94e6c7-eda0-4b73-9010-2529edce1c27}"),  
+ EventVersion(0),  
+ EventDeprecated,  
+ EventArea(0),  
+ DisplayName("Isapi"),  
+ locale("MS\\0x409")  
+]  
+class Isapi_Trans_V0:IIS_Trace  
+{  
+  
+};  
+  
+[Dynamic,  
+ Description("Map RequestId to connID") : amended,  
+ EventType(1),  
+ EventLevel(0),  
+ EventTypeName("Start") : amended  
+]  
+class IsapiMapRequestId:Isapi_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;   
+    [WmiDataId(2),  
+     Description("connID") : amended,  
+     pointer,  
+     read]  
+     uint32 connID;  
+    [WmiDataId(3),  
+     Description("Boolean Out Of Process Flag") : amended,  
+     read]  
+     uint32  fOop;  
+};  
+  
+[Dynamic,  
+ Description("Delete Isapi Context") : amended,  
+ EventLevel(0),  
+ EventType{2, 10, 11, 12, 13, 14, 15},  
+ EventTypeName{"End", "SndHdr", "SndHdrEx", "VecSnd", "ErrSnd", "SsfSnd", "SsfErr"} : amended  
+]  
+class IsapiDeleteContext:Isapi_Trans_V0  
+{  
+    [WmiDataId(1),  
+     Description("Request ID") : amended,  
+     read]  
+     uint64  RequestId;   
+    [WmiDataId(2),  
+     Description("connID") : amended,  
+     pointer,  
+     read]  
+     uint32 connID;  
+};  
+  
+[Dynamic,  
+  Description("IIS: WWW Global"),  
+  Guid("{d55d3bc9-cba9-44df-827e-132d3a4596c2}"),  
+  HttpGlobalRawEtw,  
+  locale("MS\\0x409")]  
+class IIS_Global_Trace:EventTrace  
+{  
+    [Description ("Enable Flags") : amended,  
+        ValueDescriptions{  
+            "IIS process startup events",  
+            "IIS process shutdown events",  
+            "IIS global all events"} : amended,  
+         DefineValues{  
+            "ETW_IIS_GLOBAL_STARTUP",  
+            "ETW_IIS_GLOBAL_SHUTDOWN",  
+            "ETW_IIS_GLOBAL_ALL"},  
+        Values{  
+            "IISStartup",  
+            "IISShutdown",  
+            "All"  
+             },  
+        ValueMap{  
+            "0x0001",  
+            "0x0002",  
+            "0x0003"}  
+    ]  
+    uint32 Flags;  
+  
+    [Description ("Levels") : amended,  
+        ValueDescriptions{  
+            "Abnormal exit or termination",  
+            "Severe errors",  
+            "Warnings",  
+            "Information",  
+            "Detailed information" } : amended,  
+         DefineValues{  
+            "TRACE_LEVEL_FATAL",  
+            "TRACE_LEVEL_ERROR",   
+            "TRACE_LEVEL_WARNING",  
+            "TRACE_LEVEL_INFORMATION",             
+            "TRACE_LEVEL_VERBOSE" },                     
+        Values{  
+            "Fatal",  
+            "Error",  
+            "Warning",  
+            "Information",  
+            "Verbose" },  
+        ValueMap{  
+            "0x1",  
+            "0x2",  
+            "0x3",  
+            "0x4",  
+            "0x5" },  
+        ValueType("index")  
+    ]  
+    uint32 Level;  
+};  
+
+[Dynamic,  
+ Description("IIS process startup events") : amended,  
+ Guid("{35646e78-fe59-47e9-a617-eef5fc640816}"),  
+ EventVersion(1),  
+ DisplayName("IISStartup"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Startup_Trans:IIS_Global_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS process initialization info") : amended,  
+ EventType(10),  
+ EventLevel(4),  
+ EventTypeName("GLOBAL_PROCESS_START_INFO") : amended  
+]  
+class W3StartupProcessStartInfo:IIS_Startup_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Command line arguments") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  CommandLineArgs;  
+    [WmiDataId(2),  
+     Description("IIS5 compatibility mode") : amended,  
+     read]  
+     boolean IIS5CompatMode;  
+    [WmiDataId(3),  
+     Description("User name of the process") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string  UserName;  
+    [WmiDataId(4),  
+     Description("Process affinity mask") : amended,  
+     format("x"),  
+     read]  
+     uint32  ProcessAffinityMask;  
+};  
+  
+[Dynamic,  
+ Description("W3 server initialization starts") : amended,  
+ EventType(11),  
+ EventLevel(4),  
+ EventTypeName("GLOBAL_W3_SERVER_START") : amended  
+]  
+class W3StartupW3serverStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Resource dll initialization starts") : amended,  
+ EventType(12),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_RESOURCE_DLL_START") : amended  
+]  
+class W3StartupResourceDllStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("IISUTIL initialization starts") : amended,  
+ EventType(13),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_IISUTIL_START") : amended  
+]  
+class W3StartupIISUtilStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("WINSOCK initialization starts") : amended,  
+ EventType(14),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_WINSOCK_START") : amended  
+]  
+class W3StartupWinsockStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Metabase initialization starts") : amended,  
+ EventType(15),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_METABASE_START") : amended  
+]  
+class W3StartupMetabaseStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("MB listener initialization starts") : amended,  
+ EventType(16),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_MB_LISTENER_START") : amended  
+]  
+class W3StartupMblistenerStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 site initialization starts") : amended,  
+ EventType(17),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_W3_SITE_START") : amended  
+]  
+class W3StartupW3siteStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("ULATQ initialization starts") : amended,  
+ EventType(18),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_ULATQ_START") : amended  
+]  
+class W3StartupUlatqStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Global filter initialization starts") : amended,  
+ EventType(19),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_FILTER_START") : amended  
+]  
+class W3StartupGlobalFilterStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Site list initialization starts") : amended,  
+ EventType(20),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_SITE_LIST_START") : amended  
+]  
+class W3StartupSiteListStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Cache initialization starts") : amended,  
+ EventType(21),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_CACHE_START") : amended  
+]  
+class W3StartupCacheStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 connection initialization starts") : amended,  
+ EventType(22),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_W3_CONNECTION_START") : amended  
+]  
+class W3StartupW3connectionStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 context initialization starts") : amended,  
+ EventType(23),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_W3_CONTEXT_START") : amended  
+]  
+class W3StartupW3contextStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 request initialization starts") : amended,  
+ EventType(24),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_W3_REQUEST_START") : amended  
+]  
+class W3StartupW3requestStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 response initialization starts") : amended,  
+ EventType(25),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_W3_RESPONSE_START") : amended  
+]  
+class W3StartupW3responseStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Server variable initialization starts") : amended,  
+ EventType(26),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_SERVER_VARIABLE_START") : amended  
+]  
+class W3StartupServerVariableStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Mime map initialization starts") : amended,  
+ EventType(27),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_MIME_MAP_START") : amended  
+]  
+class W3StartupMimeMapStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Logging initialization starts") : amended,  
+ EventType(28),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_LOGGING_START") : amended  
+]  
+class W3StartupLoggingStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Raw connection initialization starts") : amended,  
+ EventType(29),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_RAW_CONNECTION_START") : amended  
+]  
+class W3StartupRawConnectionStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Certificate initialization starts") : amended,  
+ EventType(30),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_CERTIFICATE_START") : amended  
+]  
+class W3StartupCertificateStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("ISAPI restriction list initialization starts") : amended,  
+ EventType(31),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_ISAPI_RESTRICTION_LIST_START") : amended  
+]  
+class W3StartupISAPIRestrictionListStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("CGI restriction list initialization starts") : amended,  
+ EventType(32),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_CGI_RESTRICTION_LIST_START") : amended  
+]  
+class W3StartupCGIRestrictionListStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("Compression initialization starts") : amended,  
+ EventType(33),  
+ EventLevel(5),  
+ EventTypeName("GLOBAL_COMPRESSION_START") : amended  
+]  
+class W3StartupCompressionStart:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 server initialization ends") : amended,  
+ EventType(34),  
+ EventLevel(4),  
+ EventTypeName("GLOBAL_W3_SERVER_END") : amended  
+]  
+class W3StartupW3serverEnd:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 server initialization error") : amended,  
+ EventType(35),  
+ EventLevel(2),  
+ EventTypeName("GLOBAL_W3_SERVER_INIT_ERROR") : amended  
+]  
+class W3StartupW3serverInitError:IIS_Startup_Trans  
+{  
+    [WmiDataId(1),  
+     Description("W3 server initialization status") : amended,  
+     read]  
+     uint32 InitStatus;  
+    [WmiDataId(2),  
+     Description("W3 server initialization error code") : amended,  
+     format("x"),  
+     read]  
+     uint32 ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("W3 filter load starts") : amended,  
+ EventType(36),  
+ EventLevel(4),  
+ EventTypeName("FILTER_LOAD_START") : amended  
+]  
+class W3StartupFilterLoadStart:IIS_Startup_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Filter Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FilterName;  
+};  
+  
+[Dynamic,  
+ Description("W3 filter load ends") : amended,  
+ EventType(37),  
+ EventLevel(4),  
+ EventTypeName("FILTER_LOAD_END") : amended  
+]  
+class W3StartupFilterLoadEnd:IIS_Startup_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Filter Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FilterName;  
+    [WmiDataId(2),  
+     Description("W3 filter load return code") : amended,  
+     format("x"),  
+     read]  
+     uint32 ErrorCode;  
+};  
+  
+[Dynamic,  
+ Description("ULATQ starts listening for requests") : amended,  
+ EventType(38),  
+ EventLevel(4),  
+ EventTypeName("GLOBAL_ULATQ_START_LISTENING") : amended  
+]  
+class W3StartupUlatqStartListening:IIS_Startup_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS process shutdown events") : amended,  
+ Guid("{e1af7c2a-7bbe-4bec-b5e0-ba064e1d77da}"),  
+ EventVersion(1),  
+ DisplayName("IISShutdown"),  
+ locale("MS\\0x409")  
+]  
+class IIS_Shutdown_Trans:IIS_Global_Trace  
+{  
+};  
+  
+[Dynamic,  
+ Description("IIS process shutdown mode") : amended,  
+ EventType(10),  
+ EventLevel(4),  
+ EventTypeName("GLOBAL_PROCESS_SHUTDOWN_MODE") : amended  
+]  
+class W3ShutdownProcessMode:IIS_Shutdown_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Immediate shutdown") : amended,  
+     read]  
+     boolean ShutdownImmediate;  
+    [WmiDataId(2),  
+     Description("All CGI has been killed") : amended,  
+     read]  
+     boolean AllCGIKilled;  
+};  
+  
+[Dynamic,  
+ Description("W3 server termination starts") : amended,  
+ EventType(11),  
+ EventLevel(4),  
+ EventTypeName("GLOBAL_W3_SERVER_SHUTDOWN_START") : amended  
+]  
+class W3ShutdownW3serverShutdownStart:IIS_Shutdown_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 server termination ends") : amended,  
+ EventType(12),  
+ EventLevel(4),  
+ EventTypeName("GLOBAL_W3_SERVER_SHUTDOWN_END") : amended  
+]  
+class W3ShutdownW3serverShutdownEnd:IIS_Shutdown_Trans  
+{  
+};  
+  
+[Dynamic,  
+ Description("W3 filter unload starts") : amended,  
+ EventType(13),  
+ EventLevel(4),  
+ EventTypeName("FILTER_UNLOAD_START") : amended  
+]  
+class W3ShutdownFilterUnloadStart:IIS_Shutdown_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Filter Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FilterName;  
+};  
+  
+[Dynamic,  
+ Description("W3 filter unload ends") : amended,  
+ EventType(14),  
+ EventLevel(4),  
+ EventTypeName("FILTER_UNLOAD_END") : amended  
+]  
+class W3ShutdownFilterUnloadEnd:IIS_Shutdown_Trans  
+{  
+    [WmiDataId(1),  
+     Description("Filter Name") : amended,  
+     StringTermination("NullTerminated"),  
+     format("w"),  
+     read]  
+     string FilterName;  
+};  
+  
+[Dynamic,  
+ Description("IIS global cache events") : amended,  
+ Guid("{c4ccfe5b-639e-42d9-a9af-a5dee1688f35}"),  
+ EventVersion(1),  
+ DisplayName("IISGlobalCache"),  
+ locale("MS\\0x409")  
+]  
+class IISGlobalCacheEvents:IIS_Global_Trace  
+{  
+}; 


### PR DESCRIPTION
Regenerated the IisTraceEventParser.cs after fixing some issues in TraceParserGen. Also adding the w3core.mof and w3core.mof.man file generated as a result of TraceParserGen exe.

Updated the relevant code in PerfviewData to reflect the new function names.