### PR TITLE
Add source.AddProcessLifetimeLimits as a mechanism to reduce how much information that computers accumulate

### DIFF
--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -295,6 +295,20 @@ namespace Microsoft.Diagnostics.Tracing
         public bool IsRealTime { get; protected set; }
 
         /// <summary>
+        /// Time based threshold for how long data should be retained 
+        /// by accumulates that are processing this TraceEventSource.
+        /// A value of 0, the default, indicates an infinite accumulation.
+        /// </summary>
+        public double DataLifetimeMsec { get; set; }
+
+        /// <summary>
+        /// Check if a DataLifetime model is enabled
+        /// </summary>
+        /// <returns>True - lifetime tracking is enabled</returns>
+        /// <returns>False - lifetime tracking is not enabled</returns>
+        public bool DataLifetimeEnabled() { return DataLifetimeMsec > 0; }
+
+        /// <summary>
         /// Closes any files and cleans up any resources associated with this TraceEventSource
         /// </summary>
         public void Dispose()


### PR DESCRIPTION
Added a Lifetime tracking mechanism for TraceEvent Computers.  The contract is that for primary caches they should consult the source if there is a lifetime model being applied, if so trim the cache based on the minimum relative timestamp (remove everything earlier).  This is a best effort mechanism to ensure that information is not accumulated indefinitely.

TraceGC.PinnedPlugs and PinnedObjects are now lazy initialized and eagerly cleaned up to further help keep accumulated memory consumption as low as possible.

The primary scenario is for live ETW sessions that want to run for long periods of time (or forever).  The mechanism will provide a best effort to restrict future memory growth by trimming core caches based on the lifetime provided to the source.  

Parameters:
Lifetime - The oldest item in a cache
Interval - Trimming may be expensive, so the interval between subsequent trims is configurable.  A smaller value indicates that the cache should be trimmed more frequently.