### PR TITLE
Bypass getting assembly map on targeting .NetStandard 2.0

### DIFF
--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -964,8 +964,8 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
             // TODO: Verify if Dia can be loaded when TraceEvent targets .NET Standard 2.0.
             if (m_mergedAssemblies == null && !m_checkedForMergedAssemblies)
             {
-#if NETSTANDARD1_6
-                _log.WriteLine($"WARNING: {nameof(GetMergedAssembliesMap)} is not supported in .NETStandard 1.6.");
+#if NETSTANDARD1_6 || NETSTANDARD2_0
+                _log.WriteLine($"WARNING: {nameof(GetMergedAssembliesMap)} is not supported in .NETStandard.");
 #else
                 IDiaEnumInputAssemblyFiles diaMergedAssemblyRecords;
                 m_session.findInputAssemblyFiles(out diaMergedAssemblyRecords);


### PR DESCRIPTION
Unfortunately, loading DIA is failing when targeting .NET Standard 2.0. Just the same as targeting .NET Standard 1.6. Bypass it to avoid exceptions that break the proper symbol resolving for other cases.