### PR TITLE
Bump ETLX version number

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3203,7 +3203,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         int IFastSerializableVersion.Version
         {
-            get { return 67; }
+            get { return 68; }
         }
         int IFastSerializableVersion.MinimumVersionCanRead
         {


### PR DESCRIPTION
A previous fix (made on 12/20/17) has an affect on ETLX files but I did not bump the version number to force rebuild of the ETLX file.
Doing so here, so that the fix becomes 'visible' even for ETL files that have a cached ETLX file.