### PR TITLE
Make TraceEvent have a specific build for Netstandard2.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,8 +21,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PerfViewVersion>2.0.9</PerfViewVersion>
-    <TraceEventVersion>2.0.9</TraceEventVersion>
+    <!-- These are the versions of the things we are CREATING in this repository -->
+    <PerfViewVersion>2.0.10</PerfViewVersion>
+    <TraceEventVersion>2.0.10</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -35,12 +35,28 @@
     <file src="Microsoft.Diagnostics.Tracing.TraceEvent.props" target="build\Microsoft.Diagnostics.Tracing.TraceEvent.props" />
 
     <!-- Native binaries -->
-    <file src="$OutDir$netstandard1.6\amd64\KernelTraceControl.dll" target="lib\native\amd64\KernelTraceControl.dll" />
-    <file src="$OutDir$netstandard1.6\amd64\msdia140.dll" target="lib\native\amd64\msdia140.dll" />
+    <file src="$OutDir$netstandard2.0\amd64\KernelTraceControl.dll" target="lib\native\amd64\KernelTraceControl.dll" />
+    <file src="$OutDir$netstandard2.0\amd64\msdia140.dll" target="lib\native\amd64\msdia140.dll" />
 
-    <file src="$OutDir$netstandard1.6\x86\KernelTraceControl.dll" target="lib\native\x86\KernelTraceControl.dll" />
-    <file src="$OutDir$netstandard1.6\x86\KernelTraceControl.Win61.dll" target="lib\native\x86\KernelTraceControl.Win61.dll" />
-    <file src="$OutDir$netstandard1.6\x86\msdia140.dll" target="lib\native\x86\msdia140.dll" />
+    <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.dll" target="lib\native\x86\KernelTraceControl.dll" />
+    <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.Win61.dll" target="lib\native\x86\KernelTraceControl.Win61.dll" />
+    <file src="$OutDir$netstandard2.0\x86\msdia140.dll" target="lib\native\x86\msdia140.dll" />
+
+    <!-- NetStandard 2.0 Framework -->
+	
+    <!-- Built libraries -->
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\netstandard2.0" />
+
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.xml" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\netstandard2.0" />
+
+    <!-- Support Dlls -->
+    <file src="$OutDir$netstandard2.0\Dia2Lib.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\TraceReloggerLib.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$netstandard2.0\OSExtensions.dll" target="lib\netstandard2.0" />
 
     <!-- NetStandard 1.6 Framework -->
 	

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk"> 
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -40,33 +40,27 @@
     Unconditional use of PackageReference would work if we targeted net46, but the reference APIs do not include
     support for net45 targets. Work around the issue by using conditional references.
   -->
-  <Choose>
-    <When Condition="'$(TargetFramework)' == 'netstandard1.6'">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
-        <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-        <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-        <PackageReference Include="System.Runtime" Version="4.3.0" />
-        <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-        <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-        <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-        <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-        <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-        <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-        <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-        <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-        <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-      </ItemGroup>
-    </When>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
+    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
 
-    <When Condition="'$(TargetFramework)' == 'net45'">
-      <ItemGroup>
-        <Reference Include="System.IO.Compression" />
-        <Reference Include="System.Net.Http" />
-        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-      </ItemGroup>
-    </When>
-  </Choose>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
@@ -127,22 +121,25 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
+  </ItemGroup>
 
     <!-- *********************************************************** -->
     <!-- Copying thee managed binaries explicitly should not be needed because the 
          dependency logic should just do it for us, but for some reason ths only
-         works for the net45 target framework and not the netstandard1.6.  We 
-         work around it here by copying the files explicitly. -->
+         works for the net45 target framework and not the netstandard1.6.  and netstanard2.0 
+         We work around it here by copying the files explicitly. 
+	 We don't have version for 2.0 so we use the 1.6 versions.  -->
 
-    <None Include="$(TraceEventSupportFilesBase)$(TargetFramework)\Dia2Lib.dll">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6'">
+    <None Include="$(TraceEventSupportFilesBase)\netstandard1.6\Dia2Lib.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Include="$(TraceEventSupportFilesBase)$(TargetFramework)\OSExtensions.dll">
+    <None Include="$(TraceEventSupportFilesBase)netstandard1.6\OSExtensions.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Include="$(TraceEventSupportFilesBase)$(TargetFramework)\TraceReloggerLib.dll">
+    <None Include="$(TraceEventSupportFilesBase)netstandard1.6\TraceReloggerLib.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
Previously this was a Netstandard 1.6 build and it had some features turned off.