### PR TITLE
remove invalid xml comment which makes build fail

### DIFF
--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -139,7 +139,6 @@
       <Visible>False</Visible>
     </None>
 
-    <!-------------------------------------------------------------------------->
     <!-- Copying thee managed binaries explicitly should not be needed because the 
          dependency logic should just do it for us, but for some reason ths only
          works for the net45 target framework and not the netstandard1.6.  We 


### PR DESCRIPTION
Csproj contained invalid xml comment.

`error MSB4025: The project file could not be loaded. An XML comment cannot contain '--', and '-' cannot be the last character. Line 142, position 9.`