### PR TITLE
Improved performance of drawing Flame Graph

### DIFF
--- a/src/PerfView/StackViewer/FlameGraph.cs
+++ b/src/PerfView/StackViewer/FlameGraph.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 using Microsoft.Diagnostics.Tracing.Stacks;
 
 namespace PerfView
@@ -13,7 +12,6 @@ namespace PerfView
     public static class FlameGraph
     {
         private static readonly FontFamily FontFamily = new FontFamily("Consolas");
-        private static readonly Brush[] Brushes = GenerateBrushes(new Random(12345));
 
         /// <summary>
         /// (X=0, Y=0) is the left bottom corner of the canvas
@@ -68,6 +66,7 @@ namespace PerfView
                 foreach (var child in currentNode.Callees)
                 {
                     double childBoxWidth = child.InclusiveMetric * pixelsPerIncusiveSample;
+
                     var childBox = new FlameBox(child, childBoxWidth, boxHeight, parentBox.X + nextBoxX, parentBox.Y + boxHeight);
                     nextBoxX += childBoxWidth;
 
@@ -76,21 +75,6 @@ namespace PerfView
 
                     yield return childBox;
                 }
-            }
-        }
-
-        public static void Draw(IEnumerable<FlameBox> boxes, Canvas canvas)
-        {
-            canvas.Children.Clear();
-
-            int index = 0;
-            foreach (var box in boxes)
-            {
-                FrameworkElement rectangle = CreateRectangle(box, ++index);
-
-                Canvas.SetLeft(rectangle, box.X);
-                Canvas.SetBottom(rectangle, box.Y);
-                canvas.Children.Add(rectangle);
             }
         }
         
@@ -107,15 +91,6 @@ namespace PerfView
                 pngEncoder.Save(file);
         }
 
-        private static Brush[] GenerateBrushes(Random random)
-            => Enumerable.Range(0, 100)
-                    .Select(_ => (Brush)new SolidColorBrush(
-                        Color.FromRgb(
-                            (byte)(205.0 + 50.0 * random.NextDouble()),
-                            (byte)(230.0 * random.NextDouble()),
-                            (byte)(55.0 * random.NextDouble()))))
-                    .ToArray();
-
         private static double GetMaxDepth(CallTreeNode callTree)
         {
             double deepest = 0;
@@ -125,36 +100,6 @@ namespace PerfView
                     deepest = Math.Max(deepest, GetMaxDepth(callee));
 
             return deepest + 1;
-        }
-
-        private static FrameworkElement CreateRectangle(FlameBox box, int index)
-        {
-            var tooltip = $"Method: {box.Node.DisplayName} ({box.Node.InclusiveCount} inclusive samples, {box.Node.InclusiveMetricPercent:F}%)";
-            var background = Brushes[++index % Brushes.Length]; // in the future, the color could be chosen according to the belonging of the method (JIT, GC, user code, OS etc)
-
-            // for small boxes we create Rectangles, because they are much faster (too many TextBlocks === bad perf) 
-            // also for small rectangles it's impossible to read the name of the method anyway (only few characters are printed)
-            if (box.Width < 50) 
-                return new Rectangle
-                {
-                    Height = box.Height,
-                    Width = box.Width,
-                    Fill = background, 
-                    ToolTip = new ToolTip { Content = tooltip },
-                    DataContext = box.Node
-                };
-
-            return new TextBlock
-            {
-                Height = box.Height,
-                Width = box.Width,
-                Background = background,
-                ToolTip = new ToolTip { Content = tooltip },
-                Text = box.Node.DisplayName,
-                DataContext = box.Node,
-                FontFamily = FontFamily,
-                FontSize = Math.Min(20.0, box.Height)
-            };
         }
     }
 }

--- a/src/PerfView/StackViewer/FlameGraph.cs
+++ b/src/PerfView/StackViewer/FlameGraph.cs
@@ -11,8 +11,6 @@ namespace PerfView
 {
     public static class FlameGraph
     {
-        private static readonly FontFamily FontFamily = new FontFamily("Consolas");
-
         /// <summary>
         /// (X=0, Y=0) is the left bottom corner of the canvas
         /// </summary>

--- a/src/PerfView/StackViewer/FlameGraph.cs
+++ b/src/PerfView/StackViewer/FlameGraph.cs
@@ -12,7 +12,7 @@ namespace PerfView
     public static class FlameGraph
     {
         /// <summary>
-        /// (X=0, Y=0) is the left bottom corner of the canvas
+        /// (X=0, Y=0) is the left upper corner of the canvas
         /// </summary>
         public struct FlameBox
         {
@@ -47,7 +47,7 @@ namespace PerfView
             double boxHeight = maxHeight / maxDepth;
             double pixelsPerIncusiveSample = maxWidth / callTree.Root.InclusiveMetric;
 
-            var rootBox = new FlameBox(callTree.Root, maxWidth, boxHeight, 0, 0);
+            var rootBox = new FlameBox(callTree.Root, maxWidth, boxHeight, 0, maxHeight - boxHeight);
             yield return rootBox;
 
             var nodesToVisit = new Queue<FlamePair>();
@@ -65,7 +65,7 @@ namespace PerfView
                 {
                     double childBoxWidth = child.InclusiveMetric * pixelsPerIncusiveSample;
 
-                    var childBox = new FlameBox(child, childBoxWidth, boxHeight, parentBox.X + nextBoxX, parentBox.Y + boxHeight);
+                    var childBox = new FlameBox(child, childBoxWidth, boxHeight, parentBox.X + nextBoxX, parentBox.Y - boxHeight);
                     nextBoxX += childBoxWidth;
 
                     if (child.Callees != null)

--- a/src/PerfView/StackViewer/FlameGraph.cs
+++ b/src/PerfView/StackViewer/FlameGraph.cs
@@ -18,10 +18,12 @@ namespace PerfView
         {
             public readonly double Width, Height, X, Y;
             public readonly CallTreeNode Node;
+            public string TooltipText;
 
             public FlameBox(CallTreeNode node, double width, double height, double x, double y)
             {
                 Node = node;
+                TooltipText = $"Method: {node.DisplayName} ({node.InclusiveCount} inclusive samples, {node.InclusiveMetricPercent:F}%)";
                 Width = width;
                 Height = height;
                 X = x;

--- a/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
+++ b/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Media;
+using static PerfView.FlameGraph;
+
+namespace PerfView
+{
+    public class FlameGraphDrawingCanvas : Canvas
+    {
+        private static readonly Brush[] Brushes = GenerateBrushes(new Random(12345));
+
+        private List<Visual> visuals = new List<Visual>();
+
+        protected override int VisualChildrenCount => visuals.Count;
+
+        protected override Visual GetVisualChild(int index) => visuals[index];
+
+        public bool IsEmpty => visuals.Count == 0;
+
+        public void Draw(IEnumerable<FlameBox> boxes)
+        {
+            for (int i = visuals.Count - 1; i >= 0; i--)
+            {
+                DeleteVisual(visuals[i]);
+                visuals.RemoveAt(i);
+            }
+
+            var visual = new DrawingVisual();
+
+            using (DrawingContext drawingContext = visual.RenderOpen())
+            {
+                int index = 0;
+                foreach (var box in boxes)
+                {
+                    var brush = Brushes[index++ % Brushes.Length];
+
+                    drawingContext.DrawRectangle(
+                        brush, 
+                        null,  // if we provide any Pen the drawing process becomes very slow for large data sets
+                        new System.Windows.Rect(box.X, box.Y, box.Width, box.Height));
+                }
+
+                AddVisual(visual);
+            }
+        }
+
+        private void AddVisual(Visual visual)
+        {
+            visuals.Add(visual);
+
+            base.AddVisualChild(visual);
+            base.AddLogicalChild(visual);
+        }
+
+        private void DeleteVisual(Visual visual)
+        {
+            base.RemoveVisualChild(visual);
+            base.RemoveLogicalChild(visual);
+        }
+
+        private static Brush[] GenerateBrushes(Random random)
+            => Enumerable.Range(0, 100)
+                    .Select(_ => (Brush)new SolidColorBrush(
+                        Color.FromRgb(
+                            (byte)(205.0 + 50.0 * random.NextDouble()),
+                            (byte)(230.0 * random.NextDouble()),
+                            (byte)(55.0 * random.NextDouble()))))
+                    .ToArray();
+    }
+}

--- a/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
+++ b/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
@@ -38,7 +38,7 @@ namespace PerfView
 
                     drawingContext.DrawRectangle(
                         brush, 
-                        null,  // if we provide any Pen the drawing process becomes very slow for large data sets
+                        null,  // this is crucial for performance
                         new System.Windows.Rect(box.X, box.Y, box.Width, box.Height));
                 }
 
@@ -61,12 +61,19 @@ namespace PerfView
         }
 
         private static Brush[] GenerateBrushes(Random random)
-            => Enumerable.Range(0, 100)
+        {
+            var brushes = Enumerable.Range(0, 100)
                     .Select(_ => (Brush)new SolidColorBrush(
                         Color.FromRgb(
                             (byte)(205.0 + 50.0 * random.NextDouble()),
                             (byte)(230.0 * random.NextDouble()),
                             (byte)(55.0 * random.NextDouble()))))
                     .ToArray();
+
+            foreach (var brush in brushes)
+                brush.Freeze(); // this is crucial for performance
+
+            return brushes;
+        }
     }
 }

--- a/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
+++ b/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using static PerfView.FlameGraph;
 
@@ -14,23 +16,29 @@ namespace PerfView
 
         private static readonly Brush[] Brushes = GenerateBrushes(new Random(12345));
 
+        public event EventHandler<string> CurrentFlameBoxChanged;
+
         private List<Visual> visuals = new List<Visual>();
+        private FlameBoxesMap flameBoxesMap = new FlameBoxesMap();
+        private ToolTip tooltip = new ToolTip();
+
+        public FlameGraphDrawingCanvas()
+        {
+            MouseMove += OnMouseMove;
+            MouseLeave += (s, e) => HideTooltip();
+        }
+
+        public bool IsEmpty => visuals.Count == 0;
 
         protected override int VisualChildrenCount => visuals.Count;
 
         protected override Visual GetVisualChild(int index) => visuals[index];
 
-        public bool IsEmpty => visuals.Count == 0;
-
         public void Draw(IEnumerable<FlameBox> boxes)
         {
-            for (int i = visuals.Count - 1; i >= 0; i--)
-            {
-                DeleteVisual(visuals[i]);
-                visuals.RemoveAt(i);
-            }
+            Clear();
 
-            var visual = new DrawingVisual();
+            var visual = new DrawingVisual(); // we have only one visual to provide best possible perf
 
             using (DrawingContext drawingContext = visual.RenderOpen())
             {
@@ -40,16 +48,16 @@ namespace PerfView
                     var brush = Brushes[index++ % Brushes.Length];
 
                     drawingContext.DrawRectangle(
-                        brush, 
-                        null,  // this is crucial for performance
-                        new System.Windows.Rect(box.X, box.Y, box.Width, box.Height));
+                        brush,
+                        null,  // no Pen is crucial for performance
+                        new Rect(box.X, box.Y, box.Width, box.Height));
 
                     if (box.Width > 50 && box.Height >= 6) // we draw the text only if humans can see something
                     {
                         var text = new FormattedText(
                                 box.Node.DisplayName,
                                 CultureInfo.InvariantCulture,
-                                System.Windows.FlowDirection.LeftToRight,
+                                FlowDirection.LeftToRight,
                                 Typeface,
                                 Math.Min(box.Height, 20),
                                 System.Windows.Media.Brushes.Black);
@@ -57,12 +65,61 @@ namespace PerfView
                         text.MaxTextWidth = box.Width;
                         text.MaxTextHeight = box.Height;
 
-                        drawingContext.DrawText(text, new System.Windows.Point(box.X, box.Y));
+                        drawingContext.DrawText(text, new Point(box.X, box.Y));
                     }
+
+                    flameBoxesMap.Add(box);
                 }
 
                 AddVisual(visual);
+
+                flameBoxesMap.Sort();
             }
+        }
+
+        /// <summary>
+        /// DrawingVisual provides no tooltip support, so I had to implement it myself.. I feel bad for it.
+        /// </summary>
+        private void OnMouseMove(object sender, MouseEventArgs e)
+        {
+            if (!IsEmpty)
+            {
+                var position = Mouse.GetPosition(this);
+                var tooltipText = flameBoxesMap.Find(position);
+                if (tooltipText != null)
+                {
+                    ShowTooltip(tooltipText);
+                    CurrentFlameBoxChanged(this, tooltipText);
+                    return;
+                }
+            }
+
+            HideTooltip();
+        }
+
+        private void ShowTooltip(string text)
+        {
+            if (object.ReferenceEquals(tooltip.Content, text) && tooltip.IsOpen)
+                return;
+
+            tooltip.IsOpen = false; // by closing and opening it again we restart it's position to the current mouse position..
+            tooltip.Content = text;
+            tooltip.Placement = System.Windows.Controls.Primitives.PlacementMode.Mouse;
+            tooltip.IsOpen = true;
+            tooltip.PlacementTarget = this;
+        }
+
+        private void HideTooltip() => tooltip.IsOpen = false;
+
+        private void Clear()
+        {
+            for (int i = visuals.Count - 1; i >= 0; i--)
+            {
+                DeleteVisual(visuals[i]);
+                visuals.RemoveAt(i);
+            }
+
+            flameBoxesMap.Clear();
         }
 
         private void AddVisual(Visual visual)
@@ -93,6 +150,80 @@ namespace PerfView
                 brush.Freeze(); // this is crucial for performance
 
             return brushes;
+        }
+
+        private class FlameBoxesMap
+        {
+            SortedDictionary<Range, List<FlameBox>> boxesMap = new SortedDictionary<Range, List<FlameBox>>();
+
+            internal void Clear() => boxesMap.Clear();
+
+            internal void Add(FlameBox flameBox)
+            {
+                var row = new Range(flameBox.Y, flameBox.Y + flameBox.Height);
+
+                if (!boxesMap.TryGetValue(row, out var list))
+                    boxesMap.Add(row, list = new List<FlameBox>());
+
+                list.Add(flameBox);
+            }
+
+            internal void Sort()
+            {
+                foreach (var row in boxesMap.Values)
+                    row.Sort(CompareByX); // sort the boxes from left to the right
+            }
+
+            internal string Find(Point point)
+            {
+                foreach (var rowData in boxesMap)
+                    if (rowData.Key.Contains(point.Y))
+                    {
+                        int low = 0, high = rowData.Value.Count - 1, mid = 0;
+
+                        while (low <= high)
+                        {
+                            mid = (low + high) / 2;
+
+                            if (rowData.Value[mid].X > point.X)
+                                high = mid - 1;
+                            else if ((rowData.Value[mid].X + rowData.Value[mid].Width) < point.X)
+                                low = mid + 1;
+                            else
+                                break;
+                        }
+
+                        if (rowData.Value[mid].X <= point.X && point.X <= (rowData.Value[mid].X + rowData.Value[mid].Width))
+                            return rowData.Value[mid].TooltipText;
+
+                        return null;
+                    }
+
+                return null;
+            }
+
+            private static int CompareByX(FlameBox left, FlameBox right) => left.X.CompareTo(right.X);
+
+            struct Range : IEquatable<Range>, IComparable<Range>
+            {
+                private readonly double Start, End;
+
+                internal Range(double start, double end)
+                {
+                    Start = start;
+                    End = end;
+                }
+
+                internal bool Contains(double y) => Start <= y && y <= End;
+
+                public override bool Equals(object obj) => throw new InvalidOperationException("No boxing");
+
+                public bool Equals(Range other) => other.Start == Start && other.End == End;
+
+                public int CompareTo(Range other) => other.Start.CompareTo(Start);
+
+                public override int GetHashCode() => (Start * End).GetHashCode();
+            }
         }
     }
 }

--- a/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
+++ b/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
@@ -43,6 +43,8 @@ namespace PerfView
             using (DrawingContext drawingContext = visual.RenderOpen())
             {
                 int index = 0;
+                System.Drawing.Font forSize = null; 
+
                 foreach (var box in boxes)
                 {
                     var brush = Brushes[index++ % Brushes.Length];
@@ -54,12 +56,15 @@ namespace PerfView
 
                     if (box.Width > 50 && box.Height >= 6) // we draw the text only if humans can see something
                     {
+                        if (forSize == null)
+                            forSize = new System.Drawing.Font("Consolas", (float)box.Height, System.Drawing.GraphicsUnit.Pixel);
+
                         var text = new FormattedText(
                                 box.Node.DisplayName,
                                 CultureInfo.InvariantCulture,
                                 FlowDirection.LeftToRight,
                                 Typeface,
-                                Math.Min(box.Height, 20),
+                                Math.Min(forSize.SizeInPoints, 20),
                                 System.Windows.Media.Brushes.Black);
 
                         text.MaxTextWidth = box.Width;

--- a/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
+++ b/src/PerfView/StackViewer/FlameGraphDrawingCanvas.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -9,6 +10,8 @@ namespace PerfView
 {
     public class FlameGraphDrawingCanvas : Canvas
     {
+        private static readonly Typeface Typeface = new Typeface("Consolas");
+
         private static readonly Brush[] Brushes = GenerateBrushes(new Random(12345));
 
         private List<Visual> visuals = new List<Visual>();
@@ -40,6 +43,22 @@ namespace PerfView
                         brush, 
                         null,  // this is crucial for performance
                         new System.Windows.Rect(box.X, box.Y, box.Width, box.Height));
+
+                    if (box.Width > 50 && box.Height >= 6) // we draw the text only if humans can see something
+                    {
+                        var text = new FormattedText(
+                                box.Node.DisplayName,
+                                CultureInfo.InvariantCulture,
+                                System.Windows.FlowDirection.LeftToRight,
+                                Typeface,
+                                Math.Min(box.Height, 20),
+                                System.Windows.Media.Brushes.Black);
+
+                        text.MaxTextWidth = box.Width;
+                        text.MaxTextHeight = box.Height;
+
+                        drawingContext.DrawText(text, new System.Windows.Point(box.X, box.Y));
+                    }
                 }
 
                 AddVisual(visual);

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -481,13 +481,13 @@
                             Flame Graph <Hyperlink Command="Help" CommandParameter="FlameGraphView">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
-                    <Canvas Name="FlameGraphCanvas" Background="Transparent" SizeChanged="FlameGraphCanvas_SizeChanged" MouseMove="FlameGraphCanvas_MouseMove">
+                    <src:FlameGraphDrawingCanvas x:Name="FlameGraphCanvas" Background="White" ClipToBounds="True" SizeChanged="FlameGraphCanvas_SizeChanged" MouseMove="FlameGraphCanvas_MouseMove" >
                         <Canvas.ContextMenu>
                             <ContextMenu Name="noContextMenu" Visibility="Visible">
                                 <MenuItem Header="Save Flame Graph" Command="{x:Static src:StackWindow.SaveFlameGraphCommand}" />
                             </ContextMenu>
                         </Canvas.ContextMenu>
-                    </Canvas>
+                    </src:FlameGraphDrawingCanvas>
                 </TabItem>
                 <!-- NotesTab -->
                 <TabItem Name="NotesTab" GotFocus="NotesTab_GotFocus" LostFocus="NotesTab_LostFocus">

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -481,7 +481,7 @@
                             Flame Graph <Hyperlink Command="Help" CommandParameter="FlameGraphView">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
-                    <src:FlameGraphDrawingCanvas x:Name="FlameGraphCanvas" Background="White" ClipToBounds="True" SizeChanged="FlameGraphCanvas_SizeChanged" MouseMove="FlameGraphCanvas_MouseMove" >
+                    <src:FlameGraphDrawingCanvas x:Name="FlameGraphCanvas" Background="White" ClipToBounds="True" SizeChanged="FlameGraphCanvas_SizeChanged" CurrentFlameBoxChanged="FlameGraphCanvas_CurrentFlameBoxChanged">
                         <Canvas.ContextMenu>
                             <ContextMenu Name="noContextMenu" Visibility="Visible">
                                 <MenuItem Header="Save Flame Graph" Command="{x:Static src:StackWindow.SaveFlameGraphCommand}" />

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2581,7 +2581,7 @@ namespace PerfView
 
         private void FlameGraphTab_GotFocus(object sender, RoutedEventArgs e)
         {
-            if (FlameGraphCanvas.Children.Count == 0 || m_RedrawFlameGraphWhenItBecomesVisible)
+            if (FlameGraphCanvas.IsEmpty || m_RedrawFlameGraphWhenItBecomesVisible)
                 RedrawFlameGraph();
         }
 
@@ -2597,24 +2597,23 @@ namespace PerfView
 
         private void RedrawFlameGraph()
         {
-            FlameGraph.Draw(
+            FlameGraphCanvas.Draw(
                   CallTree.Root.HasChildren
                       ? FlameGraph.Calculate(CallTree, FlameGraphCanvas.ActualWidth, FlameGraphCanvas.ActualHeight)
-                      : Enumerable.Empty<FlameGraph.FlameBox>(),
-                  FlameGraphCanvas);
+                      : Enumerable.Empty<FlameGraph.FlameBox>());
 
             m_RedrawFlameGraphWhenItBecomesVisible = false;
         }
 
         private void FlameGraphCanvas_MouseMove(object sender, MouseEventArgs e)
         {
-            if (StatusBar.LoggedError || FlameGraphCanvas.Children.Count == 0)
-                return;
+            //if (StatusBar.LoggedError || FlameGraphCanvas.Children.Count == 0)
+            //    return;
 
-            var pointed = FlameGraphCanvas.Children.OfType<FrameworkElement>().FirstOrDefault(box => box.IsMouseOver);
-            var toolTip = pointed?.ToolTip as ToolTip;
-            if (toolTip != null)
-                StatusBar.Status = toolTip.Content as string;
+            //var pointed = FlameGraphCanvas.Children.OfType<FrameworkElement>().FirstOrDefault(box => box.IsMouseOver);
+            //var toolTip = pointed?.ToolTip as ToolTip;
+            //if (toolTip != null)
+            //    StatusBar.Status = toolTip.Content as string;
         }
 
         private void DoSaveFlameGraph(object sender, RoutedEventArgs e)

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2605,15 +2605,12 @@ namespace PerfView
             m_RedrawFlameGraphWhenItBecomesVisible = false;
         }
 
-        private void FlameGraphCanvas_MouseMove(object sender, MouseEventArgs e)
+        private void FlameGraphCanvas_CurrentFlameBoxChanged(object sender, string toolTipText)
         {
-            //if (StatusBar.LoggedError || FlameGraphCanvas.Children.Count == 0)
-            //    return;
+            if (StatusBar.LoggedError)
+                return;
 
-            //var pointed = FlameGraphCanvas.Children.OfType<FrameworkElement>().FirstOrDefault(box => box.IsMouseOver);
-            //var toolTip = pointed?.ToolTip as ToolTip;
-            //if (toolTip != null)
-            //    StatusBar.Status = toolTip.Content as string;
+            StatusBar.Status = toolTipText;
         }
 
         private void DoSaveFlameGraph(object sender, RoutedEventArgs e)


### PR DESCRIPTION
As reported internally drawing Flame Graphs for some very big data sets was too slow (could even take few minutes). 

This PR solves the problem by replacing `FrameworkElement` with `DrawingVisual`.

`DrawingVisual` is simpler and faster. However, it does not support ToolTips OOTB so I had to implement this. I don't feel good about it, but I did not find any better idea.

For provided `.etl` file the time for drawing flame graph got from 5 minutes to 2 seconds.

I have also improved the way text is scaled and wrapped.