### PR TITLE
Sign EtwClrProfiler.

### DIFF
--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -161,6 +161,22 @@
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
   </ItemGroup>
 
+
+  <!-- TODO REMOVE EVENTUALLY: We sign two C++ DLLs here because 
+   I can't get C++ projects to work with the signing.  When we fix this
+   this can be removed.  -->
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)..\..\..\..\EtwClrProfiler\Release\x86\ETWClrProfiler.dll" 
+	Condition="Exists('$(OutDir)..\..\..\..\EtwClrProfiler\Release\x86\ETWClrProfiler.dll')">
+        <Authenticode>Microsoft</Authenticode>
+    </FilesToSign>
+    <FilesToSign Include="$(OutDir)..\..\..\..\EtwClrProfiler\Release\amd64\ETWClrProfiler.dll" 
+	Condition="Exists('$(OutDir)..\..\..\..\EtwClrProfiler\Release\amd64\ETWClrProfiler.dll')">
+        <Authenticode>Microsoft</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
+
+
   <!-- .NET Strong Name Signing -->
   <PropertyGroup>
     <DefineConstants Condition="'$(SIGNING_BUILD)'!=''">$(DefineConstants);SIGNING_BUILD</DefineConstants>


### PR DESCRIPTION
Currently we do this when building TraceEvent because I am having problems
making C++ projects sign things.   When we figure that out we can undo this
change.    Note that this change will simply do nothing if the DLLs are not present.