### PR TITLE
Added support for presets of grouping/folding

### DIFF
--- a/src/PerfView/Dialogs/ManagePresetsDialog.xaml
+++ b/src/PerfView/Dialogs/ManagePresetsDialog.xaml
@@ -1,0 +1,149 @@
+﻿<Window x:Class="PerfView.Dialogs.ManagePresetsDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Background="#FFA7A7A7" 
+        Title="Manage Presets" Height="462" Width="800"
+        WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <Style x:Key="TextBoxStyle">
+            <Setter Property="TextBlock.FontSize" Value="14" />
+            <Setter Property="TextBlock.FontWeight" Value="Bold" />
+            <Setter Property="TextBlock.Background" Value="Transparent" />
+            <Setter Property="TextBlock.Margin" Value="0,10,0,0" />
+        </Style>
+    </Window.Resources>
+    <Window.CommandBindings>
+        <CommandBinding Command="Help" Executed="DoHyperlinkHelp" />
+    </Window.CommandBindings>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Left part (master one) -->
+        <TextBlock Grid.Column="0" Grid.Row="0" HorizontalAlignment="left" Margin="10,2,5,2" >
+            <Hyperlink Name="TitleHyperLink" Command="Help" CommandParameter="PresetList">
+                <TextBlock Name="TitleHyperLinkText" Text="Presets"/>
+            </Hyperlink>
+        </TextBlock>
+        <ListBox x:Name="PresetListBox" Grid.Row="1" Grid.Column="0" Margin="10,10,10,10" SelectionMode="Single" SelectionChanged="DoPresetSelected"/>
+
+        <!-- Right part (details) -->
+        <StackPanel Grid.Row="1" Grid.Column="1" Margin="10,10,10,10" >
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
+                    <Hyperlink Command="Help" CommandParameter="Preset" KeyboardNavigation.IsTabStop="False">Name:</Hyperlink>
+                </TextBlock>
+                <TextBox Grid.Row="0" Grid.Column="1" Name="PresetName" Margin="10,2,10,2" HorizontalScrollBarVisibility="Disabled">
+                    <TextBox.ToolTip>
+                        <ToolTip StaysOpen="True">
+                            <TextBlock>
+                                Preset name.
+                            </TextBlock>
+                        </ToolTip>
+                    </TextBox.ToolTip>
+                </TextBox>
+
+                <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
+                    <Hyperlink Command="Help" CommandParameter="GroupPatsTextBox" KeyboardNavigation.IsTabStop="False">GroupPats:</Hyperlink>
+                </TextBlock>
+                <TextBox Grid.Row="1" Grid.Column="1" Name="GroupPatsTextBox" Margin="10,2,10,2" HorizontalScrollBarVisibility="Disabled">
+                    <TextBox.ToolTip>
+                        <ToolTip StaysOpen="True">
+                            <TextBlock>
+                            A semicolon list of expressions pattern and replacements which define groups <LineBreak/>
+                            PAT -> GROUP : Replaces frame name matching PAT with GROUP<LineBreak/>
+                            PAT => GROUP : Like -> but groups by entry point into the group<LineBreak/>
+                            PAT :  * = any,  % = alphaNumeric, ^ = begin, {PAT} = captures match<LineBreak/>
+                            GROUP can have $1, $2 ... strings which get replaced with pattern captures.<LineBreak/>
+                            Every Frame will have these patterns applied (in order) before stack trees are formed.
+                            </TextBlock>
+                        </ToolTip>
+                    </TextBox.ToolTip>
+                </TextBox>
+                <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
+                <Hyperlink Command="Help" CommandParameter="FoldPercentTextBox" KeyboardNavigation.IsTabStop="False">Fold%:</Hyperlink>
+                </TextBlock>
+                <TextBox Name="FoldPercentTextBox" Grid.Row="2" Grid.Column="1" Margin="10,2,10,2" HorizontalScrollBarVisibility="Disabled">
+                    <TextBox.ToolTip>
+                        <ToolTip StaysOpen="True">
+                            <TextBlock> Nodes that have less than this % Inclusive metric will be removed and their
+                            metric added to their caller.</TextBlock>
+                        </ToolTip>
+                    </TextBox.ToolTip>
+                </TextBox>
+                <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
+                <Hyperlink Command="Help" CommandParameter="FoldPatsTextBox" KeyboardNavigation.IsTabStop="False">FoldPats:</Hyperlink>
+                </TextBlock>
+                <TextBox Name="FoldRegExTextBox" Grid.Row="3" Grid.Column="1" MinWidth="80" Margin="10,2,10,2" HorizontalScrollBarVisibility="Disabled">
+                    <TextBox.ToolTip>
+                        <ToolTip StaysOpen="True">
+                            <TextBlock> 
+                            A semicolon list of string patterns (* = any, % = anyAlphaNumeric, ^ = begin)<LineBreak/>
+                            All nodes matching any group will be removed and their metric added to their caller.
+                            </TextBlock>
+                        </ToolTip>
+                    </TextBox.ToolTip>
+                </TextBox>
+                <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
+                <Hyperlink Command="Help" CommandParameter="IncPatsTextBox" KeyboardNavigation.IsTabStop="False">IncPats:</Hyperlink>
+                </TextBlock>
+                <TextBox Name="IncludeRegExTextBox" Grid.Row="4" Grid.Column="1"  MinWidth="80" Margin="10,2,10,2" HorizontalScrollBarVisibility="Disabled">
+                    <TextBox.ToolTip>
+                        <ToolTip StaysOpen="True">
+                            <TextBlock> 
+                            A semicolon list of string patterns (* = any, % = anyAlphaNumeric, ^ = begin)<LineBreak/>
+                            Only stacks that have at least on fram that matches this pattern<LineBreak/>
+                            will be included in the trace.
+                            </TextBlock>
+                        </ToolTip>
+                    </TextBox.ToolTip>
+                </TextBox>
+                <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
+                <Hyperlink Command="Help" CommandParameter="ExcPatsTextBox" KeyboardNavigation.IsTabStop="False">ExcPats:</Hyperlink>
+                </TextBlock>
+                <TextBox x:Name="ExcludeRegExTextBox" Grid.Row="5" Grid.Column="1" MinWidth="80" Margin="10,2,10,2" HorizontalScrollBarVisibility="Disabled">
+                    <TextBox.ToolTip>
+                        <ToolTip StaysOpen="True">
+                            <TextBlock> 
+                            A semicolon list of string patterns (* = any, % = anyAlphaNumeric, ^ = begin)<LineBreak/>
+                            Any nodes matching this patter will be removed (as well as their children)<LineBreak/>
+                            will be removed completely from the trace.
+                            </TextBlock>
+                        </ToolTip>
+                    </TextBox.ToolTip>
+                </TextBox>
+            </Grid>
+
+            <StackPanel Orientation="Horizontal" FlowDirection="RightToLeft" Margin="0,20,10,0">
+                <Button Width="80" Content="Delete" Click="DeleteClicked" HorizontalAlignment="Right" Margin="0,0,10,0"/>
+                <Button Width="80" Content="Save" Click="SaveClicked" HorizontalAlignment="Right" />
+            </StackPanel>
+        </StackPanel>
+
+        <!-- Bottom (OK) -->
+        <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="10,10,10,10" FlowDirection="RightToLeft">
+            <Button Width="80" Content="OK" Click="OKClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/PerfView/Dialogs/ManagePresetsDialog.xaml
+++ b/src/PerfView/Dialogs/ManagePresetsDialog.xaml
@@ -138,12 +138,14 @@
             <StackPanel Orientation="Horizontal" FlowDirection="RightToLeft" Margin="0,20,10,0">
                 <Button Width="80" Content="Delete" Click="DeleteClicked" HorizontalAlignment="Right" Margin="0,0,10,0"/>
                 <Button Width="80" Content="Save" Click="SaveClicked" HorizontalAlignment="Right" />
-            </StackPanel>
+      </StackPanel>
         </StackPanel>
 
         <!-- Bottom (OK) -->
         <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="10,10,10,10" FlowDirection="RightToLeft">
-            <Button Width="80" Content="OK" Click="OKClicked"/>
+            <Button Width="80" Content="OK" Click="OKClicked" Margin="0,0,30,0"/>
+            <Button Width="80" Content="Import" Click="ImportPresets" Margin="0,0,10,0"/>
+            <Button Width="80" Content="Export" Click="ExportPresets"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/PerfView/Dialogs/ManagePresetsDialog.xaml.cs
+++ b/src/PerfView/Dialogs/ManagePresetsDialog.xaml.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Controls;
+
+namespace PerfView.Dialogs
+{
+    /// <summary>
+    /// Interaction logic for ManagePresetsDialog.xaml
+    /// </summary>
+    public partial class ManagePresetsDialog : Window
+    {
+        public List<Preset> Presets { get; private set; }
+
+        public ManagePresetsDialog(List<Preset> presets)
+        {
+            InitializeComponent();
+            Title = "Manage Presets";
+            Presets = presets;
+            if (Presets?.Count > 0)
+            {
+                foreach (var preset in Presets)
+                {
+                    PresetListBox.Items.Add(preset.Name);
+                }
+                PresetListBox.SelectedItem = Presets[0].Name;
+            }
+        }
+        private void DoHyperlinkHelp(object sender, ExecutedRoutedEventArgs e)
+        {
+            MainWindow.DisplayUsersGuide(e.Parameter as string);
+        }
+        private void OKClicked(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+        private void SaveClicked(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(m_currentPreset))
+            {
+                return;
+            }
+
+            // If preset was renamed, then check name uniqueness
+            if (PresetName.Text != m_currentPreset)
+            {
+                if (Presets.Exists(x => x.Name == PresetName.Text))
+                {
+                    MessageBox.Show(
+                        $"Preset '{PresetName.Text}' already exists. Choose another name.",
+                        "Preset Name",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+                    return;
+                }
+            }
+
+            var preset = Presets.Find(x => x.Name == m_currentPreset);
+            PresetListBox.SelectedItem = PresetName.Text;
+            preset.Name = PresetName.Text;
+            preset.GroupPat = GroupPatsTextBox.Text;
+            preset.FoldPercentage = FoldPercentTextBox.Text;
+            preset.FoldPat = FoldRegExTextBox.Text;
+            preset.IncPat = IncludeRegExTextBox.Text;
+            preset.ExcPat = ExcludeRegExTextBox.Text;
+        }
+        private void DeleteClicked(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(m_currentPreset))
+            {
+                return;
+            }
+
+            Presets.RemoveAll(x => x.Name == m_currentPreset);
+            PresetListBox.Items.Remove(m_currentPreset);
+            if (Presets.Count > 0)
+            {
+                PresetListBox.SelectedItem = Presets[0];
+            }
+            else
+            {
+                PresetListBox.UnselectAll();
+            }
+        }
+        private void DoPresetSelected(object sender, SelectionChangedEventArgs e)
+        {
+            var selectedItem = PresetListBox.SelectedItem;
+            if (selectedItem == null)
+            {
+                PresetName.Text = string.Empty;
+                GroupPatsTextBox.Text = string.Empty;
+                FoldPercentTextBox.Text = string.Empty;
+                FoldRegExTextBox.Text = string.Empty;
+                IncludeRegExTextBox.Text = string.Empty;
+                ExcludeRegExTextBox.Text = string.Empty;
+                return;
+            }
+
+            m_currentPreset = selectedItem.ToString();
+            var preset = Presets.Find(x => x.Name == m_currentPreset);
+            PresetName.Text = preset.Name;
+            GroupPatsTextBox.Text = preset.GroupPat;
+            FoldPercentTextBox.Text = preset.FoldPercentage;
+            FoldRegExTextBox.Text = preset.FoldPat;
+            IncludeRegExTextBox.Text = preset.IncPat;
+            ExcludeRegExTextBox.Text = preset.ExcPat;
+        }
+
+        private string m_currentPreset;
+    }
+}

--- a/src/PerfView/Dialogs/NewPresetDialog.xaml
+++ b/src/PerfView/Dialogs/NewPresetDialog.xaml
@@ -1,0 +1,30 @@
+﻿<Window x:Class="PerfView.Dialogs.NewPresetDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Background="#FFA7A7A7" 
+        Title="New Preset" Height="93.611" Width="400"
+        WindowStartupLocation="CenterOwner">
+    <Window.CommandBindings>
+        <CommandBinding Command="Help" Executed="DoHyperlinkHelp" />
+    </Window.CommandBindings>
+    <Grid Margin="0,0,0,0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="23"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        
+        <StackPanel Grid.Row="0" Orientation="Horizontal">
+            <TextBlock HorizontalAlignment="left" Margin="8,2,5,2" >
+                <Hyperlink Name="TitleHyperLink" Command="Help" CommandParameter="PresetNameTextBox">
+                    <TextBlock Name="TitleHyperLinkText" Text="Preset Name"/>
+                </Hyperlink>
+            </TextBlock>
+            <TextBox Name="PresetNameTextBox"  Width ="290" Margin="10,2,10,2" KeyDown="DoKeyDown" HorizontalScrollBarVisibility="Auto" />
+            
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" FlowDirection="RightToLeft" Margin="0,0,0,-30">
+            
+                <Button Margin="10,2,10,5" Width="80" Content="OK" Click="OKClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/PerfView/Dialogs/NewPresetDialog.xaml.cs
+++ b/src/PerfView/Dialogs/NewPresetDialog.xaml.cs
@@ -23,7 +23,7 @@ namespace PerfView.Dialogs
         }
         private void DoHyperlinkHelp(object sender, ExecutedRoutedEventArgs e)
         {
-            MainWindow.DisplayUsersGuide(e.Parameter as string);
+            MainWindow.DisplayUsersGuide("Preset");
         }
         private void OKClicked(object sender, RoutedEventArgs e)
         {

--- a/src/PerfView/Dialogs/NewPresetDialog.xaml.cs
+++ b/src/PerfView/Dialogs/NewPresetDialog.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+
+namespace PerfView.Dialogs
+{
+    /// <summary>
+    /// Interaction logic for NewPresetDialog.xaml
+    /// </summary>
+    public partial class NewPresetDialog : Window
+    {
+        public string PresetName { get; private set; }
+
+        public NewPresetDialog(string defaultValue, List<string> existingPresets)
+        {
+            m_existingPresets = existingPresets;
+            InitializeComponent();
+            Title = "New Preset";
+            PresetNameTextBox.Text = defaultValue;
+            PresetNameTextBox.CaretIndex = defaultValue.Length;
+            PresetName = defaultValue;
+            PresetNameTextBox.Focus();
+        }
+        private void DoHyperlinkHelp(object sender, ExecutedRoutedEventArgs e)
+        {
+            MainWindow.DisplayUsersGuide(e.Parameter as string);
+        }
+        private void OKClicked(object sender, RoutedEventArgs e)
+        {
+            // Check uniqueness of the name and ask if user wants to continue
+            if (m_existingPresets.Exists(x => x == PresetNameTextBox.Text))
+            {
+                if (MessageBox.Show(
+                        $"Preset {PresetNameTextBox.Text} already exists in the list of presets.\r\nDo you want to overwrite it?",
+                        "Preset Name",
+                        MessageBoxButton.OKCancel,
+                        MessageBoxImage.Warning) == MessageBoxResult.Cancel)
+                {
+                    return;
+                }
+            }
+            DialogResult = true;
+            PresetName = PresetNameTextBox.Text;
+            Close();
+        }
+
+        private void DoKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+                Close();
+            if (e.Key == Key.Enter)
+                OKClicked(null, null);
+        }
+
+        private List<string> m_existingPresets;
+    }
+}

--- a/src/PerfView/GuiUtilities/HistoryComboBox/HistoryCombBox.cs
+++ b/src/PerfView/GuiUtilities/HistoryComboBox/HistoryCombBox.cs
@@ -60,6 +60,7 @@ namespace Controls
 
             RemoveFromHistory(value);
             Items.Insert(0, value);
+            Text = value;
 
             // Keep the number of entries under control
             while (Items.Count > HistoryLength)

--- a/src/PerfView/StackViewer/Preset.cs
+++ b/src/PerfView/StackViewer/Preset.cs
@@ -8,7 +8,7 @@ namespace PerfView
     /// Stack viewer preset that includes information about grouping and folding patterns,
     /// folding percentage and inclusion/exclusion patterns.
     /// </summary>
-    public class Preset
+    public class Preset : IEquatable<Preset>
     {
         public string Name { get; set; }
         public string GroupPat { get; set; }
@@ -16,6 +16,22 @@ namespace PerfView
         public string FoldPat { get; set; }
         public string IncPat { get; set; }
         public string ExcPat { get; set; }
+
+        /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
+        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(Preset other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return string.Equals(Name, other.Name) &&
+                   string.Equals(GroupPat, other.GroupPat) &&
+                   string.Equals(FoldPercentage, other.FoldPercentage) &&
+                   string.Equals(FoldPat, other.FoldPat) &&
+                   string.Equals(IncPat, other.IncPat) &&
+                   string.Equals(ExcPat, other.ExcPat);
+        }
 
         /// <summary>
         /// Parses collection of presets kept as a string
@@ -30,40 +46,48 @@ namespace PerfView
             var entries = presets.Split(new[] { PresetSeparator }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var entry in entries)
             {
-                var preset = new Preset();
-                var presetParts = entry.Split(new[] { PartSeparator }, StringSplitOptions.None);
-                foreach (var presetPart in presetParts)
-                {
-                    int separatorIndex = presetPart.IndexOf('=');
-                    string partName = presetPart.Substring(0, separatorIndex);
-                    string partValue = presetPart.Substring(separatorIndex + 1);
-                    switch (partName)
-                    {
-                        case "Name":
-                            preset.Name = partValue;
-                            break;
-                        case "GroupPat":
-                            preset.GroupPat = partValue;
-                            break;
-                        case "FoldPercentage":
-                            preset.FoldPercentage = partValue;
-                            break;
-                        case "FoldPat":
-                            preset.FoldPat = partValue;
-                            break;
-                        case "IncPat":
-                            preset.IncPat = partValue;
-                            break;
-                        case "ExcPat":
-                            preset.ExcPat = partValue;
-                            break;
-                    }
-                }
-
-                result.Add(preset);
+                result.Add(ParsePreset(entry));
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Parses single preset.
+        /// </summary>
+        public static Preset ParsePreset(string presetString)
+        {
+            var preset = new Preset();
+            var presetParts = presetString.Split(new[] { PartSeparator }, StringSplitOptions.None);
+            foreach (var presetPart in presetParts)
+            {
+                int separatorIndex = presetPart.IndexOf('=');
+                string partName = presetPart.Substring(0, separatorIndex);
+                string partValue = presetPart.Substring(separatorIndex + 1);
+                switch (partName)
+                {
+                    case "Name":
+                        preset.Name = partValue;
+                        break;
+                    case "GroupPat":
+                        preset.GroupPat = partValue;
+                        break;
+                    case "FoldPercentage":
+                        preset.FoldPercentage = partValue;
+                        break;
+                    case "FoldPat":
+                        preset.FoldPat = partValue;
+                        break;
+                    case "IncPat":
+                        preset.IncPat = partValue;
+                        break;
+                    case "ExcPat":
+                        preset.ExcPat = partValue;
+                        break;
+                }
+            }
+
+            return preset;
         }
 
         /// <summary>
@@ -81,14 +105,24 @@ namespace PerfView
                 }
                 firstPreset = false;
 
-                result.Append("Name=" + preset.Name + PartSeparator);
-                result.Append("GroupPat=" + preset.GroupPat + PartSeparator);
-                result.Append("FoldPercentage=" + preset.FoldPercentage + PartSeparator);
-                result.Append("FoldPat=" + preset.FoldPat + PartSeparator);
-                result.Append("IncPat=" + preset.IncPat + PartSeparator);
-                result.Append("ExcPat=" + preset.ExcPat);
+                result.Append(Serialize(preset));
             }
 
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Serializes single preset to string.
+        /// </summary>
+        public static string Serialize(Preset preset)
+        {
+            var result = new StringBuilder();
+            result.Append("Name=" + preset.Name + PartSeparator);
+            result.Append("GroupPat=" + preset.GroupPat + PartSeparator);
+            result.Append("FoldPercentage=" + preset.FoldPercentage + PartSeparator);
+            result.Append("FoldPat=" + preset.FoldPat + PartSeparator);
+            result.Append("IncPat=" + preset.IncPat + PartSeparator);
+            result.Append("ExcPat=" + preset.ExcPat);
             return result.ToString();
         }
 

--- a/src/PerfView/StackViewer/Preset.cs
+++ b/src/PerfView/StackViewer/Preset.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PerfView
+{
+    /// <summary>
+    /// Stack viewer preset that includes information about grouping and folding patterns,
+    /// folding percentage and inclusion/exclusion patterns.
+    /// </summary>
+    public class Preset
+    {
+        public string Name { get; set; }
+        public string GroupPat { get; set; }
+        public string FoldPercentage { get; set; }
+        public string FoldPat { get; set; }
+        public string IncPat { get; set; }
+        public string ExcPat { get; set; }
+
+        /// <summary>
+        /// Parses collection of presets kept as a string
+        /// </summary>
+        public static List<Preset> ParseCollection(string presets)
+        {
+            var result = new List<Preset>();
+            if (presets == null)
+            {
+                return result;
+            }
+            var entries = presets.Split(new[] { PresetSeparator }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var entry in entries)
+            {
+                var preset = new Preset();
+                var presetParts = entry.Split(new[] { PartSeparator }, StringSplitOptions.None);
+                foreach (var presetPart in presetParts)
+                {
+                    int separatorIndex = presetPart.IndexOf('=');
+                    string partName = presetPart.Substring(0, separatorIndex);
+                    string partValue = presetPart.Substring(separatorIndex + 1);
+                    switch (partName)
+                    {
+                        case "Name":
+                            preset.Name = partValue;
+                            break;
+                        case "GroupPat":
+                            preset.GroupPat = partValue;
+                            break;
+                        case "FoldPercentage":
+                            preset.FoldPercentage = partValue;
+                            break;
+                        case "FoldPat":
+                            preset.FoldPat = partValue;
+                            break;
+                        case "IncPat":
+                            preset.IncPat = partValue;
+                            break;
+                        case "ExcPat":
+                            preset.ExcPat = partValue;
+                            break;
+                    }
+                }
+
+                result.Add(preset);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Serializes list of presets to be stored in the string.
+        /// </summary>
+        public static string Serialize(List<Preset> presets)
+        {
+            var result = new StringBuilder();
+            bool firstPreset = true;
+            foreach (var preset in presets)
+            {
+                if (!firstPreset)
+                {
+                    result.Append(PresetSeparator);
+                }
+                firstPreset = false;
+
+                result.Append("Name=" + preset.Name + PartSeparator);
+                result.Append("GroupPat=" + preset.GroupPat + PartSeparator);
+                result.Append("FoldPercentage=" + preset.FoldPercentage + PartSeparator);
+                result.Append("FoldPat=" + preset.FoldPat + PartSeparator);
+                result.Append("IncPat=" + preset.IncPat + PartSeparator);
+                result.Append("ExcPat=" + preset.ExcPat);
+            }
+
+            return result.ToString();
+        }
+
+        private const string PresetSeparator = "####";
+        private const string PartSeparator = "$$$$";
+    }
+}

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -199,7 +199,6 @@
                     <MenuItem Header="Parent _Window" Click="DoOpenParent"/>
                     <MenuItem Header="Set Symbol _Path" Click="DoSetSymbolPath" ToolTip="Sets the locations to look for symbolic information (PDB files)."/>
                     <MenuItem Header="Set Source Path" Click="DoSetSourcePath" ToolTip="Sets the locations to look for source code."/>
-                    <MenuItem Header="Set As Default Grouping/Folding" Click="DoSetDefaultGroupingFolding" ToolTip="Sets the default values of Group Patterns and Fold Patterns and % to the current values."/>
                     <MenuItem Header="Save" Command="{x:Static src:StackWindow.SaveCommand}" />
                     <MenuItem Header="Save View As" Command="{x:Static src:StackWindow.SaveAsCommand}" />
                     <MenuItem Header="_Close" Click="DoClose"/>

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -208,6 +208,7 @@
                 </MenuItem>
                 <MenuItem Name="DiffMenu" Header="_Diff"/>
                 <MenuItem Name="RegressionMenu" Header="_Regression"/>
+                <MenuItem Name="PresetMenu" Header="_Preset"/>
                 <MenuItem Header="_Help">
                     <MenuItem Header="_Help on Stack Viewer" Command="Help" CommandParameter="StackViewerQuickStart" />
                     <MenuItem Header="_Users Guide" Command="{x:Static src:StackWindow.UsersGuideCommand}" CommandParameter="UsersGuide"/>

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -767,7 +767,7 @@ namespace PerfView
             });
             symPathDialog.Show();
         }
-        private void DoSetDefaultGroupingFolding(object sender, RoutedEventArgs e)
+        private void DoSetStartupPreset(object sender, RoutedEventArgs e)
         {
             App.ConfigData["DefaultFoldPercent"] = FoldPercentTextBox.Text;
             App.ConfigData["DefaultFoldPat"] = FoldRegExTextBox.Text;
@@ -2926,10 +2926,8 @@ namespace PerfView
             // Make up a trivial call tree (so that the rest of the code works).  
             m_callTree = new CallTree(ScalingPolicy);
 
-            // Finalize the Preset menu (add default commands)
-            var presets = App.ConfigData["Presets"];
-            m_presets = Preset.ParseCollection(presets);
-            FinishPresetMenu();
+            // Configure the Preset menu (add standard commands and known presets)
+            ConfigurePresetMenu();
 
             StackWindows.Add(this);
 
@@ -3436,8 +3434,11 @@ namespace PerfView
             diffMenuItem.Items.Add(helpMenuItem);
         }
 
-        private void FinishPresetMenu()
+        private void ConfigurePresetMenu()
         {
+            var presets = App.ConfigData["Presets"];
+            m_presets = Preset.ParseCollection(presets);
+
             foreach (var preset in m_presets)
             {
                 var presetMenuItem = new MenuItem();
@@ -3449,18 +3450,25 @@ namespace PerfView
 
             PresetMenu.Items.Add(new Separator());
 
+            var setDefaultPresetMenuItem = new MenuItem();
+            setDefaultPresetMenuItem.Header = "S_et Startup Preset";
+            setDefaultPresetMenuItem.Click += DoSetStartupPreset;
+            setDefaultPresetMenuItem.ToolTip =
+                "Sets the default values of Group Patterns and Fold Patterns and % to the current values.";
+            PresetMenu.Items.Add(setDefaultPresetMenuItem);
+
             var newPresetMenuItem = new MenuItem();
-            newPresetMenuItem.Header = "Save As Preset";
+            newPresetMenuItem.Header = "_Save As Preset";
             newPresetMenuItem.Click += DoSaveAsPreset;
             PresetMenu.Items.Add(newPresetMenuItem);
 
             var managePresetsMenuItem = new MenuItem();
-            managePresetsMenuItem.Header = "Manage Presets";
+            managePresetsMenuItem.Header = "_Manage Presets";
             managePresetsMenuItem.Click += DoManagePresets;
             PresetMenu.Items.Add(managePresetsMenuItem);
 
             var helpMenuItem = new MenuItem();
-            helpMenuItem.Header = "Help for Preset";
+            helpMenuItem.Header = "_Help for Preset";
             helpMenuItem.Click += delegate { MainWindow.DisplayUsersGuide("Preset"); };
             PresetMenu.Items.Add(helpMenuItem);
         }
@@ -3526,7 +3534,7 @@ namespace PerfView
 
         private void DoManagePresets(object sender, RoutedEventArgs e)
         {
-            var managePresetsDialog = new ManagePresetsDialog(m_presets);
+            var managePresetsDialog = new ManagePresetsDialog(m_presets, Path.GetDirectoryName(DataSource.FilePath));
             managePresetsDialog.Owner = this;
             managePresetsDialog.ShowDialog();
             m_presets = managePresetsDialog.Presets;

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -3534,7 +3534,7 @@ namespace PerfView
 
         private void DoManagePresets(object sender, RoutedEventArgs e)
         {
-            var managePresetsDialog = new ManagePresetsDialog(m_presets, Path.GetDirectoryName(DataSource.FilePath));
+            var managePresetsDialog = new ManagePresetsDialog(m_presets, Path.GetDirectoryName(DataSource.FilePath), StatusBar);
             managePresetsDialog.Owner = this;
             managePresetsDialog.ShowDialog();
             m_presets = managePresetsDialog.Presets;

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2926,6 +2926,11 @@ namespace PerfView
             // Make up a trivial call tree (so that the rest of the code works).  
             m_callTree = new CallTree(ScalingPolicy);
 
+            // Finalize the Preset menu (add default commands)
+            var presets = App.ConfigData["Presets"];
+            m_presets = Preset.ParseCollection(presets);
+            FinishPresetMenu();
+
             StackWindows.Add(this);
 
             // TODO really should simply update Diff Menu lazily
@@ -3430,6 +3435,119 @@ namespace PerfView
             helpMenuItem.Click += delegate (object sender, RoutedEventArgs e) { MainWindow.DisplayUsersGuide(diffName); };
             diffMenuItem.Items.Add(helpMenuItem);
         }
+
+        private void FinishPresetMenu()
+        {
+            foreach (var preset in m_presets)
+            {
+                var presetMenuItem = new MenuItem();
+                presetMenuItem.Header = preset.Name;
+                presetMenuItem.Tag = preset.Name;
+                presetMenuItem.Click += DoSelectPreset;
+                PresetMenu.Items.Add(presetMenuItem);
+            }
+
+            PresetMenu.Items.Add(new Separator());
+
+            var newPresetMenuItem = new MenuItem();
+            newPresetMenuItem.Header = "Save As Preset";
+            newPresetMenuItem.Click += DoSaveAsPreset;
+            PresetMenu.Items.Add(newPresetMenuItem);
+
+            var managePresetsMenuItem = new MenuItem();
+            managePresetsMenuItem.Header = "Manage Presets";
+            managePresetsMenuItem.Click += DoManagePresets;
+            PresetMenu.Items.Add(managePresetsMenuItem);
+
+            var helpMenuItem = new MenuItem();
+            helpMenuItem.Header = "Help for Preset";
+            helpMenuItem.Click += delegate { MainWindow.DisplayUsersGuide("Preset"); };
+            PresetMenu.Items.Add(helpMenuItem);
+        }
+
+        private void DoUpdatePresetMenu()
+        {
+            // Clean existing preset items
+            while (!(PresetMenu.Items[0] is Separator))
+            {
+                PresetMenu.Items.RemoveAt(0);
+            }
+            // Sort in reverse order since menu items are created from last to first.
+            m_presets.Sort((x, y) => Comparer<string>.Default.Compare(y.Name, x.Name));
+            foreach (var preset in m_presets)
+            {
+                var presetMenuItem = new MenuItem();
+                presetMenuItem.Header = preset.Name;
+                presetMenuItem.Tag = preset.Name;
+                presetMenuItem.Click += DoSelectPreset;
+                PresetMenu.Items.Insert(0, presetMenuItem);
+            }
+        }
+
+        private void DoSaveAsPreset(object sender, RoutedEventArgs e)
+        {
+            string groupPat = this.GroupRegExTextBox.Text.Trim();
+            string nameCandidate = "Preset " + (m_presets.Count + 1).ToString();
+            // Try to extract pattern name as a [Name] prefix
+            if (groupPat[0] == '[')
+            {
+                int closingBracketIndex = groupPat.IndexOf(']');
+                if (closingBracketIndex > 0)
+                {
+                    nameCandidate = groupPat.Substring(1, closingBracketIndex - 1);
+                    groupPat = groupPat.Substring(closingBracketIndex + 1).Trim();
+                }
+            }
+            
+            var newPresetDialog = new NewPresetDialog(nameCandidate, m_presets.Select(x => x.Name).ToList());
+            newPresetDialog.Owner = this;
+            if (!(newPresetDialog.ShowDialog() ?? false))
+            {
+                return;
+            }
+
+            Preset preset = m_presets.FirstOrDefault(x => x.Name == newPresetDialog.PresetName) ?? new Preset();
+            preset.Name = newPresetDialog.PresetName;
+            preset.GroupPat = groupPat;
+            preset.FoldPercentage = this.FoldPercentTextBox.Text;
+            preset.FoldPat = this.FoldRegExTextBox.Text;
+            preset.ExcPat = this.ExcludeRegExTextBox.Text;
+            preset.IncPat = this.IncludeRegExTextBox.Text;
+
+            if (m_presets.FindIndex(x => x.Name == newPresetDialog.PresetName) == -1)
+            {
+                m_presets.Insert(0, preset);
+                m_presets.Sort((x, y) => Comparer<string>.Default.Compare(x.Name, y.Name));
+            }
+            App.ConfigData["Presets"] = Preset.Serialize(m_presets);
+
+            DoUpdatePresetMenu();
+        }
+
+        private void DoManagePresets(object sender, RoutedEventArgs e)
+        {
+            var managePresetsDialog = new ManagePresetsDialog(m_presets);
+            managePresetsDialog.Owner = this;
+            managePresetsDialog.ShowDialog();
+            m_presets = managePresetsDialog.Presets;
+            App.ConfigData["Presets"] = Preset.Serialize(m_presets);
+            DoUpdatePresetMenu();
+        }
+
+        private void DoSelectPreset(object sender, RoutedEventArgs e)
+        {
+            var menuItem = sender as MenuItem;
+            string presetName = menuItem.Tag as string;
+
+            var preset = m_presets.Find(x => x.Name == presetName);
+            this.GroupRegExTextBox.AddToHistory($"[{preset.Name}] {preset.GroupPat}");
+            this.FoldPercentTextBox.AddToHistory(preset.FoldPercentage);
+            this.FoldRegExTextBox.AddToHistory(preset.FoldPat);
+            this.ExcludeRegExTextBox.AddToHistory(preset.ExcPat);
+            this.IncludeRegExTextBox.AddToHistory(preset.IncPat);
+            Update();
+        }
+
         private void CopyTo(ItemCollection toCollection, IEnumerable fromCollection)
         {
             toCollection.Clear();
@@ -3609,6 +3727,9 @@ namespace PerfView
 
         // What fileName to save as
         string m_fileName;
+
+        // List of presets loaded from configuration (and then maybe adjusted later)
+        List<Preset> m_presets;
 
         #endregion
     }

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -4871,6 +4871,25 @@
         the app will beep.&nbsp; The next F3 after that starts over.
         &nbsp;
     </p>
+    <!--  ****************** -->
+    <h3>
+        <a id="Preset">Presets (Save Grouping and Folding Preferences)</a>
+    </h3>
+    <p>
+        <a href="#GroupPatsTextBox">GroupPats</a>, <a href="#FoldPatsTextBox">FoldPats</a>, <a href="#FoldPercentTextBox">Fold%</a>,
+        <a href="#IncPatsTextBox">IncPats</a> and <a href="#ExcPatsTextBox">ExcPats</a> text boxes can be edited to contain custom
+        patterns. These patterns combined together can be saved as a named preset.
+    </p>
+    <p>
+        In order to create new preset use Preset -&gt; New Preset menu item. If <a href="#GroupPatsTextBox">GroupPats</a>
+        text box contains description (enclosed in []), then the description will be offered as a preset name.
+        Otherwise automatically generated name will be suggested.
+    </p>
+    <p>
+        All created presets are added to the Preset menu for all active PerfView windows. Select menu item in the Preset menu
+        to activate a preset. The name of the preset will be shown in [] in the <a href="#GroupPatsTextBox">GroupPats</a> textbox.
+        Presets are saved across sessions. Preset ->&gt; Manage Presets menu item allows editing existing presets as well as deleting them.
+    </p>
     <hr />
     <!--  ********************************** -->
     <h2><a id="BlockedTimeInvestigation">Blocked/Wall Clock Time Investigation: The Thread Time Views</a></h2>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -4888,7 +4888,7 @@
     <p>
         All created presets are added to the Preset menu for all active PerfView windows. Select menu item in the Preset menu
         to activate a preset. The name of the preset will be shown in [] in the <a href="#GroupPatsTextBox">GroupPats</a> textbox.
-        Presets are saved across sessions. Preset ->&gt; Manage Presets menu item allows editing existing presets as well as deleting them.
+        Presets are saved across sessions. Preset -&gt; Manage Presets menu item allows editing existing presets as well as deleting them.
     </p>
     <hr />
     <!--  ********************************** -->


### PR DESCRIPTION
Initial implementation of the grouping/folding presets (#446).
Presets only include Grouping/folding/include/exclude and do not include Memory Stack specific fields.
"Builtin" GroupPats are kept as is (only updated in the text boxes), so PerfView restart will restore them even if they were overwritten by dropdown history.

This implementation works for my needs, but I'm opened to suggestion about how to improve it for wider acceptance.