### PR TITLE
Restrict .editorconfig to *.cs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 root=true
 
-[*]
+[*.cs]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
The previous settings were applying to file types which didn't match these settings. The main case was project files, but for now we simply restrict the .editorconfig settings to **\*.cs** until if/when we figure out other cases where we want specific settings.