### PR TITLE
TraceParserGen: fix provider opcodes loading

### DIFF
--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -250,7 +250,7 @@ namespace ETWManifest
                                     // Remember enuough to resolve opcodes nested inside this task.  
                                     curTask = value;
                                     curTaskDepth = reader.Depth;
-                                    reader.Skip();
+                                    reader.Read();
                                 } break;
                             case "opcode":
                                 {


### PR DESCRIPTION
Fixing an issue that make parser generation failed when providers are defining custom opcodes.
In manifests files (like wpf-etw.man) opcodes are defined this way:
``` xml  
<task name="WClientMeasure" symbol="TWClientMeasure" value="26" eventGUID="{3005e67b-129c-4ced-bcaa-91d7d73b1544}">
    <opcodes>
        <opcode name="MeasureAbort" symbol="OP_MEASURE_ABORT" value="10" />
        <opcode name="MeasureElementBegin" symbol="OP_MEASURE_ELEMENT_BEGIN" value="11" />
        <opcode name="MeasureElementEnd" symbol="OP_MEASURE_ELEMENT_END" value="12" />
    </opcodes>
</task>
```
The current Provider method is calling a `reader.Skip()` after reading a task, which is skiping children, and opcodes are never loaded.