### PR TITLE
Add DLR support for TraceEvent dynamic properties

### DIFF
--- a/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
@@ -163,7 +163,9 @@ namespace TraceEventTests
 
                     Assert.False(activityIdHasBeenSet); // make sure the event comes only once
 
-                    if (@event.PayloadByName("NewId").Equals(ExpectedActivityId))
+                    // Sneak in a test of the DLR support here (casting to 'dynamic'
+                    // instead of using PayloadByName("NewId")):
+                    if (((dynamic) @event).NewId.Equals(ExpectedActivityId))
                         activityIdHasBeenSet = true;
                 };
 

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -46,6 +46,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 


### PR DESCRIPTION
The Dynamic Language Runtime approach won't be as efficient as the
TraceParserGen approach, but it is convenient for prototyping or
accessing event data from PowerShell.

(see the updates to the documentation for a bit more info)

The DLR is supported in .NET Standard 2.0, but not 1.6, so we #if it out
for 1.6.

Addresses #617.