### PR TITLE
Enable TestIncludeItemOnCallerCalleeTabCallerAsync

### DIFF
--- a/src/PerfView.Tests/StackViewer/StackWindowTests.cs
+++ b/src/PerfView.Tests/StackViewer/StackWindowTests.cs
@@ -37,7 +37,7 @@ namespace PerfViewTests.StackViewer
             return TestIncludeItemAsync(KnownDataGrid.ByName);
         }
 
-        [WpfFact(Skip = "Failing with indexOutOfRange.  See issue https://github.com/Microsoft/perfview/issues/354")]
+        [WpfFact]
         [WorkItem(316, "https://github.com/Microsoft/perfview/issues/316")]
         public Task TestIncludeItemOnCallerCalleeTabCallerAsync()
         {


### PR DESCRIPTION
The previously reported failure appears to have been a transient issue (not reproducible).

Closes #364