### PR TITLE
Update to xunit 2.3.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,6 +29,8 @@
     <PerfViewSupportFilesVersion>1.0.5</PerfViewSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.8</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
+    <XunitVersion>2.3.0</XunitVersion>
+    <XunitRunnerVisualstudioVersion>2.3.0</XunitRunnerVisualstudioVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
+++ b/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
+++ b/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.23" />
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" PrivateAssets="all" />
     <PackageReference Include="Xunit.StaFact" Version="0.2.3-beta" />
   </ItemGroup>
 

--- a/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
+++ b/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
@@ -84,7 +84,7 @@ namespace PerfViewTests.Utilities
         {
             GuiApp.MainWindow?.Close();
             JoinableTaskFactory?.Context.Dispose();
-            Assert.Equal(0, StackWindow.StackWindows.Count);
+            Assert.Empty(StackWindow.StackWindows);
 
             GuiApp.MainWindow = new MainWindow();
             JoinableTaskFactory = new JoinableTaskFactory(new JoinableTaskContext());

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TraceEvent/TraceEvent.Tests/DispatchTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/DispatchTests.cs
@@ -795,13 +795,13 @@ namespace TraceEventTests
                 SendEvent(template.ProviderGuid, (int)template.eventID, template.lookupAsClassic);
 
             foreach (var template in m_inactiveTemplates)
-                Assert.True(!m_visited.Contains(template));
+                Assert.DoesNotContain(template, m_visited);
 
             foreach (var template in m_activeTemplates)
-                Assert.True(m_visited.Contains(template));
+                Assert.Contains(template, m_visited);
 
             foreach (var template in m_repeatTemplates)
-                Assert.True(m_visited.Contains(template));
+                Assert.Contains(template, m_visited);
         }
 
         Action<EmptyTraceData> MakeTarget(int i)

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes test explorer behavior in some Visual Studio 2017 updates.

:memo: Please make sure to not rebase or squash this change during the merge process.