### PR TITLE
Increase TraceEvent Package Version

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
     <PerfViewVersion>2.0.5</PerfViewVersion>
-    <TraceEventVersion>2.0.5</TraceEventVersion>
+    <TraceEventVersion>2.0.6</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->


### PR DESCRIPTION
Prior to the release of TraceEvent 2.0.5, the TraceEvent version was already set to 2.0.5 in preparation for a future release.  This PR sets things up for 2.0.6 release in the future.