### PR TITLE
make Set Time Range work for single cell selection

### DIFF
--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -1586,22 +1586,13 @@ namespace PerfView
             var cells = SelectedCells();
             if (cells != null)
             {
-                if (cells.Count == 2) // First and Last column cells
-                {
-                    StartTextBox.Text = GetCellStringValue(cells[0]);
-                    EndTextBox.Text = GetCellStringValue(cells[1]);
-                    Update();
-                }
-                else if (cells.Count == 1) // single cell from a row
-                {
-                    var callTreeNode = cells[0].Item as CallTreeNodeBase;
+                var callTreeNodes = cells.Select(cell => cell.Item).OfType<CallTreeNodeBase>();
 
-                    if (callTreeNode != null)
-                    {
-                        StartTextBox.Text = callTreeNode.FirstTimeRelativeMSec.ToString("n3");
-                        EndTextBox.Text = callTreeNode.LastTimeRelativeMSec.ToString("n3");
-                        Update();
-                    }
+                if (callTreeNodes.Any())
+                {
+                    StartTextBox.Text = callTreeNodes.Min(node => node.FirstTimeRelativeMSec).ToString("n3");
+                    EndTextBox.Text = callTreeNodes.Max(node => node.LastTimeRelativeMSec).ToString("n3");
+                    Update();
                 }
                 else
                     StatusBar.LogError("Could not set time range.");

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -1586,11 +1586,22 @@ namespace PerfView
             var cells = SelectedCells();
             if (cells != null)
             {
-                if (cells.Count == 2)
+                if (cells.Count == 2) // First and Last column cells
                 {
                     StartTextBox.Text = GetCellStringValue(cells[0]);
                     EndTextBox.Text = GetCellStringValue(cells[1]);
                     Update();
+                }
+                else if (cells.Count == 1) // single cell from a row
+                {
+                    var callTreeNode = cells[0].Item as CallTreeNodeBase;
+
+                    if (callTreeNode != null)
+                    {
+                        StartTextBox.Text = callTreeNode.FirstTimeRelativeMSec.ToString("n3");
+                        EndTextBox.Text = callTreeNode.LastTimeRelativeMSec.ToString("n3");
+                        Update();
+                    }
                 }
                 else
                     StatusBar.LogError("Could not set time range.");


### PR DESCRIPTION
Currently, the user needs to select "First" and "Last" columns cells to make "Set Time Range" menu item work.

This is rather non-intuitive, you most probably use keyboard shortcuts so you don't hit this issue.

The PR is trivial. Single cell selected? If it's CallTreeNode, use the right values to set the time filter.

![image](https://user-images.githubusercontent.com/6011991/31893696-78910138-b80c-11e7-823b-2b29b9e17949.png)
