### PR TITLE
Fix for DLL not found on Desktop for TraceEvent when collecting

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -27,11 +27,8 @@
       <Visible>False</Visible>
     </None>
 
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll">
-      <Link>OSExtensions.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
+    <!-- There are no static references to these so I need to copy them explicitly.  
+         These are both COM interop assemblies so they are the same for all targets, I pick netstandard1.6 pretty arbitraily -->
     <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll">
       <Link>TraceReloggerLib.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Problem reported by Ben Teitler if you use the library to collect data on the Desktop runtime.  