### PR TITLE
Consume TraceEvent.SupportFiles 1.0.13

### DIFF
--- a/Nuget.config
+++ b/Nuget.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="Local" value=".\src\NugetSupportFiles" />
+    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/Nuget.config
+++ b/Nuget.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Local" value=".\src\NugetSupportFiles" />
-    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,7 @@
   <!-- versions of dependencies that more than one project use -->
   <PropertyGroup>
     <PerfViewSupportFilesVersion>1.0.5</PerfViewSupportFilesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.12</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.13</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.3.0</XunitVersion>
     <XunitRunnerVisualstudioVersion>2.3.0</XunitRunnerVisualstudioVersion>

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -54,9 +54,9 @@
     <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\netstandard1.6" />
 
     <!-- Support Dlls -->
-    <file src="$OutDir$net45\Dia2Lib.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$net45\TraceReloggerLib.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$net45\OSExtensions.dll" target="lib\netstandard1.6" />
+    <file src="$OutDir$netstandard1.6\Dia2Lib.dll" target="lib\netstandard1.6" />
+    <file src="$OutDir$netstandard1.6\TraceReloggerLib.dll" target="lib\netstandard1.6" />
+    <file src="$OutDir$netstandard1.6\OSExtensions.dll" target="lib\netstandard1.6" />
 
     <!-- NET 4.5 Framework -->
 


### PR DESCRIPTION
This updates TraceEvent to use a netstandard1.6 OSExtensions.dll for the netstandard1.6 version of TraceEvent.  Prior to this change TraceEvent is inadvertently using a net45 version of OSExtensions.dll which does not work on versions of .NET Core prior to 2.0.

Note - the addition of the dotnet-core MyGet feed is because the TraceEvent.SupportFiles package is posted on MyGet.