### PR TITLE
tell xunit to use method name as every test name instead of namespace.class.methodName

### DIFF
--- a/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
+++ b/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
@@ -37,6 +37,9 @@
     <None Include="Sources\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/LinuxEvent.Tests/xunit.runner.json
+++ b/src/LinuxEvent.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "methodDisplay": "method"
+}

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -41,6 +41,9 @@
 
   <ItemGroup>
     <None Include="app.config" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/PerfView.Tests/xunit.runner.json
+++ b/src/PerfView.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "methodDisplay": "method"
+}

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
@@ -34,6 +34,9 @@
     <None Include="inputs\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/xunit.runner.json
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "methodDisplay": "method"
+}

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -40,6 +40,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="MSFT.snk" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TraceEvent/TraceEvent.Tests/xunit.runner.json
+++ b/src/TraceEvent/TraceEvent.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "methodDisplay": "method"
+}


### PR DESCRIPTION
I am currently working on Dell XPS 13*, it's hard to work with very long method names. 

By default xunit uses namespace.typeName.methodName for test names.

This PR tells it to use just methodName

Before:
![image](https://user-images.githubusercontent.com/6011991/34948837-93f6f664-fa0e-11e7-9a14-9dd6bec576a7.png)

After:
![image](https://user-images.githubusercontent.com/6011991/34948848-9a679134-fa0e-11e7-8065-ab9fad6afe78.png)

