### PR TITLE
Added a Dispatch Hook to enable locking process thread and event filtering

### DIFF
--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -2827,7 +2827,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// </summary>
         public void AddDispatchHook(Func<TraceEvent, bool> onDispatch)
         {
-            if (onDispatch == null) throw new ArgumentException("Must provide a non-null callback", "onDispatch", null);
+            if (onDispatch == null) throw new ArgumentException("Must provide a non-null callback", nameof(onDispatch), null);
 
             var hook = new DispatchHookEntry()
             {


### PR DESCRIPTION
Added a hook right before event dispatch so that 1) programs can gain frequent access to the processing thread and 2) events can be filtered before dispatch.  The primary scenario is to allow a multi-threaded application inspect data accumulated on the source by using a synchronization mechanism in the dispatch hook.

The primary scenario for the DispatchHook is when a secondary thread wants to inspect the contents of accumulators (like TraceManagedDotNetRuntime) during a live ETW session.  The pattern would be to add a hook which sets a manual reset event.  This synchronization will block further processing as the secondary thread inspects the state, and is largely an no-op when no inspection is necessary.