### PR TITLE
Allow Events to have too more fields than have been serialized.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ OSExtentions.cs
 *.VC.opendb
 *.VC.db
 
+# VSCode
+.vscode/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/documentation/Downloading.md
+++ b/documentation/Downloading.md
@@ -1,18 +1,25 @@
-# Downloading PerfView 
+# PerfView Overview
 
-The [PerfView GitHub Releases page](https://github.com/Microsoft/perfview/releases)
-is now the official way to download versions of the PerfView.
-It shows the release notes and the full set of binaries for all current and past releases.
+See the [PerfView Overview](https://github.com/Microsoft/perfview#perfview-overview) for general information
+about PerfView.   
+
+# PerfView Releases
+
+The [PerfView GitHub Releases page](https://github.com/Microsoft/perfview/releases) is now the official 
+way to download versions of the PerfView.
+It shows the release notes and the full set of binaries for all current and past releases.  If you
+care about specific bug fixes or features go there.  
 
 ## Shortcut to Download the Latest PerfView.exe
 
-In the common case, the only file you need one file, PerfView.exe, to use the tool.  It can be downloaded here
+In the common case, the only file you need one file, PerfView.exe, to use the tool.  The most recent copy of
+this file can be downloaded here
 
 * [Download Version 2.02 of PerfView.exe](https://github.com/Microsoft/perfview/releases/download/P2.0.2/PerfView.exe)
 
 Once you click the above link in your browser it will start downloading, the details of which vary from browser to browser.
 In some cases it will prompt for more information (IE) and in others (Chrome) it may not be obvious that
-you clicked on anything (look at the bottom of the pane for changes).  The result, however will be a PerfVIew.exe on your
+you clicked on anything (look at the bottom of the pane for changes).  The result, however will be a PerfView.exe on your
 local machine.   
 
 Once downloaded you you can simply double click on the downloaded EXE to launch PerfView.

--- a/documentation/TraceEvent/TraceEventLibrary.md
+++ b/documentation/TraceEvent/TraceEventLibrary.md
@@ -7,12 +7,12 @@
 basic architecture and usefulness from a programmer's perspective. 
 
 * Samples - There are a number of useful samples on github at
-```  
-    https://github.com/Microsoft/perfview/tree/master/src/TraceEvent/Samples
-``` 
-If you download the PerfView repositotry you can build the TraceEventSamples.csproj which 
-will build all the samples.  The TraceEvent\Samples directory is self contained 
-(you can build that directory independently of anything else)
+
+  * https://github.com/Microsoft/perfview/tree/master/src/TraceEvent/Samples
+
+  If you download the PerfView repository you can build the TraceEventSamples.csproj which 
+  will build all the samples.  The TraceEvent\Samples directory is self contained (you can build 
+  that directory independently of anything else)
 
 * Release Notes - the [Releases](https://github.com/Microsoft/perfview/releases) page 
 for PerfView also shows the releases for the TraceEvent library.   Note that PerfView's 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PerfViewVersion>2.0.4.0</PerfViewVersion>
-    <TraceEventVersion>2.0.4.0</TraceEventVersion>
+    <PerfViewVersion>2.0.5</PerfViewVersion>
+    <TraceEventVersion>2.0.5</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/PerfView/Properties/launchSettings.json
+++ b/src/PerfView/Properties/launchSettings.json
@@ -1,7 +1,0 @@
-{
-  "profiles": {
-    "PerfView": {
-      "executablePath": "$(OutDir)$(AssemblyName)$(TargetExt)"
-    }
-  }
-}

--- a/src/TraceEvent/EventPipe/EventPipeFormat.md
+++ b/src/TraceEvent/EventPipe/EventPipeFormat.md
@@ -183,11 +183,11 @@ There are however several ways to do this.  The simplest way is to
 
 Every object has a begin tag, a type, data objects, and an end tag.
 One feature of the FastSerialiable library is that it has a tag 
-for all the different data types (bool, byte, short, int, long, string blob).
+for all the different data types (bool, byte, short, int, long, string, blob).
 It also has logic that after parsing the data area it 'looks' for 
 the end tag (so we know the data is partially sane at least).  However
 during this search if it finds other tags, it knows how to skip them.
-Thus if after the 'Know Version 0' data objects, you place tagged
+Thus if after the 'Known Version 0' data objects, you place tagged
 data, ANY reader will know how to skip it (it skips all tagged things
 until it finds an endObject tag).  
 
@@ -202,7 +202,7 @@ The format is basically a list of objects, but there is no requirement
 that there are only very loose requirements on the order or number of these
 Thus you can create a new object type and insert that object in the
 stream (that object must have only tagged fields however but a tagged
-blob can do almost anything).  This allows whole new objects to be 
+blob can represent almost anything).  This allows whole new objects to be 
 added to the file format without breaking existing readers.  
 
 #### Version Numbers and forward compatibility.


### PR DESCRIPTION
Also updated the docs a bit.

Previously it was an error if an event had more fileds than were serialized.
Now it simply makes the 'extra' fields empty.   This allows versioning (you can add more fileds, but if
some older EventSource does not create the new fields, it is not an error, you simply just don't get the
information.  This makes for better versioning.