### PR TITLE
Intern tree strings

### DIFF
--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -1107,7 +1107,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             Debug.Assert(source.IsGraphSource);
             Debug.Assert(samplesToNodes != null);
 
-            var childrenSet = new Dictionary<string, CallTreeNode>();
+            var childrenSet = new SortedDictionary<string, CallTreeNode>(StringComparer.Ordinal);
             // Exclude myself
             childrenSet[Name] = null;
             // Exclude the primary children

--- a/src/TraceEvent/Stacks/Interner.cs
+++ b/src/TraceEvent/Stacks/Interner.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tracing.Stacks
+{
+    public class Interner
+    {
+        private GrowableArray<string> _strings;
+        private readonly Dictionary<string, int> _stringToIndex;
+        private StrongBox<Interner> _version;
+
+        public Interner()
+        {
+            _stringToIndex = new Dictionary<string, int>();
+            _version = new StrongBox<Interner>(this);
+        }
+
+        public Key Intern(string value)
+        {
+            int index;
+            if (_stringToIndex.TryGetValue(value, out index))
+                return new Key(this, _strings[index], index);
+
+            index = _strings.Count;
+            _stringToIndex[value] = index;
+            _strings.Set(index, value);
+            return new Key(this, value, index);
+        }
+
+        private void Clear()
+        {
+            _strings.Count = 0;
+            _stringToIndex.Clear();
+            _version.Value = null;
+            _version = new StrongBox<Interner>(this);
+        }
+
+        public struct Key
+        {
+            private readonly StrongBox<Interner> _internerId;
+            private readonly string _value;
+            private readonly int _index;
+
+            public Key(Interner interner, string value, int index)
+            {
+                Debug.Assert(index == -1 || ReferenceEquals(interner._strings[index], value));
+                _internerId = interner._version;
+                _value = value;
+                _index = index;
+            }
+
+            public int Index
+            {
+                get
+                {
+                    Debug.Assert(_index >= 0 && _internerId.Value != null);
+                    return _index;
+                }
+            }
+
+            public override string ToString()
+            {
+                return _value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Improves the performance of the call stacks by interning the strings used in comparison operations.

:memo: Please make sure to not rebase or squash this change during the merge process.