### PR TITLE
Make TraceLog real time sessions handle exceptions well.

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -32,6 +32,8 @@ using Microsoft.Diagnostics.Tracing.Session;
 using System.Threading;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Tracing.EventPipe;
+using System.Threading.Tasks;
+
 
 namespace Microsoft.Diagnostics.Tracing.Etlx
 {
@@ -3607,10 +3609,10 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             {
                 Debug.Assert(this == TraceLog.realTimeSource);
 
-                Thread kernelTask = null;
+                Task kernelTask = null;
                 if (TraceLog.rawKernelEventSource != null)
                 {
-                    kernelTask = new Thread(delegate (object o)
+                    kernelTask = Task.Factory.StartNew(delegate
                     {
                         TraceLog.rawKernelEventSource.Process();
                         TraceLog.rawEventSourceToConvert.StopProcessing();
@@ -3621,7 +3623,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 if (kernelTask != null)
                 {
                     TraceLog.rawKernelEventSource.StopProcessing();
-                    kernelTask.Join();
+                    kernelTask.Wait();
                 }
                 return true;
             }


### PR DESCRIPTION
Today if there is an exception when processing some events in a TraceLog real time session. it wil tear down the process.

This is because we need another thread to process kernel events and if an exception
happens there it reaches the base of that thread.    Instead of using Threads, use
Tasks which automatically capture exceptions thrown in them and re-raise them
when the Task is waited upon.  This is what we want here, so the fix was very easy.

This fixes issue #399