### PR TITLE
Support SourceLink in Microsoft PDBs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PerfViewVersion>2.0.1.0</PerfViewVersion>
+    <PerfViewVersion>2.0.2.0</PerfViewVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -8095,6 +8095,19 @@
     </li>
     -->
         <li>
+            Version 2.0.2 1/12/18
+            <ul>
+                <li>
+                    Added support for SourceLink for 'Goto Source' functionality.   
+                    Symlink is a technique of finding source files by placing a mapping from built time file name to URL into the
+                    symbol file so that the source code can be fetched by url at debug/profiling time.  
+                    .NET Core annotates all its symbol files this way.   The result is that 'Goto Source' on .NET Core assemblies
+                    (that is the framework and ASP.NET) just work in PerfView (it will bring up the relevant source).  
+                </li>
+
+            </ul>
+        </li>
+        <li>
             Version 2.0.1 1/8/18
             <ul>
                 <li>
@@ -8106,8 +8119,9 @@
         <li>
             Version 2.0.0 1/5/18
             <ul>
-                <li> Officially update the version number to 2.0 in preparation for signing and releasing officially.  
-                     Only the version number update happens here.   
+                <li>
+                    Officially update the version number to 2.0 in preparation for signing and releasing officially.
+                    Only the version number update happens here.
                 </li>
 
             </ul>

--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Diagnostics.Symbols
             _stream = stream;
             _provider = MetadataReaderProvider.FromPortablePdbStream(_stream);
             _metaData = _provider.GetMetadataReader();
-
-            InitializeFileToUrlMap();
         }
 
         public override Guid PdbGuid
@@ -58,68 +56,7 @@ namespace Microsoft.Diagnostics.Symbols
 
         #region private 
 
-        private string GetUrlForFilePath(string buildTimeFilePath)
-        {
-            if (_fileToUrlMap != null)
-            {
-                foreach (Tuple<string, string> map in _fileToUrlMap)
-                {
-                    string path = map.Item1;
-                    string urlReplacement = map.Item2;
-
-                    if (buildTimeFilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase))
-                    {
-                        string tail = buildTimeFilePath.Substring(path.Length, buildTimeFilePath.Length - path.Length).Replace('\\', '/');
-                        return urlReplacement.Replace("*", tail);
-                    }
-                }
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Looks up SourceLink information (if present) and initializes _fileToUrlMap from it
-        /// </summary>  
-        private void InitializeFileToUrlMap()
-        {
-            string sourceLinkJson = GetSourceLinkJson();
-            if (sourceLinkJson == null)
-                return;
-
-            // TODO this is not right for corner cases (e.g. file paths with " or , } in them)
-            Match m = Regex.Match(sourceLinkJson, @"documents.?\s*:\s*{(.*?)}", RegexOptions.Singleline);
-            if (m.Success)
-            {
-                string mappings = m.Groups[1].Value;
-                while (!string.IsNullOrWhiteSpace(mappings))
-                {
-                    m = Regex.Match(m.Groups[1].Value, "^\\s*\"(.*?)\"\\s*:\\s*\"(.*?)\"\\s*,?(.*)", RegexOptions.Singleline);
-                    if (m.Success)
-                    {
-                        if (_fileToUrlMap == null)
-                            _fileToUrlMap = new List<Tuple<string, string>>();
-                        string pathSpec = m.Groups[1].Value.Replace("\\\\", "\\");
-                        if (pathSpec.EndsWith("*"))
-                        {
-                            pathSpec = pathSpec.Substring(0, pathSpec.Length - 1);      // Remove the *
-                            _fileToUrlMap.Add(new Tuple<string, string>(pathSpec, m.Groups[2].Value));
-                        }
-                        else
-                            _log.WriteLine("Warning: {0} does not end in *, skipping this mapping.", pathSpec);
-                        mappings = m.Groups[3].Value;
-                    }
-                    else
-                    {
-                        _log.WriteLine("Error: Could not parse SourceLink Mapping: {0}", mappings);
-                        break;
-                    }
-                }
-            }
-            else
-                _log.WriteLine("Error: Could not parse SourceLink Json: {0}", sourceLinkJson);
-        }
-
-        private string GetSourceLinkJson()
+        protected override string GetSourceLinkJson()
         {
             foreach(CustomDebugInformationHandle customDebugInformationHandle in _metaData.CustomDebugInformation)
             {
@@ -162,8 +99,6 @@ namespace Microsoft.Diagnostics.Symbols
                 _log.WriteLine("Opened Portable Pdb Source File: {0}", BuildTimeFilePath);
             }
 
-            public override string Url { get { return _portablePdb.GetUrlForFilePath(BuildTimeFilePath); } }
-
             #region private 
             private static Guid HashAlgorithmSha1 = Guid.Parse("ff1816ec-aa5e-4d10-87f7-6f4963833460");
             private static Guid HashAlgorithmSha256 = Guid.Parse("8829d00f-11b8-4213-878b-770e8597ac16");
@@ -179,7 +114,7 @@ namespace Microsoft.Diagnostics.Symbols
         // Needed by other things to look up data
         internal MetadataReader _metaData;
 
-        List<Tuple<string, string>> _fileToUrlMap;      // Used by SourceLink to map build paths to URLs (see GetUrlForFilePath)
+
         MetadataReaderProvider _provider;
         Stream _stream;
         #endregion


### PR DESCRIPTION
This allows the 'Goto Source' functionality to work on PDBs (Microsoft or Portable) that uses SourceLink to describe how to fetch the source.  This is the mechanism used in .NET Core and thus Goto Source 'Just works' on .NET Core V2.0.3 or later.