### PR TITLE
Strip Function Offsets from Stack Frames

### DIFF
--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptEventParser.cs
@@ -474,6 +474,7 @@ namespace Diagnostics.Tracing.StackSources
 
             // Can't use Path.GetFileName Because it throws on illegal Windows characters 
             actualModule = GetFileName(actualModule);
+            actualSymbol = this.RemoveOffset(actualSymbol.Trim());
 
             return new StackFrame(address, actualModule, actualSymbol);
         }
@@ -536,6 +537,25 @@ namespace Diagnostics.Tracing.StackSources
                 || (s[0] == '[' && s[s.Length - 1] == ']'))
             {
                 s = s.Substring(1, s.Length - 2);
+            }
+
+            return s;
+        }
+
+        private string RemoveOffset(string s)
+        {
+            // Perf stack entries look like func+0xFFFFFFFFFFFFFFFF.
+            // Strip off the +0xFFFFFFFFFFFFFFFF so that PerfView can aggregate the stacks properly.
+
+            const string offsetPrefix = "+0x";
+            int offsetPrefixLength = offsetPrefix.Length;
+
+
+            // If the offset prefix is found and is not the beginning or end of the frame, then remove the offset.
+            int index = s.LastIndexOf(offsetPrefix);
+            if((index > 0) && (index < s.Length - offsetPrefixLength))
+            {
+                return s.Substring(0, index);
             }
 
             return s;


### PR DESCRIPTION
Stack traces from perf on Linux have method offsets appended to the method name.  This means that samples in each method are not properly aggregated.  They are aggregated at the method and offset level, not just at the method level.

Before this change:

\|   \|            \|  + System.Net.Sockets!System.Net.Sockets.Socket::SendAsync(class System.Net.Sockets.SocketAsyncEventArgs)+0xec
\|   \|            \|  \|+ System.Net.Sockets!System.Net.Sockets.Socket::SendAsync(valuetype [System.Runtime]System.ArraySegment`1,valuetype System.Net.Sockets.SocketFlags,bool)+0x8b
\|   \|            \|  \| + System.Net.Sockets!System.Net.Sockets.NetworkStream::WriteAsync(uint8[],int32,int32,valuetype [System.Runtime]System.Threading.CancellationToken)+0x118
\|   \|            \|  \|  + SocketPerfTest!SslStreamPerf.ServerHandler+<Run>d__2::MoveNext()+0x226


After this change:

\|   \|            \|  + System.Net.Sockets!System.Net.Sockets.Socket::SendAsync(class System.Net.Sockets.SocketAsyncEventArgs)
\|   \|            \|  \|+ System.Net.Sockets!System.Net.Sockets.Socket::SendAsync(valuetype [System.Runtime]System.ArraySegment`1,valuetype System.Net.Sockets.SocketFlags,bool)
\|   \|            \|  \| + System.Net.Sockets!System.Net.Sockets.NetworkStream::WriteAsync(uint8[],int32,int32,valuetype [System.Runtime]System.Threading.CancellationToken)
\|   \|            \|  \|  + SocketPerfTest!SslStreamPerf.ServerHandler+<Run>d__2::MoveNext()


