### PR TITLE
Change fallback module name

### DIFF
--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -117,26 +117,31 @@ namespace Microsoft.Diagnostics.Symbols
                     prefixMatchFound = true;
                     var original = m.Groups[1].Value;
                     var moduleIndex = int.Parse(original);
-                    string fullAssemblyName;
-                    if (mergedAssembliesMap.TryGetValue(moduleIndex, out fullAssemblyName))
-                    {
-                        try
-                        {
-                            var assemblyName = new AssemblyName(fullAssemblyName);
-                            return assemblyName.Name + "!";
-                        }
-                        catch (Exception) { } // Catch all AssemlyName fails with ' in the name.   
-                    }
-                    return original;
+                    return GetAssemblyNameFromModuleIndex(mergedAssembliesMap, moduleIndex) ?? original;
                 });
 
                 // By default - .NET native compilers do not generate a $#_ prefix for the methods coming from 
-                // the assembly containing System.Object - most of the time, it should be System.Private.CoreLib.dll
+                // the assembly containing System.Object - the implicit module number is int.MaxValue
 
                 if (!prefixMatchFound)
-                    ret = "System.Private.CoreLib!" + ret;
+                    ret = GetAssemblyNameFromModuleIndex(mergedAssembliesMap, int.MaxValue) + ret;
             }
             return ret;
+        }
+
+        private static string GetAssemblyNameFromModuleIndex(Dictionary<int, string> mergedAssembliesMap, int moduleIndex)
+        {
+            string fullAssemblyName;
+            if (mergedAssembliesMap.TryGetValue(moduleIndex, out fullAssemblyName))
+            {
+                try
+                {
+                    var assemblyName = new AssemblyName(fullAssemblyName);
+                    return assemblyName.Name + "!";
+                }
+                catch (Exception) { } // Catch all AssemblyName fails with ' in the name.   
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -130,8 +130,8 @@ namespace Microsoft.Diagnostics.Symbols
                     return original;
                 });
 
-		// By default - .NET native compilers do not generate a $#_ prefix for the methods coming from 
-		// the assembly containing System.Object - most of the time, it should be System.Private.CoreLib.dll
+                // By default - .NET native compilers do not generate a $#_ prefix for the methods coming from 
+                // the assembly containing System.Object - most of the time, it should be System.Private.CoreLib.dll
 
                 if (!prefixMatchFound)
                     ret = "System.Private.CoreLib!" + ret;

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -117,19 +117,19 @@ namespace Microsoft.Diagnostics.Symbols
                     prefixMatchFound = true;
                     var original = m.Groups[1].Value;
                     var moduleIndex = int.Parse(original);
-                    return GetAssemblyNameFromModuleIndex(mergedAssembliesMap, moduleIndex) ?? original;
+                    return GetAssemblyNameFromModuleIndex(mergedAssembliesMap, moduleIndex, original);
                 });
 
                 // By default - .NET native compilers do not generate a $#_ prefix for the methods coming from 
                 // the assembly containing System.Object - the implicit module number is int.MaxValue
 
                 if (!prefixMatchFound)
-                    ret = GetAssemblyNameFromModuleIndex(mergedAssembliesMap, int.MaxValue) + ret;
+                    ret = GetAssemblyNameFromModuleIndex(mergedAssembliesMap, int.MaxValue, String.Empty) + ret;
             }
             return ret;
         }
 
-        private static string GetAssemblyNameFromModuleIndex(Dictionary<int, string> mergedAssembliesMap, int moduleIndex)
+        private static string GetAssemblyNameFromModuleIndex(Dictionary<int, string> mergedAssembliesMap, int moduleIndex, string defaultValue)
         {
             string fullAssemblyName;
             if (mergedAssembliesMap.TryGetValue(moduleIndex, out fullAssemblyName))
@@ -141,7 +141,7 @@ namespace Microsoft.Diagnostics.Symbols
                 }
                 catch (Exception) { } // Catch all AssemblyName fails with ' in the name.   
             }
-            return null;
+            return defaultValue;
         }
 
         /// <summary>

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -130,9 +130,11 @@ namespace Microsoft.Diagnostics.Symbols
                     return original;
                 });
 
-                // corefx.dll does not have a tag.  TODO this feels like a hack!
+		// By default - .NET native compilers do not generate a $#_ prefix for the methods coming from 
+		// the assembly containing System.Object - most of the time, it should be System.Private.CoreLib.dll
+
                 if (!prefixMatchFound)
-                    ret = "mscorlib!" + ret;
+                    ret = "System.Private.CoreLib!" + ret;
             }
             return ret;
         }


### PR DESCRIPTION
By default - .NET native compilers do not generate a $#_ prefix for the methods coming from the assembly containing System.Object - most of the time, it should be System.Private.CoreLib.dll