### PR TITLE
Corrected MaxRet default value in documentation

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -3646,7 +3646,7 @@
     <p>
         Traces can be very large, and thus a very large number of results can be returned
         in the right panel.&nbsp;&nbsp; To speed things up, on a reasonable number (by default
-        1000) of records are returned.&nbsp; This is the &#39;MaxRet&#39; value.&nbsp;&nbsp;
+        10000) of records are returned.&nbsp; This is the &#39;MaxRet&#39; value.&nbsp;&nbsp;
         If it is too small, you can update this textbox to something larger.
     </p>
     <h4>


### PR DESCRIPTION
The default value is 10,000 not 1,000 - https://github.com/Microsoft/perfview/blob/bf565bc8fd801c9ec86a2d33d499aa75cf10b4d6/src/PerfView/EventViewer/EventWindow.xaml.cs#L873