### PR TITLE
Default heap dump processing to all objects instead of a sampling

### DIFF
--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -48,8 +48,6 @@ public class GCHeapDumper
         m_origLog = log;
         m_copyOfLog = new StringWriter();
         m_log = new TeeTextWriter(m_copyOfLog, m_origLog);
-
-        MaxDumpCountK = 250;
     }
 
     /// <summary>

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -67,7 +67,7 @@ namespace PerfView
         public bool SaveETL;                // Save the ETL file when dumping the JS heap
         public bool DumpData;               // Dump the heap data as well as the connectivity info
         public bool Freeze;                 // Freeze the process while the dump is taken
-        public int MaxDumpCountK = 250;     // Maximum size of the File to generate.   We sample aggressively enough to try to hit this count of objects in the file
+        public int MaxDumpCountK;           // Maximum size of the File to generate.   We sample aggressively enough to try to hit this count of objects in the file
         public int MaxNodeCountK;           // Maximum size to even look at in the heap 
 
 #if CROSS_GENERATION_LIVENESS

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2404,7 +2404,7 @@ namespace PerfView
                 cmdLineArgs += " /SaveETL";
             if (parsedArgs.DumpData)
                 cmdLineArgs += " /DumpData";
-            if (parsedArgs.MaxDumpCountK != 250)
+            if (parsedArgs.MaxDumpCountK != 0)
                 cmdLineArgs += " /MaxDumpCountK=" + parsedArgs.MaxDumpCountK;
             if (parsedArgs.MaxNodeCountK != 0)
                 cmdLineArgs += " /MaxNodeCountK=" + parsedArgs.MaxNodeCountK;

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
@@ -135,21 +135,6 @@ namespace PerfView.Dialogs
                 return;
             }
 
-            if (m_args.MaxDumpCountK >= 10000)
-            {
-                var response = MessageBox.Show("WARNING: you have selected a Max Dump Count larger than 10M objects.\r\n" +
-                    "You should only need 100K to do a good job, even at 10M the GUI will be very sluggish.\r\n" +
-                    "Consider canceling and picking a smaller value.", "Max Dump Size Too Big",
-                    MessageBoxButton.OKCancel);
-                if (response != MessageBoxResult.OK)
-                {
-                    StatusBar.Log("Memory collection canceled.");
-                    Close();
-                    GuiApp.MainWindow.Focus();
-                    return;
-                }
-            }
-
             m_args.NoView = true;
             m_tookASnapshot = true;
             m_mainWindow.ExecuteCommand("Dumping GC Heap to " + System.IO.Path.GetFullPath(App.CommandLineArgs.DataFile),


### PR DESCRIPTION
Based on my experiences with processing heap dumps to improve reliability in Visual Studio over the past several months, I found that processing all objects in a heap provided such an overwhelming advantage for actionable results that it was always worth the cost (i.e. the larger the dump, the more valuable the unsampled result was). This change preserves the ability to sample the heap, but makes two notable changes to help users make the right decision on their first pass through the UI:

1. Removes the warning about heap dump extraction being too large
2. Defaults the UI and command line to not sample unless explicitly specified

:memo: Please make sure to not rebase or squash this change during the merge process.