### PR TITLE
enforce "en-US" culture for parsing-based tests which are based on "en-US" input data

### DIFF
--- a/src/TraceEvent/TraceEvent.Tests/EtlTestBase.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EtlTestBase.cs
@@ -5,11 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Diagnostics.Tracing;
+using PerfView.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace TraceEventTests
 {
+    [UseCulture("en-US")]
     public abstract class EtlTestBase : TestBase
     {
         protected EtlTestBase(ITestOutputHelper output)

--- a/src/TraceEvent/TraceEvent.Tests/EventPipeTestBase.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EventPipeTestBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using PerfView.TestUtilities;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -8,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace TraceEventTests
 {
+    [UseCulture("en-US")]
     public abstract class EventPipeTestBase : TestBase
     {
         protected EventPipeTestBase(ITestOutputHelper output)


### PR DESCRIPTION
The input data was recorded with "en-US" culture so when I run it with polish it fails (different delimiters).

This PR enforces the "en-US" culture for parsing tests.

![image](https://user-images.githubusercontent.com/6011991/34949040-328a5cbc-fa0f-11e7-9eb3-fdf120108f8d.png)

