### PR TITLE
Enable row color changes

### DIFF
--- a/src/PerfView/StackViewer/CallTreeView.cs
+++ b/src/PerfView/StackViewer/CallTreeView.cs
@@ -301,6 +301,14 @@ namespace PerfView
         #endregion
     }
 
+    public enum BackgroundColor
+    {
+        Default = 0,
+        Blue = 1,
+        Brown = 2,
+        Red = 3
+    }
+
     /// <summary>
     /// This is basically a CallTreeNode with extra state (state of expand boxes) associated needed for the viewer 
     /// </summary>
@@ -313,6 +321,13 @@ namespace PerfView
             m_treeView.Validate();
 #endif
         }
+
+        public void SetBackgroundColor(BackgroundColor color)
+        {
+            State = ((int)color).ToString();
+        }
+
+        public string State { get; set; }
 
         /// <summary>
         /// Is the node expanded or not.  

--- a/src/PerfView/StackViewer/CallTreeView.cs
+++ b/src/PerfView/StackViewer/CallTreeView.cs
@@ -301,14 +301,6 @@ namespace PerfView
         #endregion
     }
 
-    public enum BackgroundColor
-    {
-        Default = 0,
-        Blue = 1,
-        Brown = 2,
-        Red = 3
-    }
-
     /// <summary>
     /// This is basically a CallTreeNode with extra state (state of expand boxes) associated needed for the viewer 
     /// </summary>
@@ -322,12 +314,12 @@ namespace PerfView
 #endif
         }
 
-        public void SetBackgroundColor(BackgroundColor color)
+        public void SetBackgroundColor(System.Drawing.Color color)
         {
-            State = ((int)color).ToString();
+            BackgroundColor = color.Name;
         }
 
-        public string State { get; set; }
+        public string BackgroundColor { get; set; }
 
         /// <summary>
         /// Is the node expanded or not.  

--- a/src/PerfView/StackViewer/ColorValidatorConverter.cs
+++ b/src/PerfView/StackViewer/ColorValidatorConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PerfView.StackViewer
+{
+    class ColorValidatorConverter: IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return "false";
+            }
+            // Do the conversion from bool to visibility
+            return "true";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+}

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml
@@ -7,7 +7,6 @@
         xmlns:WPFToolKit="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
         mc:Ignorable="d" 
         d:DesignHeight="223" d:DesignWidth="600">
-
     <UserControl.Resources>
         <!-- Shared Styles -->
         <Style x:Key="RightAlign">
@@ -25,11 +24,27 @@
             <Setter Property="FontSize" Value="10"/>
             <Setter Property="IsReadOnly" Value="True"/>
         </Style>
+        <Style x:Key="customDataGridRowStyle" TargetType="{x:Type DataGridRow}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding State}" Value="1">
+                    <Setter Property="Background" Value="LightSkyBlue"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding State}" Value="2">
+                    <Setter Property="Background" Value="BurlyWood"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding State}" Value="3">
+                    <Setter Property="Background" Value="Coral"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="dataGridStyle" TargetType="DataGrid">
+            <Setter Property="AlternatingRowBackground" Value="#FFF2F1A4"/>
+            <Setter Property="AutoGenerateColumns" Value="False"/>
+        </Style>
     </UserControl.Resources>
     <WPFToolKit:DataGrid Name="Grid" 
-        AutoGenerateColumns="False" 
-        Background="White"
-        AlternatingRowBackground="#FFF2F1A4"
+        Style="{StaticResource dataGridStyle}"
+        RowStyle ="{StaticResource customDataGridRowStyle}"
         SelectionMode="Extended" SelectionUnit="CellOrRowHeader" 
         SelectedCellsChanged="SelectedCellsChanged" 
         CanUserSortColumns="False" 

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml
@@ -5,9 +5,11 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:WPFToolKit="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+        xmlns:converter="clr-namespace:PerfView.StackViewer"
         mc:Ignorable="d" 
         d:DesignHeight="223" d:DesignWidth="600">
     <UserControl.Resources>
+        <converter:ColorValidatorConverter x:Key="converter" />
         <!-- Shared Styles -->
         <Style x:Key="RightAlign">
             <Setter Property="TextBlock.TextAlignment" Value="Right" />
@@ -26,14 +28,8 @@
         </Style>
         <Style x:Key="customDataGridRowStyle" TargetType="{x:Type DataGridRow}">
             <Style.Triggers>
-                <DataTrigger Binding="{Binding State}" Value="1">
-                    <Setter Property="Background" Value="LightSkyBlue"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding State}" Value="2">
-                    <Setter Property="Background" Value="BurlyWood"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding State}" Value="3">
-                    <Setter Property="Background" Value="Coral"/>
+                <DataTrigger Binding="{Binding BackgroundColor, Converter={StaticResource converter}}" Value="true">
+                    <Setter Property="Background" Value="{Binding BackgroundColor}"/>
                 </DataTrigger>
             </Style.Triggers>
         </Style>

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
@@ -135,6 +135,7 @@ namespace PerfView
                 }
             }
         }
+
         public void Select(object item)
         {
             Grid.SelectedCells.Clear();

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -86,6 +86,9 @@
             <CommandBinding Command="{x:Static src:StackWindow.ExpandCommand}" Executed="DoExpand" CanExecute="CanExpand"/>
             <CommandBinding Command="{x:Static src:StackWindow.CollapseCommand}" Executed="DoCollapse" CanExecute="CanExpand"/>
             <CommandBinding Command="{x:Static src:StackWindow.ExpandAllCommand}" Executed="DoExpandAll" CanExecute="CanExpand"/>
+            <CommandBinding Command="{x:Static src:StackWindow.SetBrownBackgroundColorCommand}" Executed="DoSetBrownBackgroundColor" CanExecute="CanSetBackgroundColor"/>
+            <CommandBinding Command="{x:Static src:StackWindow.SetBlueBackgroundColorCommand}" Executed="DoSetBlueBackgroundColor" CanExecute="CanSetBackgroundColor"/>
+            <CommandBinding Command="{x:Static src:StackWindow.SetRedBackgroundColorCommand}" Executed="DoSetRedBackgroundColor" CanExecute="CanSetBackgroundColor"/>
             <CommandBinding Command="{x:Static src:StackWindow.FoldPercentCommand}" Executed="DoFoldPercent" />
             <CommandBinding Command="{x:Static src:StackWindow.IncreaseFoldPercentCommand}" Executed="DoIncreaseFoldPercent" />
             <CommandBinding Command="{x:Static src:StackWindow.DecreaseFoldPercentCommand}" Executed="DoDecreaseFoldPercent" />
@@ -159,6 +162,11 @@
                 <MenuItem Command="{x:Static src:StackWindow.ExpandAllCommand}" />
                 <MenuItem Command="{x:Static src:StackWindow.ExpandCommand}" />
                 <MenuItem Command="{x:Static src:StackWindow.CollapseCommand}" />
+                <MenuItem Header="Set Background Color">
+                    <MenuItem Command="{x:Static src:StackWindow.SetBrownBackgroundColorCommand}" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBlueBackgroundColorCommand}" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetRedBackgroundColorCommand}" />
+                </MenuItem>
                 <Separator/>
                 <MenuItem Header="FilterParams">
                     <MenuItem Command="{x:Static src:StackWindow.CopyFilterParamsCommand}" />

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2352,6 +2352,51 @@ namespace PerfView
                            (CallersTab.IsSelected && m_callersView.SelectedNode != null) ||
                            (CalleesTab.IsSelected && m_calleesView.SelectedNode != null);
         }
+
+        private void DoSetBrownBackgroundColor(object sender, ExecutedRoutedEventArgs e)
+        {
+            DoSetBackgroundColor(sender, e, BackgroundColor.Brown);
+        }
+
+        private void DoSetBlueBackgroundColor(object sender, ExecutedRoutedEventArgs e)
+        {
+            DoSetBackgroundColor(sender, e, BackgroundColor.Blue);
+        }
+
+        private void DoSetRedBackgroundColor(object sender, ExecutedRoutedEventArgs e)
+        {
+            DoSetBackgroundColor(sender, e, BackgroundColor.Red);
+        }
+
+        private void DoSetBackgroundColor(object sender, ExecutedRoutedEventArgs e, BackgroundColor color)
+        {
+            CallTreeViewNode selectedNode = null;
+            CallTreeView view = null;
+            if (CallTreeTab.IsSelected)
+                view = CallTreeView;
+            else if (CallersTab.IsSelected)
+                view = m_callersView;
+            else if (CalleesTab.IsSelected)
+                view = m_calleesView;
+
+            if (view != null)
+            {
+                selectedNode = view.SelectedNode;
+                if (selectedNode != null)
+                {
+                    selectedNode.SetBackgroundColor(color);
+                    view.m_perfGrid.Grid.Items.Refresh();
+                }
+            }
+        }
+
+        private void CanSetBackgroundColor(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = (CallTreeTab.IsSelected && CallTreeView.SelectedNode != null) ||
+                           (CallersTab.IsSelected && m_callersView.SelectedNode != null) ||
+                           (CalleesTab.IsSelected && m_calleesView.SelectedNode != null);
+        }
+
         private void DoFoldPercent(object sender, ExecutedRoutedEventArgs e)
         {
             FoldPercentTextBox.Focus();
@@ -2831,6 +2876,9 @@ namespace PerfView
             new InputGestureCollection() { new KeyGesture(Key.Space) });
         public static RoutedUICommand CollapseCommand = new RoutedUICommand("Collapse", "Collapse", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.Space, ModifierKeys.Shift) });
+        public static RoutedUICommand SetBrownBackgroundColorCommand = new RoutedUICommand("Set Brown Background Color", "SetBrownBackgroundColor", typeof(StackWindow)); 
+        public static RoutedUICommand SetBlueBackgroundColorCommand = new RoutedUICommand("Set Blue Background Color", "SetBlueBackgroundColor", typeof(StackWindow)); 
+        public static RoutedUICommand SetRedBackgroundColorCommand = new RoutedUICommand("Set Red Background Color", "SetRedBackgroundColor", typeof(StackWindow));
         public static RoutedUICommand FoldPercentCommand = new RoutedUICommand("Fold %", "FoldPercent", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.F6) });
         public static RoutedUICommand IncreaseFoldPercentCommand = new RoutedUICommand("Increase Fold %", "Increase FoldPercent", typeof(StackWindow),

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2355,20 +2355,20 @@ namespace PerfView
 
         private void DoSetBrownBackgroundColor(object sender, ExecutedRoutedEventArgs e)
         {
-            DoSetBackgroundColor(sender, e, BackgroundColor.Brown);
+            DoSetBackgroundColor(sender, e, System.Drawing.Color.BurlyWood);
         }
 
         private void DoSetBlueBackgroundColor(object sender, ExecutedRoutedEventArgs e)
         {
-            DoSetBackgroundColor(sender, e, BackgroundColor.Blue);
+            DoSetBackgroundColor(sender, e, System.Drawing.Color.LightSkyBlue);
         }
 
         private void DoSetRedBackgroundColor(object sender, ExecutedRoutedEventArgs e)
         {
-            DoSetBackgroundColor(sender, e, BackgroundColor.Red);
+            DoSetBackgroundColor(sender, e, System.Drawing.Color.Coral);
         }
 
-        private void DoSetBackgroundColor(object sender, ExecutedRoutedEventArgs e, BackgroundColor color)
+        private void DoSetBackgroundColor(object sender, ExecutedRoutedEventArgs e, System.Drawing.Color color)
         {
             CallTreeViewNode selectedNode = null;
             CallTreeView view = null;

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -604,11 +604,6 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         public CallTree CallTree { get { return m_callTree; } }
 
         /// <summary>
-        /// This sets the background color of the CallTreeNode. For CallTreeNodeBase it should be the default color.
-        /// </summary>
-        public string State { get { return "0"; } }
-
-        /// <summary>
         /// Returns the histogram that groups of samples associated with this node or any of its children by time buckets
         /// </summary>
         public Histogram InclusiveMetricByTime { get { return m_inclusiveMetricByTime; } }

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -604,6 +604,11 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         public CallTree CallTree { get { return m_callTree; } }
 
         /// <summary>
+        /// This sets the background color of the CallTreeNode. For CallTreeNodeBase it should be the default color.
+        /// </summary>
+        public string State { get { return "0"; } }
+
+        /// <summary>
         /// Returns the histogram that groups of samples associated with this node or any of its children by time buckets
         /// </summary>
         public Histogram InclusiveMetricByTime { get { return m_inclusiveMetricByTime; } }


### PR DESCRIPTION
This change allows row colors of the perf data grid to be set to either red, blue, or brown.

A nice feature to have when staring at two different call stack trees.