### PR TITLE
Enable Puneet's IIS parser by default

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -131,21 +131,22 @@
     </p>
     <p>
         Inevitably however, there will be questions that the docs don't answer, or features
-        you would like to have that don't yet exist, or bugs you want to report. For that
-        you need a human being to help you. PerfView is currently using the .NET Forum site
+        you would like to have that don't yet exist, or bugs you want to report.  PerfView 
+        is an <a href="https://github.com/Microsoft/perfview">Github open source project</a> 
+        and you should log questions, bugs or other feedback at
     </p>
     <center>
-        <a href="http://social.msdn.microsoft.com/Forums/en-US/netfxtoolsdev">
-            Building Development
-            and Diagnostic Tools for .Net
-        </a>
+        <a href="https://github.com/Microsoft/perfview/issues"> PerfView Issues </a>
     </center>
     <p>
-        for this purpose. Click the 'Ask A Question' link to sign in and post a question
-        or give feedback. It is a good idea to use the search option on that page to see
-        if your question has already been answered before posting. We are definitely interested
-        in your feedback, so we do appreciate the time you take to let us know how you like
-        PerfView and what we can do to make it better.
+        If you are just asking a question there is a Label called 'Question' that you can 
+        use to indicate that.  If it is a bug, it REALLY helps if you supply enough information
+        to reproduce the bug.  Typically this includes the data file you are operating on.
+        You can drag small files into the issue itself, however more likely you will need 
+        to put the data file in the cloud somewhere and refer to it in the issue.   Finally
+        if you are making a suggestion, the more specific you can be the better.   Large features
+        are much less likely to ever be implemented unless you yourself help with the implementation.  
+        Please keep that in mind.   
     </p>
     <!--  **************** -->
     <hr />

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -4148,32 +4148,34 @@
                 </li>
             </ul>
         </li>
-        <ul>
-            <li>
-                <em>values</em> this is a list of semicolon-separated values KEY=VALUE, which are used to pass extra information to the provider or to the ETW system.&nbsp;&nbsp; KEY values that begin with an @ are commands to the ETW system.&nbsp;&nbsp; Everything else is passed
-                on the the provider (EventSources have direct support for accepting this information
-                in its OnEventCommand method).&nbsp; The special ETW keywords include
-                <ul>
-                    <li>@StacksEnabled - If this key&#39;s value is &#39;true&#39; then the stack associated with the event is taken (for every event in the provider)</li>
-                    <li>
-                        @ProcessIDFilter - a space separated list of decimal process IDs to collect data from.&nbsp; Only events from these processes (or those named in the @ProcessNameFilter) will be collected.
-                        Since IDs only exist after a process is created, this only works on processes that are running at the time collection starts.
-                    </li>
-                    <li>
-                        @ProcessNameFilter - a space separated list of process names (a process name is the file name (no path) of the executable INCLUDING the .EXE extension).&nbsp;&nbsp; Only events from the names processes&nbsp; (or those named in the @ProcessIDFilter)&nbsp; will be collected.&nbsp;
-                        It does not matter if the process was running before collection or not.
-                    </li>
-                    <li>@EventIDsToEnable -a space separated list of decimal event ID numbers to collect.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will be collected in addition to any events specified by the Keywords.&nbsp;&nbsp; </li>
-                    <li>@EventIDsToDisable - a space separated list of decimal event ID numbers to collect.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will be suppressed from those specified by the Keywords.&nbsp;&nbsp; </li>
-                    <li>@EventIDStacksToEnable - a space separated list of decimal event ID numbers whose events should have their stacks collected.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will have a stack logged as well as the event information.</li>
-                    <li>@EventIDStacksToDisable - a space separated list of decimal event ID numbers whose events should have their stack collection suppressed.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will not have a stack collected even though the @StacksEnabled would otherwise have cause a stack collection.&nbsp; </li>
-                </ul>
-                <p>
-                    Because
-                    some of the lists use whitespace as a separator if you specify these on the command line, you will need to quote the command line qualifier.&nbsp;&nbsp;
-                </p>
-            </li>
-        </ul>
+        <li>
+            <ul>
+                <li>
+                    <em>values</em> this is a list of semicolon-separated values KEY=VALUE, which are used to pass extra information to the provider or to the ETW system.&nbsp;&nbsp; KEY values that begin with an @ are commands to the ETW system.&nbsp;&nbsp; Everything else is passed
+                    on the the provider (EventSources have direct support for accepting this information
+                    in its OnEventCommand method).&nbsp; The special ETW keywords include
+                    <ul>
+                        <li>@StacksEnabled - If this key&#39;s value is &#39;true&#39; then the stack associated with the event is taken (for every event in the provider)</li>
+                        <li>
+                            @ProcessIDFilter - a space separated list of decimal process IDs to collect data from.&nbsp; Only events from these processes (or those named in the @ProcessNameFilter) will be collected.
+                            Since IDs only exist after a process is created, this only works on processes that are running at the time collection starts.
+                        </li>
+                        <li>
+                            @ProcessNameFilter - a space separated list of process names (a process name is the file name (no path) of the executable INCLUDING the .EXE extension).&nbsp;&nbsp; Only events from the names processes&nbsp; (or those named in the @ProcessIDFilter)&nbsp; will be collected.&nbsp;
+                            It does not matter if the process was running before collection or not.
+                        </li>
+                        <li>@EventIDsToEnable -a space separated list of decimal event ID numbers to collect.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will be collected in addition to any events specified by the Keywords.&nbsp;&nbsp; </li>
+                        <li>@EventIDsToDisable - a space separated list of decimal event ID numbers to collect.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will be suppressed from those specified by the Keywords.&nbsp;&nbsp; </li>
+                        <li>@EventIDStacksToEnable - a space separated list of decimal event ID numbers whose events should have their stacks collected.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will have a stack logged as well as the event information.</li>
+                        <li>@EventIDStacksToDisable - a space separated list of decimal event ID numbers whose events should have their stack collection suppressed.&nbsp;&nbsp; Event ETW event has a unique event ID and any IDs in this list will not have a stack collected even though the @StacksEnabled would otherwise have cause a stack collection.&nbsp; </li>
+                    </ul>
+                    <p>
+                        Because
+                        some of the lists use whitespace as a separator if you specify these on the command line, you will need to quote the command line qualifier.&nbsp;&nbsp;
+                    </p>
+                </li>
+            </ul>
+        </li>
     </ul>
     <p>
         In addition to the more advanced events there are additional advanced options that

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -2460,6 +2460,10 @@ namespace Microsoft.Diagnostics.Tracing
                 if (eventName == "GCSampledObjectAllocation")       // One event has two templates. 
                     continue;
 
+                // The IIs parser uses Cap _ instead of PascalCase, normalize
+                if (GetType().Name == "IisTraceEventParser")
+                    eventName = eventName.ToLower();
+
                 declaredSet.Add(eventName, eventName);
             }
 
@@ -2484,6 +2488,10 @@ namespace Microsoft.Diagnostics.Tracing
                     eventName = "EventTraceHeader"; // They use opcode 0 which gets truncated.  
                 if (eventName == "Jscript_GC_IdleCollect")
                     eventName = eventName + template.OpcodeName;  // They use opcode 0 which gets truncated.
+
+                // The IIs parser uses Cap _ instead of PascalCase, normalize
+                if (template.ProviderGuid == IisTraceEventParser.ProviderGuid)
+                    eventName = eventName.ToLower().Replace("_", "");
 
                 // We register the same name for old classic and manifest for some old GC events (
                 if (eventName.StartsWith("GC") && template.ID == (TraceEventID)0xFFFF &&

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -844,6 +844,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             new SymbolTraceEventParser(this);
             new HeapTraceProviderTraceEventParser(this);
             new MicrosoftWindowsKernelFileTraceEventParser(this);
+            new IisTraceEventParser(this);
 
             new SampleProfilerTraceEventParser(this);
 #if false 
@@ -3178,7 +3179,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         int IFastSerializableVersion.Version
         {
-            get { return 66; }
+            get { return 67; }
         }
         int IFastSerializableVersion.MinimumVersionCanRead
         {


### PR DESCRIPTION
This allows PerfVIew users to decode the IIS events without having to install IIS ETW providers on the machine doing the analysis.

Also cleaned up an unrelated help file fix (pointing people at Github for logging feedback) in UsersGuide.htm

@puneet-gupta 