### PR TITLE
Fix RuntimeInformation DLL loading issue

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PerfViewVersion>1.9.69.0</PerfViewVersion>
+    <PerfViewVersion>1.9.70.0</PerfViewVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -228,6 +228,13 @@
       <Link>Microsoft.Diagnostics.FastSerialization.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Runtime.InteropServices.RuntimeInformation.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\System.Runtime.InteropServices.RuntimeInformation.dll</LogicalName>
+      <Link>System.Runtime.InteropServices.RuntimeInformation.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\TraceEvent\$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.xml">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -8078,10 +8078,20 @@
     </li>
     -->
         <li>
+            Version 1.9.70 12/15/17
+            <ul>
+                <li>
+                    Fixed issue where when PerfView is run on older .NET Runtime's it fails to load the 
+                    System.Runtime.InteropServices.RuntimeInformation.dll.  
+                </li>
+
+            </ul>
+        </li>
+        <li>
             Version 1.9.69 12/14/17
             <ul>
                 <li>
-                    Added the /LowPriority command line qualifier that causes the merging/NGENing/ZIPPing that 
+                    Added the /LowPriority command line qualifier that causes the merging/NGENing/ZIPPing that
                     perfview does to package up the data to happen at low CPU priority to minimize the impact
                     to the system.
                 </li>


### PR DESCRIPTION
Add System.Runtime.InteropServices.RuntimeInformation to PerfView payload because it is not always present on older runtimes.   By also carrying it as a private DLL it insures it works regardless of the version of the .NET Runtime PerfVIew runs on.  