### PR TITLE
Fix PerfViewCollect Breaks

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -162,6 +162,7 @@ namespace PerfView
                 CommandLineArgs.DataFile.IndexOf('.') < 0 && CommandLineArgs.DataFile.IndexOf('\\') < 0)
                 throw new ApplicationException("Error " + CommandLineArgs.DataFile + " not a perfView command.");
 
+#if !PERFVIEW_COLLECT
             // Check for error where you have a TraceEvent dll in the wrong place.
             var traceEventDllPath = typeof(TraceEvent).Assembly.ManifestModule.FullyQualifiedName;
             if (!traceEventDllPath.StartsWith(SupportFiles.SupportFileDir, StringComparison.OrdinalIgnoreCase))
@@ -175,6 +176,7 @@ namespace PerfView
                             "   You cannot place a version of Microsoft.Diagnostics.Tracing.TraceEvent.dll next to PerfView.exe.");
                 }
             }
+#endif
 
             // The 64 bit version of some of the native DLLs we use are built against the new Win10 libraries and will 
             // fail to bind if they are loaded on an older OS (it would probably work for Win8 but do we care?) 
@@ -217,7 +219,7 @@ namespace PerfView
                         CommandProcessor.LogFile.WriteLine("Trying to view {0}", CommandLineArgs.DataFile);
                     else
                         CommandProcessor.LogFile.WriteLine("No command given, Trying to open viewer.");
-#endif 
+#endif
                     CommandProcessor.LogFile.WriteLine("Use 'PerfView collect' or 'PerfView HeapSnapshot' to collect data.");
                     return -4;
                 }
@@ -750,7 +752,7 @@ namespace PerfView
             return ret;
         }
 
-        #region private
+#region private
         /// <summary>
         /// This routine gets called every time we find a PDB.  We copy any PDBs to 'localPdbDir' if it is not
         /// already there.  That way every PDB that is needed is locally available, which is a nice feature.  
@@ -898,7 +900,7 @@ namespace PerfView
         private static string m_SymbolPath;
         private static string m_SourcePath;
 
-        #region CreateConsole
+#region CreateConsole
         [System.Runtime.InteropServices.DllImport("kernel32", SetLastError = true)]
         static extern int AllocConsole();
         [System.Runtime.InteropServices.DllImport("kernel32", SetLastError = true)]
@@ -982,7 +984,7 @@ namespace PerfView
             });
 
             return true;
-#endif 
+#endif
         }
 
 #if !DOTNET_CORE

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeFrameworkVersion>2.0.5</RuntimeFrameworkVersion>
     <RootNamespace>PerfView</RootNamespace>
   </PropertyGroup>
 

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>2.0.5</RuntimeFrameworkVersion>
     <RootNamespace>PerfView</RootNamespace>
   </PropertyGroup>
 
@@ -45,28 +46,29 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
   </ItemGroup>
 
+  <!-- Ensure that the native components of TraceEvent are restored into the target and publish directories so that TraceEvent can pinvoke into them. -->
+  <Target Name="CopyTraceEventNativeFilesToTarget" AfterTargets="Build">
+    <ItemGroup>
+      <TraceEventNativeFiles
+        Include="$(TraceEventSupportFilesBase)native\**\*.*" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(TraceEventNativeFiles)"
+      DestinationFiles="@(TraceEventNativeFiles->'$(TargetDir)%(RecursiveDir)%(FileName)%(Extension)')"
+      SkipUnchangedFiles="true" />
+  </Target>
+  <Target Name="CopyTraceEventNativeFilesToPublish" AfterTargets="Publish">
+    <ItemGroup>
+      <TraceEventNativeFiles
+        Include="$(TraceEventSupportFilesBase)native\**\*.*" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(TraceEventNativeFiles)"
+      DestinationFiles="@(TraceEventNativeFiles->'$(PublishDir)%(RecursiveDir)%(FileName)%(Extension)')"
+      SkipUnchangedFiles="true" />
+  </Target>
+
   <ItemGroup>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\x86\KernelTraceControl.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\x86\KernelTraceControl.dll</LogicalName>
-      <Link>x86\KernelTraceControl.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\arm\KernelTraceControl.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\arm\KernelTraceControl.dll</LogicalName>
-      <Link>arm\KernelTraceControl.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\KernelTraceControl.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\amd64\KernelTraceControl.dll</LogicalName>
-      <Link>amd64\KernelTraceControl.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
 
 <!-- TODO: These are needed for Heap dump and fine grained .NET allocation and call profiling but 
      I have pruned these out for now so we can at least get ETW working.   Bring them back eventually.
@@ -107,29 +109,6 @@
       <Visible>False</Visible>
     </EmbeddedResource>
 -->
-
-    <EmbeddedResource Include="..\TraceEvent\bin\$(ConfigurationName)\netstandard1.6\Microsoft.Diagnostics.Tracing.TraceEvent.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\Microsoft.Diagnostics.Tracing.TraceEvent.dll</LogicalName>
-      <Link>Microsoft.Diagnostics.Tracing.TraceEvent.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\FastSerialization\bin\$(ConfigurationName)\netstandard1.3\Microsoft.Diagnostics.FastSerialization.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\Microsoft.Diagnostics.FastSerialization.dll</LogicalName>
-      <Link>Microsoft.Diagnostics.FastSerialization.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)\netstandard1.6\OSExtensions.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\OSExtensions.dll</LogicalName>
-      <Link>OSExtensions.dll</Link>
-      <Visible>False</Visible>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
 
     <EmbeddedResource Include="..\PerfView\SupportFiles\Eula.rtf">
       <Type>Non-Resx</Type>


### PR DESCRIPTION
There are a couple of issues that showed up when I tried to capture data on an ARM32 device running Win10:

 - Self-contained publishes of PerfViewCollect fail to start because they seem to select an old version of .NET Core 2.0 that is missing a type needed by PerfViewCollect (ByReference<T>).  This is solved by requiring .NET Core 2.0.5.  This is what my machine was using by default when running against the shared framework.
 - SupportFiles were being unpacked but were not being used for DLL loading.  This is because the loader found TraceEvent and its dependencies next to the app, which is what one would expect for a .NET Core build.  Furthermore, because the files have a different timestamp when they are unpacked, this results in an exception because PerfView tries to make sure that SupportFiles version is used or that it at least matches the version that was used (see https://github.com/Microsoft/perfview/blob/68a35e78d2cd6f6d681727792b419c2f497fe0ad/src/PerfView/App.cs#L166).  I've solved this by (a) not embedding the DLLs into PerfViewCollect.dll and (b) disabling the TraceEvent check for PerfViewCollect.  While it is certainly nice to have everything self-contained in a single EXE, .NET Core doesn't really allow for this, and as such I'm assuming that we'll follow the self-contained semantics for PerfViewCollect.

NOTE: I have left in-place the unpacking of the EULA and users guides so that they can still be used from PerfViewCollect if possible.