### PR TITLE
Give a clean error if runing 64 bit on old oses

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -176,6 +176,17 @@ namespace PerfView
                 }
             }
 
+            // The 64 bit version of some of the native DLLs we use are built against the new Win10 libraries and will 
+            // fail to bind if they are loaded on an older OS (it would probably work for Win8 but do we care?) 
+            // It also can work if we only do viewing operations (msdia* uses old libraries), but again do we care?  
+            // If we do we can move this to before the DLLs are loaded.   
+            // Give the user a clean error.   
+            if (Environment.Is64BitProcess && Environment.OSVersion.Version.Major < 10)
+            {
+                throw new ApplicationException("The PerfView64 does not work properly Windows version < 10\r\n" +
+                    "    Please use the 32 bit version (PerfView.exe).");
+            }
+
             // For reasons I have not dug into SetFileName does not work if you attach to a session.  Warn the user.  
             if (CommandLineArgs.InMemoryCircularBuffer && CommandLineArgs.DoCommand == CommandProcessor.Start)
                 throw new ApplicationException("Error: InMemoryCircularBuffer currently can't be used with separate Start and Stop processes.");


### PR DESCRIPTION
The native DLLs we have for 64 bit do not work on old OSes.
Give a clean error that tells people what to do