### PR TITLE
Make Path Parsing logic work with slashes and backslashes.

### DIFF
--- a/src/PerfView/OtherSources/XMLStackSource.cs
+++ b/src/PerfView/OtherSources/XMLStackSource.cs
@@ -221,7 +221,7 @@ namespace Diagnostics.Tracing.StackSources
                     if (0 < exclaimIdx)
                     {
                         // Becomes 0 if it fails, which is what we want. 
-                        var startIdx = ret.LastIndexOf('\\', exclaimIdx - 1, exclaimIdx - 1) + 1;
+                        var startIdx = ret.LastIndexOfAny(s_directorySeparators, exclaimIdx - 1, exclaimIdx - 1) + 1;
                         shortName = ret.Substring(startIdx);
                     }
                     m_shortFrameNames.Set((int)frameIndex, shortName);
@@ -471,6 +471,8 @@ namespace Diagnostics.Tracing.StackSources
             public int frameID;
             public int callerID;
         }
+
+        private static char[] s_directorySeparators = { '\\', '/' };
 
         GrowableArray<string> m_shortFrameNames;
         GrowableArray<string> m_frames;

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -708,7 +708,7 @@ namespace PerfView
             stackWindow.RemoveColumn("LastColumn");
             stackWindow.RemoveColumn("IncAvgColumn");
         }
-        internal static void ConfigureAsEtwStackWindow(StackWindow stackWindow, bool removeCounts = true, bool removeScenarios = true, bool removeIncAvg = true)
+        internal static void ConfigureAsEtwStackWindow(StackWindow stackWindow, bool removeCounts = true, bool removeScenarios = true, bool removeIncAvg = true, bool windows = true)
         {
             if (removeCounts)
             {
@@ -728,12 +728,13 @@ namespace PerfView
             stackWindow.FoldRegExTextBox.Items.Clear();
             if (!string.IsNullOrWhiteSpace(defaultEntry))
                 stackWindow.FoldRegExTextBox.Items.Add(defaultEntry);
-            if (defaultEntry != "ntoskrnl!%ServiceCopyEnd")
+            if (windows && defaultEntry != "ntoskrnl!%ServiceCopyEnd")
                 stackWindow.FoldRegExTextBox.Items.Add("ntoskrnl!%ServiceCopyEnd");
 
             stackWindow.GroupRegExTextBox.Text = stackWindow.GetDefaultGroupPat();
             stackWindow.GroupRegExTextBox.Items.Clear();
             stackWindow.GroupRegExTextBox.Items.Add(@"[no grouping]");
+            if (windows)
             stackWindow.GroupRegExTextBox.Items.Add(@"[group CLR/OS entries] \Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.*!=>LIB;Presentation%=>WPF;WindowsBase%=>WPF;system32\*!=>OS;syswow64\*!=>OS;{%}!=> module $1");
             stackWindow.GroupRegExTextBox.Items.Add(@"[group modules]           {%}!->module $1");
             stackWindow.GroupRegExTextBox.Items.Add(@"[group module entries]  {%}!=>module $1");
@@ -7526,6 +7527,7 @@ table {
 
         protected internal override void ConfigureStackWindow(string stackSourceName, StackWindow stackWindow)
         {
+            ConfigureAsEtwStackWindow(stackWindow, true, true, true, false);
             if (stackSourceName.Contains("(with Tasks)") || stackSourceName.Contains("(with StartStop Activities)"))
             {
                 var taskFoldPat = "^STARTING TASK";

--- a/src/TraceEvent/Stacks/Stacks.cs
+++ b/src/TraceEvent/Stacks/Stacks.cs
@@ -935,9 +935,10 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 
             if (!fullModulePath)
             {
-                var lastBackSlash = moduleName.LastIndexOf('\\');
-                if (lastBackSlash >= 0)
-                    moduleName = moduleName.Substring(lastBackSlash + 1);
+                var lastDirectorySep = moduleName.LastIndexOfAny(s_directorySeparators);
+                if (0 <= lastDirectorySep)
+                    moduleName = moduleName.Substring(lastDirectorySep + 1);
+
             }
             // Remove a .dll or .exe extension 
             // TODO should we be doing this here?  This feels like a presentation transformation
@@ -1260,6 +1261,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             private T[] _entries;
             private int _count;
         }
+        private static char[] s_directorySeparators = { '\\', '/' };
 
         private readonly InternTable<string> m_moduleIntern;
         private readonly StackSourceModuleIndex m_emptyModuleIdx;

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -2877,18 +2877,20 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             Debug.Assert(0 < MaxEventIndex);
         }
 
+        private static char[] s_directorySeparators = { '\\', '/' };
+
         // Path  GetFileNameWithoutExtension will throw on illegal chars, which is too strong, so avoid that here.  
         internal static string GetFileNameWithoutExtensionNoIllegalChars(string filePath)
         {
-            int lastBackslashIdx = filePath.LastIndexOf('\\');
-            if (lastBackslashIdx < 0)
-                lastBackslashIdx = 0;
+            int lastDirectorySep = filePath.LastIndexOfAny(s_directorySeparators);
+            if (lastDirectorySep < 0)
+                lastDirectorySep = 0;
             else
-                lastBackslashIdx++;
+                lastDirectorySep++;
             int dotIdx = filePath.LastIndexOf('.');
-            if (dotIdx < lastBackslashIdx)
+            if (dotIdx < lastDirectorySep)
                 dotIdx = filePath.Length;
-            return filePath.Substring(lastBackslashIdx, dotIdx - lastBackslashIdx);
+            return filePath.Substring(lastDirectorySep, dotIdx - lastDirectorySep);
         }
 
 #if DEBUG


### PR DESCRIPTION
There is some logic that parses paths in TraceEvent.  They were wired to use Windows \
Change it so that / also works.

Note that this makes things consistant with the System.Path (which accepts either as a directory separator.