### PR TITLE
Increase the default buffer size to 256MiB

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -104,7 +104,7 @@ namespace PerfView
 
         // Start options.
         public bool StackCompression;           // Used compresses stacks when collecting traces. 
-        public int BufferSizeMB = 64;
+        public int BufferSizeMB = 256;
         public int CircularMB;
         public bool InMemoryCircularBuffer;         // Uses EVENT_TRACE_BUFFERING_MODE for an in-memory circular buffer
         public KernelTraceEventParser.Keywords KernelEvents = KernelTraceEventParser.Keywords.Default;


### PR DESCRIPTION
Reduces the chance of missed events.

I was missing some events (often thousands) measuring Visual Studio even though I have NVMe drives and 28 logical processors. With this change, the events are no longer dropped.

:memo: Please make sure to not rebase or squash this change during the merge process.