### PR TITLE
Fix tests that were passing when they should not 

### DIFF
--- a/src/PerfView.TestUtilities/ThrowingTraceListener.cs
+++ b/src/PerfView.TestUtilities/ThrowingTraceListener.cs
@@ -21,6 +21,7 @@ namespace PerfView.TestUtilities
     {
         public override void Fail(string message, string detailMessage)
         {
+            Xunit.Assert.True(false, message + Environment.NewLine + detailMessage);
             throw new DebugAssertFailureException(message + Environment.NewLine + detailMessage);
         }
 

--- a/src/TraceEvent/TraceEvent.Tests/EtlTestBase.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EtlTestBase.cs
@@ -61,15 +61,32 @@ namespace TraceEventTests
             s_fileUnzipped = true;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         protected void PrepareTestData()
         {
+            Assert.True(Directory.Exists(TestDataDir));
+            TestDataDir = Path.GetFullPath(TestDataDir);
+            Assert.True(Directory.Exists(OriginalBaselineDir));
+            OriginalBaselineDir = Path.GetFullPath(OriginalBaselineDir);
+
+            // This is all atomic because this method is synchronized.  
             Assert.True(Directory.Exists(TestDataDir));
             UnzipDataFiles();
             if (Directory.Exists(OutputDir))
                 Directory.Delete(OutputDir, true);
-
             Directory.CreateDirectory(OutputDir);
-            Output.WriteLine(string.Format("OutputDir: {0}", Path.GetFullPath(OutputDir)));
+            Output.WriteLine(string.Format("OutputDir: {0}", OutputDir));
+            Assert.True(Path.GetFullPath(OutputDir) == OutputDir);
+
+            Directory.CreateDirectory(NewBaselineDir);
+            NewBaselineDir = Path.GetFullPath(NewBaselineDir);
+            Output.WriteLine(string.Format("NewBaselineDir: {0}", NewBaselineDir));
+
+            Assert.True(Directory.Exists(UnZippedDataDir));
+            UnZippedDataDir = Path.GetFullPath(UnZippedDataDir);
+            Assert.True(Directory.Exists(BaseOutputDir));
+            BaseOutputDir = Path.GetFullPath(BaseOutputDir);
+            Assert.True(Directory.Exists(NewBaselineDir));
         }
     }
 }

--- a/src/TraceEvent/TraceEvent.Tests/EventPipeTestBase.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EventPipeTestBase.cs
@@ -31,7 +31,11 @@ namespace TraceEventTests
         protected void PrepareTestData()
         {
             Assert.True(Directory.Exists(TestDataDir));
+            TestDataDir = Path.GetFullPath(TestDataDir);
+            Assert.True(Directory.Exists(OriginalBaselineDir));
+            OriginalBaselineDir = Path.GetFullPath(OriginalBaselineDir);
 
+            // This is atomic because this method is synchronized.  
             if (!s_fileUnzipped)
             {
                 Directory.CreateDirectory(UnZippedDataDir);
@@ -54,9 +58,19 @@ namespace TraceEventTests
 
             if (Directory.Exists(OutputDir))
                 Directory.Delete(OutputDir, true);
-
             Directory.CreateDirectory(OutputDir);
             Output.WriteLine(string.Format("OutputDir: {0}", Path.GetFullPath(OutputDir)));
+            Assert.True(Directory.Exists(OutputDir));
+
+            Directory.CreateDirectory(NewBaselineDir);
+            NewBaselineDir = Path.GetFullPath(NewBaselineDir);
+            Output.WriteLine(string.Format("NewBaselineDir: {0}", NewBaselineDir));
+
+            Assert.True(Directory.Exists(UnZippedDataDir));
+            UnZippedDataDir = Path.GetFullPath(UnZippedDataDir);
+            Assert.True(Directory.Exists(BaseOutputDir));
+            BaseOutputDir = Path.GetFullPath(BaseOutputDir);
+            Assert.True(Directory.Exists(NewBaselineDir));
         }
     }
 }

--- a/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/GeneralParsing.cs
@@ -11,8 +11,6 @@ namespace TraceEventTests
 {
     public class GeneralParsing : EtlTestBase
     {
-        static string NewBaselineDir = @".\newBaseLines";
-
         public GeneralParsing(ITestOutputHelper output)
             : base(output)
         {
@@ -32,12 +30,13 @@ namespace TraceEventTests
 
             string etlFilePath = Path.Combine(UnZippedDataDir, etlFileName);
             bool anyFailure = false;
-            Output.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", Path.GetFullPath(etlFilePath)));
+            Output.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", etlFilePath));
             string eltxFilePath = Path.ChangeExtension(etlFilePath, ".etlx");
 
             // See if we have a cooresponding baseline file 
-            string baselineName = Path.Combine(Path.GetFullPath(TestDataDir),
+            string baselineName = Path.Combine(TestDataDir,
                 Path.GetFileNameWithoutExtension(etlFilePath) + ".baseline.txt");
+
             string newBaselineName = Path.Combine(NewBaselineDir,
                 Path.GetFileNameWithoutExtension(etlFilePath) + ".baseline.txt");
             string outputName = Path.Combine(OutputDir,
@@ -50,13 +49,11 @@ namespace TraceEventTests
             else
             {
                 Output.WriteLine("WARNING: No baseline file");
-                Output.WriteLine(string.Format("    ETL FILE: {0}", Path.GetFullPath(etlFilePath)));
+                Output.WriteLine(string.Format("    ETL FILE: {0}", etlFilePath));
                 Output.WriteLine(string.Format("    NonExistant Baseline File: {0}", baselineName));
                 Output.WriteLine("To Create a baseline file");
-                Output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"",
-                    Path.GetFullPath(newBaselineName),
-                    Path.GetFullPath(baselineName)
-                    ));
+                Output.WriteLine(string.Format("    copy /y \"{0}\" \"{1}\"", newBaselineName, baselineName));
+                anyFailure = true;
             }
 
             bool unexpectedUnknownEvent = false;
@@ -135,10 +132,7 @@ namespace TraceEventTests
                         Output.WriteLine(string.Format("   Actual  : {0}", parsedEvent));
 
                         Output.WriteLine("To Compare output and baseline (baseline is SECOND)");
-                        Output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
-                            Path.GetFullPath(newBaselineName),
-                            Path.GetFullPath(baselineName)
-                            ));
+                        Output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"", newBaselineName, baselineName));
                     }
                 }
 
@@ -187,30 +181,22 @@ namespace TraceEventTests
                 if (!histogramMismatch && expectedistogramLine != histogramLine)
                 {
                     histogramMismatch = true;
+                    anyFailure = true;
                     Output.WriteLine(string.Format("ERROR: File {0}: histogram not equal on  {1}", etlFilePath, lineNum));
                     Output.WriteLine(string.Format("   Expected: {0}", expectedistogramLine));
                     Output.WriteLine(string.Format("   Actual  : {0}", histogramLine));
 
                     Output.WriteLine("To Compare output and baseline (baseline is SECOND)");
-                    Output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"",
-                        Path.GetFullPath(newBaselineName),
-                        Path.GetFullPath(baselineName)
-                        ));
-                    anyFailure = true;
+                    Output.WriteLine(string.Format("    windiff \"{0}\" \"{1}\"", newBaselineName, baselineName));
                 }
             }
 
             outputFile.Close();
-            if (mismatchCount > 0)
+            if (anyFailure)
             {
-                Output.WriteLine(string.Format("ERROR: File {0}: had {1} mismatches", etlFilePath, mismatchCount));
-
-                if (!Directory.Exists(NewBaselineDir))
-                    Directory.CreateDirectory(NewBaselineDir);
+                Output.WriteLine(string.Format("ERROR: File {0}: had a failure {1} mismatches. histogram mismatches: {2}", etlFilePath, mismatchCount, histogramMismatch));
                 File.Copy(outputName, newBaselineName, true);
-
-                Output.WriteLine(string.Format("To Update: xcopy /s \"{0}\" \"{1}\"", 
-                    Path.GetFullPath(NewBaselineDir), OriginalBaselineDir));
+                Output.WriteLine(string.Format("To Update: xcopy /s \"{0}\" \"{1}\"", NewBaselineDir, OriginalBaselineDir));
             }
 
             // If this fires, check the output for the TraceLine just before it for more details.  

--- a/src/TraceEvent/TraceEvent.Tests/TestBase.cs
+++ b/src/TraceEvent/TraceEvent.Tests/TestBase.cs
@@ -6,15 +6,18 @@ namespace TraceEventTests
 {
     public abstract class TestBase
     {
-        protected static readonly string OriginalBaselineDir = FindInputDir();
-        protected static readonly string TestDataDir = @".\inputs";
-        protected static readonly string UnZippedDataDir = @".\unzipped";
-        protected static readonly string BaseOutputDir = @".\output";
+        // All of these are normalized to full paths. in PrepareTestData.
+        // It also cleans out the output directory and unzips the input data
+        protected static string OriginalBaselineDir = FindInputDir();
+        protected static string TestDataDir = @".\inputs";
+        protected static string UnZippedDataDir = @".\unzipped";
+        protected static string BaseOutputDir = @".\output";
+        protected static string NewBaselineDir = @".\newBaseLines";
 
         protected TestBase(ITestOutputHelper output)
         {
             Output = output;
-            OutputDir = Path.Combine(BaseOutputDir, Guid.NewGuid().ToString("N").Substring(0, 8));
+            OutputDir = Path.Combine(Path.GetFullPath(BaseOutputDir), Guid.NewGuid().ToString("N").Substring(0, 8));
         }
 
         protected ITestOutputHelper Output

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -3046,6 +3046,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 Debug.WriteLine("Error: exception thrown during callback.  Will be swallowed!");
                 Debug.WriteLine("Exception: " + e.Message);
+                Debug.Assert(false, "Thrown exception " + e.GetType().Name +  " '" + e.Message + "'");
             }
 #endif
         }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3680,7 +3680,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         internal TraceLogEventSource realTimeSource;               // used to call back in real time case.  
         private Queue<QueueEntry> realTimeQueue;                   // We have to wait a bit to hook up stacks, so we put real time entries in the queue
-                                                                   // The can ONLY be accessed by the thread calling RealTimeEventSource.Process();
+        
+        // These can ONLY be accessed by the thread calling RealTimeEventSource.Process();
         private Timer realTimeFlushTimer;                          // Insures the queue gets flushed even if there are no incoming events.  
         private Func<TraceEvent, ulong, bool> fnAddAddressToCodeAddressMap; // PERF: Cached delegate to avoid allocations in inner loop
         #endregion
@@ -5915,8 +5916,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 var suffixPos = ilModulePath.LastIndexOf(".", StringComparison.OrdinalIgnoreCase);
                 if (0 < suffixPos)
                 {
-                    nativeModulePath = ilModulePath;                    // We treat the image as the native path
-                                                                        // and make up a dummy IL path.  
+                    // We treat the image as the native path
+                    nativeModulePath = ilModulePath;                    
+                    // and make up a dummy IL path.  
                     ilModulePath = ilModulePath.Substring(0, suffixPos) + ".il" + ilModulePath.Substring(suffixPos);
                 }
             }
@@ -6660,10 +6662,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         // This is only used when converting maps.  Maps a call stack index to a list of call stack indexes that
         // were callees of it.    This is the list you need to search when interning.  There is also 'threads'
         // which is the list of call stack indexes where stack crawling stopped. 
-        private GrowableArray<List<CallStackIndex>> callees;                // For each callstack, these are all the call stacks that it calls. 
-        private GrowableArray<List<CallStackIndex>> threads;                 // callees for threads of stacks, one for each thread
-                                                                             // a field on CallStackInfo
-        private GrowableArray<CallStackInfo> callStacks;
+        private GrowableArray<List<CallStackIndex>> callees;    // For each callstack, these are all the call stacks that it calls. 
+        private GrowableArray<List<CallStackIndex>> threads;    // callees for threads of stacks, one for each thread
+        private GrowableArray<CallStackInfo> callStacks;        // a field on CallStackInfo
         private DeferedRegion lazyCallStacks;
         private TraceCodeAddresses codeAddresses;
         private TraceLog log;
@@ -7231,8 +7232,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 startIdx++;
 
             bool removeAddressAfterCallback = (process.ProcessID != 0);      // We remove entries unless it is the kernel (process 0) after calling back
-                                                                             // since the DLL will be unloaded in that process. Kernel DLLS stay loaded. 
-                                                                             // Call back for ever code address >= start than that, and then remove any code addresses we called back on.  
+
+            // since the DLL will be unloaded in that process. Kernel DLLS stay loaded. 
+            // Call back for ever code address >= start than that, and then remove any code addresses we called back on.  
             Address end = start + (ulong)length;
             int curIdx = startIdx;
             while (curIdx < process.unresolvedCodeAddresses.Count)
@@ -8865,11 +8867,16 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             // AutoComplete codes. 
             /// <summary>
             /// An activity that allows correlation between the antecedent and continuation 
+            /// if have bit 5 set it means you auto-compete
             /// </summary>
-            TaskWait = 32,          // if have bit 5 set it means you auto-compete
-                                    /// <summary>Same as TaskWait, hwoever it auto-completes</summary>
+            TaskWait = 32,
+            /// <summary>
+            /// Same as TaskWait, hwoever it auto-completes
+            /// </summary>
             TaskWaitSynchronous = 64 + 33,
-            /// <summary>Managed timer workitem</summary>
+            /// <summary>
+            /// Managed timer workitem
+            /// </summary>
             FxTimer = 34, // FxTransfer + kind(1)
         }
 

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3414,7 +3414,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     pastEventInfo[curPastEventInfo].EventIndex < eventIndex);
                 pastEventInfo[curPastEventInfo].ThreadID = threadID;
                 pastEventInfo[curPastEventInfo].ProcessorNumber = (ushort)data.ProcessorNumber;
-                Debug.Assert(pastEventInfo[curPastEventInfo].ProcessorNumber == data.ProcessorNumber); do data truncation. 
+                Debug.Assert(pastEventInfo[curPastEventInfo].ProcessorNumber == data.ProcessorNumber);
                 pastEventInfo[curPastEventInfo].QPCTime = data.TimeStampQPC;
                 pastEventInfo[curPastEventInfo].EventIndex = eventIndex;
                 pastEventInfo[curPastEventInfo].CountForEvent = countForEvent;

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1937,6 +1937,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             }
 
             // The eventsToStacks array is sorted.  
+            // We sort this array above, so this should only fail if we have EQUAL EventIndex.
+            // This means we tried to add two stacks to an event  (we should not do that).  
+            // See the asserts in AddStackToEvent for more.  
             for (int i = 0; i < eventsToStacks.Count - 1; i++)
                 Debug.Assert(eventsToStacks[i].EventIndex < eventsToStacks[i + 1].EventIndex);
 #endif
@@ -2060,14 +2063,15 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 #if DEBUG
             double prevEventRelMSec = QPCTimeToRelMSec(eventTimeStampQPC);
 #endif
-            PastEventInfoIndex pastEventIndex = pastEventInfo.GetBestEventForQPC(eventTimeStampQPC, stackEvent.ThreadID);
+            PastEventInfoIndex pastEventIndex = pastEventInfo.GetBestEventForQPC(eventTimeStampQPC, stackEvent.ThreadID, stackEvent.ProcessorNumber);
             if (pastEventIndex == PastEventInfoIndex.Invalid)
             {
                 m_orphanedStacks++;
                 if (m_orphanedStacks < 1000)
                 {
-                    // We don't warn if the time is too close to the start of the file.  
-                    DebugWarn(stackEvent.TimeStampRelativeMSec < 100, "Stack refers to event with time " + QPCTimeToRelMSec(eventTimeStampQPC).ToString("f4") + " MSec that could not be found", stackEvent);
+                    // We don't warn if the time is too close to the start of the file
+                    // We also don't report ThreadID becasue we do throw those out purpposefully to safe space.  
+                    DebugWarn(stackEvent.TimeStampRelativeMSec < 100 || stackEvent.ThreadID == 0, "Stack refers to event with time " + QPCTimeToRelMSec(eventTimeStampQPC).ToString("f4") + " MSec that could not be found", stackEvent);
                     if (m_orphanedStacks == 999)
                         DebugWarn(true, "Last message about missing events.", stackEvent);
                 }
@@ -3409,6 +3413,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 Debug.Assert(pastEventInfo[curPastEventInfo].EventIndex == 0 || pastEventInfo[curPastEventInfo].EventIndex == EventIndex.Invalid ||
                     pastEventInfo[curPastEventInfo].EventIndex < eventIndex);
                 pastEventInfo[curPastEventInfo].ThreadID = threadID;
+                pastEventInfo[curPastEventInfo].ProcessorNumber = (ushort)data.ProcessorNumber;
+                Debug.Assert(pastEventInfo[curPastEventInfo].ProcessorNumber == data.ProcessorNumber); do data truncation. 
                 pastEventInfo[curPastEventInfo].QPCTime = data.TimeStampQPC;
                 pastEventInfo[curPastEventInfo].EventIndex = eventIndex;
                 pastEventInfo[curPastEventInfo].CountForEvent = countForEvent;
@@ -3458,53 +3464,59 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             }
 
             /// <summary>
-            /// Find the event event on thread threadID to the given QPC timestamp
+            /// Find the event event on thread threadID to the given QPC timestamp.  If there is more than
+            /// one event with the same QPC, we use thread and processor number to disambiguate.  
             /// </summary>
-            public PastEventInfoIndex GetBestEventForQPC(long QPCTime, int threadID)
+            public PastEventInfoIndex GetBestEventForQPC(long QPCTime, int threadID, int processorNumber)
             {
                 // There are times when we have the same timestamp for different events, thus we need to
                 // choose the best one (thread IDs match), when we also have a 'poorer' match (when we don't
                 // have a thread ID for the event) 
                 int idx = curPastEventInfo;
                 var ret = PastEventInfoIndex.Invalid;
-                bool exactMatch = false;
+                bool threadAndProcNumMatch = false;
                 bool updateThread = false;
                 for (; ; )
                 {
-                    // We match timestamps.  This is the main criteria 
-                    if (QPCTime == pastEventInfo[idx].QPCTime)
-                    {
-                        if (threadID == pastEventInfo[idx].ThreadID)
-                        {
-                            if (exactMatch)
-                            {
-                                // We hope this does not happen, ambiguity: two events with the same timestamp and thread ID. 
-                                // This seems to happen for CSWITCH and SAMPLING on the phone (where timestamps are coarse); 
-                                log.DebugWarn(false, "Two events with the same Timestamp " + log.QPCTimeToRelMSec(QPCTime).ToString("f4"), null);
-                                return ret;
-                            }
-
-                            exactMatch = true;
-                            ret = (PastEventInfoIndex)idx;
-                            updateThread = false;
-                        }
-                        // Some events, (like VirtualAlloc, ReadyThread) don't have the thread ID set
-                        if (pastEventInfo[idx].ThreadID == -1 && !exactMatch)
-                        {
-                            ret = (PastEventInfoIndex)idx;
-                            updateThread = true;                // we match against ThreadID == -1, remember the true thread forever.  
-                        }
-                    }
-                    // Once we found a timestamp match, we stop searching when the timestamps no longer match.   
-                    else if (ret != PastEventInfoIndex.Invalid)
-                        break;
-
                     --idx;
                     if (idx < 0)
                         idx = historySize - 1;
-                    if (idx == (int)curPastEventInfo)
+
+                    // We match timestamps.  This is the main criteria 
+                    long entryQPCTime = pastEventInfo[idx].QPCTime;
+                    if (QPCTime == entryQPCTime)
+                    {
+                        // Next we we see if the ThreadIDs  match
+                        if (threadID == pastEventInfo[idx].ThreadID)
+                        {
+                            if (threadAndProcNumMatch)
+                            {
+                                // We hope this does not happen, ambiguity: two events with the same timestamp and thread ID and processor number 
+                                // This seems to happen for CSWITCH and SAMPLING on the phone (where timestamps are coarse); 
+                                log.DebugWarn(processorNumber != pastEventInfo[idx].ProcessorNumber, "Two events with the same Timestamp " + log.QPCTimeToRelMSec(QPCTime).ToString("f4"), null);
+                                return ret;
+                            }
+
+                            // Remember if we have a perfect match 
+                            if (processorNumber == pastEventInfo[idx].ProcessorNumber)
+                                threadAndProcNumMatch = true;
+                            ret = (PastEventInfoIndex)idx;
+                            updateThread = false;
+                        } // Some events, (like VirtualAlloc, ReadyThread) don't have the thread ID set, we will rely on just QPC and processor number.  
+                        else if (pastEventInfo[idx].ThreadID == -1)
+                        {
+                            // If we have no result yet, then use this one.   If we have a result, at least the processor numbers need to match.  
+                            if (ret == PastEventInfoIndex.Invalid || (!threadAndProcNumMatch && processorNumber == pastEventInfo[idx].ProcessorNumber))
+                            {
+                                ret = (PastEventInfoIndex)idx;
+                                updateThread = true;                // we match against ThreadID == -1, remember the true thread forever.  
+                            }
+                        }
+                    }
+                    else if (entryQPCTime < QPCTime)            // We can stop after we past the QPC we are looking for.  
                         break;
-                    if ((int)pastEventInfo[idx].EventIndex == 0)
+
+                    if (idx == (int)curPastEventInfo)
                         break;
                 }
                 // Remember the thread ID that we were 'attached to'.  
@@ -3515,7 +3527,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 }
                 return ret;
             }
-
             public PastEventInfoIndex CurrentIndex { get { return (PastEventInfoIndex)curPastEventInfo; } }
             public bool IsClrEvent(PastEventInfoIndex index) { return pastEventInfo[(int)index].isClrEvent; }
             public bool HasStack(PastEventInfoIndex index) { return pastEventInfo[(int)index].hasAStack; }
@@ -3524,7 +3535,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             public EventIndex GetEventIndex(PastEventInfoIndex index) { return pastEventInfo[(int)index].EventIndex; }
             public EventIndex GetBlockingEventIndex(PastEventInfoIndex index) { return pastEventInfo[(int)index].BlockingEventIndex; }
             public TraceEventCounts GetEventCounts(PastEventInfoIndex index) { return pastEventInfo[(int)index].CountForEvent; }
-            public long GetQPCTime(PastEventInfoIndex index) { return pastEventInfo[(int)index].QPCTime; }
             public IncompleteStack GetEventStackInfo(PastEventInfoIndex index)
             {
                 var stackInfo = pastEventInfo[(int)index].EventStackInfo;
@@ -3549,6 +3559,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 #endif
                 public bool hasAStack;
                 public bool isClrEvent;
+                public ushort ProcessorNumber;
                 public long QPCTime;
                 public int ThreadID;
 
@@ -3669,7 +3680,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         internal TraceLogEventSource realTimeSource;               // used to call back in real time case.  
         private Queue<QueueEntry> realTimeQueue;                   // We have to wait a bit to hook up stacks, so we put real time entries in the queue
-        // The can ONLY be accessed by the thread calling RealTimeEventSource.Process();
+                                                                   // The can ONLY be accessed by the thread calling RealTimeEventSource.Process();
         private Timer realTimeFlushTimer;                          // Insures the queue gets flushed even if there are no incoming events.  
         private Func<TraceEvent, ulong, bool> fnAddAddressToCodeAddressMap; // PERF: Cached delegate to avoid allocations in inner loop
         #endregion
@@ -5905,7 +5916,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 if (0 < suffixPos)
                 {
                     nativeModulePath = ilModulePath;                    // We treat the image as the native path
-                    // and make up a dummy IL path.  
+                                                                        // and make up a dummy IL path.  
                     ilModulePath = ilModulePath.Substring(0, suffixPos) + ".il" + ilModulePath.Substring(suffixPos);
                 }
             }
@@ -6651,7 +6662,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         // which is the list of call stack indexes where stack crawling stopped. 
         private GrowableArray<List<CallStackIndex>> callees;                // For each callstack, these are all the call stacks that it calls. 
         private GrowableArray<List<CallStackIndex>> threads;                 // callees for threads of stacks, one for each thread
-        // a field on CallStackInfo
+                                                                             // a field on CallStackInfo
         private GrowableArray<CallStackInfo> callStacks;
         private DeferedRegion lazyCallStacks;
         private TraceCodeAddresses codeAddresses;
@@ -7220,8 +7231,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 startIdx++;
 
             bool removeAddressAfterCallback = (process.ProcessID != 0);      // We remove entries unless it is the kernel (process 0) after calling back
-            // since the DLL will be unloaded in that process. Kernel DLLS stay loaded. 
-            // Call back for ever code address >= start than that, and then remove any code addresses we called back on.  
+                                                                             // since the DLL will be unloaded in that process. Kernel DLLS stay loaded. 
+                                                                             // Call back for ever code address >= start than that, and then remove any code addresses we called back on.  
             Address end = start + (ulong)length;
             int curIdx = startIdx;
             while (curIdx < process.unresolvedCodeAddresses.Count)
@@ -7890,7 +7901,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         internal class ILToNativeMap : IFastSerializable
         {
             public ILMapIndex Next;             // We keep a link list of maps with the same start address 
-            // (can only be from different processes);
+                                                // (can only be from different processes);
             public ProcessIndex ProcessIndex;   // This is not serialized.  
             public MethodIndex MethodIndex;
             public Address MethodStart;
@@ -8856,7 +8867,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             /// An activity that allows correlation between the antecedent and continuation 
             /// </summary>
             TaskWait = 32,          // if have bit 5 set it means you auto-compete
-            /// <summary>Same as TaskWait, hwoever it auto-completes</summary>
+                                    /// <summary>Same as TaskWait, hwoever it auto-completes</summary>
             TaskWaitSynchronous = 64 + 33,
             /// <summary>Managed timer workitem</summary>
             FxTimer = 34, // FxTransfer + kind(1)


### PR DESCRIPTION
…Fix this.

Basically we were turning asserts to throws, which then got caught and swallowed.
Fix it so that we fail the test oin that case.

Also fix these tests to be more uniform about how we unpack the data files we comare to.   improve the test so that it is more helpful when there are failures.

Finally there were problems that were being ignored that needed to be fixed.
In particular, we were assigning two stacks to the same event (becase there were events with the same QPC time).   Fixed this by disambiguating based on processor number (this is the change in TraceLog.cs).