### PR TITLE
Fix double dispatch for some events

### DIFF
--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -1960,8 +1960,8 @@ public class GraphSampler
     public MemoryGraph GetSampledGraph()
     {
         m_log.WriteLine("************* SAMPLING GRAPH TO REDUCE SIZE ***************");
-        m_log.WriteLine("Original graph count {0:n0}, targetCount {1:n0} targetRatio {2:f2}", m_graph.NodeCount, m_targetNodeCount, m_filteringRatio);
-        m_log.WriteLine("Original graph Size {0:n0} TypeCount {1:n0}", m_graph.TotalSize, m_graph.NodeTypeCount);
+        m_log.WriteLine("Original graph object count {0:n0}, targetObjectCount {1:n0} targetRatio {2:f2}", m_graph.NodeCount, m_targetNodeCount, m_filteringRatio);
+        m_log.WriteLine("Original graph Size MB {0:n0} TypeCount {1:n0}", m_graph.TotalSize, m_graph.NodeTypeCount);
 
         // Get the spanning tree
         m_spanningTree = new SpanningTree(m_graph, m_log);

--- a/src/PerfView/EtwEventSource.cs
+++ b/src/PerfView/EtwEventSource.cs
@@ -466,11 +466,7 @@ namespace PerfView
 
                 AddField("ThreadID", data.ThreadID.ToString("n0"), columnOrder, restString);
 
-                var message = data.FormattedMessage;
-                if (message != null)
-                    AddField("FormattedMessage", message, columnOrder, restString);
-
-                if (0 < durationMSec)
+               if (0 < durationMSec)
                     AddField("DURATION_MSEC", durationMSec.ToString("n3"), columnOrder, restString);
 
                 var payloadNames = data.PayloadNames;
@@ -491,6 +487,10 @@ namespace PerfView
                 {
                     AddField("ErrorParsingFields", e.Message, columnOrder, restString);
                 }
+
+                var message = data.FormattedMessage;
+                if (message != null)
+                    AddField("FormattedMessage", message, columnOrder, restString);
 
                 if (source.m_needsComputers)
                 {

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -1258,27 +1258,34 @@ namespace PerfView
                         StatusBar.Status = "CellContents: " + cellAsHexDec;
                     }
 
-                    var clipBoardStr = Clipboard.GetText().Trim();
-                    if (clipBoardStr.Length > 0)
+                   try
                     {
-                        double clipBoardVal;
-                        double cellVal;
-                        if (double.TryParse(clipBoardStr, out clipBoardVal) &&
-                            double.TryParse(cellStr, out cellVal))
+                        var clipBoardStr = Clipboard.GetText().Trim();
+                        if (clipBoardStr.Length > 0)
                         {
-                            var reply = string.Format("Cell Contents: {0:f3} ClipBoard: {1:n3}   Sum={2:n3}   Diff={3:n3}",
-                                cellAsHexDec, clipBoardVal, cellVal + clipBoardVal, Math.Abs(cellVal - clipBoardVal));
+                            double clipBoardVal;
+                            double cellVal;
+                            if (double.TryParse(clipBoardStr, out clipBoardVal) &&
+                                double.TryParse(cellStr, out cellVal))
+                            {
+                                var reply = string.Format("Cell Contents: {0:f3} ClipBoard: {1:n3}   Sum={2:n3}   Diff={3:n3}",
+                                    cellAsHexDec, clipBoardVal, cellVal + clipBoardVal, Math.Abs(cellVal - clipBoardVal));
 
-                            double product = cellVal * clipBoardVal;
-                            if (Math.Abs(product) <= 1000)
-                                reply += string.Format("   X*Y={0:n3}", product);
+                                double product = cellVal * clipBoardVal;
+                                if (Math.Abs(product) <= 1000)
+                                    reply += string.Format("   X*Y={0:n3}", product);
 
-                            double ratio = cellVal / clipBoardVal;
-                            if (.001 <= Math.Abs(ratio) && Math.Abs(ratio) <= 1000000)
-                                reply += string.Format("   X/Y={0:n3}   Y/X={1:n3}", ratio, 1 / ratio);
+                                double ratio = cellVal / clipBoardVal;
+                                if (.001 <= Math.Abs(ratio) && Math.Abs(ratio) <= 1000000)
+                                    reply += string.Format("   X/Y={0:n3}   Y/X={1:n3}", ratio, 1 / ratio);
 
-                            StatusBar.Status = reply;
+                                StatusBar.Status = reply;
+                            }
                         }
+                    }
+                    catch(Exception eClipBoard)
+                    {
+                        StatusBar.Log("Warning: exception trying to get Clipboard: " + eClipBoard.Message);
                     }
                 }
                 Grid.ClipboardCopyMode = DataGridClipboardCopyMode.ExcludeHeader;

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -122,7 +122,7 @@ namespace PerfViewExtensibility
                         gcDump.AverageCountMultiplier, gcDump.AverageSizeMultiplier);
             }
 
-            log.WriteLine("Type Histograph > 1% of heap size");
+            log.WriteLine("Type Histogram > 1% of heap size");
             log.Write(graph.HistogramByTypeXml(graph.TotalSize / 100));
 
             // TODO FIX NOW better name. 

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -6604,7 +6604,7 @@ table {
                    graph.TotalNumberOfReferences / 1000.0, (int)graph.NodeTypeIndexLimit / 1000.0,
                    graph.SizeOfGraphDescription() / 1000000.0);
 
-            log.WriteLine("Type Histograph > 1% of heap size");
+            log.WriteLine("Type Histogram > 1% of heap size");
             log.Write(graph.HistogramByTypeXml(graph.TotalSize / 100));
 
 #if false // TODO FIX NOW remove
@@ -6646,7 +6646,7 @@ table {
                    graph.TotalNumberOfReferences / 1000.0, (int)graph.NodeTypeIndexLimit / 1000.0,
                    graph.SizeOfGraphDescription() / 1000000.0);
 
-            log.WriteLine("Type Histograph > 1% of heap size");
+            log.WriteLine("Type Histogram > 1% of heap size");
             log.Write(graph.HistogramByTypeXml(graph.TotalSize / 100));
 
 #if false // TODO FIX NOW remove
@@ -6731,7 +6731,7 @@ table {
                         gcDump.AverageCountMultiplier, gcDump.AverageSizeMultiplier);
             }
 
-            log.WriteLine("Type Histograph > 1% of heap size");
+            log.WriteLine("Type Histogram > 1% of heap size");
             log.Write(graph.HistogramByTypeXml(graph.TotalSize / 100));
             return ret;
         }


### PR DESCRIPTION
This fix is in RegisteredTraceEventParser.  The issue is that events generated by the MetaData events were
being logged by ANY parser that derived from ExternalTraceEventParser.  There are now two (EventPipeTraceEventParser)
which caused the events to be delivered twice.   Fixed by moving these events into JUST RegisteredTraceEventParser.

All other fixes are minor logging, whitespace and spelling fixes.