### PR TITLE
ContinueOnError, minor fixes

### DIFF
--- a/Nuget.config
+++ b/Nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Local" value=".\src\NugetSupportFiles" />
   </packageSources>
 </configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.10</PerfViewVersion>
-    <TraceEventVersion>2.0.10</TraceEventVersion>
+    <PerfViewVersion>2.0.11</PerfViewVersion>
+    <TraceEventVersion>2.0.11</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -181,6 +181,7 @@ namespace PerfView
         public float CpuSampleMSec = 1.0F;
         public bool KeepAllEvents;
         public int MaxEventCount;
+        public bool ContinueOnError;
         public double SkipMSec;
         public bool ForceNgenRundown;
         public bool DumpHeap;
@@ -337,6 +338,7 @@ namespace PerfView
                 "Useful for trimming large ETL files. 1M typically yields 300-400 Meg of data considered.");
             parser.DefineOptionalQualifier("SkipMSec", ref SkipMSec, "Skips the first N MSec of the trace.  " +
                 "Useful for trimming large ETL files in conjunction with the /MaxEventCount qualifier.");
+            parser.DefineOptionalQualifier("ContinueOnError", ref ContinueOnError, "Processes bad traces as best it can.");
 
             parser.DefineOptionalQualifier("CpuCounters", ref CpuCounters,
                 "A comma separated list of hardware CPU counters specifications NAME:COUNT to turn on.  " +

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2378,6 +2378,8 @@ namespace PerfView
                 cmdLineArgs += " /UnsafePdbMatch";
             if (parsedArgs.ShowUnknownAddresses)
                 cmdLineArgs += " /ShowUnknownAddresses";
+            if (parsedArgs.ContinueOnError)
+                cmdLineArgs += " /ContinueOnError";
             if (parsedArgs.MaxEventCount != 0)
                 cmdLineArgs += " /MaxEventCount:" + parsedArgs.MaxEventCount.ToString();
             if (parsedArgs.SkipMSec != 0)

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -494,6 +494,7 @@ namespace PerfViewExtensibility
                         if (App.CommandLineArgs.KeepAllEvents)
                             options.KeepAllEvents = true;
                         options.MaxEventCount = App.CommandLineArgs.MaxEventCount;
+                        options.ContinueOnError = App.CommandLineArgs.ContinueOnError;
                         options.SkipMSec = App.CommandLineArgs.SkipMSec;
                         options.OnLostEvents = onLostEvents;
                         options.LocalSymbolsOnly = false;

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4687,8 +4687,10 @@ table {
                                             var callStackIdx = asCSwitch.BlockingStack();
                                             if (callStackIdx != CallStackIndex.Invalid)
                                             {
+                                                StackSourceCallStackIndex blockingStackIndex = stackSource.GetCallStack(callStackIdx, data);
                                                 // Make an entry for the blocking stacks as well.  
-                                                sample.StackIndex = stackSource.Interner.CallStackIntern(blockingFrame, stackSource.GetCallStack(callStackIdx, data));
+                                                blockingStackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern("EventData OldThreadState " + asCSwitch.OldThreadState), blockingStackIndex);
+                                                sample.StackIndex = stackSource.Interner.CallStackIntern(blockingFrame, blockingStackIndex);
                                                 sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
                                                 sample.Metric = 1;
                                                 stackSource.AddSample(sample);
@@ -4699,8 +4701,10 @@ table {
                                         {
                                             stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern("EventData NewProcessName " + asCSwitch.NewProcessName), stackIndex);
                                             stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern("EventData OldProcessName " + asCSwitch.OldProcessName), stackIndex);
+
                                             stackIndex = stackSource.Interner.CallStackIntern(cswitchEventFrame, stackIndex);
                                         }
+
                                         goto ADD_SAMPLE;
                                     }
 
@@ -6385,6 +6389,7 @@ table {
             if (App.CommandLineArgs.KeepAllEvents)
                 options.KeepAllEvents = true;
             options.MaxEventCount = App.CommandLineArgs.MaxEventCount;
+            options.ContinueOnError = App.CommandLineArgs.ContinueOnError;
             options.SkipMSec = App.CommandLineArgs.SkipMSec;
             options.OnLostEvents = onLostEvents;
             options.LocalSymbolsOnly = false;
@@ -7438,6 +7443,7 @@ table {
             if (App.CommandLineArgs.KeepAllEvents)
                 options.KeepAllEvents = true;
             options.MaxEventCount = App.CommandLineArgs.MaxEventCount;
+            options.ContinueOnError = App.CommandLineArgs.ContinueOnError;
             options.SkipMSec = App.CommandLineArgs.SkipMSec;
             //options.OnLostEvents = onLostEvents;
             options.LocalSymbolsOnly = false;
@@ -7664,6 +7670,7 @@ table {
             if (App.CommandLineArgs.KeepAllEvents)
                 options.KeepAllEvents = true;
             options.MaxEventCount = App.CommandLineArgs.MaxEventCount;
+            options.ContinueOnError = App.CommandLineArgs.ContinueOnError;
             options.SkipMSec = App.CommandLineArgs.SkipMSec;
             //options.OnLostEvents = onLostEvents;
             options.LocalSymbolsOnly = false;

--- a/src/PerfView/UserCommands.cs
+++ b/src/PerfView/UserCommands.cs
@@ -51,6 +51,7 @@ namespace PerfViewExtensibility
             if (App.CommandLineArgs.KeepAllEvents)
                 options.KeepAllEvents = true;
             options.MaxEventCount = App.CommandLineArgs.MaxEventCount;
+            options.ContinueOnError = App.CommandLineArgs.ContinueOnError;
             options.SkipMSec = App.CommandLineArgs.SkipMSec;
             options.LocalSymbolsOnly = false;
             options.ShouldResolveSymbols = delegate (string moduleFilePath) { return false; };       // Don't resolve any symbols
@@ -83,6 +84,7 @@ namespace PerfViewExtensibility
             if (App.CommandLineArgs.KeepAllEvents)
                 options.KeepAllEvents = true;
             options.MaxEventCount = App.CommandLineArgs.MaxEventCount;
+            options.ContinueOnError = App.CommandLineArgs.ContinueOnError;
             options.SkipMSec = App.CommandLineArgs.SkipMSec;
             options.LocalSymbolsOnly = false;
             options.ShouldResolveSymbols = delegate (string moduleFilePath) { return false; };       // Don't resolve any symbols

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -958,19 +958,16 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
         /// <summary>
         /// For Project N modules it returns the list of pre merged IL assemblies and the corresponding mapping.
         /// </summary>
-        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public Dictionary<int, string> GetMergedAssembliesMap()
         {
-            // TODO: Verify if Dia can be loaded when TraceEvent targets .NET Standard 2.0.
             if (m_mergedAssemblies == null && !m_checkedForMergedAssemblies)
             {
-#if NETSTANDARD1_6
-                _log.WriteLine($"WARNING: {nameof(GetMergedAssembliesMap)} is not supported in .NETStandard 1.6.");
-#else
                 IDiaEnumInputAssemblyFiles diaMergedAssemblyRecords;
                 m_session.findInputAssemblyFiles(out diaMergedAssemblyRecords);
-                foreach (IDiaInputAssemblyFile inputAssembly in diaMergedAssemblyRecords)
+                int count = diaMergedAssemblyRecords.count;
+                for (uint i = 0; i < count; i++)
                 {
+                    IDiaInputAssemblyFile inputAssembly = diaMergedAssemblyRecords.Item(i);
                     int index = (int)inputAssembly.index;
                     string assemblyName = inputAssembly.fileName;
 
@@ -978,7 +975,6 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
                         m_mergedAssemblies = new Dictionary<int, string>();
                     m_mergedAssemblies.Add(index, assemblyName);
                 }
-#endif
                 m_checkedForMergedAssemblies = true;
             }
             return m_mergedAssemblies;

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -964,10 +964,14 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
             {
                 IDiaEnumInputAssemblyFiles diaMergedAssemblyRecords;
                 m_session.findInputAssemblyFiles(out diaMergedAssemblyRecords);
-                int count = diaMergedAssemblyRecords.count;
-                for (uint i = 0; i < count; i++)
+                for (; ;)
                 {
-                    IDiaInputAssemblyFile inputAssembly = diaMergedAssemblyRecords.Item(i);
+                    IDiaInputAssemblyFile inputAssembly;
+                    uint fetchCount;
+                    diaMergedAssemblyRecords.Next(1, out inputAssembly, out fetchCount);
+                    if (fetchCount != 1)
+                        break;
+
                     int index = (int)inputAssembly.index;
                     string assemblyName = inputAssembly.fileName;
 


### PR DESCRIPTION
1. Added a ContinOneError option when creating an ETLX file.  Basically if there is an error reading the input it simply stops converting and makes an ETLX file out of what it has.  This is useful when there corruption, but it is not at the start.  This not the default.   PerfView uses it when the /ContinueOnError option is given.

2. Fixed issue with msdia140 not working on .NET Core properly (we were using foreach which drags in conversion routines not supported on .NET Core.

3.  Added an explict reference to nuget.org when looking up packages.  We have had people trying to build PerfView in environments that don't have this reference (they have a clone).

4.  Added a 'ThreadState' entry ot the 'Blocked CSwitch' stack in the 'AnyStacks view'.  This is useful.