### PR TITLE
Remove TraceEventNativeMethods.ZeroMemory

### DIFF
--- a/src/TraceEvent/Ctf/CtfTraceEventSource.cs
+++ b/src/TraceEvent/Ctf/CtfTraceEventSource.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Diagnostics.Tracing
                 }
 
 
-                IntPtr mem = Marshal.AllocHGlobal(sizeof(TraceEventNativeMethods.EVENT_RECORD));
-                TraceEventNativeMethods.ZeroMemory(mem, sizeof(TraceEventNativeMethods.EVENT_RECORD));
-                _header = (TraceEventNativeMethods.EVENT_RECORD*)mem;
+                var mem = (TraceEventNativeMethods.EVENT_RECORD*)Marshal.AllocHGlobal(sizeof(TraceEventNativeMethods.EVENT_RECORD));
+                *mem = default(TraceEventNativeMethods.EVENT_RECORD);
+                _header = mem;
 
                 int processors = (from entry in _channels
                                   let filename = entry.Item1.FullName

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -379,9 +379,9 @@ namespace Microsoft.Diagnostics.Tracing
             useClassicETW = !OperatingSystemVersion.AtLeast(OperatingSystemVersion.Vista);
             if (useClassicETW)
             {
-                IntPtr mem = Marshal.AllocHGlobal(sizeof(TraceEventNativeMethods.EVENT_RECORD));
-                TraceEventNativeMethods.ZeroMemory(mem, sizeof(TraceEventNativeMethods.EVENT_RECORD));
-                convertedHeader = (TraceEventNativeMethods.EVENT_RECORD*)mem;
+                var mem = (TraceEventNativeMethods.EVENT_RECORD*)Marshal.AllocHGlobal(sizeof(TraceEventNativeMethods.EVENT_RECORD));
+                *mem = default(TraceEventNativeMethods.EVENT_RECORD);
+                convertedHeader = mem;
                 logFiles[0].EventCallback = RawDispatchClassic;
             }
             else

--- a/src/TraceEvent/EventPipe/EventPipeEventSourceV1.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSourceV1.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             // We need to read the header to get the sync time information here
             ReadEventPipeTimeInfo();
 
-            IntPtr mem = Marshal.AllocHGlobal(sizeof(TraceEventNativeMethods.EVENT_RECORD));
-            TraceEventNativeMethods.ZeroMemory(mem, sizeof(TraceEventNativeMethods.EVENT_RECORD));
-            _header = (TraceEventNativeMethods.EVENT_RECORD*)mem;
+            var mem = (TraceEventNativeMethods.EVENT_RECORD*)Marshal.AllocHGlobal(sizeof(TraceEventNativeMethods.EVENT_RECORD));
+            *mem = default(TraceEventNativeMethods.EVENT_RECORD);
+            _header = mem;
 
             _eventParser = new EventPipeTraceEventParser(this);
         }

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -3171,13 +3171,10 @@ namespace Microsoft.Diagnostics.Tracing
             }
 
             if (templatesInfo == null)
-            {
-                var newTemplatesInfo = (TemplateEntry*)Marshal.AllocHGlobal(sizeof(TemplateEntry) * newLength);
-                for (int i = 0; i < newLength; i++)
-                    newTemplatesInfo[i] = default(TemplateEntry);
+                templatesInfo = (TemplateEntry*)Marshal.AllocHGlobal(sizeof(TemplateEntry) * newLength);
 
-                templatesInfo = newTemplatesInfo;
-            }
+            for (int i = 0; i < newLength; i++)
+                templatesInfo[i] = default(TemplateEntry);
 
             numTemplates = 0;
             if (oldTemplates != null)

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -3169,9 +3169,15 @@ namespace Microsoft.Diagnostics.Tracing
                     templatesInfo = null;
                 }
             }
+
             if (templatesInfo == null)
-                templatesInfo = (TemplateEntry*)Marshal.AllocHGlobal(sizeof(TemplateEntry) * newLength);
-            TraceEventNativeMethods.ZeroMemory((IntPtr)templatesInfo, sizeof(TemplateEntry) * newLength);
+            {
+                var newTemplatesInfo = (TemplateEntry*)Marshal.AllocHGlobal(sizeof(TemplateEntry) * newLength);
+                for (int i = 0; i < newLength; i++)
+                    newTemplatesInfo[i] = default(TemplateEntry);
+
+                templatesInfo = newTemplatesInfo;
+            }
 
             numTemplates = 0;
             if (oldTemplates != null)

--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -683,15 +683,6 @@ namespace Microsoft.Diagnostics.Tracing
 
         #endregion
 
-        // TODO remove this from TraceEventNativeMethods.  
-        internal static void ZeroMemory(IntPtr handle, int length)
-        {
-            byte* ptr = (byte*) handle;
-            byte* endPtr = ptr + length;
-            while (ptr < endPtr)
-                *ptr++ = 0;
-        }
-
         // TODO what is this for?
         internal static int GetHRForLastWin32Error()
         {

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1895,7 +1895,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// </summary>
         private TraceEventNativeMethods.EVENT_TRACE_PROPERTIES* GetProperties(byte* buffer)
         {
-            TraceEventNativeMethods.ZeroMemory((IntPtr)buffer, PropertiesSize);
+            Marshal.Copy(PropertiesMemoryInitializer, 0, (IntPtr)buffer, PropertiesSize);
             var properties = (TraceEventNativeMethods.EVENT_TRACE_PROPERTIES*)buffer;
 
             properties->LoggerNameOffset = (uint)sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES);
@@ -1972,7 +1972,8 @@ namespace Microsoft.Diagnostics.Tracing.Session
 
         internal const int MaxNameSize = 1024;
         private const int MaxExtensionSize = 256;
-        private static int PropertiesSize = sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES) + 2 * MaxNameSize * sizeof(char) + MaxExtensionSize;
+        private static readonly int PropertiesSize = sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES) + 2 * MaxNameSize * sizeof(char) + MaxExtensionSize;
+        private static readonly byte[] PropertiesMemoryInitializer = new byte[PropertiesSize];
 
         // Data that is exposed through properties.  
         private string m_SessionName;             // Session name (identifies it uniquely on the machine)


### PR DESCRIPTION
I tried other approaches as well:

1. Using `initblk` via `ILGenerator` (fast but high overhead)
1. Using `UnmanagedMemoryStream` to wrap a `byte*` and calling `SetLength` (incurs allocation penalty or object sharing costs)

The approach I used in this pull request is simple, but in the end it works well for each case.