### PR TITLE
Make error text bold briefly in the status bar

### DIFF
--- a/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
+++ b/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:perfview="clr-namespace:PerfView"
              mc:Ignorable="d" 
              d:DesignHeight="25" d:DesignWidth="500">
 
@@ -13,7 +14,30 @@
             <ColumnDefinition Width="auto"/>
             <ColumnDefinition Width="auto"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" Name="m_StatusMessage" ContextMenu="{x:Null}" IsReadOnly="True" VerticalScrollBarVisibility="Auto"/> 
+        <TextBox Grid.Column="0" Name="m_StatusMessage" ContextMenu="{x:Null}" IsReadOnly="True" VerticalScrollBarVisibility="Auto">
+            <TextBox.Triggers>
+                <EventTrigger RoutedEvent="perfview:StatusBar.HighlightMessage">
+                    <EventTrigger.Actions>
+                        <BeginStoryboard>
+                            <Storyboard RepeatBehavior="2x" TargetName="m_StatusMessage" TargetProperty="(TextElement.FontWeight)">
+                                <ObjectAnimationUsingKeyFrames Duration="00:00:00.5">
+                                    <DiscreteObjectKeyFrame>
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <FontWeight>Bold</FontWeight>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                    <DiscreteObjectKeyFrame>
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <FontWeight>Normal</FontWeight>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </EventTrigger.Actions>
+                </EventTrigger>
+            </TextBox.Triggers>g
+        </TextBox>
         <TextBlock Grid.Column="1" Name ="m_ProgressText" Width="85" Text="Ready" Margin="5,0,0,0" TextAlignment="Left" VerticalAlignment="Center"></TextBlock>
         <Button Grid.Column="2" Name ="m_LogButton" IsEnabled="true" Margin="5,2" ToolTip="Open the diagnostic log" Click="Log_Click">Log</Button>
         <Button Grid.Column="3" Name ="m_CancelButton" IsEnabled="false" Margin="5,2" ToolTip="Cancel the operation in flight (ESC)" Click="Cancel_Click">Cancel</Button>

--- a/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
+++ b/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
@@ -36,7 +36,7 @@
                         </BeginStoryboard>
                     </EventTrigger.Actions>
                 </EventTrigger>
-            </TextBox.Triggers>g
+            </TextBox.Triggers>
         </TextBox>
         <TextBlock Grid.Column="1" Name ="m_ProgressText" Width="85" Text="Ready" Margin="5,0,0,0" TextAlignment="Left" VerticalAlignment="Center"></TextBlock>
         <Button Grid.Column="2" Name ="m_LogButton" IsEnabled="true" Margin="5,2" ToolTip="Open the diagnostic log" Click="Log_Click">Log</Button>

--- a/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml.cs
+++ b/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml.cs
@@ -39,6 +39,7 @@ namespace PerfView
                 return;
             };
         }
+
         /// <summary>
         /// Report messages are short messages that are not persisted in the history, these are meant for
         /// messages that are not in direct response to a user command (and thus might be 'noise')
@@ -76,7 +77,18 @@ namespace PerfView
                     });
             }
             LoggedError = true;
+
+            m_StatusMessage.RaiseEvent(new RoutedEventArgs(StatusBar.HighlightMessageEvent, this));
         }
+
+        public static readonly RoutedEvent HighlightMessageEvent = EventManager.RegisterRoutedEvent("HighlightMessage", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(StatusBar));
+
+        public event RoutedEventHandler HighlightMessage
+        {
+            add { AddHandler(HighlightMessageEvent, value); }
+            remove { RemoveHandler(HighlightMessageEvent, value); }
+        }
+
         /// <summary>
         /// Have we just logged an error (last message in status bar is an error message)
         /// </summary>


### PR DESCRIPTION
A few times I did not notice that an error message had been written to the status bar. This change causes error message text (but not other messages) to briefly bold twice so the error is not overlooked then return to normal weight. I did some experimentation and this did the job without being irritating.