### PR TITLE
Remove histogram from memory stacks

### DIFF
--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -269,7 +269,7 @@ namespace PerfView
                 if (double.TryParse(filterParams.EndTimeRelativeMSec, out histogramEnd))
                     histogramEnd += .0006;
 
-                if (histogramEnd > histogramStart)
+                if (histogramEnd > histogramStart && asMemoryGraphSource == null)
                     newCallTree.TimeHistogramController = new TimeHistogramController(newCallTree, histogramStart, histogramEnd);
 
                 if (m_stackSource.ScenarioCount > 0)
@@ -353,13 +353,13 @@ namespace PerfView
                         stats = string.Format("{0}  First: {1:n3} Last: {2:n3}  Last-First: {3:n3}  Metric/Interval: {4:n2}  TimeBucket: {5:n1}", stats,
                         CallTree.Root.FirstTimeRelativeMSec, CallTree.Root.LastTimeRelativeMSec, CallTree.Root.DurationMSec,
                         CallTree.Root.InclusiveMetric / CallTree.Root.DurationMSec,
-                        CallTree.TimeHistogramController.BucketDuration);
+                        CallTree.TimeHistogramController?.BucketDuration);
                     }
 
                     if (ExtraTopStats != null)
                         stats = stats + " " + ExtraTopStats;
 
-                    if (ComputeMaxInTopStats)
+                    if (ComputeMaxInTopStats && CallTree.Root.InclusiveMetricByTime != null)
                     {
                         Histogram histogram = CallTree.Root.InclusiveMetricByTime;
                         TimeHistogramController controller = histogram.Controller as TimeHistogramController;


### PR DESCRIPTION
The histogram in this view showed the location of managed objects in memory. I didn't find it particularly useful, but calculating it resulted in substantial performance overhead when trying to review the results from large heap dumps.

:memo: Please make sure to not rebase or squash this change during the merge process.