### PR TITLE
Make ZeroMemory portable to Linux

### DIFF
--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -683,8 +683,14 @@ namespace Microsoft.Diagnostics.Tracing
 
         #endregion
 
-        [DllImport("kernel32.dll", EntryPoint = "RtlZeroMemory", SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
-        internal static extern void ZeroMemory(IntPtr handle, int length);
+        // TODO remove this from TraceEventNativeMethods.  
+        internal static void ZeroMemory(IntPtr handle, int length)
+        {
+            byte* ptr = (byte*) handle;
+            byte* endPtr = ptr + length;
+            while (ptr < endPtr)
+                *ptr++ = 0;
+        }
 
         // TODO what is this for?
         internal static int GetHRForLastWin32Error()


### PR DESCRIPTION
This is not used in perf critical paths, so the simplest implementation was used.  