### PR TITLE
Fix problem with finding PDBs of some DLLs

### DIFF
--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.Diagnostics.Symbols
             {
                 bool ret = contentType.EndsWith("octet-stream");
                 if (!ret)
-                    m_log.WriteLine("FindSymbolFilePath: expecting 'octet-stream' (Binary) data, got {0} (are you redirected to a login page?)", contentType);
+                    m_log.WriteLine("FindSymbolFilePath: expecting 'octet-stream' (Binary) data, got '{0}' (are you redirected to a login page?)", contentType);
                 return ret;
             };
 

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -1190,6 +1190,7 @@ namespace Microsoft.Diagnostics.Tracing
             XmlAttrib(sb, "Version", Version);
             XmlAttribHex(sb, "Keywords", (ulong)Keywords);
             XmlAttrib(sb, "TimeStampQPC", TimeStampQPC);
+            sb.Append(" QPC=\"").Append((1000000.0 / Source.QPCFreq).ToString("f3")).Append("us\"");
             sb.AppendLine().Append(" ");
 
             XmlAttrib(sb, "Level", Level);


### PR DESCRIPTION
A previous checkin broke a unsual case where several DLLs all have the same load timestamp (this can happen for DCSTARTs).   The result is that information
about the PDB signature is not attached to the DLL, and thus we can't look that
PDB up on a symbol server.     fixed this.

Also some minor tweeks (fix a logging message, add the QPC time to an event dump).