### PR TITLE
Fixes for SysCall support in PerfView 

### DIFF
--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -9217,6 +9217,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Kernel
             Debug.Assert(!(Version > 2 && EventDataLength < HostOffset(4, 1)));
             Action(this);
         }
+
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -482,6 +482,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// This is intended to be overridden by the TraceLog class that has this additional information. 
         /// </summary>
         internal virtual int LastChanceGetThreadID(TraceEvent data) { return -1; }
+        internal virtual int LastChanceGetProcessID(TraceEvent data) { return -1; }
         internal unsafe virtual Guid GetRelatedActivityID(TraceEventNativeMethods.EVENT_RECORD* eventRecord)
         {
             var extendedData = eventRecord->ExtendedData;
@@ -717,6 +718,8 @@ namespace Microsoft.Diagnostics.Tracing
             get
             {
                 var ret = eventRecord->EventHeader.ProcessId;
+                if (ret == -1)
+                    ret = source.LastChanceGetProcessID(this);     // See if the source has additional information (like a stack event associated with it)
                 return ret;
             }
         }

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1575,7 +1575,8 @@ namespace Microsoft.Diagnostics.Tracing.Session
             if ((stackCapture & KernelTraceEventParser.Keywords.SystemCall) != 0)
             {
                 stackTracingIds[curID].EventGuid = KernelTraceEventParser.PerfInfoTaskGuid;
-                stackTracingIds[curID].Type = 0x33;     // SysCall
+                // stackTracingIds[curID].Type = 0x33;     // SysCallEnter
+                stackTracingIds[curID].Type = 0x34;     // SysCallExit  (We want the stack on the exit as it has the return value).  
                 curID++;
             }
             // Thread

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -883,6 +883,20 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             return thread.ThreadID;
         }
+        internal unsafe override int LastChanceGetProcessID(TraceEvent data)
+        {
+            Debug.Assert(data.eventRecord->EventHeader.ProcessId == -1);          // we should only be calling this when we have no better answer.      
+            CallStackIndex callStack = data.CallStackIndex();
+            if (callStack == CallStackIndex.Invalid)
+                return -1;
+
+            TraceThread thread = CallStacks.Thread(callStack);
+            if (thread == null)
+                return -1;
+
+            return thread.Process.ProcessID;
+        }
+
 
         private void AddMarkThread(int threadID, long timeStamp, int heapNum)
         {


### PR DESCRIPTION
Basically in the SysCall events don't have process or thread IDs but we DO collect stacks, which have these things.
We already had logic that uses these stacks to fix events without thread IDs and so we just extend this for Process IDs.

Also changed it so that the stack is on the 'SysCall' exit since that has better information (the return code).

If you don't care about syscalls (almost no one does, you can ignore this). 