### PR TITLE
Moves FetchSymbolsForProcess to be a user command.

### DIFF
--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -56,7 +56,7 @@
     <Compile Include="..\PerfView\memory\ETWClrProfilerTraceEventParser.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptDumpGraph.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptHeapDumper.cs" />
-    <Compile Include="..\PerfView\PerfViewEventSource.cs" />
+    <Compile Include="..\PerfView\PerfViewLogger.cs" />
     <Compile Include="..\PerfView\Triggers.cs" />
     <Compile Include="..\Utilities\TeeTextWriter.cs" />
     <Compile Include="..\ETWHeapDump\DotNetHeapDumper.cs" />

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -560,11 +560,6 @@ namespace PerfView
                 "Creates a VS project for creates a perfView extension.");
             parser.DefineOptionalParameter("ExtensionName", ref ExtensionName, "The name of the extension (no .DLL)");
 
-            // TODO FIX NOW, this should be a user command 
-            parser.DefineParameterSet("FetchSymbolsForProcess", ref DoCommand, App.CommandProcessor.FetchSymbolsForProcess,
-                "Fetch all the PDBs files needed for viewing locally.  ");
-            parser.DefineOptionalParameter("DataFile", ref DataFile, "ETL file containing profile data.");
-
 #if CROSS_GENERATION_LIVENESS
             parser.DefineParameterSet("CollectCrossGenerationLiveness", ref DoCommand, App.CommandProcessor.CollectCrossGenerationLiveness,
                 "Collect a heap snapshot that can be used to do cross-generation liveness analysis.");

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -422,7 +422,7 @@ namespace PerfView
                                 SymbolReaderOptions.CacheOnly | SymbolReaderOptions.NoNGenSymbolCreation))
                             {
                                 // TODO FIX NOW, make this so that it uses the stacks in the view.  
-                                var moduleFiles = CommandProcessor.GetInterestingModuleFiles(etlDataFile, 5.0, StatusBar.LogWriter, null);
+                                var moduleFiles = ETLPerfViewData.GetInterestingModuleFiles(etlDataFile, 5.0, StatusBar.LogWriter, null);
                                 foreach (var moduleFile in moduleFiles)
                                     traceLog.CodeAddresses.LookupSymbolsForModule(reader, moduleFile);
                             }

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -167,8 +167,6 @@
       <Link>amd64\KernelTraceControl.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\msdia140.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>

--- a/src/PerfView/PerfViewLogger.cs
+++ b/src/PerfView/PerfViewLogger.cs
@@ -1,14 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.Diagnostics.Tracing.Parsers;
-using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
-using Microsoft.Diagnostics.Tracing.Session;
+using System.Diagnostics.Tracing;
 
 [EventSource(Name = "PerfView")]
-class PerfViewLogger : Microsoft.Diagnostics.Tracing.EventSource
+class PerfViewLogger : System.Diagnostics.Tracing.EventSource
 {
     [Event(1)]
     public void Mark(string message) { WriteEvent(1, message); }
@@ -39,12 +34,12 @@ class PerfViewLogger : Microsoft.Diagnostics.Tracing.EventSource
         WriteEvent(12, (int)keywords, (int)stacks);
     }
     [Event(13)]
-    public void ClrEnableParameters(ulong keywords, TraceEventLevel level)
+    public void ClrEnableParameters(ulong keywords, Microsoft.Diagnostics.Tracing.TraceEventLevel level)
     {
         WriteEvent(13, (long)keywords, (int)level);
     }
     [Event(14)]
-    public void ProviderEnableParameters(string providerName, Guid providerGuid, TraceEventLevel level, ulong keywords, int stacks, string values)
+    public void ProviderEnableParameters(string providerName, Guid providerGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel level, ulong keywords, int stacks, string values)
     {
         WriteEvent(14, providerName, providerGuid, (int)level, keywords, stacks, values);
     }


### PR DESCRIPTION
This was put in as a 'direct' command understood by PerfView directly.   Moved it to be
a user command.  We have wanted to do this for a while because this command is not really
that central, and we do it now becuase it is convinient for making a .NET Core version
of the PerfView collector (for Nano-OS).

FetchSymbolsForProcess has dependencies on code that are related to the GUI which is
not available on .NET Core.   By moving to be an extension, we make the 'core' parts
of perfview less entagled with the GUI which makes the port easier.

I also happened to rename PerfViewEventSource.cs to PerfViewLogger.cs, because that
is the name of hte class in that file.   This is just cleanup.