### PR TITLE
Fix issue were orphaned kernel stack fragment given questionable user stack fragment

### DIFF
--- a/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
@@ -194,7 +194,7 @@ namespace TraceEventTests
             }
 
             outputFile.Close();
-            if (mismatchCount > 0)
+            if (mismatchCount > 0 || histogramMismatch)
             {
                 Output.WriteLine(string.Format("ERROR: File {0}: had {1} mismatches", etlFilePath, mismatchCount));
 

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1528,7 +1528,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 thread.cpuSamples++;
 
                 // This is for robustness.   If we logged a user mode stack fragment on every kernel->user transition than 
-                // this woudl not be necessary.  However sometimes these get lost.  If we notice we did a CPU sample and 
+                // this would not be necessary.  However sometimes these get lost.  If we notice we did a CPU sample and 
                 // we are outside the kernel, then give up on attaching a user mode fragment (since we missed the transition).  
                 if (thread.lastEntryIntoKernel != null && IsKernelAddress(data.InstructionPointer, data.PointerSize))
                     EmitStackOnExitFromKernel(ref thread.lastEntryIntoKernel, TraceCallStacks.GetRootForThread(thread.ThreadIndex), null);
@@ -4881,7 +4881,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// Sets the 'Parent' field for the process (based on the ParentID).   
         /// 
         /// sentinel is internal to the implementation, external callers should always pass null. 
-        /// TraceProcesses that have a parent==sentinel considered 'illegal' since it woudl form
+        /// TraceProcesses that have a parent==sentinel considered 'illegal' since it would form
         /// a loop in the parent chain, which we definately don't want.  
         /// </summary>
         internal void SetParentForProcess(TraceProcess sentinel = null)


### PR DESCRIPTION
ETW stack traces for Kernel events come in two pieces.  A kernel piece fired right after the event, and then a user mode piece that is only fired when the thread exits the kernel (evidently, you can't walk the user mode part while in the kernel).  

This works because the user mode part fragment CAN'T change until you leave the Kernel, so if you ALWAYS log the user fragment on exit from the kernel you can defer logging the fragment.

Thus the algorithm is that when you see a user mode fragment you 'attach' it to any kernel stack fragment on the same thread (since the last time you did this).   This works well as long as user mode fragments are logged every time a thread leaves the kernel (if you logged a kernel fragment on that thread).  

However we have seen cases where the kernel is not perfect about logging such user mode fragments.  The result is that user mode fragments may be attached to kernel fragments that are not an accurate representation of the user mode stack at the time the kernel fragment was created (although it is 'nearby' and some part of it is likely to be correct).

As a back-stop against this this PR also watches CPU sampling events and if a CPU sampling event shows the thread OUTSIDE the kernel but Kernel Events are still waiting for a 'user mode' event to attach to, we know that the kernel did NOT properly log a user mode fragment on the TRANSITION (Since we are outside and it did not get logged).    In this situation it now abandons the attempt to wait for a user mode fragment and simply logs the kernel fragment alone.    

This is only a partial mitigation (but arguably the issue is that we are not logging at the transition as we should), but since CPU sampling events happen reasonably frequently, it limits the damage.

I will open a issue to track an effort to do better than this, but this improves things in many if not most cases.   

@mjsabby 