### PR TITLE
Prepare to Update Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles Nuget Package

### DIFF
--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
@@ -3,7 +3,11 @@ REM
 REM *** This is mostly a template for doing the copy.      ****  
 REM *** Most likey you want this to be the current version ****
 REM *** PLEASE MODIFY THE VERSION NUMBER TO BE CURRENT!    ****
-xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.12\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
+xcopy /s /Y %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.12\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
+
+REM Overwrite OSExtensions.dll with the latest built versions.
+xcopy /s /Y ..\OSExtensions\bin\Release\net45\OSExtensions.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\lib\net45
+xcopy /s /Y ..\OSExtensions\bin\Release\netstandard1.6\OSExtensions.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\lib\netstandard1.6
 
 @REM These are the binary files we need from somewhere to for the support package
 @REM lib\native\amd64\KernelTraceControl.dll

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.5">
     <id>Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles</id>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <title>Non-Source files needed to Build TraceEvent</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/OSExtensions/OSExtensions.csproj
+++ b/src/OSExtensions/OSExtensions.csproj
@@ -20,4 +20,22 @@
   <PropertyGroup>
     <PreBuildEvent>"..\..\..\syncEncrypted.exe" "/P:..\..\..\password.txt" ..\..\..\OSExtensions.cs"</PreBuildEvent>
   </PropertyGroup>
+
+  <!-- ******************* Signing Support *********************** -->
+  <ItemGroup>
+    <FilesToSign Include="$(TargetPath)">
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+    </FilesToSign>
+    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+  </ItemGroup>
+
+  <!-- .NET Strong Name Signing -->
+  <PropertyGroup>
+    <DefineConstants Condition="'$(SIGNING_BUILD)'!=''">$(DefineConstants);SIGNING_BUILD</DefineConstants>
+    <SignAssembly Condition="'$(SIGNING_BUILD)'!= ''">true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\MSFT.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
 </Project>

--- a/src/OSExtensions/OSExtensions.csproj
+++ b/src/OSExtensions/OSExtensions.csproj
@@ -6,11 +6,16 @@
     <RootNamespace>OSExtensions</RootNamespace>
     <AssemblyName>OSExtensions</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 
     <Company>Microsoft</Company>
     <Description>Operating System Extensions for profiling</Description>
     <Copyright>Copyright © Microsoft 2010</Copyright>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="OSExtensions.cs" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'"> 
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" /> 


### PR DESCRIPTION
This PR contains preparatory steps to produce a new TraceEvent SupportFiles nuget package.  The following changes are included:

1. Add signing support for OSExtensions.dll.
2. Update the nuget package population script to ensure that it pulls the freshly built OSExtensions.dll into the package for both net45 and netstandard1.6.
3. Increase the version of TraceEvent.SupportFiles in the nuspec to 1.0.13.

Once this PR is merged, the official build can be modified to build and sign OSExtensions.dll.

cc:@jorive