### PR TITLE
Added support for Windows Containers.

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -47,7 +47,9 @@ namespace PerfView
             {
                 // Can't display on ARM because the SplashScreen is WPF
                 var noGui = SupportFiles.ProcessArch == ProcessorArchitecture.Arm ||
-                    (args.Length > 0 && string.Compare(args[0], "/noGui", StringComparison.OrdinalIgnoreCase) == 0);
+                    (args.Length > 0 &&
+                    (string.Compare(args[0], "/noGui", StringComparison.OrdinalIgnoreCase) == 0 ||
+                     string.Compare(args[0], 0, "/logFile", 0, 8, StringComparison.OrdinalIgnoreCase) == 0));              
 
                 // If we need to install, display the splash screen early, otherwise wait
                 if (!Directory.Exists(SupportFiles.SupportFileDir) && !noGui)
@@ -798,8 +800,9 @@ namespace PerfView
             if (s_splashScreen != null)
             {
                 var splashScreen = (SplashScreen)s_splashScreen.Target;
-                splashScreen.Close(new TimeSpan(0));
                 s_splashScreen = null;
+                if (splashScreen != null)
+                    splashScreen.Close(new TimeSpan(0));
             }
         }
         private static WeakReference s_splashScreen;

--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
@@ -428,10 +428,10 @@ namespace Diagnostics.Tracing.StackSources
 
                 return foundEntry.Open();
             }
-            else if (path.EndsWith(".data.txt", StringComparison.OrdinalIgnoreCase))
+            else if (path.EndsWith(".data.txt", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".perf.data.dump", StringComparison.OrdinalIgnoreCase))
                 return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             else
-                throw new ApplicationException($"file {path} is not a *.trace.zip or *.data.txt file");
+                throw new ApplicationException($"file {path} is not a *.trace.zip *.data.txt or a *.perf.data.dump suffix.");
         }
 
         private double? SampleEndTime;

--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptStackSource.cs
@@ -409,24 +409,29 @@ namespace Diagnostics.Tracing.StackSources
         private Stream GetPerfScriptStream(string path, out ZipArchive archive)
         {
             archive = null;
-            if (path.EndsWith(".trace.zip"))
+            if (path.EndsWith(".trace.zip", StringComparison.OrdinalIgnoreCase))
             {
                 archive = ZipFile.OpenRead(path);
                 ZipArchiveEntry foundEntry = null;
 
                 foreach (ZipArchiveEntry entry in archive.Entries)
                 {
-                    if (entry.FullName.EndsWith(".data.txt"))
+                    if (entry.FullName.EndsWith(".data.txt", StringComparison.OrdinalIgnoreCase))
                     {
                         foundEntry = entry;
                         break;
                     }
                 }
 
-                return foundEntry?.Open();
+                if (foundEntry == null)
+                    throw new ApplicationException($"file {path} is does not have a *.data.txt file inside.");
+
+                return foundEntry.Open();
             }
-            else
+            else if (path.EndsWith(".data.txt", StringComparison.OrdinalIgnoreCase))
                 return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            else
+                throw new ApplicationException($"file {path} is not a *.trace.zip or *.data.txt file");
         }
 
         private double? SampleEndTime;

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -11,7 +11,7 @@
     <Description>PerfView</Description>
     <Company>Microsoft</Company>
     <Copyright>Copyright © Microsoft 2010</Copyright>
-    <FileVersion>1.9.62.0</FileVersion>
+    <FileVersion>1.9.64.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -5844,7 +5844,7 @@ table {
                     {
                         obsolete.Children.Add(new PerfViewStackSource(this, "ASP.NET Thread Time (with Tasks)"));
                     }
-                    else
+                    else if (!hasCSwitchStacks)
                         name += " (CPU ONLY)";
                     obsolete.Children.Add(new PerfViewStackSource(this, name));
                 }

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -8051,8 +8051,8 @@
                 <li>
                     Added Support for Argon (light weight) Windows containers.   Most of this is in fact work-arounds which
                     will eventually be removed, but this makes PerfView work with Argon containers in the RS3 version of the OS
-                    (review currently available).   Note that there seems to still be issues with looking up symbols for SOME
-                    OS DLLs, but all managed code should work.    Also PerfView is a GUI app and ARgon containers don't use
+                    (the version currently available).   Note that there seems to still be issues with looking up symbols for SOME
+                    OS DLLs, but all managed code should work.    Also PerfView is a GUI app and Argon containers don't use
                     gui, so you need to use the techniques in 'Automating data collection' to use perfView in the container. 
                     (for example 'Perfview.exe /logfile:logfile.txt /accepteula /maxcollectsec:30 collect').  PerfView (like 
                     all gui apps) will run in the background if run from the command line directly, but will block until exit

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -8046,6 +8046,21 @@
         </li>
         -->
         <li>
+            Version 1.9.64 9/27/17
+            <ul>
+                <li>
+                    Added Support for Argon (light weight) Windows containers.   Most of this is in fact work-arounds which
+                    will eventually be removed, but this makes PerfView work with Argon containers in the RS3 version of the OS
+                    (review currently available).   Note that there seems to still be issues with looking up symbols for SOME
+                    OS DLLs, but all managed code should work.    Also PerfView is a GUI app and ARgon containers don't use
+                    gui, so you need to use the techniques in 'Automating data collection' to use perfView in the container. 
+                    (for example 'Perfview.exe /logfile:logfile.txt /accepteula /maxcollectsec:30 collect').  PerfView (like 
+                    all gui apps) will run in the background if run from the command line directly, but will block until exit
+                    when run from a batch script).  
+                   </li>
+            </ul>
+        </li> 
+        <li>
             Version 1.9.55 5/9/17
             <ul>
                 <li>

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -453,7 +453,7 @@ namespace Microsoft.Diagnostics.Symbols
             var clrDir = GetClrDirectoryForNGenImage(ngenImageFullPath, m_log, out privateRuntimeVerString);
             if (clrDir == null)
             {
-                m_log.WriteLine("Could not find CLR Director for NGEN image {0}, Trying .NET Core", ngenImageFullPath);
+                m_log.WriteLine("Could not find CLR directory for NGEN image {0}, Trying .NET Core", ngenImageFullPath);
                 return HandleNetCorePdbs(ngenImageFullPath, pdbPath);
             }
 

--- a/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
@@ -12,29 +12,6 @@ namespace TraceEventTests
 {
     public class EventPipeParsing : EventPipeTestBase
     {
-        private class DebugListenerBlock : IDisposable
-        {
-            public DebugListenerBlock()
-            {
-                if (System.Diagnostics.Debug.Listeners != null && System.Diagnostics.Debug.Listeners.Count > 0)
-                {
-                    _blockedListeners = new System.Diagnostics.TraceListener[System.Diagnostics.Debug.Listeners.Count];
-                    System.Diagnostics.Debug.Listeners.CopyTo(_blockedListeners, 0);
-                    System.Diagnostics.Debug.Listeners.Clear();
-                }
-            }
-
-            public void Dispose()
-            {
-                if (_blockedListeners != null)
-                {
-                    System.Diagnostics.Debug.Listeners.AddRange(_blockedListeners);
-                }
-            }
-
-            private System.Diagnostics.TraceListener[] _blockedListeners;
-        }
-
         private class EventRecord
         {
             public int TotalCount;

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 // we detect if we are in a container and if so strip out kernel events that might cause 
                 // problems.   Can be removed when containers do this automatically 
                 var containerTypeObj = Registry.GetValue(@"HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control", "ContainerType", null);
-                if (containerTypeObj != null && containerTypeObj is int)
+                if (containerTypeObj is int)    // false if containerTypeObj is null
                 {
                     flags &= ~KernelTraceEventParser.Keywords.NonContainer;
                     stackCapture &= ~KernelTraceEventParser.Keywords.NonContainer;

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -9154,6 +9154,31 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
 
         /// <summary>
+        /// For a PMCCounterProfTraceData event, gets the TraceCodeAddress associated with the InstructionPointer address. 
+        /// </summary>
+        public static TraceCodeAddress IntructionPointerCodeAddress(this PMCCounterProfTraceData anEvent)
+        {
+            TraceLog log = anEvent.Source as TraceLog;
+            if (null == log)
+            {
+                throw new InvalidOperationException("Attempted to use TraceLog support on a non-TraceLog TraceEventSource.");
+            }
+            return log.GetCodeAddressAtEvent(anEvent.InstructionPointer, anEvent);
+        }
+        /// <summary>
+        /// For a PMCCounterProfTraceData event, gets the CodeAddressIndex associated with the InstructionPointer address. 
+        /// </summary>
+        public static CodeAddressIndex IntructionPointerCodeAddressIndex(this PMCCounterProfTraceData anEvent)
+        {
+            TraceLog log = anEvent.Source as TraceLog;
+            if (null == log)
+            {
+                throw new InvalidOperationException("Attempted to use TraceLog support on a non-TraceLog TraceEventSource.");
+            }
+            return log.GetCodeAddressIndexAtEvent(anEvent.InstructionPointer, anEvent);
+        }
+
+        /// <summary>
         /// For a ISRTraceData event, gets the CodeAddressIndex associated with the Routine address. 
         /// </summary>
         public static CodeAddressIndex RoutineCodeAddressIndex(this ISRTraceData anEvent)


### PR DESCRIPTION
This makes PerfVIew mostly work for RS3.   Some unmanaged symbol lookup of OS DLLs may not work until the OS fixes some things, but mostly it works.    

There are some hacks here that hopefully will be backed out soon under the !CONTAINER_WORKAROUND_NOT_NEEDED ifdef when the OS is fixed.   

Also did some unrelated updates
1) Simple Linux scripting fix.
2) Turn off splash screen when /logFile is being used
3) Removed dead code in EventPipe test
4) Added TraceCodeAddress support for PMCCounterProfTraceData
5) Strip out support we dont' care about any more for source code lookup on pre 4.6.1 runtimes