### PR TITLE
Added the Gen 2 object Deaths view for 100K Sampling

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PerfViewVersion>1.9.66.0</PerfViewVersion>
+    <PerfViewVersion>1.9.67.0</PerfViewVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3637,13 +3637,31 @@ table {
                         sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);       // We remove the same stack we added at alloc.  
                         stackSource.AddSample(sample);
                     };
+
+                    newHeap.OnGC += delegate (double time, int gen)
+                    {
+                        sample.Metric = float.Epsilon;
+                        sample.Count = 1;
+                        sample.TimeRelativeMSec = time;
+                        StackSourceCallStackIndex processStack = stackSource.GetCallStackForProcess(newHeap.Process);
+                        StackSourceFrameIndex gcFrame = stackSource.Interner.FrameIntern("GC Occured Gen(" + gen + ")");
+                        sample.StackIndex = stackSource.Interner.CallStackIntern(gcFrame, processStack);
+                        stackSource.AddSample(sample);
+                    };
                 };
                 eventSource.Process();
                 stackSource.DoneAddingSamples();
             }
-            else if (streamName == "Gen 2 Object Deaths")
+            else if (streamName.StartsWith("Gen 2 Object Deaths"))
             {
                 var gcHeapSimulators = new GCHeapSimulators(eventLog, eventSource, stackSource, log);
+
+                if (streamName == "Gen 2 Object Deaths (Coarse Sampling)")
+                {
+                    gcHeapSimulators.UseOnlyAllocTicks = true;
+                    m_extraTopStats = "Sampled only 100K bytes";
+                }
+
                 gcHeapSimulators.OnNewGCHeapSimulator = delegate (GCHeapSimulator newHeap)
                 {
                     newHeap.OnObjectDestroy += delegate (double time, int gen, Address objAddress, GCHeapSimulatorObject objInfo)
@@ -3657,7 +3675,19 @@ table {
                             stackSource.AddSample(sample);
                         }
                     };
+
+                    newHeap.OnGC += delegate (double time, int gen)
+                    {
+                        sample.Metric = float.Epsilon;
+                        sample.Count = 1;
+                        sample.TimeRelativeMSec = time;
+                        StackSourceCallStackIndex processStack = stackSource.GetCallStackForProcess(newHeap.Process);
+                        StackSourceFrameIndex gcFrame = stackSource.Interner.FrameIntern("GC Occured Gen(" + gen + ")");
+                        sample.StackIndex = stackSource.Interner.CallStackIntern(gcFrame, processStack);
+                        stackSource.AddSample(sample);
+                    };
                 };
+
                 eventSource.Process();
                 stackSource.DoneAddingSamples();
             }
@@ -5847,14 +5877,17 @@ table {
             if (hasGCAllocationTicks)
             {
                 if (hasObjectUpdate)
+                {
                     memory.Children.Add(new PerfViewStackSource(this, "GC Heap Net Mem (Coarse Sampling)"));
+                    memory.Children.Add(new PerfViewStackSource(this, "Gen 2 Object Deaths (Coarse Sampling)"));
+                }
                 memory.Children.Add(new PerfViewStackSource(this, "GC Heap Alloc Ignore Free (Coarse Sampling)"));
             }
             if (hasMemAllocStacks)
             {
                 memory.Children.Add(new PerfViewStackSource(this, "GC Heap Net Mem"));
                 memory.Children.Add(new PerfViewStackSource(this, "GC Heap Alloc Ignore Free"));
-                memory.Children.Add(new PerfViewStackSource(this, "Gen 2 Object Deaths"));
+                memory.Children.Add(new PerfViewStackSource(this, "Gen 2 Object Deaths")); 
             }
 
             if (hasDllStacks)

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -2193,12 +2193,14 @@
                         </li>
 
                         <li>
+                            <a id="Gen2ObjectDeaths(CoarseSampling)Stacks"/>
                             <strong><a id="Gen2ObjectDeathsStacks">Gen 2 Object Deaths</a></strong> - When the
                             DotNetAlloc or DotNetAllocSamp events are turned on the runtime will log the
                             stack of allocations as well as when GCs happen and what objects are collected.
                             In this view we show you the allocation stack of objects that DIED in Gen 2.
                             If your Gen 2 GCs are expensive, then reducing these objects are the most important
-                            way of bring the cost of those Gen 2 GCs down.
+                            way of bring the cost of those Gen 2 GCs down.  There is a (Coarse Sampling) version
+                            of this based on the sampling that happens by default every 100KB of allocation.  
                         </li>
                         <li>
                             <strong><a id="ServerGCStacks">Server GC Stacks</a></strong> - This
@@ -8053,6 +8055,20 @@
             </ul>
         </li>
         -->
+        <li>
+            Version 1.9.67 11/2/17
+            <ul>
+                <li> Added the Gen2 Object Death view that use the 100KB allocation events (coarse sampling).  Thus most traces 
+                will now have this view (inncluding the /GCOnly view).   This view shows you were you allocated objects that then die in Gen 2 (These are the 
+                most important for reducing the number of Gen2 GCs (and Gen 2 GC fragmentation)).   You coudl do this before 
+                when you truned on /DotNetAlloc or /DotNetAllocSampled collection but those are more expensive and can have
+                logistic issues (you can't attach to a existing process).    The view will only show you a coarse sampling 
+                but that often has useful information.  
+                </li>
+                <li>Added the 'GC Occured Gen(X)' frame to the GC Heap Net Alloc and GC 2 Object Death views.   These are 
+                useful for seeing where the GCs in time without having to go to the GCStats or Events views.</li>
+            </ul>
+        </li>
         <li>
             Version 1.9.66 10/27/17
             <ul>

--- a/src/PerfView/memory/GCHeapSimulator.cs
+++ b/src/PerfView/memory/GCHeapSimulator.cs
@@ -261,9 +261,10 @@ namespace PerfView
         }
 
         /// <summary>
-        /// The ID of the process of interest.  Events from other processes are ignored.
+        /// The process of interest.  Events from other processes are ignored.
         /// </summary>
-        public int ProcessId { get { return m_processID; } }
+        public TraceProcess Process {  get { return m_process; } }
+
         /// <summary>
         /// The stack source where allocation stacks are interned.  
         /// </summary>
@@ -284,6 +285,13 @@ namespace PerfView
         ///    * The object information (where it was allocated)
         /// </summary>
         public Action<double, int, Address, GCHeapSimulatorObject> OnObjectDestroy;
+
+        /// <summary>
+        /// If you are interested in when GCs happen, this delegate gets called exactly once
+        /// when a GC completes (before all the OnObjectDestroy for that GC).  It is passed
+        /// the time of the GC (technically the STOP of hte GC) and the generation being collected.
+        /// </summary>
+        public Action<double, int> OnGC;
 
         /// <summary>
         /// You can override this function to cause the simulator to allocate subclasses 
@@ -353,6 +361,7 @@ namespace PerfView
                 return;
 
             double gcTime = data.TimeStampRelativeMSec;
+            OnGC?.Invoke(gcTime, m_condemedGenerationNum);
 
             for (int curGenNum = 0; curGenNum <= m_condemedGenerationNum; curGenNum++)
             {

--- a/src/PerfView/memory/GCPinnedObjectAnalyzer.cs
+++ b/src/PerfView/memory/GCPinnedObjectAnalyzer.cs
@@ -513,7 +513,7 @@ namespace PerfView
 
         private void OnSetGCHandle(SetGCHandleTraceData data)
         {
-            if (ProcessId != data.ProcessID)
+            if (Process.ProcessID != data.ProcessID)
                 return;
 
             // This is not a pinned handle.


### PR DESCRIPTION
Added the Gen2 Object Death view that use the 100KB allocation events (coarse sampling).  Thus most traces
will now have this view (inncluding the /GCOnly view).   This view shows you were you allocated objects that
then die in Gen 2 (These are the
most important for reducing the number of Gen2 GCs (and Gen 2 GC fragmentation)).   You coudl do this before
when you truned on /DotNetAlloc or /DotNetAllocSampled collection but those are more expensive and can have
logistic issues (you can't attach to a existing process).    The view will only show you a coarse sampling
but that often has useful information.

Added the 'GC Occured Gen(X)' frame to the GC Heap Net Alloc and GC 2 Object Death views.   These are
useful for seeing where the GCs in time without having to go to the GCStats or Events views.