### PR TITLE
Trace parser manifest mods

### DIFF
--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -389,6 +389,8 @@ namespace ETWManifest
             AddOpcode(GlobalScope, 7, "Resume", "win:Resume");
             AddOpcode(GlobalScope, 8, "Suspend", "win:Suspend");
             AddOpcode(GlobalScope, 9, "Send", "win:Send");
+            AddOpcode(GlobalScope, 10, "DCStart", "win:DCStart");
+            AddOpcode(GlobalScope, 11, "DCStop", "win:DCStop");
             AddOpcode(GlobalScope, 240, "Receive", "win:Receive");
         }
 

--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -389,8 +389,6 @@ namespace ETWManifest
             AddOpcode(GlobalScope, 7, "Resume", "win:Resume");
             AddOpcode(GlobalScope, 8, "Suspend", "win:Suspend");
             AddOpcode(GlobalScope, 9, "Send", "win:Send");
-            AddOpcode(GlobalScope, 10, "DCStart", "win:DCStart");
-            AddOpcode(GlobalScope, 11, "DCStop", "win:DCStop");
             AddOpcode(GlobalScope, 240, "Receive", "win:Receive");
         }
 

--- a/src/TraceParserGen/TraceParserGen.cs
+++ b/src/TraceParserGen/TraceParserGen.cs
@@ -611,19 +611,7 @@ class TraceParserGen
         output.WriteLine("    {");
 
         foreach (var keyValue in enumeration.Values)
-        {
-            string numericString = Convert.ToString(keyValue.Key, 16);
-            Int64 targetNumber = Convert.ToInt64(numericString, 16);
-
-            if (targetNumber >= Int32.MaxValue)
-            {
-                output.WriteLine("        {0} = unchecked((int)  0x{1:x}),", keyValue.Value, keyValue.Key);
-            }
-            else
-            {
-                output.WriteLine("        {0} = 0x{1:x},", keyValue.Value, keyValue.Key);
-            }
-        }
+            output.WriteLine("        {0} = 0x{1:x},", keyValue.Value, keyValue.Key);
         output.WriteLine("    }");
     }
 

--- a/src/TraceParserGen/TraceParserGen.cs
+++ b/src/TraceParserGen/TraceParserGen.cs
@@ -611,7 +611,19 @@ class TraceParserGen
         output.WriteLine("    {");
 
         foreach (var keyValue in enumeration.Values)
-            output.WriteLine("        {0} = 0x{1:x},", keyValue.Value, keyValue.Key);
+        {
+            string numericString = Convert.ToString(keyValue.Key, 16);
+            Int64 targetNumber = Convert.ToInt64(numericString, 16);
+
+            if (targetNumber >= Int32.MaxValue)
+            {
+                output.WriteLine("        {0} = unchecked((int)  0x{1:x}),", keyValue.Value, keyValue.Key);
+            }
+            else
+            {
+                output.WriteLine("        {0} = 0x{1:x},", keyValue.Value, keyValue.Key);
+            }
+        }
         output.WriteLine("    }");
     }
 


### PR DESCRIPTION
Manfiest files with a task opcode of "win:DCStart" and "win:DCStop" aren't correctly parsed.  Add these two names.