### PR TITLE
Consistently place the exclusive value columns before the inclusive value columns

### DIFF
--- a/src/PerfView/StackViewer/PerfDataGrid.xaml
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml
@@ -58,6 +58,58 @@
                     </TextBlock>
                 </WPFToolKit:DataGridTemplateColumn.Header>
             </WPFToolKit:DataGridTemplateColumn>
+
+            <WPFToolKit:DataGridTextColumn 
+                IsReadOnly="True"
+                Binding="{Binding ExclusiveMetricPercent, StringFormat={}{0:n1}}" 
+                HeaderStyle="{StaticResource CenterAlign}"
+                ElementStyle="{StaticResource RightAlign}">
+                <WPFToolKit:DataGridTextColumn.Header>
+                    <TextBlock Margin="0,0,5,0" Name="ExcPercentColumn">
+                        Exc % <Hyperlink Click="DoHyperlinkHelp" Tag="ExcPercentColumn">?</Hyperlink>
+                        <TextBlock.ToolTip>
+                                <TextBlock>
+                                    The % of the total sample metric that occured in this item exclusively (not its children, does include folding).  
+                                </TextBlock>
+                        </TextBlock.ToolTip>
+                    </TextBlock>
+                </WPFToolKit:DataGridTextColumn.Header>
+            </WPFToolKit:DataGridTextColumn>
+            
+            <WPFToolKit:DataGridTextColumn 
+                IsReadOnly="True"
+                Binding="{Binding ExclusiveMetric, StringFormat={}{0:n0}}" 
+                HeaderStyle="{StaticResource CenterAlign}"
+                ElementStyle="{StaticResource RightAlign}">
+                <WPFToolKit:DataGridTextColumn.Header>
+                    <TextBlock Margin="0,0,5,0" Name="ExcColumn">
+                        Exc <Hyperlink Click="DoHyperlinkHelp" Tag="ExcColumn">?</Hyperlink>
+                        <TextBlock.ToolTip>
+                                <TextBlock>
+                                    The sum of the sample metric that occured in this item exclusively (not its children, does include folding).  
+                                </TextBlock>
+                        </TextBlock.ToolTip>
+                    </TextBlock>
+                </WPFToolKit:DataGridTextColumn.Header>
+            </WPFToolKit:DataGridTextColumn>
+
+            <WPFToolKit:DataGridTextColumn 
+                IsReadOnly="True"
+                Binding="{Binding ExclusiveCount, StringFormat={}{0:n0}}" 
+                HeaderStyle="{StaticResource CenterAlign}"
+                ElementStyle="{StaticResource RightAlign}">
+                <WPFToolKit:DataGridTextColumn.Header>
+                    <TextBlock Margin="0,0,5,0" Name="ExcCountColumn">
+                        Exc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="ExcCountColumn ">?</Hyperlink>
+                        <TextBlock.ToolTip>
+                                <TextBlock>
+                                    The count of the instances in item (excluding its children, does include folding) 
+                                </TextBlock>
+                        </TextBlock.ToolTip>
+                    </TextBlock>
+                </WPFToolKit:DataGridTextColumn.Header>
+            </WPFToolKit:DataGridTextColumn>
+
             <WPFToolKit:DataGridTextColumn 
                 IsReadOnly="True"
                 Binding="{Binding InclusiveMetricPercent, StringFormat={}{0:n1}}" 
@@ -121,57 +173,6 @@
                             <TextBlock>
                                     The count of the instances in item or its children.
                             </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveMetricPercent, StringFormat={}{0:n1}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="ExcPercentColumn">
-                        Exc % <Hyperlink Click="DoHyperlinkHelp" Tag="ExcPercentColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The % of the total sample metric that occured in this item exclusively (not its children, does include folding).  
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-            
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveMetric, StringFormat={}{0:n0}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="ExcColumn">
-                        Exc <Hyperlink Click="DoHyperlinkHelp" Tag="ExcColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The sum of the sample metric that occured in this item exclusively (not its children, does include folding).  
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveCount, StringFormat={}{0:n0}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="ExcCountColumn">
-                        Exc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="ExcCountColumn ">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The count of the instances in item (excluding its children, does include folding) 
-                                </TextBlock>
                         </TextBlock.ToolTip>
                     </TextBlock>
                 </WPFToolKit:DataGridTextColumn.Header>

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2735,21 +2735,6 @@ namespace PerfView
 
             // Customize the control
             ByNameDataGrid.Grid.CanUserSortColumns = true;
-            var columns = ByNameDataGrid.Grid.Columns;
-
-
-            // Put the exlusive columns first if they are not already there.  
-            var col = ByNameDataGrid.GetColumnIndex("ExcPercentColumn");
-            if (0 <= col && col != 1)
-                ByNameDataGrid.Grid.Columns.Move(col, 1);
-
-            col = ByNameDataGrid.GetColumnIndex("ExcColumn");
-            if (0 <= col && col != 2)
-                ByNameDataGrid.Grid.Columns.Move(col, 2);
-
-            col = ByNameDataGrid.GetColumnIndex("ExcCountColumn");
-            if (0 <= col && col != 3)
-                ByNameDataGrid.Grid.Columns.Move(col, 3);
 
             // Initialize the CallTree, Callers, and Callees tabs
             // TODO:  Gross that the caller has to pass this in.  


### PR DESCRIPTION
This change takes a bit of time to get used to, but in the end it reduces the number of cases where a developer incorrectly reports an **Inc Ct** count value as an **Exc Ct** value due to misreading the columns of the current view.

This error occurred many times when I started using PerfView.