### PR TITLE
Added Support for Portable PDBs.   PerfView will now open either kind of PDB

### DIFF
--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -2456,15 +2456,15 @@ public class GCHeapDumper
             if (pdb == null)
                 return null;
 
-            return new SymbolResolver(m_symbolReader.OpenSymbolFile(pdb));
+            return new SymbolResolver(m_symbolReader.OpenWindowsSymbolFile(pdb));
         }
     }
 
     private class SymbolResolver : ISymbolResolver
     {
-        private SymbolModule m_symbolModule;
+        private NativeSymbolModule m_symbolModule;
 
-        public SymbolResolver(SymbolModule symbolModule)
+        public SymbolResolver(NativeSymbolModule symbolModule)
         {
             m_symbolModule = symbolModule;
         }

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -2456,7 +2456,7 @@ public class GCHeapDumper
             if (pdb == null)
                 return null;
 
-            return new SymbolResolver(m_symbolReader.OpenWindowsSymbolFile(pdb));
+            return new SymbolResolver(m_symbolReader.OpenNativeSymbolFile(pdb));
         }
     }
 

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -7409,10 +7409,10 @@ table {
             if (m_symReader == null)
                 m_symReader = App.GetSymbolReader(m_contextFilePath);
 
-            SymbolModule symbolModule = null;
+            NativeSymbolModule symbolModule = null;
             var pdbPath = m_symReader.FindSymbolFilePath(module.PdbName, module.PdbGuid, module.PdbAge, module.Path);
             if (pdbPath != null)
-                symbolModule = m_symReader.OpenSymbolFile(pdbPath);
+                symbolModule = m_symReader.OpenWindowsSymbolFile(pdbPath);
             else
             {
                 if (m_pdbLookupFailures == null)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -7412,7 +7412,7 @@ table {
             NativeSymbolModule symbolModule = null;
             var pdbPath = m_symReader.FindSymbolFilePath(module.PdbName, module.PdbGuid, module.PdbAge, module.Path);
             if (pdbPath != null)
-                symbolModule = m_symReader.OpenWindowsSymbolFile(pdbPath);
+                symbolModule = m_symReader.OpenNativeSymbolFile(pdbPath);
             else
             {
                 if (m_pdbLookupFailures == null)

--- a/src/PerfView/memory/ImageFileMemoryGraph.cs
+++ b/src/PerfView/memory/ImageFileMemoryGraph.cs
@@ -13,7 +13,7 @@ static class ImageFileMemoryGraph
         string pdbPath = symbolReader.FindSymbolFilePathForModule(dllPath);
         symbolReader.Log.WriteLine("Got PDB path {0}", pdbPath);
 
-        SymbolModule module = symbolReader.OpenSymbolFile(pdbPath);
+        NativeSymbolModule module = symbolReader.OpenWindowsSymbolFile(pdbPath);
         List<Symbol> symbols = new List<Symbol>();
         AddAllChildren(symbols, module.GlobalSymbol);
 

--- a/src/PerfView/memory/ImageFileMemoryGraph.cs
+++ b/src/PerfView/memory/ImageFileMemoryGraph.cs
@@ -13,7 +13,7 @@ static class ImageFileMemoryGraph
         string pdbPath = symbolReader.FindSymbolFilePathForModule(dllPath);
         symbolReader.Log.WriteLine("Got PDB path {0}", pdbPath);
 
-        NativeSymbolModule module = symbolReader.OpenWindowsSymbolFile(pdbPath);
+        NativeSymbolModule module = symbolReader.OpenNativeSymbolFile(pdbPath);
         List<Symbol> symbols = new List<Symbol>();
         AddAllChildren(symbols, module.GlobalSymbol);
 

--- a/src/PerfView/memory/PdbScopeMemoryGraph.cs
+++ b/src/PerfView/memory/PdbScopeMemoryGraph.cs
@@ -225,7 +225,7 @@ public class PdbScopeMemoryGraph : MemoryGraph
                     }
                 }
                 DebugWriteLine("Found pdb file " + pdbFilePath);
-                var module = symReader.OpenSymbolFile(pdbFilePath);
+                var module = symReader.OpenWindowsSymbolFile(pdbFilePath);
                 m_moduleMap = module.GetMergedAssembliesMap();
             }
         }

--- a/src/PerfView/memory/PdbScopeMemoryGraph.cs
+++ b/src/PerfView/memory/PdbScopeMemoryGraph.cs
@@ -225,7 +225,7 @@ public class PdbScopeMemoryGraph : MemoryGraph
                     }
                 }
                 DebugWriteLine("Found pdb file " + pdbFilePath);
-                var module = symReader.OpenWindowsSymbolFile(pdbFilePath);
+                var module = symReader.OpenNativeSymbolFile(pdbFilePath);
                 m_moduleMap = module.GetMergedAssembliesMap();
             }
         }

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -11,10 +11,16 @@ using Utilities;
 
 namespace Microsoft.Diagnostics.Symbols
 {
-
     /// <summary>
-    /// A symbolReaderModule represents a single PDB.   You get one from SymbolReader.OpenSymbolFile
-    /// It is effecively a managed interface to the Debug Interface Access (DIA) see 
+    /// A NativeSymbolModule represents symbol information for a native code module.   
+    /// NativeSymbolModules can potentially represent Managed modules (which is why it is a subclass of that interface).  
+    /// 
+    /// NativeSymbolModule should just be the CONTRACT for Native Symbols (some subclass implements
+    /// it for a particular format like Windows PDBs), however today because we have only one file format we
+    /// simply implement Windows PDBS here.   This can be factored out of this class when we 
+    /// support other formats (e.g. Dwarf).
+    /// 
+    /// To implmente support for Windows PDBs we use the Debug Interface Access (DIA).  See 
     /// http://msdn.microsoft.com/en-us/library/x93ctkx8.aspx for more.   I have only exposed what
     /// I need, and the interface is quite large (and not super pretty).  
     /// </summary>

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -1,0 +1,1310 @@
+﻿using Dia2Lib;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using Utilities;
+
+namespace Microsoft.Diagnostics.Symbols
+{
+
+    /// <summary>
+    /// A symbolReaderModule represents a single PDB.   You get one from SymbolReader.OpenSymbolFile
+    /// It is effecively a managed interface to the Debug Interface Access (DIA) see 
+    /// http://msdn.microsoft.com/en-us/library/x93ctkx8.aspx for more.   I have only exposed what
+    /// I need, and the interface is quite large (and not super pretty).  
+    /// </summary>
+    public unsafe class NativeSymbolModule : ManagedSymbolModule
+    {
+        /// <summary>
+        /// Finds a (method) symbolic name for a given relative virtual address of some code.  
+        /// Returns an empty string if a name could not be found. 
+        /// </summary>
+        public string FindNameForRva(uint rva)
+        {
+            uint dummy = 0;
+            return FindNameForRva(rva, ref dummy);
+        }
+        /// <summary>
+        /// Finds a (method) symbolic name for a given relative virtual address of some code.  
+        /// Returns an empty string if a name could not be found.  
+        /// symbolStartRva is set to the start of the symbol start 
+        /// </summary>
+        public string FindNameForRva(uint rva, ref uint symbolStartRva)
+        {
+            System.Threading.Thread.Sleep(0);           // Allow cancellation.  
+            if (m_symbolsByAddr == null)
+                return "";
+            IDiaSymbol symbol = m_symbolsByAddr.symbolByRVA(rva);
+            if (symbol == null)
+            {
+                Debug.WriteLine(string.Format("Warning: address 0x{0:x} not found.", rva));
+                return "";
+            }
+
+            var ret = symbol.name;
+            if (ret == null)
+            {
+                Debug.WriteLine(string.Format("Warning: address 0x{0:x} had a null symbol name.", rva));
+                return "";
+            }
+            var symbolLen = symbol.length;
+            if (symbolLen == 0)
+            {
+                Debug.WriteLine(string.Format("Warning: address 0x{0:x} symbol {1} has length 0", rva, ret));
+            }
+            symbolStartRva = symbol.relativeVirtualAddress;
+
+            // TODO determine why this happens!
+            var symbolRva = symbol.relativeVirtualAddress;
+            if (!(symbolRva <= rva && rva < symbolRva + symbolLen) && symbolLen != 0)
+            {
+                m_reader.Log.WriteLine("Warning: NOT IN RANGE: address 0x{0:x} start {2:x} end {3:x} Offset {4:x} Len {5:x}, symbol {1}, prefixing with ??.",
+                    rva, ret, symbolRva, symbolRva + symbolLen, rva - symbolRva, symbolLen);
+                ret = "??" + ret;   // Prefix with ?? to indicate it is questionable.  
+            }
+
+            // TODO FIX NOW, should not need to do this hand-unmangling.
+            if (0 <= ret.IndexOf('@'))
+            {
+                // TODO relatively inefficient.  
+                string unmangled = null;
+                symbol.get_undecoratedNameEx(0x1000, out unmangled);
+                if (unmangled != null)
+                    ret = unmangled;
+
+                if (ret.StartsWith("@"))
+                    ret = ret.Substring(1);
+                if (ret.StartsWith("_"))
+                    ret = ret.Substring(1);
+
+#if false // TODO FIX NOW remove  
+                var m = Regex.Match(ret, @"(.*)@\d+$");
+                if (m.Success)
+                    ret = m.Groups[1].Value;
+                else
+                    Debug.WriteLine(string.Format("Warning: address 0x{0:x} symbol {1} has a mangled name.", rva, ret));
+#else
+                var atIdx = ret.IndexOf('@');
+                if (0 < atIdx)
+                    ret = ret.Substring(0, atIdx);
+#endif
+            }
+
+            // See if this is a NGEN mangled name, which is $#Assembly#Token suffix.  If so strip it off. 
+            var dollarIdx = ret.LastIndexOf('$');
+            if (0 <= dollarIdx && dollarIdx + 2 < ret.Length && ret[dollarIdx + 1] == '#' && 0 <= ret.IndexOf('#', dollarIdx + 2))
+                ret = ret.Substring(0, dollarIdx);
+
+            // See if we have a Project N map that maps $_NN to a pre-merged assembly name 
+            var mergedAssembliesMap = GetMergedAssembliesMap();
+            if (mergedAssembliesMap != null)
+            {
+                bool prefixMatchFound = false;
+                Regex prefixMatch = new Regex(@"\$(\d+)_");
+                ret = prefixMatch.Replace(ret, delegate (Match m)
+                {
+                    prefixMatchFound = true;
+                    var original = m.Groups[1].Value;
+                    var moduleIndex = int.Parse(original);
+                    string fullAssemblyName;
+                    if (mergedAssembliesMap.TryGetValue(moduleIndex, out fullAssemblyName))
+                    {
+                        try
+                        {
+                            var assemblyName = new AssemblyName(fullAssemblyName);
+                            return assemblyName.Name + "!";
+                        }
+                        catch (Exception) { } // Catch all AssemlyName fails with ' in the name.   
+                    }
+                    return original;
+                });
+
+                // corefx.dll does not have a tag.  TODO this feels like a hack!
+                if (!prefixMatchFound)
+                    ret = "mscorlib!" + ret;
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Fetches the source location (line number and file), given the relative virtual address (RVA)
+        /// of the location in the executable.  
+        /// </summary>
+        public SourceLocation SourceLocationForRva(uint rva)
+        {
+            string dummyString;
+            uint dummyToken;
+            int dummyILOffset;
+            return SourceLocationForRva(rva, out dummyString, out dummyToken, out dummyILOffset);
+        }
+
+        /// <summary>
+        /// This overload of SourceLocationForRva like the one that takes only an RVA will return a source location
+        /// if it can.   However this version has additional support for NGEN images.   In the case of NGEN images 
+        /// for .NET V4.6.1 or later), the NGEN images can't convert all the way back to a source location, but they 
+        /// can convert the RVA back to IL artifacts (ilAssemblyName, methodMetadataToken, iloffset).  THese can then
+        /// be used to look up the source line using the IL PDB.  
+        /// 
+        /// Thus if the return value from this is null, check to see if the ilAssemblyName is non-null, and if not 
+        /// you can look up the source location using that information.  
+        /// </summary>
+        public SourceLocation SourceLocationForRva(uint rva, out string ilAssemblyName, out uint methodMetadataToken, out int ilOffset)
+        {
+            ilAssemblyName = null;
+            methodMetadataToken = 0;
+            ilOffset = -1;
+            m_reader.m_log.WriteLine("SourceLocationForRva: looking up RVA {0:x} ", rva);
+
+            // First fetch the line number information 'normally'.  (for the non-NGEN case, and old style NGEN (with /lines)). 
+            uint fetchCount;
+            IDiaEnumLineNumbers sourceLocs;
+            m_session.findLinesByRVA(rva, 0, out sourceLocs);
+            IDiaLineNumber sourceLoc;
+            sourceLocs.Next(1, out sourceLoc, out fetchCount);
+            if (fetchCount == 0)
+            {
+                // We have no native line number information.   See if we are an NGEN image and we can convert the RVA to an IL Offset.   
+                m_reader.m_log.WriteLine("SourceLocationForRva: did not find line info Looking for mangled symbol name (for NGEN pdbs)");
+                IDiaSymbol method = m_symbolsByAddr.symbolByRVA(rva);
+                if (method != null)
+                {
+                    // Check to see if the method name follows the .NET V4.6.1 conventions
+                    // of $#ASSEMBLY#TOKEN.   If so the line number we got back is not a line number at all but
+                    // an ILOffset. 
+                    string name = method.name;
+                    if (name != null)
+                    {
+                        m_reader.m_log.WriteLine("SourceLocationForRva: RVA lives in method with 4.6.1 mangled name {0}", name);
+                        int suffixIdx = name.LastIndexOf("$#");
+                        if (0 <= suffixIdx && suffixIdx + 2 < name.Length)
+                        {
+                            int tokenIdx = name.IndexOf('#', suffixIdx + 2);
+                            if (tokenIdx < 0)
+                            {
+                                m_reader.m_log.WriteLine("SourceLocationForRva: Error parsing method name mangling.  No # separating token");
+                                return null;
+                            }
+                            string tokenStr = name.Substring(tokenIdx + 1);
+                            int token;
+                            if (!int.TryParse(tokenStr, System.Globalization.NumberStyles.AllowHexSpecifier, null, out token))
+                            {
+                                m_reader.m_log.WriteLine("SourceLocationForRva: Could not parse token as a Hex number {0}", tokenStr);
+                                return null;
+                            }
+
+                            // We need the metadata token and assembly.   We get this from the name mangling of the method symbol, 
+                            // so look that up.  
+                            if (tokenIdx == suffixIdx + 2)      // The assembly name is null
+                            {
+                                ilAssemblyName = Path.GetFileNameWithoutExtension(SymbolFilePath);
+                                // strip off the .ni if present
+                                if (ilAssemblyName.EndsWith(".ni", StringComparison.OrdinalIgnoreCase))
+                                    ilAssemblyName = ilAssemblyName.Substring(0, ilAssemblyName.Length - 3);
+                            }
+                            else
+                                ilAssemblyName = name.Substring(suffixIdx + 2, tokenIdx - (suffixIdx + 2));
+                            methodMetadataToken = (uint)token;
+                            ilOffset = 0;           // If we don't find an IL offset, we 'guess' an ILOffset of 0
+
+                            m_reader.m_log.WriteLine("SourceLocationForRva: Looking up IL Offset by RVA 0x{0:x}", rva);
+                            m_session.findILOffsetsByRVA(rva, 0, out sourceLocs);
+                            // FEEFEE is some sort of illegal line number that is returned some time,  It is better to ignore it.  
+                            // and take the next valid line
+                            for (; ; )
+                            {
+                                sourceLocs.Next(1, out sourceLoc, out fetchCount);
+                                if (fetchCount == 0)
+                                {
+                                    m_reader.m_log.WriteLine("SourceLocationForRva: Ran out of IL mappings, guessing 0x{0:x}", ilOffset);
+                                    break;
+                                }
+                                ilOffset = (int)sourceLoc.lineNumber;
+                                if (ilOffset != 0xFEEFEE)
+                                    break;
+                                m_reader.m_log.WriteLine("SourceLocationForRva: got illegal offset FEEFEE picking next offset.");
+                                ilOffset = 0;
+                            }
+                            m_reader.m_log.WriteLine("SourceLocationForRva: Found native to IL mappings, IL offset 0x{0:x}", ilOffset);
+                            return null;                           // we don't have source information but we did return the IL information. 
+                        }
+                    }
+                }
+                m_reader.m_log.WriteLine("SourceLocationForRva: No lines for RVA {0:x} ", rva);
+                return null;
+            }
+
+            // If we reach here we are in the non-NGEN case, we are not mapping to IL information and 
+            IDiaSourceFile diaSrcFile = sourceLoc.sourceFile;
+            var lineNum = (int)sourceLoc.lineNumber;
+
+            var sourceFile = new MicrosoftPdbSourceFile(this, diaSrcFile);
+            if (lineNum == 0xFEEFEE)
+                lineNum = 0;
+            var sourceLocation = new SourceLocation(sourceFile, lineNum);
+            m_reader.m_log.WriteLine("SourceLocationForRva: RVA {0:x} maps to line {1} file {2} ", rva, lineNum, sourceFile.BuildTimeFilePath);
+            return sourceLocation;
+        }
+
+        /// <summary>
+        /// Managed code is shipped as IL, so RVA to NATIVE mapping can't be placed in the PDB. Instead
+        /// what is placed in the PDB is a mapping from a method's meta-data token and IL offset to source
+        /// line number.  Thus if you have a metadata token and IL offset, you can again get a source location
+        /// </summary>
+        public override SourceLocation SourceLocationForManagedCode(uint methodMetadataToken, int ilOffset)
+        {
+            m_reader.m_log.WriteLine("SourceLocationForManaged: Looking up method token {0:x} ilOffset {1:x}", methodMetadataToken, ilOffset);
+
+            IDiaSymbol methodSym;
+            m_session.findSymbolByToken(methodMetadataToken, SymTagEnum.SymTagFunction, out methodSym);
+            if (methodSym == null)
+            {
+                m_reader.m_log.WriteLine("SourceLocationForManaged: No symbol for token {0:x} ilOffset {1:x}", methodMetadataToken, ilOffset);
+                return null;
+            }
+
+            uint fetchCount;
+            IDiaEnumLineNumbers sourceLocs;
+            IDiaLineNumber sourceLoc;
+
+            // TODO FIX NOW, this code here is for debugging only turn if off when we are happy.  
+            //m_session.findLinesByRVA(methodSym.relativeVirtualAddress, (uint)(ilOffset + 256), out sourceLocs);
+            //for (int i = 0; ; i++)
+            //{
+            //    sourceLocs.Next(1, out sourceLoc, out fetchCount);
+            //    if (fetchCount == 0)
+            //        break;
+            //    if (i == 0)
+            //        m_reader.m_log.WriteLine("SourceLocationForManaged source file: {0}", sourceLoc.sourceFile.fileName);
+            //    m_reader.m_log.WriteLine("SourceLocationForManaged ILOffset {0:x} -> line {1}",
+            //        sourceLoc.relativeVirtualAddress - methodSym.relativeVirtualAddress, sourceLoc.lineNumber);
+            //} // End TODO FIX NOW debugging code
+
+            // For managed code, the 'RVA' is a 'cumulative IL offset' (amount of IL bytes before this in the module)
+            // Thus you find the line number of a particular IL offset by adding the offset within the method to
+            // the cumulative IL offset of the start of the method.  
+            m_session.findLinesByRVA(methodSym.relativeVirtualAddress + (uint)ilOffset, 256, out sourceLocs);
+            sourceLocs.Next(1, out sourceLoc, out fetchCount);
+            if (fetchCount == 0)
+            {
+                m_reader.m_log.WriteLine("SourceLocationForManaged: No lines for token {0:x} ilOffset {1:x}", methodMetadataToken, ilOffset);
+                return null;
+            }
+
+            var sourceFile = new MicrosoftPdbSourceFile(this, sourceLoc.sourceFile);
+            int lineNum;
+            // FEEFEE is some sort of illegal line number that is returned some time,  It is better to ignore it.  
+            // and take the next valid line
+            for (; ; )
+            {
+                lineNum = (int)sourceLoc.lineNumber;
+                if (lineNum != 0xFEEFEE)
+                    break;
+                lineNum = 0;
+                sourceLocs.Next(1, out sourceLoc, out fetchCount);
+                if (fetchCount == 0)
+                    break;
+            }
+
+            var sourceLocation = new SourceLocation(sourceFile, lineNum);
+            m_reader.m_log.WriteLine("SourceLocationForManaged: found source linenum {0} file {1}", lineNum, sourceFile.BuildTimeFilePath);
+            return sourceLocation;
+        }
+
+        /// <summary>
+        /// The symbol representing the module as a whole.  All global symbols are children of this symbol 
+        /// </summary>
+        public Symbol GlobalSymbol { get { return new Symbol(this, m_session.globalScope); } }
+
+#if TEST_FIRST
+        /// <summary>
+        /// Returns a list of all source files referenced in the PDB
+        /// </summary>
+        public IEnumerable<SourceFile> AllSourceFiles()
+        {
+
+            IDiaEnumTables tables;
+            m_session.getEnumTables(out tables);
+
+            IDiaEnumSourceFiles sourceFiles;
+            IDiaTable table = null;
+            uint fetchCount = 0;
+            for (; ; )
+            {
+                tables.Next(1, ref table, ref fetchCount);
+                if (fetchCount == 0)
+                    return null;
+                sourceFiles = table as IDiaEnumSourceFiles;
+                if (sourceFiles != null)
+                    break;
+            }
+
+            var ret = new List<SourceFile>();
+            IDiaSourceFile sourceFile = null;
+            for (; ; )
+            {
+                sourceFiles.Next(1, out sourceFile, out fetchCount);
+                if (fetchCount == 0)
+                    break;
+                ret.Add(new SourceFile(this, sourceFile));
+            }
+            return ret;
+        }
+#endif
+
+        /// <summary>
+        /// The a unique identifier that is used to relate the DLL and its PDB.   
+        /// </summary>
+        public override Guid PdbGuid { get { return m_session.globalScope.guid; } }
+        /// <summary>
+        /// Along with the PdbGuid, there is a small integer 
+        /// call the age is also used to find the PDB (it represents the different 
+        /// post link transformations the DLL has undergone).  
+        /// </summary>
+        public override int PdbAge { get { return (int)m_session.globalScope.age; } }
+
+        #region private
+        /// <summary>
+        /// A source file represents a source file from a PDB.  This is not just a string
+        /// because the file has a build time path, a checksum, and it needs to be 'smart'
+        /// to copy down the file if requested.  
+        /// 
+        /// TODO We don't need this subclass.   We can have SourceFile simply a container
+        /// that holds the BuildTimePath, hashType and hashValue.    The lookup of the
+        /// source can then be put on NativeSymbolModule and called from SourceFile generically.  
+        /// This makes the different symbol files more simmilar and is a nice simplification.  
+        /// </summary>
+        public class MicrosoftPdbSourceFile : SourceFile
+        {
+            /// <summary>
+            /// If the source file is directly available on the web (that is there is a Url that 
+            /// can be used to fetch it with HTTP Get), then return that Url.   If no such publishing 
+            /// point exists this property will return null.   
+            /// </summary>
+            public override string Url
+            {
+                get
+                {
+                    string target, command;
+                    GetSourceServerTargetAndCommand(out target, out command);
+
+                    if (!string.IsNullOrEmpty(target) && Uri.IsWellFormedUriString(target, UriKind.Absolute))
+                        return target;
+                    else
+                        return null;
+                }
+            }
+
+            /// <summary>
+            /// Try to fetch the source file associated with 'buildTimeFilePath' from the symbol server 
+            /// information from the PDB from 'pdbPath'.   Will return a path to the returned file (uses 
+            /// SourceCacheDirectory associated symbol reader for context where to put the file), 
+            /// or null if unsuccessful.  
+            /// 
+            /// There is a tool called pdbstr associated with srcsrv that basically does this.  
+            ///     pdbstr -r -s:srcsrv -p:PDBPATH
+            /// will dump it. 
+            ///
+            /// The basic flow is 
+            /// 
+            /// There is a variables section and a files section
+            /// 
+            /// The file section is a list of items separated by *.   The first is the path, the rest are up to you
+            /// 
+            /// You form a command by using the SRCSRVTRG variable and substituting variables %var1 where var1 is the first item in the * separated list
+            /// There are special operators %fnfile%(XXX), etc that manipulate the string XXX (get file name, translate \ to / ...
+            /// 
+            /// If what is at the end is a valid URL it is looked up.   
+            /// </summary>
+            public override  string GetSourceFromSrcServer()
+            {
+                var cacheDir = _symbolModule.SymbolReader.SourceCacheDirectory;
+
+                string target, fetchCmdStr;
+                GetSourceServerTargetAndCommand(out target, out fetchCmdStr, cacheDir);
+
+                if (target != null)
+                {
+                    if (!target.StartsWith(cacheDir, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // if target is not in cache dir, it means it's from a remote server.
+                        Uri uri = null;
+                        if (Uri.TryCreate(target, UriKind.Absolute, out uri))
+                        {
+                            target = null;
+                            var newTarget = Path.Combine(cacheDir, uri.AbsolutePath.TrimStart('/').Replace('/', '\\'));
+                            if (_symbolModule.SymbolReader.GetPhysicalFileFromServer(uri.GetLeftPart(UriPartial.Authority), uri.AbsolutePath, newTarget))
+                                target = newTarget;
+
+                            if (target == null)
+                            {
+                                _log.WriteLine("Could not fetch {0} from web", uri.AbsoluteUri);
+                                return null;
+                            }
+                        }
+                        else
+                        {
+                            _log.WriteLine("Source Server string {0} is targeting an unsafe location.  Giving up.", target);
+                            return null;
+                        }
+                    }
+
+                    if (!File.Exists(target) && fetchCmdStr != null)
+                    {
+                        _log.WriteLine("Trying to generate the file {0}.", target);
+                        var toolsDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().ManifestModule.FullyQualifiedName);
+                        var archToolsDir = Path.Combine(toolsDir, NativeDlls.ProcessArchitectureDirectory);
+
+                        // Find the EXE to do the source server fetch.  We only support SD.exe and TF.exe.   
+                        string addToPath = null;
+                        if (fetchCmdStr.StartsWith("sd.exe ", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!File.Exists(Path.Combine(archToolsDir, "sd.exe")))
+                                _log.WriteLine("WARNING: Could not find sd.exe that should have been deployed at {0}", archToolsDir);
+                            addToPath = archToolsDir;
+                        }
+                        else
+                        if (fetchCmdStr.StartsWith("tf.exe ", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var tfExe = Command.FindOnPath("tf.exe");
+                            if (tfExe == null)
+                            {
+                                tfExe = FindTfExe();
+                                if (tfExe == null)
+                                {
+                                    _log.WriteLine("Could not find TF.exe, place it on the PATH environment variable to fix this.");
+                                    return null;
+                                }
+                                addToPath = Path.GetDirectoryName(tfExe);
+                            }
+                        }
+                        else
+                        {
+                            _log.WriteLine("Source Server command is not recognized as safe (sd.exe or tf.exe), failing.");
+                            return null;
+                        }
+                        Directory.CreateDirectory(Path.GetDirectoryName(target));
+                        fetchCmdStr = "cmd /c " + fetchCmdStr;
+                        var options = new CommandOptions().AddOutputStream(_log).AddNoThrow();
+                        if (addToPath != null)
+                            options = options.AddEnvironmentVariable("PATH", addToPath + ";%PATH%");
+
+                        _log.WriteLine("Source Server command {0}", fetchCmdStr);
+                        var fetchCmd = Command.Run(fetchCmdStr, options);
+                        if (fetchCmd.ExitCode != 0)
+                            _log.WriteLine("Source Server command failed with exit code {0}", fetchCmd.ExitCode);
+                        if (File.Exists(target))
+                        {
+                            // If TF.exe command files it might still create an empty output file.   Fix that 
+                            if (new FileInfo(target).Length == 0)
+                            {
+                                File.Delete(target);
+                                target = null;
+                            }
+                        }
+                        else
+                            target = null;
+
+                        if (target == null)
+                            _log.WriteLine("Source Server command failed to produce the output file.");
+                        else
+                            _log.WriteLine("Source Server command succeeded creating {0}", target);
+                    }
+                    else
+                        _log.WriteLine("Found an existing source server file {0}.", target);
+                    return target;
+                }
+
+                _log.WriteLine("Did not find source file in the set of source files in the PDB.");
+                return null;
+            }
+
+
+            #region private
+            unsafe internal MicrosoftPdbSourceFile(NativeSymbolModule module, IDiaSourceFile sourceFile) : base(module)
+            {
+                BuildTimeFilePath = sourceFile.fileName;
+
+                // 0 No checksum present.
+                // 1 CALG_MD5 checksum generated with the MD5 hashing algorithm.
+                // 2 CALG_SHA1 checksum generated with the SHA1 hashing algorithm.
+                // 3 checksum generated with the SHA256 hashing algorithm.
+                if (sourceFile.checksumType == 1)
+                    _hashAlgorithm = new System.Security.Cryptography.MD5CryptoServiceProvider();
+                else if (sourceFile.checksumType == 2)
+                    _hashAlgorithm = new System.Security.Cryptography.SHA1CryptoServiceProvider();
+                else if (sourceFile.checksumType == 3)
+                    _hashAlgorithm = new System.Security.Cryptography.SHA256CryptoServiceProvider();
+
+                if (_hashAlgorithm != null)
+                {
+                    uint hashSizeInBytes;
+                    byte* dummy = null;
+                    sourceFile.get_checksum(0, out hashSizeInBytes, out *dummy);
+
+                    // MD5 is 16 bytes
+                    // SHA1 is 20 bytes  
+                    // SHA-256 is 32 bytes
+                    _hash = new byte[hashSizeInBytes];
+
+                    uint bytesFetched;
+                    fixed (byte* bufferPtr = _hash)
+                        sourceFile.get_checksum((uint)_hash.Length, out bytesFetched, out *bufferPtr);
+                    Debug.Assert(bytesFetched == _hash.Length);
+                }
+            }
+
+            /// <summary>
+            /// Parse the 'srcsrv' stream in a PDB file and return the target for SourceFile
+            /// represented by the 'this' pointer.   This target is iether a ULR or a local file
+            /// path.  
+            /// 
+            /// You can dump the srcsrv stream using a tool called pdbstr 
+            ///     pdbstr -r -s:srcsrv -p:PDBPATH
+            /// 
+            /// The target in this stream is called SRCSRVTRG and there is another variable SRCSRVCMD
+            /// which represents the command to run to fetch the soruce into SRCSRVTRG
+            /// 
+            /// To form the target, the stream expect you to private a %targ% variable which is a directory
+            /// prefix to tell where to put the source file being fetched.   If the source file is
+            /// available via a URL this variable is not needed.  
+            /// 
+            ///  ********* This is a typical example of what is in a PDB with source server information. 
+            ///  SRCSRV: ini ------------------------------------------------
+            ///  VERSION=3
+            ///  INDEXVERSION=2
+            ///  VERCTRL=Team Foundation Server
+            ///  DATETIME=Thu Mar 10 16:15:55 2016
+            ///  SRCSRV: variables ------------------------------------------
+            ///  TFS_EXTRACT_CMD=tf.exe view /version:%var4% /noprompt "$%var3%" /server:%fnvar%(%var2%) /output:%srcsrvtrg%
+            ///  TFS_EXTRACT_TARGET=%targ%\%var2%%fnbksl%(%var3%)\%var4%\%fnfile%(%var1%)
+            ///  VSTFDEVDIV_DEVDIV2=http://vstfdevdiv.redmond.corp.microsoft.com:8080/DevDiv2
+            ///  SRCSRVVERCTRL=tfs
+            ///  SRCSRVERRDESC=access
+            ///  SRCSRVERRVAR=var2
+            ///  SRCSRVTRG=%TFS_extract_target%
+            ///  SRCSRVCMD=%TFS_extract_cmd%
+            ///  SRCSRV: source files ---------------------------------            ------
+            ///  f:\dd\externalapis\legacy\vctools\vc12\inc\cvconst.h*VSTFDEVDIV_DEVDIV2*/DevDiv/Fx/Rel/NetFxRel3Stage/externalapis/legacy/vctools/vc12/inc/cvconst.h*1363200
+            ///  f:\dd\externalapis\legacy\vctools\vc12\inc\cvinfo.h*VSTFDEVDIV_DEVDIV2*/DevDiv/Fx/Rel/NetFxRel3Stage/externalapis/legacy/vctools/vc12/inc/cvinfo.h*1363200
+            ///  f:\dd\externalapis\legacy\vctools\vc12\inc\vc\ammintrin.h*VSTFDEVDIV_DEVDIV2*/DevDiv/Fx/Rel/NetFxRel3Stage/externalapis/legacy/vctools/vc12/inc/vc/ammintrin.h*1363200
+            ///  SRCSRV: end ------------------------------------------------
+            ///  
+            ///  ********* And here is a more modern one where the source code is available via a URL.  
+            ///  SRCSRV: ini ------------------------------------------------
+            ///  VERSION=2
+            ///  INDEXVERSION=2
+            ///  VERCTRL=http
+            ///  SRCSRV: variables ------------------------------------------
+            ///  SRCSRVTRG=https://nuget.smbsrc.net/src/%fnfile%(%var1%)/%var2%/%fnfile%(%var1%)
+            ///  SRCSRVCMD=
+            ///  SRCSRVVERCTRL=http
+            ///  SRCSRV: source files ---------------------------------------
+            ///  c:\Users\rafalkrynski\Documents\Visual Studio 2012\Projects\DavidSymbolSourceTest\DavidSymbolSourceTest\Demo.cs*SQPvxWBMtvANyCp8Pd3OjoZEUgpKvjDVIY1WbaiFPMw=
+            ///  SRCSRV: end ------------------------------------------------
+            ///  
+            /// </summary>
+            /// <param name="target">returns the target source file path</param>
+            /// <param name="command">returns the command to fetch the target source file</param>
+            /// <param name="localDirectoryToPlaceSourceFiles">Specify the value for %targ% variable. This is the
+            /// directory where source files can be fetched to.  Typically the returned file is under this directory
+            /// If the value is null, %targ% variable be emtpy.  This assumes that the resulting file is something
+            /// that does not need to be copied to the machine (either a URL or a file that already exists)</param>
+            private void GetSourceServerTargetAndCommand(out string target, out string command, string localDirectoryToPlaceSourceFiles = null)
+            {
+                target = null;
+                command = null;
+
+                _log.WriteLine("*** Looking up {0} using source server", BuildTimeFilePath);
+
+                var srcServerPdb = (_symbolModule as NativeSymbolModule).PdbForSourceServer as NativeSymbolModule;
+                if (srcServerPdb == null)
+                {
+                    _log.WriteLine("*** Could not find PDB to look up source server information");
+                    return;
+                }
+
+                string srcsvcStream = srcServerPdb.GetSrcSrvStream();
+                if (srcsvcStream == null)
+                {
+                    _log.WriteLine("*** Could not find srcsrv stream in PDB file");
+                    return;
+                }
+
+                _log.WriteLine("*** Found srcsrv stream in PDB file. of size {0}", srcsvcStream.Length);
+                StringReader reader = new StringReader(srcsvcStream);
+
+                bool inSrc = false;
+                bool inVars = false;
+                var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                if (localDirectoryToPlaceSourceFiles != null)
+                    vars.Add("targ", localDirectoryToPlaceSourceFiles);
+
+                for (; ; )
+                {
+                    var line = reader.ReadLine();
+                    if (line == null)
+                        break;
+
+                    // log.WriteLine("Got srcsrv line {0}", line);
+                    if (line.StartsWith("SRCSRV: "))
+                    {
+                        inSrc = line.StartsWith("SRCSRV: source files");
+                        inVars = line.StartsWith("SRCSRV: variables");
+                        continue;
+                    }
+                    if (inSrc)
+                    {
+                        var pieces = line.Split('*');
+                        if (pieces.Length >= 2)
+                        {
+                            var buildTimePath = pieces[0];
+                            // log.WriteLine("Found source {0} in the PDB", buildTimePath);
+                            if (string.Compare(BuildTimeFilePath, buildTimePath, StringComparison.OrdinalIgnoreCase) == 0)
+                            {
+                                // Create variables for each of the pieces.  
+                                for (int i = 0; i < pieces.Length; i++)
+                                    vars.Add("var" + (i + 1).ToString(), pieces[i]);
+
+                                target = SourceServerFetchVar("SRCSRVTRG", vars);
+                                command = SourceServerFetchVar("SRCSRVCMD", vars);
+
+                                return;
+                            }
+                        }
+                    }
+                    else if (inVars)
+                    {
+                        // Gather up the KEY=VALUE pairs into a dictionary.  
+                        var m = Regex.Match(line, @"^(\w+)=(.*?)\s*$");
+                        if (m.Success)
+                            vars[m.Groups[1].Value] = m.Groups[2].Value;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Returns the location of the tf.exe executable or 
+            /// </summary>
+            /// <returns></returns>
+            private static string FindTfExe()
+            {
+                // If you have VS installed used that TF.exe associated with that.  
+                var progFiles = Environment.GetEnvironmentVariable("ProgramFiles (x86)");
+                if (progFiles == null)
+                    progFiles = Environment.GetEnvironmentVariable("ProgramFiles");
+                if (progFiles != null)
+                {
+                    // Find the oldest Visual Studio directory;
+                    var dirs = Directory.GetDirectories(progFiles, "Microsoft Visual Studio*");
+                    Array.Sort(dirs);
+                    if (dirs.Length > 0)
+                    {
+                        var VSDir = Path.Combine(dirs[dirs.Length - 1], @"Common7\IDE");
+                        var tfexe = Path.Combine(VSDir, "tf.exe");
+                        if (File.Exists(tfexe))
+                            return tfexe;
+                    }
+                }
+                return null;
+            }
+
+            private string SourceServerFetchVar(string variable, Dictionary<string, string> vars)
+            {
+                string result = "";
+                if (vars.TryGetValue(variable, out result))
+                {
+                    if (0 <= result.IndexOf('%'))
+                        _log.WriteLine("SourceServerFetchVar: Before Evaluation {0} = '{1}'", variable, result);
+                    result = SourceServerEvaluate(result, vars);
+                }
+                _log.WriteLine("SourceServerFetchVar: {0} = '{1}'", variable, result);
+                return result;
+            }
+
+            private string SourceServerEvaluate(string result, Dictionary<string, string> vars)
+            {
+                if (0 <= result.IndexOf('%'))
+                {
+                    // see http://msdn.microsoft.com/en-us/library/windows/desktop/ms680641(v=vs.85).aspx for details on the %fn* variables 
+                    result = Regex.Replace(result, @"%fnvar%\((.*?)\)", delegate (Match m)
+                    {
+                        return SourceServerFetchVar(SourceServerEvaluate(m.Groups[1].Value, vars), vars);
+                    });
+                    result = Regex.Replace(result, @"%fnbksl%\((.*?)\)", delegate (Match m)
+                    {
+                        return SourceServerEvaluate(m.Groups[1].Value, vars).Replace('/', '\\');
+                    });
+                    result = Regex.Replace(result, @"%fnfile%\((.*?)\)", delegate (Match m)
+                    {
+                        return Path.GetFileName(SourceServerEvaluate(m.Groups[1].Value, vars));
+                    });
+                    // Normal variable substitution
+                    result = Regex.Replace(result, @"%(\w+)%", delegate (Match m)
+                    {
+                        return SourceServerFetchVar(m.Groups[1].Value, vars);
+                    });
+                }
+                return result;
+            }
+
+            // Here is an example of the srcsrv stream.  
+#if false
+SRCSRV: ini ------------------------------------------------
+VERSION=3
+INDEXVERSION=2
+VERCTRL=Team Foundation Server
+DATETIME=Wed Nov 28 03:47:14 2012
+SRCSRV: variables ------------------------------------------
+TFS_EXTRACT_CMD=tf.exe view /version:%var4% /noprompt "$%var3%" /server:%fnvar%(%var2%) /console >%srcsrvtrg%
+TFS_EXTRACT_TARGET=%targ%\%var2%%fnbksl%(%var3%)\%var4%\%fnfile%(%var1%)
+SRCSRVVERCTRL=tfs
+SRCSRVERRDESC=access
+SRCSRVERRVAR=var2
+DEVDIV_TFS2=http://vstfdevdiv.redmond.corp.microsoft.com:8080/devdiv2
+SRCSRVTRG=%TFS_extract_target%
+SRCSRVCMD=%TFS_extract_cmd%
+SRCSRV: source files ---------------------------------------
+f:\dd\ndp\clr\src\vm\i386\gmsasm.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/gmsasm.asm*592925
+f:\dd\ndp\clr\src\vm\i386\jithelp.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/jithelp.asm*592925
+f:\dd\ndp\clr\src\vm\i386\RedirectedHandledJITCase.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/RedirectedHandledJITCase.asm*592925
+f:\dd\public\devdiv\inc\ddbanned.h*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/public/devdiv/inc/ddbanned.h*592925
+f:\dd\ndp\clr\src\debug\ee\i386\dbghelpers.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/Debug/EE/i386/dbghelpers.asm*592925
+SRCSRV: end ------------------------------------------------
+      
+        // Here is one for SD. 
+
+SRCSRV: ini ------------------------------------------------
+VERSION=1
+VERCTRL=Source Depot
+SRCSRV: variables ------------------------------------------
+SRCSRVTRG=%targ%\%var2%\%fnbksl%(%var3%)\%var4%\%fnfile%(%var1%)
+SRCSRVCMD=sd.exe -p %fnvar%(%var2%) print -o %srcsrvtrg% -q %depot%/%var3%#%var4%
+DEPOT=//depot
+SRCSRVVERCTRL=sd
+SRCSRVERRDESC=Connect to server failed
+SRCSRVERRVAR=var2
+WIN_MINKERNEL=minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020
+WIN_PUBLIC=publicdepot.sys-ntgroup.ntdev.microsoft.com:2017
+WIN_PUBLICINT=publicintdepot.sys-ntgroup.ntdev.microsoft.com:2018
+SRCSRV: source files ---------------------------------------
+d:\win7sp1_gdr.public.amd64fre\sdk\inc\pshpack4.h*WIN_PUBLIC*win7sp1_gdr/public/sdk/inc/pshpack4.h*1
+d:\win7sp1_gdr.public.amd64fre\internal\minwin\priv_sdk\inc\ntos\pnp.h*WIN_PUBLICINT*win7sp1_gdr/publicint/minwin/priv_sdk/inc/ntos/pnp.h*1
+d:\win7sp1_gdr.public.amd64fre\internal\minwin\priv_sdk\inc\ntos\cm.h*WIN_PUBLICINT*win7sp1_gdr/publicint/minwin/priv_sdk/inc/ntos/cm.h*1
+d:\win7sp1_gdr.public.amd64fre\internal\minwin\priv_sdk\inc\ntos\pnp_x.h*WIN_PUBLICINT*win7sp1_gdr/publicint/minwin/priv_sdk/inc/ntos/pnp_x.h*2
+SRCSRV: end ------------------------------------------------
+
+
+#endif
+#if false
+        // Here is ana example of the stream in use for the jithlp.asm file.  
+
+f:\dd\ndp\clr\src\vm\i386\jithelp.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/jithelp.asm*592925
+
+        // Here is the command that it issues.  
+tf.exe view /version:592925 /noprompt "$/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/jithelp.asm" /server:http://vstfdevdiv.redmond.corp.microsoft.com:8080/devdiv2 /console >"C:\Users\vancem\AppData\Local\Temp\PerfView\src\DEVDIV_TFS2\DevDiv\D11RelS\FX45RTMGDR\ndp\clr\src\VM\i386\jithelp.asm\592925\jithelp.asm"
+
+sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users\vancem\AppData\Local\Temp\PerfView\src\WIN_MINKERNEL\win8_gdr\minkernel\ntdll\rtlstrt.c\1\rtlstrt.c" -q //depot/win8_gdr/minkernel/ntdll/rtlstrt.c#1
+
+#endif
+            #endregion
+        }
+
+        private void Initialize(SymbolReader reader, string pdbFilePath, Action loadData)
+        {
+            this.m_reader = reader;
+
+            m_source = DiaLoader.GetDiaSourceObject();
+            loadData();
+            m_source.openSession(out m_session);
+            m_session.getSymbolsByAddr(out m_symbolsByAddr);
+
+            m_reader.m_log.WriteLine("Opening PDB {0} with signature GUID {1} Age {2}", pdbFilePath, PdbGuid, PdbAge);
+        }
+
+        internal NativeSymbolModule(SymbolReader reader, string pdbFilePath) : base(reader, pdbFilePath)
+        {
+            Initialize(reader, pdbFilePath, () => m_source.loadDataFromPdb(pdbFilePath));
+        }
+
+        internal NativeSymbolModule(SymbolReader reader, string pdbFilePath, Stream pdbStream) : base(reader, pdbFilePath)
+        {
+            IStream comStream = new ComStreamWrapper(pdbStream);
+            Initialize(reader, pdbFilePath, () => m_source.loadDataFromIStream(comStream));
+        }
+
+        internal void LogManagedInfo(string pdbName, Guid pdbGuid, int pdbAge)
+        {
+            // Simply remember this if we decide we need it for source server support
+            m_managedPdbName = pdbName;
+            m_managedPdbGuid = pdbGuid;
+            m_managedPdbAge = pdbAge;
+        }
+
+        /// <summary>
+        /// Gets the 'srcsvc' data stream from the PDB and return it in as a string.   Returns null if it is not present. 
+        /// 
+        /// There is a tool called pdbstr associated with srcsrv that basically does this.  
+        ///     pdbstr -r -s:srcsrv -p:PDBPATH
+        /// will dump it. 
+        /// </summary>
+        internal string GetSrcSrvStream()
+        {
+            // In order to get the IDiaDataSource3 which includes'getStreamSize' API, you need to use the 
+            // dia2_internal.idl file from devdiv to produce the Interop.Dia2Lib.dll 
+            // see class DiaLoader for more
+            var log = m_reader.m_log;
+            log.WriteLine("Getting source server stream for PDB {0}", SymbolFilePath);
+            uint len = 0;
+            m_source.getStreamSize("srcsrv", out len);
+            if (len == 0)
+            {
+                if (0 <= SymbolFilePath.IndexOf(".ni.", StringComparison.OrdinalIgnoreCase))
+                    log.WriteLine("Error, trying to look up source information on an NGEN file, giving up");
+                else
+                    log.WriteLine("Pdb {0} does not have source server information (srcsrv stream) in it", SymbolFilePath);
+                return null;
+            }
+
+            byte[] buffer = new byte[len];
+            fixed (byte* bufferPtr = buffer)
+            {
+                m_source.getStreamRawData("srcsrv", len, out *bufferPtr);
+                var ret = UTF8Encoding.Default.GetString(buffer);
+                return ret;
+            }
+        }
+
+        // returns the path of the PDB that has source server information in it (which for NGEN images is the PDB for the managed image)
+        internal ManagedSymbolModule PdbForSourceServer
+        {
+            get
+            {
+                if (m_managedPdbName == null)
+                    return this;
+
+                if (!m_managedPdbAttempted)
+                {
+                    m_reader.m_log.WriteLine("We have a NGEN image with an IL PDB {0}, looking it up", m_managedPdbName);
+                    m_managedPdbAttempted = true;
+                    var managedPdbPath = m_reader.FindSymbolFilePath(m_managedPdbName, m_managedPdbGuid, m_managedPdbAge);
+                    if (managedPdbPath != null)
+                    {
+                        m_reader.m_log.WriteLine("Found managed PDB path {0}", managedPdbPath);
+                        m_managedPdb = m_reader.OpenSymbolFile(managedPdbPath);
+                    }
+                    else
+                        m_reader.m_log.WriteLine("Could not find managed PDB {0}", m_managedPdbName);
+                }
+                return m_managedPdb;
+            }
+        }
+
+        /// <summary>
+        /// For Project N modules it returns the list of pre merged IL assemblies and the corresponding mapping.
+        /// </summary>
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
+        public Dictionary<int, string> GetMergedAssembliesMap()
+        {
+            if (m_mergedAssemblies == null && !m_checkedForMergedAssemblies)
+            {
+                IDiaEnumInputAssemblyFiles diaMergedAssemblyRecords;
+                m_session.findInputAssemblyFiles(out diaMergedAssemblyRecords);
+                foreach (IDiaInputAssemblyFile inputAssembly in diaMergedAssemblyRecords)
+                {
+                    int index = (int)inputAssembly.index;
+                    string assemblyName = inputAssembly.fileName;
+
+                    if (m_mergedAssemblies == null)
+                        m_mergedAssemblies = new Dictionary<int, string>();
+                    m_mergedAssemblies.Add(index, assemblyName);
+                }
+                m_checkedForMergedAssemblies = true;
+            }
+            return m_mergedAssemblies;
+        }
+
+        /// <summary>
+        /// For ProjectN modules, gets the merged IL image embedded in the .PDB (only valid for single-file compilation)
+        /// </summary>
+        public MemoryStream GetEmbeddedILImage()
+        {
+            try
+            {
+                uint ilimageSize;
+                m_source.getStreamSize("ilimage", out ilimageSize);
+                if (ilimageSize > 0)
+                {
+                    byte[] ilImage = new byte[ilimageSize];
+                    m_source.getStreamRawData("ilimage", ilimageSize, out ilImage[0]);
+                    return new MemoryStream(ilImage);
+                }
+            }
+            catch (COMException)
+            {
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// For ProjectN modules, gets the pseudo-assembly embedded in the .PDB, if there is one.
+        /// </summary>
+        /// <returns></returns>
+        public MemoryStream GetPseudoAssembly()
+        {
+            try
+            {
+                uint ilimageSize;
+                m_source.getStreamSize("pseudoil", out ilimageSize);
+                if (ilimageSize > 0)
+                {
+                    byte[] ilImage = new byte[ilimageSize];
+                    m_source.getStreamRawData("pseudoil", ilimageSize, out ilImage[0]);
+                    return new MemoryStream(ilImage, writable: false);
+                }
+            }
+            catch (COMException)
+            {
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// For ProjectN modules, gets the binary blob that describes the mapping from RVAs to methods.
+        /// </summary>
+        public byte[] GetFuncMDTokenMap()
+        {
+            uint mapSize;
+            m_session.getFuncMDTokenMapSize(out mapSize);
+
+            byte[] buf = new byte[mapSize];
+            fixed (byte* pBuf = buf)
+            {
+                m_session.getFuncMDTokenMap((uint)buf.Length, out mapSize, out buf[0]);
+                Debug.Assert(mapSize == buf.Length);
+            }
+
+            return buf;
+        }
+
+        /// <summary>
+        /// For ProjectN modules, gets the binary blob that describes the mapping from RVAs to types.
+        /// </summary>
+        /// <returns></returns>
+        public byte[] GetTypeMDTokenMap()
+        {
+            uint mapSize;
+            m_session.getTypeMDTokenMapSize(out mapSize);
+
+            byte[] buf = new byte[mapSize];
+            fixed (byte* pBuf = buf)
+            {
+                m_session.getTypeMDTokenMap((uint)buf.Length, out mapSize, out buf[0]);
+                Debug.Assert(mapSize == buf.Length);
+            }
+
+            return buf;
+        }
+
+        bool m_checkedForMergedAssemblies;
+        Dictionary<int, string> m_mergedAssemblies;
+
+        private string m_managedPdbName;
+        private Guid m_managedPdbGuid;
+        private int m_managedPdbAge;
+        private ManagedSymbolModule m_managedPdb;
+        private bool m_managedPdbAttempted;
+
+        internal SymbolReader m_reader;
+        internal IDiaSession m_session;
+        IDiaDataSource3 m_source;
+        IDiaEnumSymbolsByAddr m_symbolsByAddr;
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Represents a single symbol in a PDB file.  
+    /// </summary>
+    public class Symbol : IComparable<Symbol>
+    {
+        /// <summary>
+        /// The name for the symbol 
+        /// </summary>
+        public string Name { get { return m_name; } }
+        /// <summary>
+        /// The relative virtual address (offset from the image base when loaded in memory) of the symbol
+        /// </summary>
+        public uint RVA { get { return m_diaSymbol.relativeVirtualAddress; } }
+        /// <summary>
+        /// The length of the memory that the symbol represents.  
+        /// </summary>
+        public ulong Length { get { return m_diaSymbol.length; } }
+        /// <summary>
+        /// A small integer identifier tat is unique for that symbol in the DLL. 
+        /// </summary>
+        public uint Id { get { return m_diaSymbol.symIndexId; } }
+
+        /// <summary>
+        /// Decorated names are names that most closely resemble the source code (have overloading).  
+        /// However when the linker does not directly support all the expressiveness of the
+        /// source language names are encoded to represent this.   This return this encoded name. 
+        /// </summary>
+        public string UndecoratedName
+        {
+            get
+            {
+                const uint UNDNAME_NO_PTR64 = 0x20000;
+                string undecoratedName;
+                m_diaSymbol.get_undecoratedNameEx(UNDNAME_NO_PTR64, out undecoratedName);
+
+                return undecoratedName ?? m_diaSymbol.name;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the two symbols live in the same linker section (e.g. text,  data ...)
+        /// </summary>
+        public static bool InSameSection(Symbol a, Symbol b)
+        {
+            return a.m_diaSymbol.addressSection == b.m_diaSymbol.addressSection;
+        }
+
+        /// <summary>
+        /// Returns the children of the symbol.  Will return null if there are no children.  
+        /// </summary>
+        public IEnumerable<Symbol> GetChildren()
+        {
+            return GetChildren(SymTagEnum.SymTagNull);
+        }
+
+        /// <summary>
+        /// Returns the children of the symbol, with the given tag.  Will return null if there are no children.  
+        /// </summary>
+        public IEnumerable<Symbol> GetChildren(SymTagEnum tag)
+        {
+            IDiaEnumSymbols symEnum = null;
+            m_module.m_session.findChildren(m_diaSymbol, tag, null, 0, out symEnum);
+            if (symEnum == null)
+                return null;
+
+            uint fetchCount;
+            var ret = new List<Symbol>();
+            for (; ; )
+            {
+                IDiaSymbol sym;
+                symEnum.Next(1, out sym, out fetchCount);
+                if (fetchCount == 0)
+                    break;
+                SymTagEnum symTag = (SymTagEnum)sym.symTag;
+                ret.Add(new Symbol(m_module, sym));
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        /// Compares the symbol by their relative virtual address (RVA)
+        /// </summary>
+        public int CompareTo(Symbol other)
+        {
+            return ((int)RVA - (int)other.RVA);
+        }
+        #region private
+#if false
+        // TODO FIX NOW use or remove
+        internal enum NameSearchOptions
+        {
+            nsNone,
+            nsfCaseSensitive = 0x1,
+            nsfCaseInsensitive = 0x2,
+            nsfFNameExt = 0x4,                  // treat as a file path
+            nsfRegularExpression = 0x8,         // * and ? wildcards
+            nsfUndecoratedName = 0x10,          // A undecorated name is the name you see in the source code.  
+        };
+#endif
+
+        /// <summary>
+        /// override
+        /// </summary>
+        public override string ToString()
+        {
+            return string.Format("Symbol({0}, RVA=0x{1:x}", Name, RVA);
+        }
+
+        internal Symbol(NativeSymbolModule module, IDiaSymbol diaSymbol)
+        {
+            m_module = module;
+            m_diaSymbol = diaSymbol;
+            m_name = m_diaSymbol.name;
+        }
+        private string m_name;
+        private IDiaSymbol m_diaSymbol;
+        private NativeSymbolModule m_module;
+        #endregion
+    }
+}
+
+#region private classes
+
+internal sealed class ComStreamWrapper : IStream
+{
+    private readonly Stream stream;
+
+    public ComStreamWrapper(Stream stream)
+    {
+        this.stream = stream;
+    }
+
+    public void Commit(uint grfCommitFlags)
+    {
+        throw new NotSupportedException();
+    }
+
+    public unsafe void RemoteRead(out byte pv, uint cb, out uint pcbRead)
+    {
+        byte[] buf = new byte[cb];
+
+        int bytesRead = stream.Read(buf, 0, (int)cb);
+        pcbRead = (uint)bytesRead;
+
+        fixed (byte* p = &pv)
+        {
+            for (int i = 0; i < bytesRead; i++)
+                p[i] = buf[i];
+        }
+    }
+
+    public unsafe void RemoteSeek(_LARGE_INTEGER dlibMove, uint origin, out _ULARGE_INTEGER plibNewPosition)
+    {
+        long newPosition = stream.Seek(dlibMove.QuadPart, (SeekOrigin)origin);
+        plibNewPosition.QuadPart = (ulong)newPosition;
+    }
+
+    public void SetSize(_ULARGE_INTEGER libNewSize)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void Stat(out tagSTATSTG pstatstg, uint grfStatFlag)
+    {
+        pstatstg = new tagSTATSTG()
+        {
+            cbSize = new _ULARGE_INTEGER() { QuadPart = (ulong)stream.Length }
+        };
+    }
+
+    public unsafe void RemoteWrite(ref byte pv, uint cb, out uint pcbWritten)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void Clone(out IStream ppstm)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void RemoteCopyTo(IStream pstm, _ULARGE_INTEGER cb, out _ULARGE_INTEGER pcbRead, out _ULARGE_INTEGER pcbWritten)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void LockRegion(_ULARGE_INTEGER libOffset, _ULARGE_INTEGER cb, uint lockType)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void Revert()
+    {
+        throw new NotSupportedException();
+    }
+
+    public void UnlockRegion(_ULARGE_INTEGER libOffset, _ULARGE_INTEGER cb, uint lockType)
+    {
+        throw new NotSupportedException();
+    }
+}
+
+namespace Dia2Lib
+{
+    /// <summary>
+    /// The DiaLoader class knows how to load the msdia140.dll (the Debug Access Interface) (see docs at
+    /// http://msdn.microsoft.com/en-us/library/x93ctkx8.aspx), without it being registered as a COM object.
+    /// Basically it just called the DllGetClassObject interface directly.
+    /// 
+    /// It has one public method 'GetDiaSourceObject' which knows how to create a IDiaDataSource object. 
+    /// From there you can do anything you need.  
+    /// 
+    /// In order to get IDiaDataSource3 which includes'getStreamSize' API, you need to use the 
+    /// vctools\langapi\idl\dia2_internal.idl file from devdiv to produce Dia2Lib.dll
+    /// 
+    /// roughly what you need to do is 
+    ///     copy vctools\langapi\idl\dia2_internal.idl .
+    ///     copy vctools\langapi\idl\dia2.idl .
+    ///     copy vctools\langapi\include\cvconst.h .
+    ///     Change dia2.idl to include interface IDiaDataSource3 inside library Dia2Lib->importlib->coclass DiaSource
+    ///     midl dia2_internal.idl /D CC_DP_CXX
+    ///     tlbimp dia2_internal.tlb
+    ///     REM result is Dia2Lib.dll 
+    /// </summary>
+    internal static class DiaLoader
+    {
+        /// <summary>
+        /// Load the msdia100 dll and get a IDiaDataSource from it.  This is your gateway to PDB reading.   
+        /// </summary>
+        public static IDiaDataSource3 GetDiaSourceObject()
+        {
+            if (!s_loadedNativeDll)
+            {
+                // Insure that the native DLL we need exist.  
+                NativeDlls.LoadNative("msdia140.dll");
+                s_loadedNativeDll = true;
+            }
+
+            // This is the value it was for msdia120 and before 
+            // var diaSourceClassGuid = new Guid("{3BFCEA48-620F-4B6B-81F7-B9AF75454C7D}");
+
+            // This is the value for msdia140.  
+            var diaSourceClassGuid = new Guid("{e6756135-1e65-4d17-8576-610761398c3c}");
+            var comClassFactory = (IClassFactory)DllGetClassObject(diaSourceClassGuid, typeof(IClassFactory).GUID);
+
+            object comObject = null;
+            Guid iDataDataSourceGuid = typeof(IDiaDataSource3).GUID;
+            comClassFactory.CreateInstance(null, ref iDataDataSourceGuid, out comObject);
+            return (comObject as IDiaDataSource3);
+        }
+        #region private
+        [ComImport, ComVisible(false), Guid("00000001-0000-0000-C000-000000000046"),
+         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IClassFactory
+        {
+            void CreateInstance([MarshalAs(UnmanagedType.Interface)] object aggregator,
+                                ref Guid refiid,
+                                [MarshalAs(UnmanagedType.Interface)] out object createdObject);
+            void LockServer(bool incrementRefCount);
+        }
+
+        // Methods
+        [return: MarshalAs(UnmanagedType.Interface)]
+        [DllImport("msdia140.dll", CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = false)]
+        private static extern object DllGetClassObject(
+            [In, MarshalAs(UnmanagedType.LPStruct)] Guid rclsid,
+            [In, MarshalAs(UnmanagedType.LPStruct)] Guid riid);
+
+        /// <summary>
+        /// Used to ensure the native library is loaded at least once prior to trying to use it. No protection is
+        /// included to avoid multiple loads, but this is not a problem since we aren't trying to unload the library
+        /// after use.
+        /// </summary>
+        static bool s_loadedNativeDll;
+        #endregion
+    }
+}
+#endregion

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -443,7 +443,7 @@ namespace Microsoft.Diagnostics.Symbols
                         {
                             target = null;
                             var newTarget = Path.Combine(cacheDir, uri.AbsolutePath.TrimStart('/').Replace('/', '\\'));
-                            if (_symbolModule.SymbolReader.GetPhysicalFileFromServer(uri.GetLeftPart(UriPartial.Authority), uri.AbsolutePath, newTarget))
+                            if (_symbolModule.SymbolReader.GetPhysicalFileFromServer(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped), uri.AbsolutePath, newTarget))
                                 target = newTarget;
 
                             if (target == null)
@@ -462,7 +462,7 @@ namespace Microsoft.Diagnostics.Symbols
                     if (!File.Exists(target) && fetchCmdStr != null)
                     {
                         _log.WriteLine("Trying to generate the file {0}.", target);
-                        var toolsDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().ManifestModule.FullyQualifiedName);
+                        var toolsDir = Path.GetDirectoryName(typeof(SourceFile).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName);
                         var archToolsDir = Path.Combine(toolsDir, NativeDlls.ProcessArchitectureDirectory);
 
                         // Find the EXE to do the source server fetch.  We only support SD.exe and TF.exe.   
@@ -490,7 +490,7 @@ namespace Microsoft.Diagnostics.Symbols
                         }
                         else
                         {
-                            _log.WriteLine("Source Server command is not recognized as safe (sd.exe or tf.exe), failing.");
+                            _log.WriteLine("Source Server command {0} is not recognized as safe (sd.exe or tf.exe), failing.", fetchCmdStr);
                             return null;
                         }
                         Directory.CreateDirectory(Path.GetDirectoryName(target));
@@ -540,11 +540,11 @@ namespace Microsoft.Diagnostics.Symbols
                 // 2 CALG_SHA1 checksum generated with the SHA1 hashing algorithm.
                 // 3 checksum generated with the SHA256 hashing algorithm.
                 if (sourceFile.checksumType == 1)
-                    _hashAlgorithm = new System.Security.Cryptography.MD5CryptoServiceProvider();
+                    _hashAlgorithm = System.Security.Cryptography.MD5.Create();
                 else if (sourceFile.checksumType == 2)
-                    _hashAlgorithm = new System.Security.Cryptography.SHA1CryptoServiceProvider();
+                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create();
                 else if (sourceFile.checksumType == 3)
-                    _hashAlgorithm = new System.Security.Cryptography.SHA256CryptoServiceProvider();
+                    _hashAlgorithm = System.Security.Cryptography.SHA256.Create();
 
                 if (_hashAlgorithm != null)
                 {
@@ -881,7 +881,7 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
             fixed (byte* bufferPtr = buffer)
             {
                 m_source.getStreamRawData("srcsrv", len, out *bufferPtr);
-                var ret = UTF8Encoding.Default.GetString(buffer);
+                var ret = new UTF8Encoding().GetString(buffer);
                 return ret;
             }
         }
@@ -1279,10 +1279,10 @@ namespace Dia2Lib
 
             // This is the value for msdia140.  
             var diaSourceClassGuid = new Guid("{e6756135-1e65-4d17-8576-610761398c3c}");
-            var comClassFactory = (IClassFactory)DllGetClassObject(diaSourceClassGuid, typeof(IClassFactory).GUID);
+            var comClassFactory = (IClassFactory)DllGetClassObject(diaSourceClassGuid, typeof(IClassFactory).GetTypeInfo().GUID);
 
             object comObject = null;
-            Guid iDataDataSourceGuid = typeof(IDiaDataSource3).GUID;
+            Guid iDataDataSourceGuid = typeof(IDiaDataSource3).GetTypeInfo().GUID;
             comClassFactory.CreateInstance(null, ref iDataDataSourceGuid, out comObject);
             return (comObject as IDiaDataSource3);
         }

--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -152,9 +152,9 @@ namespace Microsoft.Diagnostics.Symbols
 
                 Guid hashAlgorithmGuid = _portablePdb._metaData.GetGuid(_sourceFileDocument.HashAlgorithm);
                 if (hashAlgorithmGuid == HashAlgorithmSha1)
-                    _hashAlgorithm = new System.Security.Cryptography.SHA1CryptoServiceProvider();
+                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create();
                 else if (hashAlgorithmGuid == HashAlgorithmSha256)
-                    _hashAlgorithm = new System.Security.Cryptography.SHA256CryptoServiceProvider();
+                    _hashAlgorithm = System.Security.Cryptography.SHA256.Create();
                 if (_hashAlgorithm != null)
                     _hash = _portablePdb._metaData.GetBlobBytes(_sourceFileDocument.Hash);
 

--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Text.RegularExpressions;
+
+
+namespace Microsoft.Diagnostics.Symbols
+{
+    public class PortableSymbolModule : ManagedSymbolModule
+    {
+        public PortableSymbolModule(SymbolReader reader, string pdbFileName) : this(reader, File.Open(pdbFileName, FileMode.Open, FileAccess.Read, FileShare.Read), pdbFileName) { }
+
+        public PortableSymbolModule(SymbolReader reader, Stream stream, string pdbFileName = "") : base(reader, pdbFileName)
+        {
+            _stream = stream;
+            _provider = MetadataReaderProvider.FromPortablePdbStream(_stream);
+            _metaData = _provider.GetMetadataReader();
+
+            InitializeFileToUrlMap();
+        }
+
+        public override Guid PdbGuid
+        {
+            get
+            {
+                // The first 16 bytes are the PDB Guid, the next 4 are the DLL timestamp.  
+                var idBytes = _metaData.DebugMetadataHeader.Id;
+                byte[] guidBytes = new byte[16];
+                idBytes.CopyTo(0, guidBytes, 0, guidBytes.Length);
+                return new Guid(guidBytes);
+            }
+        }
+
+        public override SourceLocation SourceLocationForManagedCode(uint methodMetadataToken, int ilOffset)
+        {
+            MethodDefinitionHandle methodDefinitionHandle = (MethodDefinitionHandle)MetadataTokens.Handle((int)methodMetadataToken);
+            MethodDebugInformationHandle methodDebugInfoHandle = methodDefinitionHandle.ToDebugInformationHandle();
+            MethodDebugInformation methodDebugInfo = _metaData.GetMethodDebugInformation(methodDebugInfoHandle);
+
+            int methodToken = MetadataTokens.GetToken(methodDebugInfoHandle.ToDefinitionHandle());
+            SequencePoint lastSequencePoint = default(SequencePoint);
+            foreach (SequencePoint sequencePoint in methodDebugInfo.GetSequencePoints())
+            {
+                if (sequencePoint.Offset > ilOffset)
+                {
+                    if (lastSequencePoint.Document.IsNil)
+                        lastSequencePoint = sequencePoint;
+                    break;
+                }
+                lastSequencePoint = sequencePoint;
+            }
+            if (lastSequencePoint.Document.IsNil)
+                return null;
+            return new SourceLocation(GetSourceFile(lastSequencePoint.Document), lastSequencePoint.StartLine);
+        }
+
+        #region private 
+
+        private string GetUrlForFilePath(string buildTimeFilePath)
+        {
+            if (_fileToUrlMap != null)
+            {
+                foreach (Tuple<string, string> map in _fileToUrlMap)
+                {
+                    string path = map.Item1;
+                    string urlReplacement = map.Item2;
+
+                    if (buildTimeFilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase))
+                    {
+                        string tail = buildTimeFilePath.Substring(path.Length, buildTimeFilePath.Length - path.Length).Replace('\\', '/');
+                        return urlReplacement.Replace("*", tail);
+                    }
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Looks up SourceLink information (if present) and initializes _fileToUrlMap from it
+        /// </summary>  
+        private void InitializeFileToUrlMap()
+        {
+            string sourceLinkJson = GetSourceLinkJson();
+            if (sourceLinkJson == null)
+                return;
+
+            // TODO this is not right for corner cases (e.g. file paths with " or , } in them)
+            Match m = Regex.Match(sourceLinkJson, @"documents.?\s*:\s*{(.*?)}", RegexOptions.Singleline);
+            if (m.Success)
+            {
+                string mappings = m.Groups[1].Value;
+                while (!string.IsNullOrWhiteSpace(mappings))
+                {
+                    m = Regex.Match(m.Groups[1].Value, "^\\s*\"(.*?)\"\\s*:\\s*\"(.*?)\"\\s*,?(.*)", RegexOptions.Singleline);
+                    if (m.Success)
+                    {
+                        if (_fileToUrlMap == null)
+                            _fileToUrlMap = new List<Tuple<string, string>>();
+                        string pathSpec = m.Groups[1].Value.Replace("\\\\", "\\");
+                        if (pathSpec.EndsWith("*"))
+                        {
+                            pathSpec = pathSpec.Substring(0, pathSpec.Length - 1);      // Remove the *
+                            _fileToUrlMap.Add(new Tuple<string, string>(pathSpec, m.Groups[2].Value));
+                        }
+                        else
+                            _log.WriteLine("Warning: {0} does not end in *, skipping this mapping.", pathSpec);
+                        mappings = m.Groups[3].Value;
+                    }
+                    else
+                    {
+                        _log.WriteLine("Error: Could not parse SourceLink Mapping: {0}", mappings);
+                        break;
+                    }
+                }
+            }
+            else
+                _log.WriteLine("Error: Could not parse SourceLink Json: {0}", sourceLinkJson);
+        }
+
+        private string GetSourceLinkJson()
+        {
+            foreach(CustomDebugInformationHandle customDebugInformationHandle in _metaData.CustomDebugInformation)
+            {
+                CustomDebugInformation customDebugInformation = _metaData.GetCustomDebugInformation(customDebugInformationHandle);
+
+                EntityHandle parent = customDebugInformation.Parent;
+                Guid guid = _metaData.GetGuid(customDebugInformation.Kind);
+                if (guid == SourceLinkKind)
+                {
+                    BlobReader blobReader = _metaData.GetBlobReader(customDebugInformation.Value);
+                    var ret =  blobReader.ReadUTF8(blobReader.Length);
+                    return ret;
+                }
+            }
+
+            return null;
+        }
+
+        private SourceFile GetSourceFile(DocumentHandle documentHandle)
+        {
+            return new PortablePdbSourceFile(_metaData.GetDocument(documentHandle), this);
+        }
+
+        private class PortablePdbSourceFile : SourceFile
+        {
+            internal PortablePdbSourceFile(Document sourceFileDocument, PortableSymbolModule portablePdb) : base(portablePdb)
+            {
+                _sourceFileDocument = sourceFileDocument;
+                _portablePdb = portablePdb;
+
+                Guid hashAlgorithmGuid = _portablePdb._metaData.GetGuid(_sourceFileDocument.HashAlgorithm);
+                if (hashAlgorithmGuid == HashAlgorithmSha1)
+                    _hashAlgorithm = new System.Security.Cryptography.SHA1CryptoServiceProvider();
+                else if (hashAlgorithmGuid == HashAlgorithmSha256)
+                    _hashAlgorithm = new System.Security.Cryptography.SHA256CryptoServiceProvider();
+                if (_hashAlgorithm != null)
+                    _hash = _portablePdb._metaData.GetBlobBytes(_sourceFileDocument.Hash);
+
+                BuildTimeFilePath = _portablePdb._metaData.GetString(_sourceFileDocument.Name);
+                _log.WriteLine("Opened Portable Pdb Source File: {0}", BuildTimeFilePath);
+            }
+
+            public override string Url { get { return _portablePdb.GetUrlForFilePath(BuildTimeFilePath); } }
+
+            #region private 
+            private static Guid HashAlgorithmSha1 = Guid.Parse("ff1816ec-aa5e-4d10-87f7-6f4963833460");
+            private static Guid HashAlgorithmSha256 = Guid.Parse("8829d00f-11b8-4213-878b-770e8597ac16");
+
+            // Fields 
+            private Document _sourceFileDocument;
+            private PortableSymbolModule _portablePdb;
+            #endregion
+        }   // Class PortablePdbSourceFile
+
+        private static Guid SourceLinkKind = Guid.Parse("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+
+        // Needed by other things to look up data
+        internal MetadataReader _metaData;
+
+        List<Tuple<string, string>> _fileToUrlMap;      // Used by SourceLink to map build paths to URLs (see GetUrlForFilePath)
+        MetadataReaderProvider _provider;
+        Stream _stream;
+        #endregion
+    }
+}
+

--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Diagnostics.Symbols
 {
-    public class PortableSymbolModule : ManagedSymbolModule
+    class PortableSymbolModule : ManagedSymbolModule
     {
         public PortableSymbolModule(SymbolReader reader, string pdbFileName) : this(reader, File.Open(pdbFileName, FileMode.Open, FileAccess.Read, FileShare.Read), pdbFileName) { }
 

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -1,20 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel; // For Win32Excption;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.Diagnostics.Symbols;
-using Dia2Lib;
-using Address = System.UInt64;
 using Utilities;
-using System.Reflection;
 using Microsoft.Diagnostics.Utilities;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Net;
+using System.Net.Http;
 
 namespace Microsoft.Diagnostics.Symbols
 {
@@ -30,7 +24,7 @@ namespace Microsoft.Diagnostics.Symbols
         public SymbolReader(TextWriter log, string nt_symbol_path = null)
         {
             this.m_log = log;
-            this.m_symbolModuleCache = new Cache<string, SymbolModule>(10);
+            this.m_symbolModuleCache = new Cache<string, ManagedSymbolModule>(10);
             this.m_pdbPathCache = new Cache<PdbSignature, string>(10);
 
             m_symbolPath = nt_symbol_path;
@@ -290,23 +284,37 @@ namespace Microsoft.Diagnostics.Symbols
         /// </summary>
         /// <param name="pdbFilePath">The name of the PDB file to open.</param>
         /// <returns>The SymbolReaderModule that represents the information in the symbol file (PDB)</returns>
-        public SymbolModule OpenSymbolFile(string pdbFilePath)
+        public ManagedSymbolModule OpenSymbolFile(string pdbFilePath)
         {
-            SymbolModule ret;
+            ManagedSymbolModule ret;
             if (!m_symbolModuleCache.TryGet(pdbFilePath, out ret))
             {
-                ret = new SymbolModule(this, pdbFilePath);
+                Stream stream = File.Open(pdbFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                byte[] firstBytes = new byte[4];
+                if (stream.Read(firstBytes, 0, firstBytes.Length) != 4)
+                    throw new InvalidOperationException("PDB corrupted (too small) " + pdbFilePath);
+                if (firstBytes[0] == 'B' && firstBytes[1] == 'S' && firstBytes[2] == 'J' && firstBytes[3] == 'B')
+                {
+                    stream.Seek(0, SeekOrigin.Begin);   // Start over
+                    ret = new PortableSymbolModule(this, pdbFilePath);
+                }
+                else
+                {
+                    stream.Close();
+                    ret = new NativeSymbolModule(this, pdbFilePath);
+                }
                 m_symbolModuleCache.Add(pdbFilePath, ret);
             }
             return ret;
         }
 
         /// <summary>
-        /// Loads symbols from a Stream.
+        /// Like OpenSymbolFile, which opens a PDB, but this version will fail (return null)
+        /// if it is not WindowsSymbolModule.  It is a shortcut for OpenSymbolFile as WindowsSymbolModule
         /// </summary>
-        public SymbolModule OpenSymbolFile(string pdbFilePath, Stream pdbStream)
+        public NativeSymbolModule OpenWindowsSymbolFile(string pdbFileName)
         {
-            return new SymbolModule(this, pdbFilePath, pdbStream);
+            return OpenSymbolFile(pdbFileName) as NativeSymbolModule;
         }
 
         // Various state that controls symbol and source file lookup.  
@@ -814,7 +822,7 @@ namespace Microsoft.Diagnostics.Symbols
                         m_log.WriteLine("FindSymbolFilePath: No PDB Guid = Guid.Empty provided, assuming an unsafe PDB match for {0}", filePath);
                         return true;
                     }
-                    SymbolModule module = this.OpenSymbolFile(filePath);
+                    ManagedSymbolModule module = this.OpenSymbolFile(filePath);
                     if ((module.PdbGuid == pdbGuid) && (module.PdbAge == pdbAge))
                         return true;
                     else
@@ -880,10 +888,8 @@ namespace Microsoft.Diagnostics.Symbols
                             m_log.WriteLine("FindSymbolFilePath: In task, sending HTTP request {0}", fullUri);
 
                             var req = (System.Net.HttpWebRequest)System.Net.HttpWebRequest.Create(fullUri);
-                            var responseTask = req.GetResponseAsync();
-                            responseTask.Wait();
-                            var response = responseTask.Result;
-
+                            req.UserAgent = "Microsoft-Symbol-Server/6.13.0009.1140";
+                            var response = req.GetResponse();
                             alive = true;
                             if (!canceled)
                             {
@@ -1365,7 +1371,7 @@ namespace Microsoft.Diagnostics.Symbols
         private DateTime m_lastDeadTimeUtc;     // The last time something went dead.  
         private string m_SymbolCacheDirectory;
         private string m_SourceCacheDirectory;
-        private Cache<string, SymbolModule> m_symbolModuleCache;
+        private Cache<string, ManagedSymbolModule> m_symbolModuleCache;
         private Cache<PdbSignature, string> m_pdbPathCache;
         private string m_symbolPath;
 
@@ -1373,714 +1379,80 @@ namespace Microsoft.Diagnostics.Symbols
     }
 
     /// <summary>
-    /// A symbolReaderModule represents a single PDB.   You get one from SymbolReader.OpenSymbolFile
-    /// It is effecively a managed interface to the Debug Interface Access (DIA) see 
-    /// http://msdn.microsoft.com/en-us/library/x93ctkx8.aspx for more.   I have only exposed what
-    /// I need, and the interface is quite large (and not super pretty).  
+    /// A SymbolModule represents a file that contains symbolic information 
+    /// (a Windows PDB or Portable PDB).  This is the interface that is independent 
+    /// of what kind of symbolic file format you use.  Becase portable PDBs only
+    /// support managed code, this shared interface is by necessity the interface
+    /// for managed code only (currently only Windows PDBs support native code).  
     /// </summary>
-    public unsafe class SymbolModule
+    public abstract class ManagedSymbolModule
     {
-        /// <summary>
-        /// The path name to the PDB itself
-        /// </summary>
-        public string SymbolFilePath { get { return m_pdbPath; } }
         /// <summary>
         /// This is the EXE associated with the Pdb.  It may be null or an invalid path.  It is used
         /// to help look up source code (it is implicitly part of the Source Path search) 
         /// </summary>
         public string ExePath { get; set; }
-        /// <summary>
-        /// Finds a (method) symbolic name for a given relative virtual address of some code.  
-        /// Returns an empty string if a name could not be found. 
-        /// </summary>
-        public string FindNameForRva(uint rva)
-        {
-            uint dummy = 0;
-            return FindNameForRva(rva, ref dummy);
-        }
-        /// <summary>
-        /// Finds a (method) symbolic name for a given relative virtual address of some code.  
-        /// Returns an empty string if a name could not be found.  
-        /// symbolStartRva is set to the start of the symbol start 
-        /// </summary>
-        public string FindNameForRva(uint rva, ref uint symbolStartRva)
-        {
-            System.Threading.Thread.Sleep(0);           // Allow cancellation.  
-            if (m_symbolsByAddr == null)
-                return "";
-            IDiaSymbol symbol = m_symbolsByAddr.symbolByRVA(rva);
-            if (symbol == null)
-            {
-                Debug.WriteLine(string.Format("Warning: address 0x{0:x} not found.", rva));
-                return "";
-            }
-
-            var ret = symbol.name;
-            if (ret == null)
-            {
-                Debug.WriteLine(string.Format("Warning: address 0x{0:x} had a null symbol name.", rva));
-                return "";
-            }
-            var symbolLen = symbol.length;
-            if (symbolLen == 0)
-            {
-                Debug.WriteLine(string.Format("Warning: address 0x{0:x} symbol {1} has length 0", rva, ret));
-            }
-            symbolStartRva = symbol.relativeVirtualAddress;
-
-            // TODO determine why this happens!
-            var symbolRva = symbol.relativeVirtualAddress;
-            if (!(symbolRva <= rva && rva < symbolRva + symbolLen) && symbolLen != 0)
-            {
-                m_reader.Log.WriteLine("Warning: NOT IN RANGE: address 0x{0:x} start {2:x} end {3:x} Offset {4:x} Len {5:x}, symbol {1}, prefixing with ??.",
-                    rva, ret, symbolRva, symbolRva + symbolLen, rva - symbolRva, symbolLen);
-                ret = "??" + ret;   // Prefix with ?? to indicate it is questionable.  
-            }
-
-            // TODO FIX NOW, should not need to do this hand-unmangling.
-            if (0 <= ret.IndexOf('@'))
-            {
-                // TODO relatively inefficient.  
-                string unmangled = null;
-                symbol.get_undecoratedNameEx(0x1000, out unmangled);
-                if (unmangled != null)
-                    ret = unmangled;
-
-                if (ret.StartsWith("@"))
-                    ret = ret.Substring(1);
-                if (ret.StartsWith("_"))
-                    ret = ret.Substring(1);
-
-#if false // TODO FIX NOW remove  
-                var m = Regex.Match(ret, @"(.*)@\d+$");
-                if (m.Success)
-                    ret = m.Groups[1].Value;
-                else
-                    Debug.WriteLine(string.Format("Warning: address 0x{0:x} symbol {1} has a mangled name.", rva, ret));
-#else
-                var atIdx = ret.IndexOf('@');
-                if (0 < atIdx)
-                    ret = ret.Substring(0, atIdx);
-#endif
-            }
-
-            // See if this is a NGEN mangled name, which is $#Assembly#Token suffix.  If so strip it off. 
-            var dollarIdx = ret.LastIndexOf('$');
-            if (0 <= dollarIdx && dollarIdx + 2 < ret.Length && ret[dollarIdx + 1] == '#' && 0 <= ret.IndexOf('#', dollarIdx + 2))
-                ret = ret.Substring(0, dollarIdx);
-
-            // See if we have a Project N map that maps $_NN to a pre-merged assembly name 
-            var mergedAssembliesMap = GetMergedAssembliesMap();
-            if (mergedAssembliesMap != null)
-            {
-                bool prefixMatchFound = false;
-                Regex prefixMatch = new Regex(@"\$(\d+)_");
-                ret = prefixMatch.Replace(ret, delegate (Match m)
-                {
-                    prefixMatchFound = true;
-                    var original = m.Groups[1].Value;
-                    var moduleIndex = int.Parse(original);
-                    string fullAssemblyName;
-                    if (mergedAssembliesMap.TryGetValue(moduleIndex, out fullAssemblyName))
-                    {
-                        try
-                        {
-                            var assemblyName = new AssemblyName(fullAssemblyName);
-                            return assemblyName.Name + "!";
-                        }
-                        catch (Exception) { } // Catch all AssemlyName fails with ' in the name.   
-                    }
-                    return original;
-                });
-
-                // corefx.dll does not have a tag.  TODO this feels like a hack!
-                if (!prefixMatchFound)
-                    ret = "mscorlib!" + ret;
-            }
-            return ret;
-        }
 
         /// <summary>
-        /// Fetches the source location (line number and file), given the relative virtual address (RVA)
-        /// of the location in the executable.  
+        /// The path name to the PDB itself.  Might be empty if the symbol information is in memory.  
         /// </summary>
-        public SourceLocation SourceLocationForRva(uint rva)
-        {
-            string dummyString;
-            uint dummyToken;
-            int dummyILOffset;
-            return SourceLocationForRva(rva, out dummyString, out dummyToken, out dummyILOffset);
-        }
+        public string SymbolFilePath { get { return _pdbPath; } }
 
         /// <summary>
-        /// This overload of SourceLocationForRva like the one that takes only an RVA will return a source location
-        /// if it can.   However this version has additional support for NGEN images.   In the case of NGEN images 
-        /// for .NET V4.6.1 or later), the NGEN images can't convert all the way back to a source location, but they 
-        /// can convert the RVA back to IL artifacts (ilAssemblyName, methodMetadataToken, iloffset).  THese can then
-        /// be used to look up the source line using the IL PDB.  
-        /// 
-        /// Thus if the return value from this is null, check to see if the ilAssemblyName is non-null, and if not 
-        /// you can look up the source location using that information.  
+        /// The Guid that is used to uniquely identify the DLL-PDB pair (used for symbol servers)
         /// </summary>
-        public SourceLocation SourceLocationForRva(uint rva, out string ilAssemblyName, out uint methodMetadataToken, out int ilOffset)
-        {
-            ilAssemblyName = null;
-            methodMetadataToken = 0;
-            ilOffset = -1;
-            m_reader.m_log.WriteLine("SourceLocationForRva: looking up RVA {0:x} ", rva);
+        public virtual Guid PdbGuid { get { return Guid.Empty; } }
 
-            // First fetch the line number information 'normally'.  (for the non-NGEN case, and old style NGEN (with /lines)). 
-            uint fetchCount;
-            IDiaEnumLineNumbers sourceLocs;
-            m_session.findLinesByRVA(rva, 0, out sourceLocs);
-            IDiaLineNumber sourceLoc;
-            sourceLocs.Next(1, out sourceLoc, out fetchCount);
-            if (fetchCount == 0)
-            {
-                // We have no native line number information.   See if we are an NGEN image and we can convert the RVA to an IL Offset.   
-                m_reader.m_log.WriteLine("SourceLocationForRva: did not find line info Looking for mangled symbol name (for NGEN pdbs)");
-                IDiaSymbol method = m_symbolsByAddr.symbolByRVA(rva);
-                if (method != null)
-                {
-                    // Check to see if the method name follows the .NET V4.6.1 conventions
-                    // of $#ASSEMBLY#TOKEN.   If so the line number we got back is not a line number at all but
-                    // an ILOffset. 
-                    string name = method.name;
-                    if (name != null)
-                    {
-                        m_reader.m_log.WriteLine("SourceLocationForRva: RVA lives in method with 4.6.1 mangled name {0}", name);
-                        int suffixIdx = name.LastIndexOf("$#");
-                        if (0 <= suffixIdx && suffixIdx + 2 < name.Length)
-                        {
-                            int tokenIdx = name.IndexOf('#', suffixIdx + 2);
-                            if (tokenIdx < 0)
-                            {
-                                m_reader.m_log.WriteLine("SourceLocationForRva: Error parsing method name mangling.  No # separating token");
-                                return null;
-                            }
-                            string tokenStr = name.Substring(tokenIdx + 1);
-                            int token;
-                            if (!int.TryParse(tokenStr, System.Globalization.NumberStyles.AllowHexSpecifier, null, out token))
-                            {
-                                m_reader.m_log.WriteLine("SourceLocationForRva: Could not parse token as a Hex number {0}", tokenStr);
-                                return null;
-                            }
-
-                            // We need the metadata token and assembly.   We get this from the name mangling of the method symbol, 
-                            // so look that up.  
-                            if (tokenIdx == suffixIdx + 2)      // The assembly name is null
-                            {
-                                ilAssemblyName = Path.GetFileNameWithoutExtension(m_pdbPath);
-                                // strip off the .ni if present
-                                if (ilAssemblyName.EndsWith(".ni", StringComparison.OrdinalIgnoreCase))
-                                    ilAssemblyName = ilAssemblyName.Substring(0, ilAssemblyName.Length - 3);
-                            }
-                            else
-                                ilAssemblyName = name.Substring(suffixIdx + 2, tokenIdx - (suffixIdx + 2));
-                            methodMetadataToken = (uint)token;
-                            ilOffset = 0;           // If we don't find an IL offset, we 'guess' an ILOffset of 0
-
-                            m_reader.m_log.WriteLine("SourceLocationForRva: Looking up IL Offset by RVA 0x{0:x}", rva);
-                            m_session.findILOffsetsByRVA(rva, 0, out sourceLocs);
-                            // FEEFEE is some sort of illegal line number that is returned some time,  It is better to ignore it.  
-                            // and take the next valid line
-                            for (; ; )
-                            {
-                                sourceLocs.Next(1, out sourceLoc, out fetchCount);
-                                if (fetchCount == 0)
-                                {
-                                    m_reader.m_log.WriteLine("SourceLocationForRva: Ran out of IL mappings, guessing 0x{0:x}", ilOffset);
-                                    break;
-                                }
-                                ilOffset = (int)sourceLoc.lineNumber;
-                                if (ilOffset != 0xFEEFEE)
-                                    break;
-                                m_reader.m_log.WriteLine("SourceLocationForRva: got illegal offset FEEFEE picking next offset.");
-                                ilOffset = 0;
-                            }
-                            m_reader.m_log.WriteLine("SourceLocationForRva: Found native to IL mappings, IL offset 0x{0:x}", ilOffset);
-                            return null;                           // we don't have source information but we did return the IL information. 
-                        }
-                    }
-                }
-                m_reader.m_log.WriteLine("SourceLocationForRva: No lines for RVA {0:x} ", rva);
-                return null;
-            }
-
-            // If we reach here we are in the non-NGEN case, we are not mapping to IL information and 
-            IDiaSourceFile diaSrcFile = sourceLoc.sourceFile;
-            var lineNum = (int)sourceLoc.lineNumber;
-
-            var sourceFile = new SourceFile(this, diaSrcFile);
-            if (lineNum == 0xFEEFEE)
-                lineNum = 0;
-            var sourceLocation = new SourceLocation(sourceFile, lineNum);
-            m_reader.m_log.WriteLine("SourceLocationForRva: RVA {0:x} maps to line {1} file {2} ", rva, lineNum, sourceFile.BuildTimeFilePath);
-            return sourceLocation;
-        }
+        public virtual int PdbAge { get { return 1; } }
 
         /// <summary>
-        /// Managed code is shipped as IL, so RVA to NATIVE mapping can't be placed in the PDB. Instead
-        /// what is placed in the PDB is a mapping from a method's meta-data token and IL offset to source
-        /// line number.  Thus if you have a metadata token and IL offset, you can again get a source location
+        ///  Fetches the SymbolReader assoicated with this SymbolModule.  This is where shared
+        ///  attributes (like SourcePath, SymbolPath etc) are found.  
         /// </summary>
-        public SourceLocation SourceLocationForManagedCode(uint methodMetadataToken, int ilOffset)
-        {
-            m_reader.m_log.WriteLine("SourceLocationForManaged: Looking up method token {0:x} ilOffset {1:x}", methodMetadataToken, ilOffset);
-
-            IDiaSymbol methodSym;
-            m_session.findSymbolByToken(methodMetadataToken, SymTagEnum.SymTagFunction, out methodSym);
-            if (methodSym == null)
-            {
-                m_reader.m_log.WriteLine("SourceLocationForManaged: No symbol for token {0:x} ilOffset {1:x}", methodMetadataToken, ilOffset);
-                return null;
-            }
-
-            uint fetchCount;
-            IDiaEnumLineNumbers sourceLocs;
-            IDiaLineNumber sourceLoc;
-
-            // TODO FIX NOW, this code here is for debugging only turn if off when we are happy.  
-            //m_session.findLinesByRVA(methodSym.relativeVirtualAddress, (uint)(ilOffset + 256), out sourceLocs);
-            //for (int i = 0; ; i++)
-            //{
-            //    sourceLocs.Next(1, out sourceLoc, out fetchCount);
-            //    if (fetchCount == 0)
-            //        break;
-            //    if (i == 0)
-            //        m_reader.m_log.WriteLine("SourceLocationForManaged source file: {0}", sourceLoc.sourceFile.fileName);
-            //    m_reader.m_log.WriteLine("SourceLocationForManaged ILOffset {0:x} -> line {1}",
-            //        sourceLoc.relativeVirtualAddress - methodSym.relativeVirtualAddress, sourceLoc.lineNumber);
-            //} // End TODO FIX NOW debugging code
-
-            // For managed code, the 'RVA' is a 'cumulative IL offset' (amount of IL bytes before this in the module)
-            // Thus you find the line number of a particular IL offset by adding the offset within the method to
-            // the cumulative IL offset of the start of the method.  
-            m_session.findLinesByRVA(methodSym.relativeVirtualAddress + (uint)ilOffset, 256, out sourceLocs);
-            sourceLocs.Next(1, out sourceLoc, out fetchCount);
-            if (fetchCount == 0)
-            {
-                m_reader.m_log.WriteLine("SourceLocationForManaged: No lines for token {0:x} ilOffset {1:x}", methodMetadataToken, ilOffset);
-                return null;
-            }
-
-            var sourceFile = new SourceFile(this, sourceLoc.sourceFile);
-            int lineNum;
-            // FEEFEE is some sort of illegal line number that is returned some time,  It is better to ignore it.  
-            // and take the next valid line
-            for (; ; )
-            {
-                lineNum = (int)sourceLoc.lineNumber;
-                if (lineNum != 0xFEEFEE)
-                    break;
-                lineNum = 0;
-                sourceLocs.Next(1, out sourceLoc, out fetchCount);
-                if (fetchCount == 0)
-                    break;
-            }
-
-            var sourceLocation = new SourceLocation(sourceFile, lineNum);
-            m_reader.m_log.WriteLine("SourceLocationForManaged: found source linenum {0} file {1}", lineNum, sourceFile.BuildTimeFilePath);
-            return sourceLocation;
-        }
+        public SymbolReader SymbolReader { get { return _reader; } }
 
         /// <summary>
-        /// The symbol representing the module as a whole.  All global symbols are children of this symbol 
+        /// Given a method and an IL offset, return a source location (line number and file).   
+        /// Returns null if it could not find it.  
         /// </summary>
-        public Symbol GlobalSymbol { get { return new Symbol(this, m_session.globalScope); } }
+        public abstract SourceLocation SourceLocationForManagedCode(uint methodMetadataToken, int ilOffset);
 
-#if TEST_FIRST
-        /// <summary>
-        /// Returns a list of all source files referenced in the PDB
-        /// </summary>
-        public IEnumerable<SourceFile> AllSourceFiles()
-        {
+        #region private 
+        protected ManagedSymbolModule(SymbolReader reader, string path) { _pdbPath = path; _reader = reader; }
 
-            IDiaEnumTables tables;
-            m_session.getEnumTables(out tables);
+        internal TextWriter _log { get { return _reader.m_log; } }
 
-            IDiaEnumSourceFiles sourceFiles;
-            IDiaTable table = null;
-            uint fetchCount = 0;
-            for (; ; )
-            {
-                tables.Next(1, ref table, ref fetchCount);
-                if (fetchCount == 0)
-                    return null;
-                sourceFiles = table as IDiaEnumSourceFiles;
-                if (sourceFiles != null)
-                    break;
-            }
-
-            var ret = new List<SourceFile>();
-            IDiaSourceFile sourceFile = null;
-            for (; ; )
-            {
-                sourceFiles.Next(1, out sourceFile, out fetchCount);
-                if (fetchCount == 0)
-                    break;
-                ret.Add(new SourceFile(this, sourceFile));
-            }
-            return ret;
-        }
-#endif
-
-        /// <summary>
-        /// The a unique identifier that is used to relate the DLL and its PDB.   
-        /// </summary>
-        public Guid PdbGuid { get { return m_session.globalScope.guid; } }
-        /// <summary>
-        /// Along with the PdbGuid, there is a small integer 
-        /// call the age is also used to find the PDB (it represents the different 
-        /// post link transformations the DLL has undergone).  
-        /// </summary>
-        public int PdbAge { get { return (int)m_session.globalScope.age; } }
-
-        /// <summary>
-        /// The symbol reader this SymbolModule was created from.  
-        /// </summary>
-        public SymbolReader SymbolReader { get { return m_reader; } }
-
-        #region private
-
-        private void Initialize(SymbolReader reader, string pdbFilePath, Action loadData)
-        {
-            m_pdbPath = pdbFilePath;
-            this.m_reader = reader;
-
-            m_source = DiaLoader.GetDiaSourceObject();
-            loadData();
-            m_source.openSession(out m_session);
-            m_session.getSymbolsByAddr(out m_symbolsByAddr);
-
-            m_reader.m_log.WriteLine("Opening PDB {0} with signature GUID {1} Age {2}", pdbFilePath, PdbGuid, PdbAge);
-        }
-
-        internal SymbolModule(SymbolReader reader, string pdbFilePath)
-        {
-            Initialize(reader, pdbFilePath, () => m_source.loadDataFromPdb(pdbFilePath));
-        }
-
-        internal SymbolModule(SymbolReader reader, string pdbFilePath, Stream pdbStream)
-        {
-            IStream comStream = new ComStreamWrapper(pdbStream);
-            Initialize(reader, pdbFilePath, () => m_source.loadDataFromIStream(comStream));
-        }
-
-        internal void LogManagedInfo(string pdbName, Guid pdbGuid, int pdbAge)
-        {
-            // Simply remember this if we decide we need it for source server support
-            m_managedPdbName = pdbName;
-            m_managedPdbGuid = pdbGuid;
-            m_managedPdbAge = pdbAge;
-        }
-
-        /// <summary>
-        /// Gets the 'srcsvc' data stream from the PDB and return it in as a string.   Returns null if it is not present. 
-        /// 
-        /// There is a tool called pdbstr associated with srcsrv that basically does this.  
-        ///     pdbstr -r -s:srcsrv -p:PDBPATH
-        /// will dump it. 
-        /// </summary>
-        internal string GetSrcSrvStream()
-        {
-            // In order to get the IDiaDataSource3 which includes'getStreamSize' API, you need to use the 
-            // dia2_internal.idl file from devdiv to produce the Interop.Dia2Lib.dll 
-            // see class DiaLoader for more
-            var log = m_reader.m_log;
-            log.WriteLine("Getting source server stream for PDB {0}", SymbolFilePath);
-            uint len = 0;
-            m_source.getStreamSize("srcsrv", out len);
-            if (len == 0)
-            {
-                if (0 <= SymbolFilePath.IndexOf(".ni.", StringComparison.OrdinalIgnoreCase))
-                    log.WriteLine("Error, trying to look up source information on an NGEN file, giving up");
-                else
-                    log.WriteLine("Pdb {0} does not have source server information (srcsrv stream) in it", SymbolFilePath);
-                return null;
-            }
-
-            byte[] buffer = new byte[len];
-            fixed (byte* bufferPtr = buffer)
-            {
-                m_source.getStreamRawData("srcsrv", len, out *bufferPtr);
-                var ret = new UTF8Encoding().GetString(buffer);
-                return ret;
-            }
-        }
-
-        // returns the path of the PDB that has source server information in it (which for NGEN images is the PDB for the managed image)
-        internal SymbolModule PdbForSourceServer
-        {
-            get
-            {
-                if (m_managedPdbName == null)
-                    return this;
-
-                if (!m_managedPdbAttempted)
-                {
-                    m_reader.m_log.WriteLine("We have a NGEN image with an IL PDB {0}, looking it up", m_managedPdbName);
-                    m_managedPdbAttempted = true;
-                    var managedPdbPath = m_reader.FindSymbolFilePath(m_managedPdbName, m_managedPdbGuid, m_managedPdbAge);
-                    if (managedPdbPath != null)
-                    {
-                        m_reader.m_log.WriteLine("Found managed PDB path {0}", managedPdbPath);
-                        m_managedPdb = m_reader.OpenSymbolFile(managedPdbPath);
-                    }
-                    else
-                        m_reader.m_log.WriteLine("Could not find managed PDB {0}", m_managedPdbName);
-                }
-                return m_managedPdb;
-            }
-        }
-
-        /// <summary>
-        /// For Project N modules it returns the list of pre merged IL assemblies and the corresponding mapping.
-        /// </summary>
-        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
-        public Dictionary<int, string> GetMergedAssembliesMap()
-        {
-            if (m_mergedAssemblies == null && !m_checkedForMergedAssemblies)
-            {
-                IDiaEnumInputAssemblyFiles diaMergedAssemblyRecords;
-                m_session.findInputAssemblyFiles(out diaMergedAssemblyRecords);
-                foreach (IDiaInputAssemblyFile inputAssembly in diaMergedAssemblyRecords)
-                {
-                    int index = (int)inputAssembly.index;
-                    string assemblyName = inputAssembly.fileName;
-
-                    if (m_mergedAssemblies == null)
-                        m_mergedAssemblies = new Dictionary<int, string>();
-                    m_mergedAssemblies.Add(index, assemblyName);
-                }
-                m_checkedForMergedAssemblies = true;
-            }
-            return m_mergedAssemblies;
-        }
-
-        /// <summary>
-        /// For ProjectN modules, gets the merged IL image embedded in the .PDB (only valid for single-file compilation)
-        /// </summary>
-        public MemoryStream GetEmbeddedILImage()
-        {
-            try
-            {
-                uint ilimageSize;
-                m_source.getStreamSize("ilimage", out ilimageSize);
-                if (ilimageSize > 0)
-                {
-                    byte[] ilImage = new byte[ilimageSize];
-                    m_source.getStreamRawData("ilimage", ilimageSize, out ilImage[0]);
-                    return new MemoryStream(ilImage);
-                }
-            }
-            catch (COMException)
-            {
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// For ProjectN modules, gets the pseudo-assembly embedded in the .PDB, if there is one.
-        /// </summary>
-        /// <returns></returns>
-        public MemoryStream GetPseudoAssembly()
-        {
-            try
-            {
-                uint ilimageSize;
-                m_source.getStreamSize("pseudoil", out ilimageSize);
-                if (ilimageSize > 0)
-                {
-                    byte[] ilImage = new byte[ilimageSize];
-                    m_source.getStreamRawData("pseudoil", ilimageSize, out ilImage[0]);
-                    return new MemoryStream(ilImage, writable: false);
-                }
-            }
-            catch (COMException)
-            {
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// For ProjectN modules, gets the binary blob that describes the mapping from RVAs to methods.
-        /// </summary>
-        public byte[] GetFuncMDTokenMap()
-        {
-            uint mapSize;
-            m_session.getFuncMDTokenMapSize(out mapSize);
-
-            byte[] buf = new byte[mapSize];
-            fixed (byte* pBuf = buf)
-            {
-                m_session.getFuncMDTokenMap((uint)buf.Length, out mapSize, out buf[0]);
-                Debug.Assert(mapSize == buf.Length);
-            }
-
-            return buf;
-        }
-
-        /// <summary>
-        /// For ProjectN modules, gets the binary blob that describes the mapping from RVAs to types.
-        /// </summary>
-        /// <returns></returns>
-        public byte[] GetTypeMDTokenMap()
-        {
-            uint mapSize;
-            m_session.getTypeMDTokenMapSize(out mapSize);
-
-            byte[] buf = new byte[mapSize];
-            fixed (byte* pBuf = buf)
-            {
-                m_session.getTypeMDTokenMap((uint)buf.Length, out mapSize, out buf[0]);
-                Debug.Assert(mapSize == buf.Length);
-            }
-
-            return buf;
-        }
-
-        bool m_checkedForMergedAssemblies;
-        Dictionary<int, string> m_mergedAssemblies;
-
-        private string m_managedPdbName;
-        private Guid m_managedPdbGuid;
-        private int m_managedPdbAge;
-        private SymbolModule m_managedPdb;
-        private bool m_managedPdbAttempted;
-
-        internal SymbolReader m_reader;
-        internal IDiaSession m_session;
-        IDiaDataSource3 m_source;
-        IDiaEnumSymbolsByAddr m_symbolsByAddr;
-        string m_pdbPath;
-
+        string _pdbPath;
+        SymbolReader _reader;
         #endregion
     }
 
     /// <summary>
-    /// Represents a single symbol in a PDB file.  
+    /// A SourceLocation represents a point in the source code.  That is the file and the line number.  
     /// </summary>
-    public class Symbol : IComparable<Symbol>
+    public class SourceLocation
     {
         /// <summary>
-        /// The name for the symbol 
+        /// The source file for the code
         /// </summary>
-        public string Name { get { return m_name; } }
+        public SourceFile SourceFile { get; private set; }
         /// <summary>
-        /// The relative virtual address (offset from the image base when loaded in memory) of the symbol
+        /// The line number for the code.
         /// </summary>
-        public uint RVA { get { return m_diaSymbol.relativeVirtualAddress; } }
-        /// <summary>
-        /// The length of the memory that the symbol represents.  
-        /// </summary>
-        public ulong Length { get { return m_diaSymbol.length; } }
-        /// <summary>
-        /// A small integer identifier tat is unique for that symbol in the DLL. 
-        /// </summary>
-        public uint Id { get { return m_diaSymbol.symIndexId; } }
+        public int LineNumber { get; private set; }
 
-        /// <summary>
-        /// Decorated names are names that most closely resemble the source code (have overloading).  
-        /// However when the linker does not directly support all the expressiveness of the
-        /// source language names are encoded to represent this.   This return this encoded name. 
-        /// </summary>
-        public string UndecoratedName
-        {
-            get
-            {
-                const uint UNDNAME_NO_PTR64 = 0x20000;
-                string undecoratedName;
-                m_diaSymbol.get_undecoratedNameEx(UNDNAME_NO_PTR64, out undecoratedName);
-
-                return undecoratedName ?? m_diaSymbol.name;
-            }
-        }
-
-        /// <summary>
-        /// Returns true if the two symbols live in the same linker section (e.g. text,  data ...)
-        /// </summary>
-        public static bool InSameSection(Symbol a, Symbol b)
-        {
-            return a.m_diaSymbol.addressSection == b.m_diaSymbol.addressSection;
-        }
-
-        /// <summary>
-        /// Returns the children of the symbol.  Will return null if there are no children.  
-        /// </summary>
-        public IEnumerable<Symbol> GetChildren()
-        {
-            return GetChildren(SymTagEnum.SymTagNull);
-        }
-
-        /// <summary>
-        /// Returns the children of the symbol, with the given tag.  Will return null if there are no children.  
-        /// </summary>
-        public IEnumerable<Symbol> GetChildren(SymTagEnum tag)
-        {
-            IDiaEnumSymbols symEnum = null;
-            m_module.m_session.findChildren(m_diaSymbol, tag, null, 0, out symEnum);
-            if (symEnum == null)
-                return null;
-
-            uint fetchCount;
-            var ret = new List<Symbol>();
-            for (; ; )
-            {
-                IDiaSymbol sym;
-                symEnum.Next(1, out sym, out fetchCount);
-                if (fetchCount == 0)
-                    break;
-                SymTagEnum symTag = (SymTagEnum)sym.symTag;
-                ret.Add(new Symbol(m_module, sym));
-            }
-
-            return ret;
-        }
-
-        /// <summary>
-        /// Compares the symbol by their relative virtual address (RVA)
-        /// </summary>
-        public int CompareTo(Symbol other)
-        {
-            return ((int)RVA - (int)other.RVA);
-        }
         #region private
-#if false
-        // TODO FIX NOW use or remove
-        internal enum NameSearchOptions
+        internal SourceLocation(SourceFile sourceFile, int lineNumber)
         {
-            nsNone,
-            nsfCaseSensitive = 0x1,
-            nsfCaseInsensitive = 0x2,
-            nsfFNameExt = 0x4,                  // treat as a file path
-            nsfRegularExpression = 0x8,         // * and ? wildcards
-            nsfUndecoratedName = 0x10,          // A undecorated name is the name you see in the source code.  
-        };
-#endif
+            // The library seems to see FEEFEE for the 'unknown' line number.  0 seems more intuitive
+            if (0xFEEFEE <= lineNumber)
+                lineNumber = 0;
 
-        /// <summary>
-        /// override
-        /// </summary>
-        public override string ToString()
-        {
-            return string.Format("Symbol({0}, RVA=0x{1:x}", Name, RVA);
+            SourceFile = sourceFile;
+            LineNumber = lineNumber;
         }
-
-        internal Symbol(SymbolModule module, IDiaSymbol diaSymbol)
-        {
-            m_module = module;
-            m_diaSymbol = diaSymbol;
-            m_name = m_diaSymbol.name;
-        }
-        private string m_name;
-        private IDiaSymbol m_diaSymbol;
-        private SymbolModule m_module;
         #endregion
     }
-
 
     /// <summary>
     /// SymbolReaderFlags indicates preferences on how aggressively symbols should be looked up.  
@@ -2103,805 +1475,226 @@ namespace Microsoft.Diagnostics.Symbols
         NoNGenSymbolCreation = 2,
     }
 
-    /// <summary>
-    /// A source file represents a source file from a PDB.  This is not just a string
-    /// because the file has a build time path, a checksum, and it needs to be 'smart'
-    /// to copy down the file if requested.  
-    /// </summary>
-    public class SourceFile
+    public abstract class SourceFile
     {
         /// <summary>
-        /// The path of the file at the time the source file was built. 
+        /// The path of the file at the time the source file was built.   We also look here when looking for the source.  
         /// </summary>
-        public string BuildTimeFilePath { get; internal set; }
+        public string BuildTimeFilePath { get; protected set; }
 
         /// <summary>
         /// If the source file is directly available on the web (that is there is a Url that 
         /// can be used to fetch it with HTTP Get), then return that Url.   If no such publishing 
         /// point exists this property will return null.   
         /// </summary>
-        public string Url
-        {
-            get
-            {
-                string target, command;
-                GetSourceServerTargetAndCommand(out target, out command);
+        public virtual string Url { get { return null; } }
 
-                if (!string.IsNullOrEmpty(target) && Uri.IsWellFormedUriString(target, UriKind.Absolute))
-                    return target;
+        /// <summary>
+        /// Look up the source from the source server.  Returns null if it can't find the source
+        /// By default this simply uses the Url to look it up on the web.   If 'Url' returns null
+        /// so does this.   
+        /// </summary>
+        public virtual string GetSourceFromSrcServer()
+        {
+            // Search the SourceLink url location 
+            string url = Url;
+            if (url != null)
+            {
+                HttpClient httpClient = new HttpClient();
+                HttpResponseMessage response = httpClient.GetAsync(url).Result;
+
+                response.EnsureSuccessStatusCode();
+                Stream content = response.Content.ReadAsStreamAsync().Result;
+                string cachedLocation = GetCachePathForUrl(url);
+                if (cachedLocation != null)
+                {
+                    using (FileStream file = File.Create(_filePath))
+                        content.CopyTo(file);
+                    return cachedLocation;
+                }
                 else
-                    return null;
+                    _log.WriteLine("Warning: SourceCache not set, giving up fetching source from the network.");
             }
+            return null;
+        }
+
+        /// <summary>
+        /// This may fetch things from the source server, and thus can be very slow, which is why it is not a property. 
+        /// returns a path to the file on the local machine (often in some machine local cache). 
+        /// If requireChecksumMatch == false then you can see if you have an exact match by calling ChecksumMatches
+        /// (and if there is a checksum with HasChecksum). 
+        /// </summary>
+        public virtual string GetSourceFile(bool requireChecksumMatch = false)
+        {
+            if (!_getSourceCalled)
+            {
+                _getSourceCalled = true;
+                if (BuildTimeFilePath == null)
+                {
+                    _log.WriteLine("No BuildTimeFilePath, giving up looking for source file");
+                    return null;
+                }
+
+                // Check the build location
+                if (ProbeForBestMatch(BuildTimeFilePath))
+                    return _filePath;
+
+                // Look on the source server next.   
+                _log.WriteLine("Looking up {0} in the source server (or URL)", BuildTimeFilePath);
+                string srcServerLocation = GetSourceFromSrcServer();
+                if (srcServerLocation != null)
+                {
+                    if (ProbeForBestMatch(srcServerLocation))
+                        return _filePath;
+                    else
+                        _log.WriteLine("Warning. Source file from source server {0} did not match checksum", srcServerLocation);
+                }
+
+                // Try _NT_SOURCE_PATH
+                var locations = _symbolModule.SymbolReader.ParsedSourcePath;
+                _log.WriteLine("Not present on source server, looking on NT_SOURCE_PATH.");
+                _log.WriteLine("_NT_SOURCE_PATH={0}", _symbolModule.SymbolReader.SourcePath);
+
+                // If we know the exe path, add that to the search path.   
+                if (_symbolModule.ExePath != null)
+                {
+                    var exeDir = Path.GetDirectoryName(_symbolModule.ExePath);
+                    if (Directory.Exists(exeDir))
+                    {
+                        locations.Insert(0, exeDir);
+                        _log.WriteLine("Adding Exe directory to source search path {0}", exeDir);
+                    }
+                }
+
+                var curIdx = 0;
+                for (; ; )
+                {
+                    var sepIdx = BuildTimeFilePath.IndexOf('\\', curIdx);
+                    if (sepIdx < 0)
+                        break;
+                    curIdx = sepIdx + 1;
+                    var tail = BuildTimeFilePath.Substring(sepIdx);
+
+                    _log.WriteLine("Probing Path Tail {0}", tail);
+
+                    foreach (string location in locations)
+                    {
+                        var probe = location + tail;
+                        if (ProbeForBestMatch(probe))
+                            return _filePath;
+                    }
+                }
+            }
+            if (requireChecksumMatch && !_checksumMatches)
+                return null;
+            return _filePath;
         }
 
         /// <summary>
         /// true if the PDB has a checksum for the data in the source file. 
         /// </summary>
-        public bool HasChecksum { get { return m_hashAlgorithm != null; } }
-
-        /// <summary>
-        /// This may fetch things from the source server, and thus can be very slow, which is why it is not a property. 
-        /// </summary>
-        /// <returns></returns>
-        public string GetSourceFile(bool requireChecksumMatch = false)
-        {
-            m_checksumMatches = false;
-            m_getSourceCalled = true;
-            var log = m_symbolModule.m_reader.m_log;
-            string bestGuess = null;
-
-            // Did we build on this machine?  
-            if (File.Exists(BuildTimeFilePath))
-            {
-                bestGuess = BuildTimeFilePath;
-                m_checksumMatches = DoesChecksumMatch(BuildTimeFilePath);
-                if (m_checksumMatches)
-                {
-                    log.WriteLine("Found in build location.");
-                    return BuildTimeFilePath;
-                }
-            }
-            log.WriteLine("Not present at build location {0}, trying source server.", BuildTimeFilePath);
-
-            // Try the source server 
-            var ret = GetSourceFromSrcServer();
-            if (ret != null)
-            {
-                log.WriteLine("Got source from source server.");
-                m_checksumMatches = true;       // TODO we assume source server is right, is that OK? 
-                return ret;
-            }
-            log.WriteLine("Not present on source server, looking on NT_SOURCE_PATH.");
-
-            // Try _NT_SOURCE_PATH
-            var locations = m_symbolModule.m_reader.ParsedSourcePath;
-            log.WriteLine("_NT_SOURCE_PATH={0}", m_symbolModule.m_reader.SourcePath);
-
-            // If we know the exe path, add that to the search path.   
-            if (m_symbolModule.ExePath != null)
-            {
-                var exeDir = Path.GetDirectoryName(m_symbolModule.ExePath);
-                if (Directory.Exists(exeDir))
-                {
-                    // Add directories up the path, we stop somewhat arbitrarily at 3 
-                    for (int i = 0; i < 3; i++)
-                    {
-                        locations.Insert(0, exeDir);
-                        log.WriteLine("Adding Exe path {0}", exeDir);
-
-                        exeDir = Path.GetDirectoryName(exeDir);
-                        if (exeDir == null)
-                            break;
-                    }
-                }
-            }
-
-            var curIdx = 0;
-            for (; ; )
-            {
-                var sepIdx = BuildTimeFilePath.IndexOf('\\', curIdx);
-                if (sepIdx < 0)
-                    break;
-                curIdx = sepIdx + 1;
-                var tail = BuildTimeFilePath.Substring(sepIdx);
-
-                foreach (string location in locations)
-                {
-                    var probe = location + tail;
-                    log.WriteLine("Probing {0}", probe);
-                    if (File.Exists(probe))
-                    {
-                        if (bestGuess == null)
-                            bestGuess = probe;
-                        m_checksumMatches = DoesChecksumMatch(probe);
-                        if (m_checksumMatches)
-                        {
-                            log.WriteLine("Success {0}", probe);
-                            return probe;
-                        }
-                        else
-                            log.WriteLine("Found file {0} but checksum mismatches", probe);
-                    }
-                }
-            }
-
-            if (!requireChecksumMatch && bestGuess != null)
-            {
-                log.WriteLine("[Warning: Checksum mismatch for {0}]", bestGuess);
-                return bestGuess;
-            }
-
-            log.WriteLine("[Could not find source for {0}]", BuildTimeFilePath);
-            return null;
-        }
+        public bool HasChecksum { get { return _hashAlgorithm != null; } }
 
         /// <summary>
         /// If GetSourceFile is called and 'requireChecksumMatch' == false then you can call this property to 
         /// determine if the checksum actually matched or not.   This will return true if the original
         /// PDB does not have a checksum (HasChecksum == false)
-        /// </summary>
-        public bool ChecksumMatches
-        {
-            get
-            {
-                Debug.Assert(m_getSourceCalled);
-                return m_checksumMatches;
-            }
-        }
+        /// </summary>; 
+        public bool ChecksumMatches { get { return _checksumMatches; } }
 
-        #region private
+        #region private 
+        protected SourceFile(ManagedSymbolModule symbolModule) { _symbolModule = symbolModule; }
+
+        protected TextWriter _log { get { return _symbolModule._log; } }
+
         /// <summary>
-        /// Parse the 'srcsrv' stream in a PDB file and return the target for SourceFile
-        /// represented by the 'this' pointer.   This target is iether a ULR or a local file
-        /// path.  
+        /// Given 'fileName' which is a path to a file (which may  not exist), set 
+        /// _filePath and _checksumMatches appropriately.    Namely _filePath should
+        /// always be the 'best' candidate for the soruce file path (matching checksum
+        /// wins, otherwise first existing file wins).  
         /// 
-        /// You can dump the srcsrv stream using a tool called pdbstr 
-        ///     pdbstr -r -s:srcsrv -p:PDBPATH
-        /// 
-        /// The target in this stream is called SRCSRVTRG and there is another variable SRCSRVCMD
-        /// which represents the command to run to fetch the soruce into SRCSRVTRG
-        /// 
-        /// To form the target, the stream expect you to private a %targ% variable which is a directory
-        /// prefix to tell where to put the source file being fetched.   If the source file is
-        /// available via a URL this variable is not needed.  
-        /// 
-        ///  ********* This is a typical example of what is in a PDB with source server information. 
-        ///  SRCSRV: ini ------------------------------------------------
-        ///  VERSION=3
-        ///  INDEXVERSION=2
-        ///  VERCTRL=Team Foundation Server
-        ///  DATETIME=Thu Mar 10 16:15:55 2016
-        ///  SRCSRV: variables ------------------------------------------
-        ///  TFS_EXTRACT_CMD=tf.exe view /version:%var4% /noprompt "$%var3%" /server:%fnvar%(%var2%) /output:%srcsrvtrg%
-        ///  TFS_EXTRACT_TARGET=%targ%\%var2%%fnbksl%(%var3%)\%var4%\%fnfile%(%var1%)
-        ///  VSTFDEVDIV_DEVDIV2=http://vstfdevdiv.redmond.corp.microsoft.com:8080/DevDiv2
-        ///  SRCSRVVERCTRL=tfs
-        ///  SRCSRVERRDESC=access
-        ///  SRCSRVERRVAR=var2
-        ///  SRCSRVTRG=%TFS_extract_target%
-        ///  SRCSRVCMD=%TFS_extract_cmd%
-        ///  SRCSRV: source files ---------------------------------------
-        ///  f:\dd\externalapis\legacy\vctools\vc12\inc\cvconst.h*VSTFDEVDIV_DEVDIV2*/DevDiv/Fx/Rel/NetFxRel3Stage/externalapis/legacy/vctools/vc12/inc/cvconst.h*1363200
-        ///  f:\dd\externalapis\legacy\vctools\vc12\inc\cvinfo.h*VSTFDEVDIV_DEVDIV2*/DevDiv/Fx/Rel/NetFxRel3Stage/externalapis/legacy/vctools/vc12/inc/cvinfo.h*1363200
-        ///  f:\dd\externalapis\legacy\vctools\vc12\inc\vc\ammintrin.h*VSTFDEVDIV_DEVDIV2*/DevDiv/Fx/Rel/NetFxRel3Stage/externalapis/legacy/vctools/vc12/inc/vc/ammintrin.h*1363200
-        ///  SRCSRV: end ------------------------------------------------
-        ///  
-        ///  ********* And here is a more modern one where the source code is available via a URL.  
-        ///  SRCSRV: ini ------------------------------------------------
-        ///  VERSION=2
-        ///  INDEXVERSION=2
-        ///  VERCTRL=http
-        ///  SRCSRV: variables ------------------------------------------
-        ///  SRCSRVTRG=https://nuget.smbsrc.net/src/%fnfile%(%var1%)/%var2%/%fnfile%(%var1%)
-        ///  SRCSRVCMD=
-        ///  SRCSRVVERCTRL=http
-        ///  SRCSRV: source files ---------------------------------------
-        ///  c:\Users\rafalkrynski\Documents\Visual Studio 2012\Projects\DavidSymbolSourceTest\DavidSymbolSourceTest\Demo.cs*SQPvxWBMtvANyCp8Pd3OjoZEUgpKvjDVIY1WbaiFPMw=
-        ///  SRCSRV: end ------------------------------------------------
-        ///  
+        /// Returns true if we have a perfect match (no additional probing needed).  
         /// </summary>
-        /// <param name="target">returns the target source file path</param>
-        /// <param name="command">returns the command to fetch the target source file</param>
-        /// <param name="localDirectoryToPlaceSourceFiles">Specify the value for %targ% variable. This is the
-        /// directory where source files can be fetched to.  Typically the returned file is under this directory
-        /// If the value is null, %targ% variable be emtpy.  This assumes that the resulting file is something
-        /// that does not need to be copied to the machine (either a URL or a file that already exists)</param>
-        private void GetSourceServerTargetAndCommand(out string target, out string command, string localDirectoryToPlaceSourceFiles = null)
+        private bool ProbeForBestMatch(string filePath)
         {
-            target = null;
-            command = null;
+            // We already have a perfect match, this one can't be better.  
+            if (_filePath != null && _checksumMatches)
+                return false;
 
-            var log = m_symbolModule.m_reader.m_log;
-            log.WriteLine("*** Looking up {0} using source server", BuildTimeFilePath);
-
-            var srcServerPdb = m_symbolModule.PdbForSourceServer;
-            if (srcServerPdb == null)
+            // If this candidate does not even exist, we can't do anything.  
+            if (filePath == null || !File.Exists(filePath))
             {
-                log.WriteLine("*** Could not find PDB to look up source server information");
-                return;
+                _log.WriteLine("  Probe failed, file does not exist {0}", filePath);
+                return false;
             }
 
-            string srcsvcStream = srcServerPdb.GetSrcSrvStream();
-            if (srcsvcStream == null)
+            if (ComputeChecksumMatch(filePath))
             {
-                log.WriteLine("*** Could not find srcsrv stream in PDB file");
-                return;
+                _checksumMatches = true;
+                _filePath = filePath;
+                _log.WriteLine("Checksum matches for {0}", filePath);
+
+                return true;
             }
 
-            log.WriteLine("*** Found srcsrv stream in PDB file. of size {0}", srcsvcStream.Length);
-            StringReader reader = new StringReader(srcsvcStream);
-
-            bool inSrc = false;
-            bool inVars = false;
-            var vars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            if (localDirectoryToPlaceSourceFiles != null)
-                vars.Add("targ", localDirectoryToPlaceSourceFiles);
-
-            for (; ; )
+            // If we don't match but we have nothinging better, remember it.   Otherwise do nothing as first hit is better.  
+            if (filePath == null)
             {
-                var line = reader.ReadLine();
-                if (line == null)
-                    break;
-
-                // log.WriteLine("Got srcsrv line {0}", line);
-                if (line.StartsWith("SRCSRV: "))
-                {
-                    inSrc = line.StartsWith("SRCSRV: source files");
-                    inVars = line.StartsWith("SRCSRV: variables");
-                    continue;
-                }
-                if (inSrc)
-                {
-                    var pieces = line.Split('*');
-                    if (pieces.Length >= 2)
-                    {
-                        var buildTimePath = pieces[0];
-                        // log.WriteLine("Found source {0} in the PDB", buildTimePath);
-                        if (string.Compare(BuildTimeFilePath, buildTimePath, StringComparison.OrdinalIgnoreCase) == 0)
-                        {
-                            // Create variables for each of the pieces.  
-                            for (int i = 0; i < pieces.Length; i++)
-                                vars.Add("var" + (i + 1).ToString(), pieces[i]);
-
-                            target = SourceServerFetchVar("SRCSRVTRG", vars);
-                            command = SourceServerFetchVar("SRCSRVCMD", vars);
-
-                            return;
-                        }
-                    }
-                }
-                else if (inVars)
-                {
-                    // Gather up the KEY=VALUE pairs into a dictionary.  
-                    var m = Regex.Match(line, @"^(\w+)=(.*?)\s*$");
-                    if (m.Success)
-                        vars[m.Groups[1].Value] = m.Groups[2].Value;
-                }
+                _filePath = filePath;
+                _log.WriteLine("Checksum does NOT match for {0}, but it is our best guess.", filePath);
             }
+            else
+                _log.WriteLine("Checksum does NOT match for {0} but we already have a non-ideal match so discarding this probe.", filePath);
+
+            // We did not get a perfect match.  
+            return false;
         }
 
         /// <summary>
-        /// Try to fetch the source file associated with 'buildTimeFilePath' from the symbol server 
-        /// information from the PDB from 'pdbPath'.   Will return a path to the returned file (uses 
-        /// SourceCacheDirectory associated symbol reader for context where to put the file), 
-        /// or null if unsuccessful.  
-        /// 
-        /// There is a tool called pdbstr associated with srcsrv that basically does this.  
-        ///     pdbstr -r -s:srcsrv -p:PDBPATH
-        /// will dump it. 
-        ///
-        /// The basic flow is 
-        /// 
-        /// There is a variables section and a files section
-        /// 
-        /// The file section is a list of items separated by *.   The first is the path, the rest are up to you
-        /// 
-        /// You form a command by using the SRCSRVTRG variable and substituting variables %var1 where var1 is the first item in the * separated list
-        /// There are special operators %fnfile%(XXX), etc that manipulate the string XXX (get file name, translate \ to / ...
-        /// 
-        /// If what is at the end is a valid URL it is looked up.   
+        /// Returns true if 'filePath' matches the checksum OR we don't have a checkdum
+        /// (thus if we pass what validity check we have).    
         /// </summary>
-        string GetSourceFromSrcServer()
+        private bool ComputeChecksumMatch(string filePath)
         {
-            var log = m_symbolModule.m_reader.m_log;
-            var cacheDir = m_symbolModule.m_reader.SourceCacheDirectory;
-
-            string target, fetchCmdStr;
-            GetSourceServerTargetAndCommand(out target, out fetchCmdStr, cacheDir);
-
-            if (target != null)
-            {
-                if (!target.StartsWith(cacheDir, StringComparison.OrdinalIgnoreCase))
-                {
-                    // if target is not in cache dir, it means it's from a remote server.
-                    Uri uri = null;
-                    if (Uri.TryCreate(target, UriKind.Absolute, out uri))
-                    {
-                        target = null;
-                        var newTarget = Path.Combine(cacheDir, uri.AbsolutePath.TrimStart('/').Replace('/', '\\'));
-                        if (m_symbolModule.m_reader.GetPhysicalFileFromServer(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped), uri.AbsolutePath, newTarget))
-                            target = newTarget;
-
-                        if (target == null)
-                        {
-                            log.WriteLine("Could not fetch {0} from web", uri.AbsoluteUri);
-                            return null;
-                        }
-                    }
-                    else
-                    {
-                        log.WriteLine("Source Server string {0} is targeting an unsafe location.  Giving up.", target);
-                        return null;
-                    }
-                }
-
-                if (!File.Exists(target) && fetchCmdStr != null)
-                {
-                    log.WriteLine("Trying to generate the file {0}.", target);
-                    var toolsDir = Path.GetDirectoryName(typeof(SourceFile).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName);
-                    var archToolsDir = Path.Combine(toolsDir, NativeDlls.ProcessArchitectureDirectory);
-
-                    // Find the EXE to do the source server fetch.  We only support SD.exe and TF.exe.   
-                    string addToPath = null;
-                    if (fetchCmdStr.StartsWith("sd.exe ", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (!File.Exists(Path.Combine(archToolsDir, "sd.exe")))
-                            log.WriteLine("WARNING: Could not find sd.exe that should have been deployed at {0}", archToolsDir);
-                        addToPath = archToolsDir;
-                    }
-                    else
-                    if (fetchCmdStr.StartsWith("tf.exe ", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var tfExe = Command.FindOnPath("tf.exe");
-                        if (tfExe == null)
-                        {
-                            tfExe = FindTfExe();
-                            if (tfExe == null)
-                            {
-                                log.WriteLine("Could not find TF.exe, place it on the PATH environment variable to fix this.");
-                                return null;
-                            }
-                            addToPath = Path.GetDirectoryName(tfExe);
-                        }
-                    }
-                    else
-                    {
-                        log.WriteLine("Source Server command {0} is not recognized as safe (sd.exe or tf.exe), failing.", fetchCmdStr);
-                        return null;
-                    }
-                    Directory.CreateDirectory(Path.GetDirectoryName(target));
-                    fetchCmdStr = "cmd /c " + fetchCmdStr;
-                    var options = new CommandOptions().AddOutputStream(log).AddNoThrow();
-                    if (addToPath != null)
-                        options = options.AddEnvironmentVariable("PATH", addToPath + ";%PATH%");
-
-                    log.WriteLine("Source Server command {0}.", fetchCmdStr);
-                    var fetchCmd = Command.Run(fetchCmdStr, options);
-                    if (fetchCmd.ExitCode != 0)
-                        log.WriteLine("Source Server command failed with exit code {0}", fetchCmd.ExitCode);
-                    if (File.Exists(target))
-                    {
-                        // If TF.exe command files it might still create an empty output file.   Fix that 
-                        if (new FileInfo(target).Length == 0)
-                        {
-                            File.Delete(target);
-                            target = null;
-                        }
-                    }
-                    else
-                        target = null;
-
-                    if (target == null)
-                        log.WriteLine("Source Server command failed to produce the output file.");
-                    else
-                        log.WriteLine("Source Server command succeeded creating {0}", target);
-                }
-                else
-                    log.WriteLine("Found an existing source server file {0}.", target);
-                return target;
-            }
-
-            log.WriteLine("Did not find source file in the set of source files in the PDB.");
-            return null;
-        }
-
-        /// <summary>
-        /// Returns the location of the tf.exe executable or 
-        /// </summary>
-        /// <returns></returns>
-        private static string FindTfExe()
-        {
-            // If you have VS installed used that TF.exe associated with that.  
-            var progFiles = Environment.GetEnvironmentVariable("ProgramFiles (x86)");
-            if (progFiles == null)
-                progFiles = Environment.GetEnvironmentVariable("ProgramFiles");
-            if (progFiles != null)
-            {
-                // Find the oldest Visual Studio directory;
-                var dirs = Directory.GetDirectories(progFiles, "Microsoft Visual Studio*");
-                Array.Sort(dirs);
-                if (dirs.Length > 0)
-                {
-                    var VSDir = Path.Combine(dirs[dirs.Length - 1], @"Common7\IDE");
-                    var tfexe = Path.Combine(VSDir, "tf.exe");
-                    if (File.Exists(tfexe))
-                        return tfexe;
-                }
-            }
-            return null;
-        }
-
-        private string SourceServerFetchVar(string variable, Dictionary<string, string> vars)
-        {
-            var log = m_symbolModule.m_reader.m_log;
-            string result = "";
-            if (vars.TryGetValue(variable, out result))
-            {
-                if (0 <= result.IndexOf('%'))
-                    log.WriteLine("SourceServerFetchVar: Before Evaluation {0} = '{1}'", variable, result);
-                result = SourceServerEvaluate(result, vars);
-            }
-            log.WriteLine("SourceServerFetchVar: {0} = '{1}'", variable, result);
-            return result;
-        }
-
-        private string SourceServerEvaluate(string result, Dictionary<string, string> vars)
-        {
-            if (0 <= result.IndexOf('%'))
-            {
-                // see http://msdn.microsoft.com/en-us/library/windows/desktop/ms680641(v=vs.85).aspx for details on the %fn* variables 
-                result = Regex.Replace(result, @"%fnvar%\((.*?)\)", delegate (Match m)
-                {
-                    return SourceServerFetchVar(SourceServerEvaluate(m.Groups[1].Value, vars), vars);
-                });
-                result = Regex.Replace(result, @"%fnbksl%\((.*?)\)", delegate (Match m)
-                {
-                    return SourceServerEvaluate(m.Groups[1].Value, vars).Replace('/', '\\');
-                });
-                result = Regex.Replace(result, @"%fnfile%\((.*?)\)", delegate (Match m)
-                {
-                    return Path.GetFileName(SourceServerEvaluate(m.Groups[1].Value, vars));
-                });
-                // Normal variable substitution
-                result = Regex.Replace(result, @"%(\w+)%", delegate (Match m)
-                {
-                    return SourceServerFetchVar(m.Groups[1].Value, vars);
-                });
-            }
-            return result;
-        }
-
-
-        // Here is an example of the srcsrv stream.  
-#if false
-SRCSRV: ini ------------------------------------------------
-VERSION=3
-INDEXVERSION=2
-VERCTRL=Team Foundation Server
-DATETIME=Wed Nov 28 03:47:14 2012
-SRCSRV: variables ------------------------------------------
-TFS_EXTRACT_CMD=tf.exe view /version:%var4% /noprompt "$%var3%" /server:%fnvar%(%var2%) /console >%srcsrvtrg%
-TFS_EXTRACT_TARGET=%targ%\%var2%%fnbksl%(%var3%)\%var4%\%fnfile%(%var1%)
-SRCSRVVERCTRL=tfs
-SRCSRVERRDESC=access
-SRCSRVERRVAR=var2
-DEVDIV_TFS2=http://vstfdevdiv.redmond.corp.microsoft.com:8080/devdiv2
-SRCSRVTRG=%TFS_extract_target%
-SRCSRVCMD=%TFS_extract_cmd%
-SRCSRV: source files ---------------------------------------
-f:\dd\ndp\clr\src\vm\i386\gmsasm.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/gmsasm.asm*592925
-f:\dd\ndp\clr\src\vm\i386\jithelp.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/jithelp.asm*592925
-f:\dd\ndp\clr\src\vm\i386\RedirectedHandledJITCase.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/RedirectedHandledJITCase.asm*592925
-f:\dd\public\devdiv\inc\ddbanned.h*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/public/devdiv/inc/ddbanned.h*592925
-f:\dd\ndp\clr\src\debug\ee\i386\dbghelpers.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/Debug/EE/i386/dbghelpers.asm*592925
-SRCSRV: end ------------------------------------------------
-      
-        // Here is one for SD. 
-
-SRCSRV: ini ------------------------------------------------
-VERSION=1
-VERCTRL=Source Depot
-SRCSRV: variables ------------------------------------------
-SRCSRVTRG=%targ%\%var2%\%fnbksl%(%var3%)\%var4%\%fnfile%(%var1%)
-SRCSRVCMD=sd.exe -p %fnvar%(%var2%) print -o %srcsrvtrg% -q %depot%/%var3%#%var4%
-DEPOT=//depot
-SRCSRVVERCTRL=sd
-SRCSRVERRDESC=Connect to server failed
-SRCSRVERRVAR=var2
-WIN_MINKERNEL=minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020
-WIN_PUBLIC=publicdepot.sys-ntgroup.ntdev.microsoft.com:2017
-WIN_PUBLICINT=publicintdepot.sys-ntgroup.ntdev.microsoft.com:2018
-SRCSRV: source files ---------------------------------------
-d:\win7sp1_gdr.public.amd64fre\sdk\inc\pshpack4.h*WIN_PUBLIC*win7sp1_gdr/public/sdk/inc/pshpack4.h*1
-d:\win7sp1_gdr.public.amd64fre\internal\minwin\priv_sdk\inc\ntos\pnp.h*WIN_PUBLICINT*win7sp1_gdr/publicint/minwin/priv_sdk/inc/ntos/pnp.h*1
-d:\win7sp1_gdr.public.amd64fre\internal\minwin\priv_sdk\inc\ntos\cm.h*WIN_PUBLICINT*win7sp1_gdr/publicint/minwin/priv_sdk/inc/ntos/cm.h*1
-d:\win7sp1_gdr.public.amd64fre\internal\minwin\priv_sdk\inc\ntos\pnp_x.h*WIN_PUBLICINT*win7sp1_gdr/publicint/minwin/priv_sdk/inc/ntos/pnp_x.h*2
-SRCSRV: end ------------------------------------------------
-
-
-#endif
-#if false
-        // Here is ana example of the stream in use for the jithlp.asm file.  
-
-f:\dd\ndp\clr\src\vm\i386\jithelp.asm*DEVDIV_TFS2*/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/jithelp.asm*592925
-
-        // Here is the command that it issues.  
-tf.exe view /version:592925 /noprompt "$/DevDiv/D11RelS/FX45RTMGDR/ndp/clr/src/VM/i386/jithelp.asm" /server:http://vstfdevdiv.redmond.corp.microsoft.com:8080/devdiv2 /console >"C:\Users\vancem\AppData\Local\Temp\PerfView\src\DEVDIV_TFS2\DevDiv\D11RelS\FX45RTMGDR\ndp\clr\src\VM\i386\jithelp.asm\592925\jithelp.asm"
-
-sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users\vancem\AppData\Local\Temp\PerfView\src\WIN_MINKERNEL\win8_gdr\minkernel\ntdll\rtlstrt.c\1\rtlstrt.c" -q //depot/win8_gdr/minkernel/ntdll/rtlstrt.c#1
-
-#endif
-
-        private bool DoesChecksumMatch(string filePath)
-        {
-            if (!HasChecksum)
+            if (_hashAlgorithm == null && _hash == null)
                 return true;
 
-            byte[] checksum = ComputeHash(filePath);
-            if (checksum.Length != m_hash.Length)
+            using (var fileStream = File.OpenRead(filePath))
+            {
+                byte[] computedHash = _hashAlgorithm.ComputeHash(fileStream);
+                return ArrayEquals(computedHash, _hash);
+            }
+        }
+
+        private string GetCachePathForUrl(string url)
+        {
+            var cacheDir = _symbolModule.SymbolReader.SourceCacheDirectory;
+            return (Path.Combine(cacheDir, new Uri(url).AbsolutePath.TrimStart('/').Replace('/', '\\')));
+        }
+
+        // Should be in the framework, but I could  not find it quickly.  
+        private static bool ArrayEquals(byte[] bytes1, byte[] bytes2)
+        {
+            if (bytes1.Length != bytes1.Length)
                 return false;
-            for (int i = 0; i < checksum.Length; i++)
-                if (checksum[i] != m_hash[i])
+            for (int i = 0; i < bytes1.Length; i++)
+            {
+                if (bytes1[i] != bytes2[i])
                     return false;
+            }
             return true;
         }
 
-        unsafe internal SourceFile(SymbolModule module, IDiaSourceFile sourceFile)
-        {
-            m_symbolModule = module;
-            BuildTimeFilePath = sourceFile.fileName;
+        // TO be filled in by superclass on construction.  
+        protected byte[] _hash;
+        protected System.Security.Cryptography.HashAlgorithm _hashAlgorithm;
+        protected ManagedSymbolModule _symbolModule;
 
-            // 0 No checksum present.
-            // 1 CALG_MD5 checksum generated with the MD5 hashing algorithm.
-            // 2 CALG_SHA1 checksum generated with the SHA1 hashing algorithm.
-            // 3 checksum generated with the SHA256 hashing algorithm.
-            m_hashType = sourceFile.checksumType;
-            SetCryptoProvider();
-
-            if (HasChecksum)
-            {
-                uint hashSizeInBytes;
-                fixed (byte* bufferPtr = m_hash)
-                    sourceFile.get_checksum(0, out hashSizeInBytes, out *bufferPtr);
-
-                // MD5 is 16 bytes
-                // SHA1 is 20 bytes  
-                // SHA-256 is 32 bytes
-                m_hash = new byte[hashSizeInBytes];
-
-                uint bytesFetched;
-                fixed (byte* bufferPtr = m_hash)
-                    sourceFile.get_checksum((uint)m_hash.Length, out bytesFetched, out *bufferPtr);
-                Debug.Assert(bytesFetched == m_hash.Length);
-            }
-        }
-
-        private void SetCryptoProvider()
-        {
-            switch (m_hashType)
-            {
-                case 1:
-                    m_hashAlgorithm = System.Security.Cryptography.MD5.Create();
-                    break;
-
-                case 2:
-                    m_hashAlgorithm = System.Security.Cryptography.SHA1.Create();
-                    break;
-
-                case 3:
-                    m_hashAlgorithm = System.Security.Cryptography.SHA256.Create();
-                    break;
-
-                default:
-                    m_hashAlgorithm = null; // unknown hash type
-                    break;
-            }
-        }
-
-        private System.Security.Cryptography.HashAlgorithm GetCryptoProvider()
-        {
-            return m_hashAlgorithm;
-        }
-
-        private byte[] ComputeHash(string filePath)
-        {
-            Debug.Assert(m_hashAlgorithm != null);
-
-            using (var fileStream = File.OpenRead(filePath))
-                return m_hashAlgorithm.ComputeHash(fileStream);
-        }
-
-        SymbolModule m_symbolModule;
-        uint m_hashType;
-        byte[] m_hash;
-        System.Security.Cryptography.HashAlgorithm m_hashAlgorithm;
-        bool m_getSourceCalled;
-        bool m_checksumMatches;
-        #endregion
-    }
-
-    /// <summary>
-    /// A SourceLocation represents a point in the source code.  That is the file and the line number.  
-    /// </summary>
-    public class SourceLocation
-    {
-        /// <summary>
-        /// The source file for the code
-        /// </summary>
-        public SourceFile SourceFile { get; private set; }
-        /// <summary>
-        /// The line number for the code.
-        /// </summary>
-        public int LineNumber { get; private set; }
-        #region private
-        internal SourceLocation(SourceFile sourceFile, int lineNumber)
-        {
-            // The library seems to see FEEFEE for the 'unknown' line number.  0 seems more intuitive
-            if (0xFEEFEE <= lineNumber)
-                lineNumber = 0;
-
-            SourceFile = sourceFile;
-            LineNumber = lineNumber;
-        }
+        // Filled in when GetSource() is called.  
+        protected string _filePath;
+        bool _getSourceCalled;
+        bool _checksumMatches;
         #endregion
     }
 }
-
-#region private classes
-
-internal sealed class ComStreamWrapper : IStream
-{
-    private readonly Stream stream;
-
-    public ComStreamWrapper(Stream stream)
-    {
-        this.stream = stream;
-    }
-
-    public void Commit(uint grfCommitFlags)
-    {
-        throw new NotSupportedException();
-    }
-
-    public unsafe void RemoteRead(out byte pv, uint cb, out uint pcbRead)
-    {
-        byte[] buf = new byte[cb];
-
-        int bytesRead = stream.Read(buf, 0, (int)cb);
-        pcbRead = (uint)bytesRead;
-
-        fixed (byte* p = &pv)
-        {
-            for (int i = 0; i < bytesRead; i++)
-                p[i] = buf[i];
-        }
-    }
-
-    public unsafe void RemoteSeek(_LARGE_INTEGER dlibMove, uint origin, out _ULARGE_INTEGER plibNewPosition)
-    {
-        long newPosition = stream.Seek(dlibMove.QuadPart, (SeekOrigin)origin);
-        plibNewPosition.QuadPart = (ulong)newPosition;
-    }
-
-    public void SetSize(_ULARGE_INTEGER libNewSize)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void Stat(out tagSTATSTG pstatstg, uint grfStatFlag)
-    {
-        pstatstg = new tagSTATSTG()
-        {
-            cbSize = new _ULARGE_INTEGER() { QuadPart = (ulong)stream.Length }
-        };
-    }
-
-    public unsafe void RemoteWrite(ref byte pv, uint cb, out uint pcbWritten)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void Clone(out IStream ppstm)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void RemoteCopyTo(IStream pstm, _ULARGE_INTEGER cb, out _ULARGE_INTEGER pcbRead, out _ULARGE_INTEGER pcbWritten)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void LockRegion(_ULARGE_INTEGER libOffset, _ULARGE_INTEGER cb, uint lockType)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void Revert()
-    {
-        throw new NotSupportedException();
-    }
-
-    public void UnlockRegion(_ULARGE_INTEGER libOffset, _ULARGE_INTEGER cb, uint lockType)
-    {
-        throw new NotSupportedException();
-    }
-}
-
-namespace Dia2Lib
-{
-    /// <summary>
-    /// The DiaLoader class knows how to load the msdia140.dll (the Debug Access Interface) (see docs at
-    /// http://msdn.microsoft.com/en-us/library/x93ctkx8.aspx), without it being registered as a COM object.
-    /// Basically it just called the DllGetClassObject interface directly.
-    /// 
-    /// It has one public method 'GetDiaSourceObject' which knows how to create a IDiaDataSource object. 
-    /// From there you can do anything you need.  
-    /// 
-    /// In order to get IDiaDataSource3 which includes'getStreamSize' API, you need to use the 
-    /// vctools\langapi\idl\dia2_internal.idl file from devdiv to produce Dia2Lib.dll
-    /// 
-    /// roughly what you need to do is 
-    ///     copy vctools\langapi\idl\dia2_internal.idl .
-    ///     copy vctools\langapi\idl\dia2.idl .
-    ///     copy vctools\langapi\include\cvconst.h .
-    ///     Change dia2.idl to include interface IDiaDataSource3 inside library Dia2Lib->importlib->coclass DiaSource
-    ///     midl dia2_internal.idl /D CC_DP_CXX
-    ///     tlbimp dia2_internal.tlb
-    ///     REM result is Dia2Lib.dll 
-    /// </summary>
-    internal static class DiaLoader
-    {
-        /// <summary>
-        /// Load the msdia100 dll and get a IDiaDataSource from it.  This is your gateway to PDB reading.   
-        /// </summary>
-        public static IDiaDataSource3 GetDiaSourceObject()
-        {
-            if (!s_loadedNativeDll)
-            {
-                // Insure that the native DLL we need exist.  
-                NativeDlls.LoadNative("msdia140.dll");
-                s_loadedNativeDll = true;
-            }
-
-            // This is the value it was for msdia120 and before 
-            // var diaSourceClassGuid = new Guid("{3BFCEA48-620F-4B6B-81F7-B9AF75454C7D}");
-
-            // This is the value for msdia140.  
-            var diaSourceClassGuid = new Guid("{e6756135-1e65-4d17-8576-610761398c3c}");
-            var comClassFactory = (IClassFactory)DllGetClassObject(diaSourceClassGuid, typeof(IClassFactory).GetTypeInfo().GUID);
-
-            object comObject = null;
-            Guid iDataDataSourceGuid = typeof(IDiaDataSource3).GetTypeInfo().GUID;
-            comClassFactory.CreateInstance(null, ref iDataDataSourceGuid, out comObject);
-            return (comObject as IDiaDataSource3);
-        }
-        #region private
-        [ComImport, ComVisible(false), Guid("00000001-0000-0000-C000-000000000046"),
-         InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        private interface IClassFactory
-        {
-            void CreateInstance([MarshalAs(UnmanagedType.Interface)] object aggregator,
-                                ref Guid refiid,
-                                [MarshalAs(UnmanagedType.Interface)] out object createdObject);
-            void LockServer(bool incrementRefCount);
-        }
-
-        // Methods
-        [return: MarshalAs(UnmanagedType.Interface)]
-        [DllImport("msdia140.dll", CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = false)]
-        private static extern object DllGetClassObject(
-            [In, MarshalAs(UnmanagedType.LPStruct)] Guid rclsid,
-            [In, MarshalAs(UnmanagedType.LPStruct)] Guid riid);
-
-        /// <summary>
-        /// Used to ensure the native library is loaded at least once prior to trying to use it. No protection is
-        /// included to avoid multiple loads, but this is not a problem since we aren't trying to unload the library
-        /// after use.
-        /// </summary>
-        static bool s_loadedNativeDll;
-        #endregion
-    }
-}
-#endregion
 

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -310,9 +310,9 @@ namespace Microsoft.Diagnostics.Symbols
 
         /// <summary>
         /// Like OpenSymbolFile, which opens a PDB, but this version will fail (return null)
-        /// if it is not WindowsSymbolModule.  It is a shortcut for OpenSymbolFile as WindowsSymbolModule
+        /// if it is not WindowsSymbolModule.  It is a shortcut for OpenSymbolFile as NativeSymbolModule
         /// </summary>
-        public NativeSymbolModule OpenWindowsSymbolFile(string pdbFileName)
+        public NativeSymbolModule OpenNativeSymbolFile(string pdbFileName)
         {
             return OpenSymbolFile(pdbFileName) as NativeSymbolModule;
         }

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Diagnostics.Symbols
                 }
                 else
                 {
-                    stream.Close();
+                    stream.Dispose();
                     ret = new NativeSymbolModule(this, pdbFilePath);
                 }
                 m_symbolModuleCache.Add(pdbFilePath, ret);
@@ -888,8 +888,10 @@ namespace Microsoft.Diagnostics.Symbols
                             m_log.WriteLine("FindSymbolFilePath: In task, sending HTTP request {0}", fullUri);
 
                             var req = (System.Net.HttpWebRequest)System.Net.HttpWebRequest.Create(fullUri);
-                            req.UserAgent = "Microsoft-Symbol-Server/6.13.0009.1140";
-                            var response = req.GetResponse();
+                            var responseTask = req.GetResponseAsync();
+                            responseTask.Wait();
+                            var response = responseTask.Result;
+
                             alive = true;
                             if (!canceled)
                             {
@@ -1633,7 +1635,6 @@ namespace Microsoft.Diagnostics.Symbols
                 _checksumMatches = true;
                 _filePath = filePath;
                 _log.WriteLine("Checksum matches for {0}", filePath);
-
                 return true;
             }
 

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -61,6 +61,7 @@
     <When Condition="'$(TargetFramework)' == 'net45'">
       <ItemGroup>
         <Reference Include="System.IO.Compression" />
+        <Reference Include="System.Net.Http" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
       </ItemGroup>
     </When>
@@ -68,6 +69,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With this change you can do goto source on code that was built using portable PDBs and it will work.

The following Renames in TraceEvent were done (these are breaking changes), but are simple renames
    SymbolModule -> NativeSymbolModule  and
    OpenSymbolFile -> OpenNativeSymbolFile  which is what existing code should call.

We now have a hierarchy where ManagedSymbolModule is at the base contract and NativeSymbolModule is a contract subclass.   Logically WIndows PDBs subclass NativeSymbolModule (but today they ARE NativeSymbolModule), and PortablePDBs subclass ManagedSymbolModule. 
This allows much of the symbol logic to be shared for both portable PDBs.  There is more factoring that can be done, but this is a good step in the right direction.  

Note that making goto Source work with SourceLink attributed WINDOWS pdbs may not work yet.
That requires PerfView to read the new sourceLink information out of WINDOWS pdbs, which it does
not do today.  That is an independent feature.