### PR TITLE
Avoid loops in process parent.

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4956,11 +4956,7 @@ table {
             if (ret == StackSourceCallStackIndex.Invalid)
             {
                 StackSourceCallStackIndex parentStack = StackSourceCallStackIndex.Invalid;
-                // The ID check is because process 0 has itself as a parent, which creates a infinite recursion.      
-                if (process.ProcessID != process.ParentID)
-                {
-                    parentStack = GetStackForProcess(process.Parent, traceLog, stackSource, processStackCache);
-                }
+                parentStack = GetStackForProcess(process.Parent, traceLog, stackSource, processStackCache);
 
                 string parent = "";
                 if (parentStack == StackSourceCallStackIndex.Invalid)


### PR DESCRIPTION
The Process/File/Registry view had a infinit loop because the
parent process ID formed a loop.   Use the 'Parent' field instead
of the ParentID field and insure that this field never forms loops
(by giving up on pointing to a parent if it would form a loop).