### PR TITLE
Small PerfView improvements

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -35,6 +35,9 @@ namespace PerfView
         // [System.Diagnostics.DebuggerNonUserCodeAttribute()]
         public static int Main(string[] args)
         {
+            string s = DateTime.Now.ToString("MM-dd-yy-HH:mm:ss");
+            Trace.Write(s);
+
             CommandProcessor = new CommandProcessor();
 
             StreamWriter writerToCleanup = null;   // If we create a log file, we need to clean it up.  

--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -35,9 +35,6 @@ namespace PerfView
         // [System.Diagnostics.DebuggerNonUserCodeAttribute()]
         public static int Main(string[] args)
         {
-            string s = DateTime.Now.ToString("MM-dd-yy-HH:mm:ss");
-            Trace.Write(s);
-
             CommandProcessor = new CommandProcessor();
 
             StreamWriter writerToCleanup = null;   // If we create a log file, we need to clean it up.  

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -133,6 +133,7 @@ namespace PerfView
 
         // Stop options.  
         public bool NoRundown;
+       public bool NoNGenPdbs;
         public bool NoNGenRundown;
         public bool NoClrRundown;
         public bool NoV2Rundown;
@@ -320,7 +321,8 @@ namespace PerfView
                 "This also enables threadTime as well as user mode providers WPR would normally collect by default.   This option can also be used " + 
                 "On the unzip command.   See 'Working with WPA' in the help for more.");
             parser.DefineOptionalQualifier("LowPriority", ref LowPriority, "Do merging and ZIPing at low priority to minimize impact to system.");
-            parser.DefineOptionalQualifier("NoRundown", ref NoRundown, "Don't request CLR Rundown events.");
+            parser.DefineOptionalQualifier("NoRundown", ref NoRundown, "Don't collect rundown events.  Use only if you know the process of interest has exited.");
+            parser.DefineOptionalQualifier("NoNGenPdbs", ref NoNGenPdbs, "Don't generate NGEN Pdbs");
             parser.DefineOptionalQualifier("NoNGenRundown", ref NoNGenRundown,
                 "Don't do rundown of symbolic information in NGEN images (only needed pre V4.5).");
             parser.DefineOptionalQualifier("NoClrRundown", ref NoClrRundown,

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -649,7 +649,7 @@ namespace PerfView
             var cpuCounters = TraceEventProfileSources.GetInfo();
             foreach (var cpuCounter in cpuCounters.Values)
             {
-                var defaultCount = Math.Max(100000, cpuCounter.MinInterval);
+                var defaultCount = Math.Max(1000000, cpuCounter.MinInterval);
                 if (cpuCounter.Name == "Timer")
                     defaultCount = 10000;
                 var cpuCounterSpec = cpuCounter.Name + ":" + defaultCount.ToString();

--- a/src/PerfView/EtwEventSource.cs
+++ b/src/PerfView/EtwEventSource.cs
@@ -417,6 +417,7 @@ namespace PerfView
             columnsForSelectedEvents["ActivityInfo"] = "ActivityInfo";
             columnsForSelectedEvents["StartStopActivity"] = "StartStopActivity";
             columnsForSelectedEvents["ThreadID"] = "ThreadID";
+            columnsForSelectedEvents["ProcessorNumber"] = "ProcessorNumber";
             columnsForSelectedEvents["ActivityID"] = "ActivityID";
             columnsForSelectedEvents["RelatedActivityID"] = "RelatedActivityID";
             columnsForSelectedEvents["HasStack"] = "HasStack";
@@ -482,6 +483,7 @@ namespace PerfView
                     AddField("HasBlockingStack", (asCSwitch.BlockingStack() != CallStackIndex.Invalid).ToString(), columnOrder, restString);
 
                 AddField("ThreadID", data.ThreadID.ToString("n0"), columnOrder, restString);
+                AddField("ProcessorNumber", data.ProcessorNumber.ToString(), columnOrder, restString);
 
                if (0 < durationMSec)
                     AddField("DURATION_MSEC", durationMSec.ToString("n3"), columnOrder, restString);

--- a/src/PerfView/PerfViewLogger.cs
+++ b/src/PerfView/PerfViewLogger.cs
@@ -70,7 +70,7 @@ class PerfViewLogger : System.Diagnostics.Tracing.EventSource
         StartAndStopTimes(startTimeRelativeMSec, stopTimeRelativeMSec);
     }
     [Event(17)]
-    public void CpuCountersConfigured(string profileSourceName, int profileSourceCount) { WriteEvent(17, profileSourceName, profileSourceCount); }
+   public void CpuCountersConfigured(string profileSourceName, int profileSourceCount, int profileSourceID) { WriteEvent(17, profileSourceName, profileSourceCount, profileSourceID); }
     /// <summary>
     /// Logged at consistent intervals so we can see where circular buffering starts.  
     /// </summary>

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -2492,6 +2492,8 @@ namespace Microsoft.Diagnostics.Tracing
                     continue;
                 if (eventName == "GCSampledObjectAllocation")       // One event has two templates. 
                     continue;
+                if (eventName == "PerfInfoISR")                     // One event has two templates.  
+                    continue;
 
                 // The IIs parser uses Cap _ instead of PascalCase, normalize
                 if (GetType().Name == "IisTraceEventParser")
@@ -2514,6 +2516,8 @@ namespace Microsoft.Diagnostics.Tracing
                 if (eventName == "MemoryPageAccess" || eventName == "MemoryProcessMemInfo")  // One event has two templates.  
                     return;
                 if (eventName == "GCSampledObjectAllocation")       // One event has two templates. 
+                    return;
+                if (eventName == "PerfInfoISR")                     // One event has two templates. 
                     return;
                 if (eventName == "FileIO")
                     eventName = "FileIOName";       // They use opcode 0 which gets truncated.  

--- a/src/TraceEvent/ZippedETL.cs
+++ b/src/TraceEvent/ZippedETL.cs
@@ -128,21 +128,21 @@ namespace Microsoft.Diagnostics.Tracing
                         Log.WriteLine("ZIP output file {0}", ZipArchivePath);
                         Log.WriteLine("Time: {0}", DateTime.Now);
                         Log.Flush();
+                    }
 
-                        if (m_additionalFiles != null)
+                    if (m_additionalFiles != null)
+                    {
+                        foreach (Tuple<string, string> additionalFile in m_additionalFiles)
                         {
-                            foreach (Tuple<string, string> additionalFile in m_additionalFiles)
+                            // We dont use CreatEntryFromFile because it will not open files thar are open for writting.  
+                            // Since a typical use of this is to write the log file, which will be open for writing, we 
+                            // use File.Open and allow this case explicitly. 
+                            using (Stream fs = File.Open(additionalFile.Item1, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                             {
-                                // We dont use CreatEntryFromFile because it will not open files thar are open for writting.  
-                                // Since a typical use of this is to write the log file, which will be open for writing, we 
-                                // use File.Open and allow this case explicitly. 
-                                using (Stream fs = File.Open(additionalFile.Item1, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                                {
-                                    // Item2 tells you the path in the archive.  
-                                    var entry = zipArchive.CreateEntry(additionalFile.Item2, compressionLevel);
-                                    using (Stream es = entry.Open())
-                                        fs.CopyTo(es);
-                                }
+                                // Item2 tells you the path in the archive.  
+                                var entry = zipArchive.CreateEntry(additionalFile.Item2, compressionLevel);
+                                using (Stream es = entry.Open())
+                                    fs.CopyTo(es);
                             }
                         }
                     }


### PR DESCRIPTION

* Added NoNGenPdbs (useful for .NET Core scenarios which don't need them)
* Fixed issues with logging the CPU Counter IDs, (eg Cache Misses ...) (needs more work but this is a start).
* Allowed ProcessorNumber to be viewed on any event.
* Decoded another variation of the kernel interrupt Service routine event (which is used on newer OSes).
* Fixed bug where collection log is not put in the ZIP if there are no symbol files (like when you use NoNGenPdbs)