### PR TITLE
Fixing NRE in IIS Stats view and adding CLR exception details in failed requests view

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -2041,8 +2041,11 @@ table {
                 }
 
                 var iisPipelineEvent = request.PipelineEvents.FirstOrDefault(m => (m.Name == eventName) && m.EndTimeRelativeMSec == 0);
-                iisPipelineEvent.EndTimeRelativeMSec = traceEvent.TimeStampRelativeMSec;
-                iisPipelineEvent.EndThreadId = traceEvent.ThreadID;
+                if (iisPipelineEvent != null)
+                {
+                    iisPipelineEvent.EndTimeRelativeMSec = traceEvent.TimeStampRelativeMSec;
+                    iisPipelineEvent.EndThreadId = traceEvent.ThreadID;
+                }
             }
         }
         private IisPipelineEvent GetSlowestEvent(Guid contextId, List<IisPipelineEvent> pipeLineEvents)


### PR DESCRIPTION
This pull request fixes a NullReferenceException which was happening in AddGenericStopEventToRequest method and this adds additional details of CLR Exceptions in the Failed Requests view under IIS Statistics