### PR TITLE
Fix stack association logic

### DIFF
--- a/src/TraceEvent/Parsers/SymbolTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/SymbolTraceEventParser.cs
@@ -102,13 +102,39 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 source.UnregisterEventTemplate(value, DBGID_LOG_TYPE_NONE, ImageIDTaskGuid);
             }
         }
-        // I don't know much about this event at all...
+        // I don't know much about these events, they are injected by KTC
         public event Action<EmptyTraceData> ImageIDOpcode37
         {
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
                 source.RegisterEventTemplate(new EmptyTraceData(value, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 37, "Opcode37", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 37, ImageIdTaskGuid);
+            }
+        }
+
+        public event Action<EmptyTraceData> ImageIDOpcode38
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                source.RegisterEventTemplate(new EmptyTraceData(value, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 38, "Opcode38", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 37, ImageIdTaskGuid);
+            }
+        }
+
+        public event Action<EmptyTraceData> ImageIDOpcode40
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                source.RegisterEventTemplate(new EmptyTraceData(value, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 40, "Opcode40", ProviderGuid, ProviderName));
             }
             remove
             {
@@ -196,18 +222,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[10];
-                templates[0] = new DbgIDRSDSTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_RSDS, "DbgID_RSDS", ProviderGuid, ProviderName);
-                templates[1] = new ImageIDTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_IMAGEID, "Info", ProviderGuid, ProviderName);
-                templates[2] = new FileVersionTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_FILEVERSION, "FileVersion", ProviderGuid, ProviderName);
-                templates[3] = new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_NONE, "None", ProviderGuid, ProviderName);
-                templates[4] = new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 37, "Opcode37", ProviderGuid, ProviderName);
-                templates[5] = new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 33, "WinSPR", ProviderGuid, ProviderName);
-                templates[6] = new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 35, "Metrics", ProviderGuid, ProviderName);
-                templates[7] = new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 37, "SystemConfig", ProviderGuid, ProviderName);
-                templates[8] = new EmptyTraceData(null, 0xFFFF, 0, "MetaData", MetaDataTaskGuid, 32, "EventInfo", ProviderGuid, ProviderName);
-                templates[9] = new EmptyTraceData(null, 0xFFFF, 0, "MetaData", MetaDataTaskGuid, 33, "EventMapInfo", ProviderGuid, ProviderName);
-                s_templates = templates;
+                s_templates = new TraceEvent[]
+                {
+                    new DbgIDRSDSTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_RSDS, "DbgID_RSDS", ProviderGuid, ProviderName),
+                    new ImageIDTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_IMAGEID, "Info", ProviderGuid, ProviderName),
+                    new FileVersionTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_FILEVERSION, "FileVersion", ProviderGuid, ProviderName),
+                    new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_NONE, "None", ProviderGuid, ProviderName),
+                    new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 37, "Opcode37", ProviderGuid, ProviderName),
+                    new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 38, "Opcode38", ProviderGuid, ProviderName),
+                    new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 40, "Opcode40", ProviderGuid, ProviderName),
+                    new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 33, "WinSPR", ProviderGuid, ProviderName),
+                    new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 35, "Metrics", ProviderGuid, ProviderName),
+                    new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 37, "SystemConfig", ProviderGuid, ProviderName),
+                    new EmptyTraceData(null, 0xFFFF, 0, "MetaData", MetaDataTaskGuid, 32, "EventInfo", ProviderGuid, ProviderName),
+                    new EmptyTraceData(null, 0xFFFF, 0, "MetaData", MetaDataTaskGuid, 33, "EventMapInfo", ProviderGuid, ProviderName)
+                };
             }
             foreach (var template in s_templates)
                 if (eventsToObserve == null || eventsToObserve(template.ProviderName, template.EventName) == EventFilterResponse.AcceptEvent)

--- a/src/TraceEvent/Parsers/SymbolTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/SymbolTraceEventParser.cs
@@ -583,6 +583,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Symbol
                     return null;
             }
         }
+
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);

--- a/src/TraceEvent/Parsers/SymbolTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/SymbolTraceEventParser.cs
@@ -102,43 +102,42 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 source.UnregisterEventTemplate(value, DBGID_LOG_TYPE_NONE, ImageIDTaskGuid);
             }
         }
-        // I don't know much about these events, they are injected by KTC
-        public event Action<EmptyTraceData> ImageIDOpcode37
+
+        public event Action<DbgIDILRSDSTraceData> ImageIDDbgID_ILRSDS
         {
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                source.RegisterEventTemplate(new EmptyTraceData(value, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 37, "Opcode37", ProviderGuid, ProviderName));
+                source.RegisterEventTemplate(new DbgIDILRSDSTraceData(value, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_ILRSDS, "DbgID_ILRSDS", ProviderGuid, ProviderName));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 37, ImageIdTaskGuid);
+                source.UnregisterEventTemplate(value, DBGID_LOG_TYPE_ILRSDS, ImageIDTaskGuid);
+            }
+        }
+        public event Action<DbgPPDBTraceData> ImageIDDbgPPDB
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                source.RegisterEventTemplate(new DbgPPDBTraceData(value, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_PPDB, "DbgPPDB", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, DBGID_LOG_TYPE_PPDB, ImageIDTaskGuid);
             }
         }
 
-        public event Action<EmptyTraceData> ImageIDOpcode38
+        public event Action<DbgDetermTraceData> ImageIDDbgDeterm
         {
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                source.RegisterEventTemplate(new EmptyTraceData(value, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 38, "Opcode38", ProviderGuid, ProviderName));
+                source.RegisterEventTemplate(new DbgDetermTraceData(value, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_DETERM, "DbgDeterm", ProviderGuid, ProviderName));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 37, ImageIdTaskGuid);
-            }
-        }
-
-        public event Action<EmptyTraceData> ImageIDOpcode40
-        {
-            add
-            {
-                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                source.RegisterEventTemplate(new EmptyTraceData(value, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 40, "Opcode40", ProviderGuid, ProviderName));
-            }
-            remove
-            {
-                source.UnregisterEventTemplate(value, 37, ImageIdTaskGuid);
+                source.UnregisterEventTemplate(value, DBGID_LOG_TYPE_DETERM, ImageIDTaskGuid);
             }
         }
 
@@ -228,9 +227,9 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                     new ImageIDTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_IMAGEID, "Info", ProviderGuid, ProviderName),
                     new FileVersionTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_FILEVERSION, "FileVersion", ProviderGuid, ProviderName),
                     new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_NONE, "None", ProviderGuid, ProviderName),
-                    new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 37, "Opcode37", ProviderGuid, ProviderName),
-                    new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 38, "Opcode38", ProviderGuid, ProviderName),
-                    new EmptyTraceData(null, 0xFFFF, 0, "ImageID", ImageIdTaskGuid, 40, "Opcode40", ProviderGuid, ProviderName),
+                    new DbgIDILRSDSTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_ILRSDS, "DbgID_ILRSDS", ProviderGuid, ProviderName),
+                    new DbgPPDBTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_PPDB, "DbgPPDB", ProviderGuid, ProviderName),
+                    new DbgDetermTraceData(null, 0xFFFF, 0, "ImageID", ImageIDTaskGuid, DBGID_LOG_TYPE_DETERM, "DbgDeterm", ProviderGuid, ProviderName),
                     new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 33, "WinSPR", ProviderGuid, ProviderName),
                     new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 35, "Metrics", ProviderGuid, ProviderName),
                     new WinSatXmlTraceData(null, 0xFFFF, 0, "WinSat", WinSatTaskGuid, 37, "SystemConfig", ProviderGuid, ProviderName),
@@ -247,6 +246,9 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         public const int DBGID_LOG_TYPE_IMAGEID = 0x00;
         public const int DBGID_LOG_TYPE_NONE = 0x20;
         public const int DBGID_LOG_TYPE_RSDS = 0x24;
+        public const int DBGID_LOG_TYPE_ILRSDS = 0x25;
+        public const int DBGID_LOG_TYPE_PPDB = 0x26;
+        public const int DBGID_LOG_TYPE_DETERM = 0x28;
         public const int DBGID_LOG_TYPE_FILEVERSION = 0x40;
 
         // Used to log meta-data about crimson events into the log.  
@@ -254,7 +256,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         internal static readonly Guid WinSatTaskGuid = new Guid(unchecked((int)0xed54dff8), unchecked((short)0xc409), 0x4cf6, 0xbf, 0x83, 0x05, 0xe1, 0xe6, 0x1a, 0x09, 0xc4);
         internal static readonly Guid MetaDataTaskGuid = new Guid(unchecked((int)0xbbccf6c1), 0x6cd1, 0x48c4, 0x80, 0xff, 0x83, 0x94, 0x82, 0xe3, 0x76, 0x71);
         internal static readonly Guid PerfTrackMetaDataTaskGuid = new Guid(unchecked((int)0xbf6ef1cb), unchecked((short)0x89b5), 0x490, 0x80, 0xac, 0xb1, 0x80, 0xcf, 0xbc, 0xff, 0x0f);
-        internal static readonly Guid ImageIdTaskGuid = new Guid(unchecked((int)0xb3e675d7), 0x2554, 0x4f18, 0x83, 0x0b, 0x27, 0x62, 0x73, 0x25, 0x60, 0xde);
         #endregion
     }
 }
@@ -518,6 +519,228 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Symbol
         }
 
         private event Action<ImageIDTraceData> Action;
+        #endregion
+    }
+
+    public sealed class DbgIDILRSDSTraceData : TraceEvent
+    {
+        public Address ImageBase { get { return GetAddressAt(0); } }
+
+        // This seems to be redundant with the ProcessID in the event header
+        //public int ProcessID { get { return GetInt32At(HostOffset(4, 1)); } }
+        public Guid GuidSig { get { return GetGuidAt(HostOffset(8, 1)); } }
+        public int Age { get { return GetInt32At(HostOffset(24, 1)); } }
+        public string PdbFileName { get { return GetUTF8StringAt(HostOffset(28, 1)); } }
+
+        #region Private
+        internal DbgIDILRSDSTraceData(Action<DbgIDILRSDSTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opCode, string opCodeName, Guid providerGuid, string providerName) :
+            base(eventID, task, taskName, taskGuid, opCode, opCodeName, providerGuid, providerName)
+        {
+            this.Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<DbgIDILRSDSTraceData>)value; }
+        }
+
+        protected internal override void Validate()
+        {
+            Debug.Assert(EventDataLength == SkipUTF8String(HostOffset(32, 1)));
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                {
+                    payloadNames = new string[] { "ImageBase", "GuidSig", "Age", "PDBFileName" };
+                }
+                return payloadNames;
+
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ImageBase;
+                case 1:
+                    return GuidSig;
+                case 2:
+                    return Age;
+                case 3:
+                    return PdbFileName;
+                default:
+                    Debug.Assert(false, "invalid index");
+                    return null;
+            }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttribHex(sb, "ImageBase", ImageBase);
+            XmlAttrib(sb, "GuidSig", GuidSig);
+            XmlAttrib(sb, "Age", Age);
+            XmlAttrib(sb, "PdbFileName", PdbFileName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        private event Action<DbgIDILRSDSTraceData> Action;
+
+        #endregion
+    }
+
+    public sealed class DbgPPDBTraceData : TraceEvent
+    {
+        public Address ImageBase { get { return GetAddressAt(0); } }
+
+        // This seems to be redundant with the ProcessID in the event header
+        //public int ProcessID { get { return GetInt32At(HostOffset(4, 1)); } }
+
+        public int TimeDateStamp { get { return GetInt32At(HostOffset(8, 1)); } }
+
+        public int MajorVersion { get { return GetByteAt(HostOffset(12, 1)); } }
+
+        public int MinorVersion { get { return GetByteAt(HostOffset(14, 1)); } }
+
+        #region Private
+        internal DbgPPDBTraceData(Action<DbgPPDBTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opCode, string opCodeName, Guid providerGuid, string providerName) :
+    base(eventID, task, taskName, taskGuid, opCode, opCodeName, providerGuid, providerName)
+        {
+            this.Action = action;
+        }
+
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<DbgPPDBTraceData>)value; }
+        }
+
+        protected internal override void Validate()
+        {
+            Debug.Assert(EventDataLength == HostOffset(16, 1));
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                {
+                    payloadNames = new string[] { "ImageBase", "TimeDateStamp", "MajorVersion", "MinorVersion" };
+                }
+                return payloadNames;
+
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ImageBase;
+                case 1:
+                    return TimeDateStamp;
+                case 2:
+                    return MajorVersion;
+                case 3:
+                    return MinorVersion;
+                default:
+                    Debug.Assert(false, "bad index value");
+                    return null;
+            }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttribHex(sb, "ImageBase", ImageBase);
+            XmlAttribHex(sb, "TimeDateStamp", TimeDateStamp);
+            XmlAttrib(sb, "MajorVersion", MajorVersion);
+            XmlAttrib(sb, "MinorVersion", MinorVersion);
+            sb.Append("/>");
+            return sb;
+        }
+
+        private event Action<DbgPPDBTraceData> Action;
+        #endregion
+    }
+
+    public sealed class DbgDetermTraceData : TraceEvent
+    {
+        public Address ImageBase { get { return GetAddressAt(0); } }
+
+        // This seems to be redundant with the ProcessID in the event header
+        //public int ProcessID { get { return GetInt32At(HostOffset(4, 1)); } }
+
+        #region Private
+        internal DbgDetermTraceData(Action<DbgDetermTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opCode, string opCodeName, Guid providerGuid, string providerName) :
+            base(eventID, task, taskName, taskGuid, opCode, opCodeName, providerGuid, providerName)
+        {
+            this.Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<DbgDetermTraceData>)value; }
+        }
+
+        protected internal override void Validate()
+        {
+            Debug.Assert(EventDataLength == HostOffset(8, 1));
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                {
+                    payloadNames = new string[] { "ImageBase" };
+                }
+                return payloadNames;
+
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ImageBase;
+                default:
+                    Debug.Assert(false, "bad index value");
+                    return null;
+            }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttribHex(sb, "ImageBase", ImageBase);
+            sb.Append("/>");
+            return sb;
+        }
+
+        private event Action<DbgDetermTraceData> Action;
+
         #endregion
     }
 

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x64.baseline.txt
@@ -1,4 +1,4 @@
-EVENT 0.000: Windows Kernel/EventTrace PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=332; BufferSize=65,536; Version=83,951,878; ProviderVersion=7,601; NumberOfProcessors=4; EndTime=16/05/26 20:16:54.91...; TimerResolution=156,250; MaxFileSize=0; LogFileMode=65,537; BuffersWritten=1,694; StartBuffers=1; PointerSize=8; EventsLost=0; CPUSpeed=2,993; BootTime=16/05/25 21:41:46.12...; PerfFreq=10,000,000; StartTime=16/05/26 20:16:48.68...; ReservedFlags=1; BuffersLost=0; SessionName=Relogger; LogFileName=[multiple files]; UtcOffsetMinutes=480; 
+﻿EVENT 0.000: Windows Kernel/EventTrace PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=332; BufferSize=65,536; Version=83,951,878; ProviderVersion=7,601; NumberOfProcessors=4; EndTime=16/05/26 20:16:54.91...; TimerResolution=156,250; MaxFileSize=0; LogFileMode=65,537; BuffersWritten=1,694; StartBuffers=1; PointerSize=8; EventsLost=0; CPUSpeed=2,993; BootTime=16/05/25 21:41:46.12...; PerfFreq=10,000,000; StartTime=16/05/26 20:16:48.68...; ReservedFlags=1; BuffersLost=0; SessionName=Relogger; LogFileName=[multiple files]; UtcOffsetMinutes=480; 
 EVENT 0.000: Windows Kernel/EventTrace/Extension PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=36; GroupMask1=0; GroupMask2=0; GroupMask3=0; GroupMask4=0; GroupMask5=0; GroupMask6=0; GroupMask7=0; GroupMask8=0; KernelEventVersion=27; 
 EVENT 0.000: Windows Kernel/SysConfig/SystemPaths PID=0; TID=0; PName=Idle; ProceNum=0; DataLen=64; SystemDirectory=C:\Windows\system32; SystemWindowsDirectory=C:\Windows\; 
 EVENT 0.000: Windows Kernel/SysConfig/VolumeMapping PID=0; TID=0; PName=Idle; ProceNum=0; DataLen=12; NtPath=\??\; DosPath=; 
@@ -74,11 +74,11 @@ EVENT 331.057: KernelTraceControl/ImageID/None PID=960; TID=3872; PName=svchost;
 EVENT 564.271: KernelTraceControl/ImageID/None PID=1128; TID=3872; PName=svchost; ProceNum=0; DataLen=12; 
 EVENT 596.692: KernelTraceControl/ImageID/None PID=1364; TID=3872; PName=spoolsv; ProceNum=0; DataLen=12; 
 EVENT 691.347: Windows Kernel/TcpIp/RecvIPV6 PID=1128; TID=-1; PName=svchost; ProceNum=0; DataLen=56; size=85; daddr=2001:4898:e0:2018:91...; saddr=2001:4898:29:1010:dd...; dport=34,983; sport=3,389; connid=0x0; seqnum=0; 
-EVENT 752.097: KernelTraceControl/ImageID/Opcode37 PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=148; 
-EVENT 752.106: KernelTraceControl/ImageID/Opcode37 PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=149; 
-EVENT 752.133: KernelTraceControl/ImageID/Opcode37 PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=142; 
-EVENT 752.143: KernelTraceControl/ImageID/Opcode37 PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=48; 
-EVENT 752.151: KernelTraceControl/ImageID/Opcode37 PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=47; 
+EVENT 752.097: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=148; ImageBase=0xb20000; GuidSig=b3af247c-db0d-49ff-a...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 752.106: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=149; ImageBase=0xb60000; GuidSig=c5ce39de-77bc-481a-a...; Age=1; PDBFileName=c:\Users\vancem\Docu...; 
+EVENT 752.133: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=142; ImageBase=0x5c30000; GuidSig=ea5b71d9-238b-460b-b...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 752.143: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=48; ImageBase=0x701d0000; GuidSig=01209527-36eb-4019-8...; Age=1; PDBFileName=System.Core.pdb; 
+EVENT 752.151: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=47; ImageBase=0x70890000; GuidSig=88e72260-0543-4081-a...; Age=1; PDBFileName=System.Xml.pdb; 
 EVENT 752.632: Windows Kernel/PerfInfo/CollectionStart PID=3904; TID=3872; PName=PerfView; ProceNum=0; DataLen=12; SampleSource=0; NewInterval=10,000; OldInterval=10,000; 
 EVENT 802.610: Windows Kernel/Thread/Start PID=4; TID=2636; PName=System; ProceNum=0; DataLen=72; StackBase=0xfffff88006690000; StackLimit=0xfffff8800668a000; UserStackBase=0x0; UserStackLimit=0x0; StartAddr=0xf; Win32StartAddr=0xfffff800029ec614; TebBase=0x0; SubProcessTag=0; ParentThreadID=3,872; ParentProcessID=3,904; 
 EVENT 820.745: Windows Kernel/Thread/Start PID=3904; TID=3408; PName=PerfView; ProceNum=0; DataLen=72; StackBase=0xfffff88006697000; StackLimit=0xfffff88006691000; UserStackBase=0x604fd20; UserStackLimit=0x604c000; StartAddr=0xf; Win32StartAddr=0x771f5c71; TebBase=0xfffa1000; SubProcessTag=0; ParentThreadID=3,872; ParentProcessID=3,904; 
@@ -482,10 +482,10 @@ EVENT 9,984.435: PerfView/StartAndStopTimes PID=3776; TID=4036; PName=PerfView; 
 EVENT 9,984.437: PerfView/Rundown/Stop PID=3776; TID=4036; PName=PerfView; ProceNum=2; DataLen=0; 
 EVENT 9,984.437: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=2; DataLen=138; InstallDate=70/01/01 00:00:00.00...; BuildLab=7601.19160.amd64fre....; ProductName=Windows 7 Enterprise; 
 COUNT KernelTraceControl/ImageID:5572
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:44
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:5526
 COUNT KernelTraceControl/ImageID/FileVersion:726
 COUNT KernelTraceControl/ImageID/None:24
-COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
 COUNT MSNT_SystemTrace/Image/KernelBase:1
@@ -568,7 +568,7 @@ COUNT PerfView/WaitForIdle:1
 COUNT Provider(8e9f5090-2d75-4d03-8a81-e5afbf85daf1)/EventID(65534):2
 COUNT Windows Kernel/DiskIO/FlushBuffers:6
 COUNT Windows Kernel/DiskIO/FlushInit:6
-COUNT Windows Kernel/DiskIO/Read:1410
+COUNT Windows Kernel/DiskIO/Read:1412
 COUNT Windows Kernel/DiskIO/ReadInit:1413
 COUNT Windows Kernel/DiskIO/Write:2035
 COUNT Windows Kernel/DiskIO/WriteInit:2035
@@ -581,7 +581,7 @@ COUNT Windows Kernel/Image/Unload:99
 COUNT Windows Kernel/Memory/HardFault:989
 COUNT Windows Kernel/PerfInfo/CollectionEnd:1
 COUNT Windows Kernel/PerfInfo/CollectionStart:1
-COUNT Windows Kernel/PerfInfo/Sample:8320
+COUNT Windows Kernel/PerfInfo/Sample:8323
 COUNT Windows Kernel/Process/DCStart:46
 COUNT Windows Kernel/Process/DCStop:46
 COUNT Windows Kernel/Process/PerfCtr:2

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.0.x86.baseline.txt
@@ -58,11 +58,11 @@ EVENT 53.820: Windows Kernel/DiskIO/Read PID=4; TID=3420; PName=System; ProceNum
 EVENT 55.650: Windows Kernel/DiskIO/ReadInit PID=4; TID=3420; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8302e46b80; 
 EVENT 56.544: Windows Kernel/DiskIO/Read PID=4; TID=3420; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=None; Priority=Normal; TransferSize=16,384; ByteOffset=15,726,739,456; Irp=0xfffffa8302e46b80; ElapsedTimeMSec=0.894; DiskServiceTimeMSec=0.894; FileKey=0xfffff8a001b7e140; FileName=C:\temp\PerfViewData...; 
 EVENT 59.660: Windows Kernel/DiskIO/ReadInit PID=4; TID=3420; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8302e46b80; 
-EVENT 68.858: KernelTraceControl/ImageID/Opcode37 PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=148; 
-EVENT 68.873: KernelTraceControl/ImageID/Opcode37 PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=149; 
-EVENT 68.903: KernelTraceControl/ImageID/Opcode37 PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=142; 
-EVENT 68.917: KernelTraceControl/ImageID/Opcode37 PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=48; 
-EVENT 68.931: KernelTraceControl/ImageID/Opcode37 PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=47; 
+EVENT 68.858: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=148; ImageBase=0x640000; GuidSig=b3af247c-db0d-49ff-a...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 68.873: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=149; ImageBase=0x8e0000; GuidSig=c5ce39de-77bc-481a-a...; Age=1; PDBFileName=c:\Users\vancem\Docu...; 
+EVENT 68.903: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=142; ImageBase=0x5bf0000; GuidSig=ea5b71d9-238b-460b-b...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 68.917: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=48; ImageBase=0x701d0000; GuidSig=01209527-36eb-4019-8...; Age=1; PDBFileName=System.Core.pdb; 
+EVENT 68.931: KernelTraceControl/ImageID/DbgID_ILRSDS PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=47; ImageBase=0x70890000; GuidSig=88e72260-0543-4081-a...; Age=1; PDBFileName=System.Xml.pdb; 
 EVENT 69.816: Windows Kernel/PerfInfo/CollectionStart PID=3504; TID=2772; PName=PerfView; ProceNum=3; DataLen=12; SampleSource=0; NewInterval=10,000; OldInterval=10,000; 
 EVENT 69.988: Windows Kernel/DiskIO/Read PID=4; TID=3420; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=None; Priority=Normal; TransferSize=65,536; ByteOffset=15,726,755,840; Irp=0xfffffa8302e46b80; ElapsedTimeMSec=10.326; DiskServiceTimeMSec=10.326; FileKey=0xfffff8a001b7e140; FileName=C:\temp\PerfViewData...; 
 EVENT 71.342: Windows Kernel/DiskIO/ReadInit PID=4; TID=3420; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8302e46b80; 
@@ -482,21 +482,21 @@ EVENT 7,667.651: PerfView/StartAndStopTimes PID=3412; TID=2024; PName=PerfView; 
 EVENT 7,667.653: PerfView/Rundown/Stop PID=3412; TID=2024; PName=PerfView; ProceNum=1; DataLen=0; 
 EVENT 7,667.653: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=1; DataLen=138; InstallDate=70/01/01 00:00:00.00...; BuildLab=7601.19160.amd64fre....; ProductName=Windows 7 Enterprise; 
 COUNT KernelTraceControl/ImageID:5421
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:44
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:5374
 COUNT KernelTraceControl/ImageID/FileVersion:723
 COUNT KernelTraceControl/ImageID/None:25
-COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
 COUNT MSNT_SystemTrace/Image/KernelBase:1
 COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
-COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:49103
+COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:49110
 COUNT Microsoft-Windows-DotNETRuntime/GC/CreateSegment:4
 COUNT Microsoft-Windows-DotNETRuntime/GC/FinalizersStart:71
 COUNT Microsoft-Windows-DotNETRuntime/GC/FinalizersStop:71
-COUNT Microsoft-Windows-DotNETRuntime/GC/HeapStats:897
+COUNT Microsoft-Windows-DotNETRuntime/GC/HeapStats:898
 COUNT Microsoft-Windows-DotNETRuntime/GC/RestartEEStart:900
 COUNT Microsoft-Windows-DotNETRuntime/GC/RestartEEStop:900
 COUNT Microsoft-Windows-DotNETRuntime/GC/Start:898

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x64.baseline.txt
@@ -53,11 +53,11 @@ EVENT 14.040: Windows Kernel/PerfInfo/Sample PID=4; TID=5064; PName=System; Proc
 EVENT 14.111: Windows Kernel/DiskIO/WriteInit PID=4; TID=5064; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8304609b80; 
 EVENT 14.744: Windows Kernel/DiskIO/Write PID=4; TID=5064; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=Nocache, Write, Defe...; Priority=Normal; TransferSize=65,536; ByteOffset=11,945,517,056; Irp=0xfffffa8304609b80; ElapsedTimeMSec=0.633; DiskServiceTimeMSec=0.633; FileKey=0xfffff8a00a039c70; FileName=C:\temp\PerfViewData...; 
 EVENT 17.743: KernelTraceControl/ImageID/None PID=1096; TID=500; PName=svchost; ProceNum=3; DataLen=12; 
-EVENT 28.709: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=58; 
-EVENT 28.717: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=149; 
-EVENT 28.725: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=54; 
-EVENT 28.733: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=50; 
-EVENT 28.741: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=66; 
+EVENT 28.709: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=58; ImageBase=0x360000; GuidSig=37f1ba04-ce51-4adb-9...; Age=1; PDBFileName=System.ServiceProces...; 
+EVENT 28.717: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=149; ImageBase=0x810000; GuidSig=7d329456-1882-4d5a-a...; Age=1; PDBFileName=c:\Users\chulbert\So...; 
+EVENT 28.725: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=54; ImageBase=0xa70000; GuidSig=c8b65745-d80d-4fe5-8...; Age=1; PDBFileName=System.Management.pd...; 
+EVENT 28.733: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=50; ImageBase=0xae0000; GuidSig=0b42673a-4ce9-44fb-a...; Age=1; PDBFileName=SMDiagnostics.pdb; 
+EVENT 28.741: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=500; PName=Aegis.WindowsService; ProceNum=3; DataLen=66; ImageBase=0xb00000; GuidSig=7676d8fd-f131-4a10-b...; Age=1; PDBFileName=System.ServiceModel....; 
 EVENT 31.672: Windows Kernel/PerfInfo/CollectionStart PID=4228; TID=500; PName=PerfView; ProceNum=3; DataLen=12; SampleSource=0; NewInterval=10,000; OldInterval=10,000; 
 EVENT 50.348: Windows Kernel/Thread/Start PID=4; TID=924; PName=System; ProceNum=3; DataLen=72; StackBase=0xfffff8800596b000; StackLimit=0xfffff88005965000; UserStackBase=0x0; UserStackLimit=0x0; StartAddr=0xf; Win32StartAddr=0xfffff800029e0614; TebBase=0x0; SubProcessTag=0; ParentThreadID=500; ParentProcessID=4,228; 
 EVENT 58.696: Windows Kernel/Thread/Start PID=4228; TID=3032; PName=PerfView; ProceNum=3; DataLen=72; StackBase=0xfffff88005972000; StackLimit=0xfffff8800596c000; UserStackBase=0x63efd20; UserStackLimit=0x63ec000; StartAddr=0xf; Win32StartAddr=0x77165c71; TebBase=0xfffa1000; SubProcessTag=0; ParentThreadID=500; ParentProcessID=4,228; 
@@ -539,10 +539,10 @@ EVENT 4,580.282: PerfView/StartAndStopTimes PID=3012; TID=3324; PName=PerfView; 
 EVENT 4,580.283: PerfView/Rundown/Stop PID=3012; TID=3324; PName=PerfView; ProceNum=1; DataLen=0; 
 EVENT 4,580.283: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=1; DataLen=138; InstallDate=70/01/01 00:00:00.00...; BuildLab=7601.19160.amd64fre....; ProductName=Windows 7 Enterprise; 
 COUNT KernelTraceControl/ImageID:5928
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:104
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:5820
 COUNT KernelTraceControl/ImageID/FileVersion:750
 COUNT KernelTraceControl/ImageID/None:30
-COUNT KernelTraceControl/ImageID/Opcode37:104
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
 COUNT MSNT_SystemTrace/Image/KernelBase:1
@@ -550,7 +550,7 @@ COUNT MSNT_SystemTrace/SystemConfig/Platform:1
 COUNT Microsoft-Windows-DNS-Client/EventID(1001):3
 COUNT Microsoft-Windows-DNS-Client/EventID(1019):1
 COUNT Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:6
-COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:53308
+COUNT Microsoft-Windows-DotNETRuntime/GC/AllocationTick:53311
 COUNT Microsoft-Windows-DotNETRuntime/GC/BulkSurvivingObjectRanges:202
 COUNT Microsoft-Windows-DotNETRuntime/GC/CreateSegment:4
 COUNT Microsoft-Windows-DotNETRuntime/GC/FinalizeObject:29

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.2.x86.baseline.txt
@@ -53,11 +53,11 @@ EVENT 18.989: KernelTraceControl/ImageID/None PID=908; TID=4464; PName=svchost; 
 EVENT 18.998: KernelTraceControl/ImageID/None PID=908; TID=4464; PName=svchost; ProceNum=1; DataLen=12; 
 EVENT 19.431: Windows Kernel/DiskIO/Write PID=4; TID=5040; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=Nocache, Write, Defe...; Priority=Normal; TransferSize=65,536; ByteOffset=11,945,582,592; Irp=0xfffffa83031f45e0; ElapsedTimeMSec=0.527; DiskServiceTimeMSec=0.527; FileKey=0xfffff8a000842140; FileName=C:\temp\PerfViewData...; 
 EVENT 26.373: KernelTraceControl/ImageID/None PID=1096; TID=4464; PName=svchost; ProceNum=1; DataLen=12; 
-EVENT 47.954: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=58; 
-EVENT 47.964: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=149; 
-EVENT 47.975: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=54; 
-EVENT 47.986: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=50; 
-EVENT 47.998: KernelTraceControl/ImageID/Opcode37 PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=66; 
+EVENT 47.954: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=58; ImageBase=0x360000; GuidSig=37f1ba04-ce51-4adb-9...; Age=1; PDBFileName=System.ServiceProces...; 
+EVENT 47.964: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=149; ImageBase=0x810000; GuidSig=7d329456-1882-4d5a-a...; Age=1; PDBFileName=c:\Users\chulbert\So...; 
+EVENT 47.975: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=54; ImageBase=0xa70000; GuidSig=c8b65745-d80d-4fe5-8...; Age=1; PDBFileName=System.Management.pd...; 
+EVENT 47.986: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=50; ImageBase=0xae0000; GuidSig=0b42673a-4ce9-44fb-a...; Age=1; PDBFileName=SMDiagnostics.pdb; 
+EVENT 47.998: KernelTraceControl/ImageID/DbgID_ILRSDS PID=4904; TID=4464; PName=Aegis.WindowsService; ProceNum=1; DataLen=66; ImageBase=0xb00000; GuidSig=7676d8fd-f131-4a10-b...; Age=1; PDBFileName=System.ServiceModel....; 
 EVENT 51.797: Windows Kernel/PerfInfo/CollectionStart PID=4508; TID=4464; PName=PerfView; ProceNum=1; DataLen=12; SampleSource=0; NewInterval=10,000; OldInterval=10,000; 
 EVENT 80.892: Windows Kernel/Thread/Start PID=4; TID=2348; PName=System; ProceNum=1; DataLen=72; StackBase=0xfffff88005df2000; StackLimit=0xfffff88005dec000; UserStackBase=0x0; UserStackLimit=0x0; StartAddr=0xf; Win32StartAddr=0xfffff800029e0614; TebBase=0x0; SubProcessTag=0; ParentThreadID=4,464; ParentProcessID=4,508; 
 EVENT 94.861: Windows Kernel/Thread/Start PID=4508; TID=504; PName=PerfView; ProceNum=1; DataLen=72; StackBase=0xfffff88005df9000; StackLimit=0xfffff88005df3000; UserStackBase=0x630fd20; UserStackLimit=0x630c000; StartAddr=0xf; Win32StartAddr=0x77165c71; TebBase=0xfffa1000; SubProcessTag=0; ParentThreadID=4,464; ParentProcessID=4,508; 
@@ -542,10 +542,10 @@ EVENT 4,741.877: PerfView/StartAndStopTimes PID=176; TID=2884; PName=PerfView; P
 EVENT 4,741.878: PerfView/Rundown/Stop PID=176; TID=2884; PName=PerfView; ProceNum=3; DataLen=0; 
 EVENT 4,741.878: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=3; DataLen=138; InstallDate=70/01/01 00:00:00.00...; BuildLab=7601.19160.amd64fre....; ProductName=Windows 7 Enterprise; 
 COUNT KernelTraceControl/ImageID:5800
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:104
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:5688
 COUNT KernelTraceControl/ImageID/FileVersion:746
 COUNT KernelTraceControl/ImageID/None:34
-COUNT KernelTraceControl/ImageID/Opcode37:104
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
 COUNT MSNT_SystemTrace/Image/KernelBase:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x64.baseline.txt
@@ -62,11 +62,11 @@ EVENT 37.935: Windows Kernel/DiskIO/Read PID=4; TID=3652; PName=System; ProceNum
 EVENT 40.370: Windows Kernel/DiskIO/ReadInit PID=4; TID=3652; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8302e871c0; 
 EVENT 52.529: Windows Kernel/DiskIO/Read PID=4; TID=3652; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=None; Priority=Normal; TransferSize=65,536; ByteOffset=12,077,268,992; Irp=0xfffffa8302e871c0; ElapsedTimeMSec=12.158; DiskServiceTimeMSec=12.158; FileKey=0xfffff8a0037e5c70; FileName=C:\temp\PerfViewData...; 
 EVENT 54.981: Windows Kernel/DiskIO/ReadInit PID=4; TID=3652; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8302e871c0; 
-EVENT 57.586: KernelTraceControl/ImageID/Opcode37 PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=148; 
-EVENT 57.602: KernelTraceControl/ImageID/Opcode37 PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=149; 
-EVENT 57.616: KernelTraceControl/ImageID/Opcode37 PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=142; 
-EVENT 57.632: KernelTraceControl/ImageID/Opcode37 PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=48; 
-EVENT 57.647: KernelTraceControl/ImageID/Opcode37 PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=47; 
+EVENT 57.586: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=148; ImageBase=0x1140000; GuidSig=b3af247c-db0d-49ff-a...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 57.602: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=149; ImageBase=0x11c0000; GuidSig=c5ce39de-77bc-481a-a...; Age=1; PDBFileName=c:\Users\vancem\Docu...; 
+EVENT 57.616: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=142; ImageBase=0x5a70000; GuidSig=ea5b71d9-238b-460b-b...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 57.632: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=48; ImageBase=0x6ffc0000; GuidSig=126998fb-7083-4c8a-b...; Age=1; PDBFileName=System.Core.pdb; 
+EVENT 57.647: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=47; ImageBase=0x70670000; GuidSig=06dc2100-b209-4185-9...; Age=1; PDBFileName=System.Xml.pdb; 
 EVENT 58.421: Windows Kernel/PerfInfo/CollectionStart PID=2848; TID=3372; PName=PerfView; ProceNum=3; DataLen=12; SampleSource=0; NewInterval=10,000; OldInterval=10,000; 
 EVENT 60.634: Windows Kernel/DiskIO/Read PID=4; TID=3652; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=None; Priority=Normal; TransferSize=16,384; ByteOffset=15,623,127,040; Irp=0xfffffa8302e871c0; ElapsedTimeMSec=5.653; DiskServiceTimeMSec=5.653; FileKey=0xfffff8a0037e5c70; FileName=C:\temp\PerfViewData...; 
 EVENT 67.945: Windows Kernel/UdpIp/Recv PID=4; TID=-1; PName=System; ProceNum=0; DataLen=32; context=0x3200000004; saddr=10.199.28.114; sport=137; size=50; daddr=10.199.29.255; dport=137; dsize=0; 
@@ -496,10 +496,10 @@ EVENT 7,436.493: PerfView/StartAndStopTimes PID=4048; TID=2572; PName=PerfView; 
 EVENT 7,436.495: PerfView/Rundown/Stop PID=4048; TID=2572; PName=PerfView; ProceNum=1; DataLen=0; 
 EVENT 7,436.495: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=1; DataLen=138; InstallDate=70/01/01 00:00:00.00...; BuildLab=7601.19160.amd64fre....; ProductName=Windows 7 Enterprise; 
 COUNT KernelTraceControl/ImageID:5599
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:44
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:5548
 COUNT KernelTraceControl/ImageID/FileVersion:728
 COUNT KernelTraceControl/ImageID/None:29
-COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
 COUNT MSNT_SystemTrace/Image/KernelBase:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.5.x86.baseline.txt
@@ -62,11 +62,11 @@ EVENT 58.530: Windows Kernel/DiskIO/Read PID=4; TID=3416; PName=System; ProceNum
 EVENT 61.286: Windows Kernel/DiskIO/ReadInit PID=4; TID=3416; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8303645010; 
 EVENT 61.806: Windows Kernel/DiskIO/Read PID=4; TID=3416; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=None; Priority=Normal; TransferSize=65,536; ByteOffset=12,745,392,128; Irp=0xfffffa8303645010; ElapsedTimeMSec=0.519; DiskServiceTimeMSec=0.519; FileKey=0xfffff8a00bd05740; FileName=C:\temp\PerfViewData...; 
 EVENT 65.859: Windows Kernel/DiskIO/ReadInit PID=4; TID=3416; PName=System; ProceNum=0; DataLen=8; Irp=0xfffffa8303645010; 
-EVENT 73.221: KernelTraceControl/ImageID/Opcode37 PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=148; 
-EVENT 73.235: KernelTraceControl/ImageID/Opcode37 PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=149; 
-EVENT 73.251: KernelTraceControl/ImageID/Opcode37 PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=142; 
-EVENT 73.267: KernelTraceControl/ImageID/Opcode37 PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=48; 
-EVENT 73.282: KernelTraceControl/ImageID/Opcode37 PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=47; 
+EVENT 73.221: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=148; ImageBase=0x11b0000; GuidSig=b3af247c-db0d-49ff-a...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 73.235: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=149; ImageBase=0x4cc0000; GuidSig=c5ce39de-77bc-481a-a...; Age=1; PDBFileName=c:\Users\vancem\Docu...; 
+EVENT 73.251: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=142; ImageBase=0x59f0000; GuidSig=ea5b71d9-238b-460b-b...; Age=1; PDBFileName=C:\Users\vancem\Sour...; 
+EVENT 73.267: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=48; ImageBase=0x6ffc0000; GuidSig=126998fb-7083-4c8a-b...; Age=1; PDBFileName=System.Core.pdb; 
+EVENT 73.282: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=47; ImageBase=0x70670000; GuidSig=06dc2100-b209-4185-9...; Age=1; PDBFileName=System.Xml.pdb; 
 EVENT 74.095: Windows Kernel/PerfInfo/CollectionStart PID=1876; TID=3488; PName=PerfView; ProceNum=3; DataLen=12; SampleSource=0; NewInterval=10,000; OldInterval=10,000; 
 EVENT 74.185: Windows Kernel/DiskIO/Read PID=4; TID=3416; PName=System; ProceNum=0; DataLen=48; DiskNumber=0; IrpFlags=None; Priority=Normal; TransferSize=65,536; ByteOffset=12,745,457,664; Irp=0xfffffa8303645010; ElapsedTimeMSec=8.324; DiskServiceTimeMSec=8.324; FileKey=0xfffff8a00bd05740; FileName=C:\temp\PerfViewData...; 
 EVENT 91.968: Windows Kernel/UdpIp/RecvIPV6 PID=1176; TID=-1; PName=svchost; ProceNum=0; DataLen=56; size=22; dport=5,355; sport=64,487; seqnum=0; connid=0x0; 
@@ -494,10 +494,10 @@ EVENT 7,356.632: PerfView/StartAndStopTimes PID=3884; TID=2820; PName=PerfView; 
 EVENT 7,356.634: PerfView/Rundown/Stop PID=3884; TID=2820; PName=PerfView; ProceNum=1; DataLen=0; 
 EVENT 7,356.634: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=1; DataLen=138; InstallDate=70/01/01 00:00:00.00...; BuildLab=7601.19160.amd64fre....; ProductName=Windows 7 Enterprise; 
 COUNT KernelTraceControl/ImageID:5598
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:44
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:5544
 COUNT KernelTraceControl/ImageID/FileVersion:721
 COUNT KernelTraceControl/ImageID/None:32
-COUNT KernelTraceControl/ImageID/Opcode37:44
 COUNT KernelTraceControl/MetaData/EventInfo:6
 COUNT KernelTraceControl/MetaData/EventMapInfo:1
 COUNT MSNT_SystemTrace/Image/KernelBase:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/net.4.6.2.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/net.4.6.2.x86.baseline.txt
@@ -59,11 +59,11 @@ EVENT 33.030: Windows Kernel/Memory/HardFault PID=8644; TID=8744; PName=Taskmgr;
 EVENT 33.073: Windows Kernel/DiskIO/ReadInit PID=8644; TID=8744; PName=Taskmgr; ProceNum=1; DataLen=12; Irp=0xffffe001b805cb40; 
 EVENT 33.097: Windows Kernel/DiskIO/Write PID=4; TID=6348; PName=System; ProceNum=0; DataLen=52; DiskNumber=0; IrpFlags=AssociatedIrp; Priority=Normal; TransferSize=45,056; ByteOffset=35,210,272,768; Irp=0xffffe001ba038710; ElapsedTimeMSec=0.638; DiskServiceTimeMSec=0.638; FileKey=0xffffc001eab376b0; FileName=C:\temp\perfview\Per...; 
 EVENT 33.950: KernelTraceControl/ImageID/None PID=1748; TID=-1; PName=spoolsv; ProceNum=3; DataLen=12; 
-EVENT 36.616: KernelTraceControl/ImageID/Opcode37 PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=168; 
-EVENT 36.625: KernelTraceControl/ImageID/Opcode37 PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=58; 
-EVENT 36.636: KernelTraceControl/ImageID/Opcode37 PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=50; 
-EVENT 36.645: KernelTraceControl/ImageID/Opcode37 PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=135; 
-EVENT 36.657: KernelTraceControl/ImageID/Opcode37 PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=66; 
+EVENT 36.616: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=168; ImageBase=0x1050000; GuidSig=9557c59f-ba57-4511-b...; Age=1; PDBFileName=f:\binaries\Intermed...; 
+EVENT 36.625: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=58; ImageBase=0x1070000; GuidSig=b7599691-c4cf-48a3-9...; Age=1; PDBFileName=System.ServiceProces...; 
+EVENT 36.636: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=50; ImageBase=0x19970000; GuidSig=0d41a134-79c6-4132-9...; Age=1; PDBFileName=SMDiagnostics.pdb; 
+EVENT 36.645: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=135; ImageBase=0x199b0000; GuidSig=1f521253-a526-4e6b-b...; Age=1; PDBFileName=f:\binaries\Intermed...; 
+EVENT 36.657: KernelTraceControl/ImageID/DbgID_ILRSDS PID=2132; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=66; ImageBase=0x199d0000; GuidSig=57b99f6b-be08-4753-9...; Age=1; PDBFileName=System.ServiceModel....; 
 EVENT 38.347: Windows Kernel/DiskIO/Read PID=-1; TID=8744; PName=; ProceNum=0; DataLen=52; DiskNumber=0; IrpFlags=Nocache, MountComple...; Priority=Normal; TransferSize=16,384; ByteOffset=3,948,622,336; Irp=0xffffe001b805cb40; ElapsedTimeMSec=5.274; DiskServiceTimeMSec=5.274; FileKey=0xffffc001daa0f150; FileName=C:\Windows\System32\...; 
 EVENT 38.356: Windows Kernel/Memory/HardFault PID=8644; TID=8744; PName=Taskmgr; ProceNum=0; DataLen=40; ElapsedTimeMSec=5.299; ReadOffset=1,606,144; VirtualAddress=0x7ffda1a4e244; FileKey=0xffffc001daa0f150; ByteCount=16,384; FileName=C:\Windows\System32\...; 
 EVENT 38.413: Windows Kernel/DiskIO/ReadInit PID=8644; TID=8744; PName=Taskmgr; ProceNum=0; DataLen=12; Irp=0xffffe001b6ea9b40; 
@@ -934,11 +934,11 @@ EVENT 8,455.125: PerfView/Rundown/Stop PID=24464; TID=13020; PName=PerfView; Pro
 EVENT 8,455.125: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=2; DataLen=146; InstallDate=70/01/01 00:00:00.00...; BuildLab=10586.306.amd64fre.t...; ProductName=Windows 10 Enterpris...; 
 EVENT 8,455.125: Windows Kernel/SysConfig/Opcode(37) PID=0; TID=0; PName=Idle; ProceNum=2; DataLen=16; 
 COUNT KernelTraceControl/ImageID:21312
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:4394
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:16750
 COUNT KernelTraceControl/ImageID/FileVersion:2285
 COUNT KernelTraceControl/ImageID/None:916
 COUNT KernelTraceControl/ImageID/Opcode(34):2
-COUNT KernelTraceControl/ImageID/Opcode37:4394
 COUNT KernelTraceControl/MetaData/EventInfo:153
 COUNT KernelTraceControl/MetaData/EventMapInfo:30
 COUNT MSNT_SystemTrace/Image/KernelBase:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x64.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x64.baseline.txt
@@ -55,11 +55,11 @@ EVENT 30.877: Windows Kernel/DiskIO/Write PID=4; TID=4628; PName=System; ProceNu
 EVENT 30.963: Windows Kernel/DiskIO/WriteInit PID=4; TID=4628; PName=System; ProceNum=0; DataLen=12; Irp=0xffffe000d7503140; 
 EVENT 31.743: Windows Kernel/DiskIO/Write PID=4; TID=4628; PName=System; ProceNum=0; DataLen=52; DiskNumber=0; IrpFlags=Nocache, Write, Defe...; Priority=Normal; TransferSize=65,536; ByteOffset=5,065,834,496; Irp=0xffffe000d7503140; ElapsedTimeMSec=0.779; DiskServiceTimeMSec=0.779; FileKey=0xffffc00198046150; FileName=C:\temp\PerfViewData...; 
 EVENT 34.846: KernelTraceControl/ImageID/None PID=1820; TID=-1; PName=spoolsv; ProceNum=3; DataLen=12; 
-EVENT 36.522: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=168; 
-EVENT 36.533: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=58; 
-EVENT 36.545: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=50; 
-EVENT 36.555: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=66; 
-EVENT 36.575: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=57; 
+EVENT 36.522: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=168; ImageBase=0xc50000; GuidSig=9557c59f-ba57-4511-b...; Age=1; PDBFileName=f:\binaries\Intermed...; 
+EVENT 36.533: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=58; ImageBase=0xc60000; GuidSig=ea17b53c-1b4c-49a4-9...; Age=1; PDBFileName=System.ServiceProces...; 
+EVENT 36.545: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=50; ImageBase=0x198a0000; GuidSig=5274cf64-bdc5-4eae-a...; Age=1; PDBFileName=SMDiagnostics.pdb; 
+EVENT 36.555: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=66; ImageBase=0x19900000; GuidSig=5dda8dd7-f6d0-4d59-a...; Age=1; PDBFileName=System.ServiceModel....; 
+EVENT 36.575: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=3; DataLen=57; ImageBase=0x199d0000; GuidSig=870cb491-dac3-444a-a...; Age=1; PDBFileName=System.Configuration...; 
 EVENT 37.149: Windows Kernel/DiskIO/Read PID=-1; TID=21144; PName=; ProceNum=0; DataLen=52; DiskNumber=0; IrpFlags=Nocache, MountComple...; Priority=Normal; TransferSize=16,384; ByteOffset=62,111,852,544; Irp=0xffffe000d1b41010; ElapsedTimeMSec=9.783; DiskServiceTimeMSec=9.783; FileKey=0xffffc00197ea2c00; FileName=C:\ProgramData\Micro...; 
 EVENT 37.364: Windows Kernel/Memory/HardFault PID=2192; TID=21144; PName=MsMpEng; ProceNum=2; DataLen=40; ElapsedTimeMSec=10.020; ReadOffset=10,250,240; VirtualAddress=0x7fff4dbf81b0; FileKey=0xffffc00197ea2c00; ByteCount=16,384; FileName=C:\ProgramData\Micro...; 
 EVENT 37.444: Windows Kernel/DiskIO/ReadInit PID=2192; TID=21144; PName=MsMpEng; ProceNum=2; DataLen=12; Irp=0xffffe000d1b41010; 
@@ -554,10 +554,10 @@ EVENT 8,698.881: PerfView/Rundown/Stop PID=7184; TID=19132; PName=PerfView; Proc
 EVENT 8,698.881: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=3; DataLen=146; InstallDate=70/01/01 00:00:00.00...; BuildLab=10586.306.amd64fre.t...; ProductName=Windows 10 Enterpris...; 
 EVENT 8,698.881: Windows Kernel/SysConfig/Opcode(37) PID=0; TID=0; PName=Idle; ProceNum=3; DataLen=16; 
 COUNT KernelTraceControl/ImageID:8890
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:356
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:8582
 COUNT KernelTraceControl/ImageID/FileVersion:1296
 COUNT KernelTraceControl/ImageID/None:60
-COUNT KernelTraceControl/ImageID/Opcode37:356
 COUNT KernelTraceControl/MetaData/EventInfo:54
 COUNT KernelTraceControl/MetaData/EventMapInfo:24
 COUNT MSNT_SystemTrace/Image/KernelBase:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/netfx.4.6.1080.0.netfxrel3stage.x86.baseline.txt
@@ -50,11 +50,11 @@ EVENT 25.436: Windows Kernel/DiskIO/WriteInit PID=4; TID=9104; PName=System; Pro
 EVENT 25.904: KernelTraceControl/ImageID/None PID=1820; TID=-1; PName=spoolsv; ProceNum=1; DataLen=12; 
 EVENT 26.176: Windows Kernel/DiskIO/Write PID=4; TID=9104; PName=System; ProceNum=0; DataLen=52; DiskNumber=0; IrpFlags=Nocache, Write, Defe...; Priority=Normal; TransferSize=65,536; ByteOffset=5,065,768,960; Irp=0xffffe000d5e94460; ElapsedTimeMSec=0.740; DiskServiceTimeMSec=0.740; FileKey=0xffffc001a8582c00; FileName=C:\temp\PerfViewData...; 
 EVENT 26.879: Windows Kernel/DiskIO/WriteInit PID=4; TID=9104; PName=System; ProceNum=2; DataLen=12; Irp=0xffffe000d7503140; 
-EVENT 27.185: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=168; 
-EVENT 27.193: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=58; 
-EVENT 27.200: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=50; 
-EVENT 27.207: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=66; 
-EVENT 27.222: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=57; 
+EVENT 27.185: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=168; ImageBase=0xc50000; GuidSig=9557c59f-ba57-4511-b...; Age=1; PDBFileName=f:\binaries\Intermed...; 
+EVENT 27.193: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=58; ImageBase=0xc60000; GuidSig=ea17b53c-1b4c-49a4-9...; Age=1; PDBFileName=System.ServiceProces...; 
+EVENT 27.200: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=50; ImageBase=0x198a0000; GuidSig=5274cf64-bdc5-4eae-a...; Age=1; PDBFileName=SMDiagnostics.pdb; 
+EVENT 27.207: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=66; ImageBase=0x19900000; GuidSig=5dda8dd7-f6d0-4d59-a...; Age=1; PDBFileName=System.ServiceModel....; 
+EVENT 27.222: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=1; DataLen=57; ImageBase=0x199d0000; GuidSig=870cb491-dac3-444a-a...; Age=1; PDBFileName=System.Configuration...; 
 EVENT 28.034: Windows Kernel/DiskIO/Write PID=4; TID=9104; PName=System; ProceNum=0; DataLen=52; DiskNumber=0; IrpFlags=Nocache, Write, Defe...; Priority=Normal; TransferSize=65,536; ByteOffset=5,065,834,496; Irp=0xffffe000d7503140; ElapsedTimeMSec=1.155; DiskServiceTimeMSec=1.155; FileKey=0xffffc001a8582c00; FileName=C:\temp\PerfViewData...; 
 EVENT 34.190: KernelTraceControl/ImageID/None PID=3516; TID=-1; PName=explorer; ProceNum=1; DataLen=12; 
 EVENT 34.598: KernelTraceControl/ImageID/None PID=3516; TID=-1; PName=explorer; ProceNum=1; DataLen=12; 
@@ -531,10 +531,10 @@ EVENT 4,171.739: PerfView/Rundown/Stop PID=18716; TID=23384; PName=PerfView; Pro
 EVENT 4,171.739: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=1; DataLen=146; InstallDate=70/01/01 00:00:00.00...; BuildLab=10586.306.amd64fre.t...; ProductName=Windows 10 Enterpris...; 
 EVENT 4,171.739: Windows Kernel/SysConfig/Opcode(37) PID=0; TID=0; PName=Idle; ProceNum=1; DataLen=16; 
 COUNT KernelTraceControl/ImageID:8136
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:78
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:8044
 COUNT KernelTraceControl/ImageID/FileVersion:1153
 COUNT KernelTraceControl/ImageID/None:36
-COUNT KernelTraceControl/ImageID/Opcode37:78
 COUNT KernelTraceControl/MetaData/EventInfo:51
 COUNT KernelTraceControl/MetaData/EventMapInfo:24
 COUNT MSNT_SystemTrace/Image/KernelBase:1

--- a/src/TraceEvent/TraceEvent.Tests/inputs/sl.5.x86.baseline.txt
+++ b/src/TraceEvent/TraceEvent.Tests/inputs/sl.5.x86.baseline.txt
@@ -51,11 +51,11 @@ EVENT 12.351: Windows Kernel/DiskIO/Write PID=4; TID=23944; PName=System; ProceN
 EVENT 13.664: Windows Kernel/DiskIO/WriteInit PID=4; TID=23944; PName=System; ProceNum=0; DataLen=12; Irp=0xffffe000d5451420; 
 EVENT 14.139: Windows Kernel/DiskIO/Write PID=4; TID=23944; PName=System; ProceNum=0; DataLen=52; DiskNumber=0; IrpFlags=Nocache, Write, Defe...; Priority=Normal; TransferSize=65,536; ByteOffset=3,043,594,240; Irp=0xffffe000d5451420; ElapsedTimeMSec=0.475; DiskServiceTimeMSec=0.475; FileKey=0xffffc0019a3dc150; FileName=C:\temp\PerfViewData...; 
 EVENT 14.694: KernelTraceControl/ImageID/None PID=1820; TID=-1; PName=spoolsv; ProceNum=2; DataLen=12; 
-EVENT 15.620: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=168; 
-EVENT 15.626: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=58; 
-EVENT 15.632: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=50; 
-EVENT 15.642: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=66; 
-EVENT 15.659: KernelTraceControl/ImageID/Opcode37 PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=57; 
+EVENT 15.620: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=168; ImageBase=0xc50000; GuidSig=9557c59f-ba57-4511-b...; Age=1; PDBFileName=f:\binaries\Intermed...; 
+EVENT 15.626: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=58; ImageBase=0xc60000; GuidSig=ea17b53c-1b4c-49a4-9...; Age=1; PDBFileName=System.ServiceProces...; 
+EVENT 15.632: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=50; ImageBase=0x198a0000; GuidSig=5274cf64-bdc5-4eae-a...; Age=1; PDBFileName=SMDiagnostics.pdb; 
+EVENT 15.642: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=66; ImageBase=0x19900000; GuidSig=5dda8dd7-f6d0-4d59-a...; Age=1; PDBFileName=System.ServiceModel....; 
+EVENT 15.659: KernelTraceControl/ImageID/DbgID_ILRSDS PID=1712; TID=-1; PName=Aegis.WindowsService; ProceNum=2; DataLen=57; ImageBase=0x199d0000; GuidSig=870cb491-dac3-444a-a...; Age=1; PDBFileName=System.Configuration...; 
 EVENT 24.270: KernelTraceControl/ImageID/None PID=3516; TID=-1; PName=explorer; ProceNum=2; DataLen=12; 
 EVENT 24.569: KernelTraceControl/ImageID/None PID=3516; TID=-1; PName=explorer; ProceNum=2; DataLen=12; 
 EVENT 25.745: KernelTraceControl/ImageID/None PID=4424; TID=-1; PName=TabTip; ProceNum=2; DataLen=12; 
@@ -573,10 +573,10 @@ EVENT 11,922.943: PerfView/Rundown/Stop PID=24000; TID=8440; PName=PerfView; Pro
 EVENT 11,922.943: Windows Kernel/SysConfig/BuildInfo PID=0; TID=0; PName=Idle; ProceNum=3; DataLen=146; InstallDate=70/01/01 00:00:00.00...; BuildLab=10586.306.amd64fre.t...; ProductName=Windows 10 Enterpris...; 
 EVENT 11,922.943: Windows Kernel/SysConfig/Opcode(37) PID=0; TID=0; PName=Idle; ProceNum=3; DataLen=16; 
 COUNT KernelTraceControl/ImageID:8942
+COUNT KernelTraceControl/ImageID/DbgID_ILRSDS:96
 COUNT KernelTraceControl/ImageID/DbgID_RSDS:8846
 COUNT KernelTraceControl/ImageID/FileVersion:1241
 COUNT KernelTraceControl/ImageID/None:40
-COUNT KernelTraceControl/ImageID/Opcode37:96
 COUNT KernelTraceControl/MetaData/EventInfo:69
 COUNT KernelTraceControl/MetaData/EventMapInfo:24
 COUNT MSNT_SystemTrace/Image/KernelBase:1

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1118,15 +1118,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             };
             var symbolParser = new SymbolTraceEventParser(rawEvents);
 
-            symbolParser.ImageIDNone += delegate (EmptyTraceData data)
-            {
-                // If I don't have this, the code ends up not attaching the stack to the image load which has the same timestamp. 
-                noStack = true;
-            };
+            // Symbol parser events never have a stack (but will have a QPC associated with the imageLoad) so we want them ignored
+            symbolParser.All += delegate (TraceEvent data) { noStack = true; };
             symbolParser.ImageIDDbgID_RSDS += delegate (DbgIDRSDSTraceData data)
             {
                 hasPdbInfo = true;
-                noStack = true;
 
                 // The ImageIDDbgID_RSDS may be after the ImageLoad
                 if (lastTraceModuleFile != null && lastTraceModuleFileQPC == data.TimeStampQPC && lastTraceModuleFile.pdbName == null)
@@ -1144,7 +1140,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             };
             symbolParser.ImageID += delegate (ImageIDTraceData data)
             {
-                noStack = true;
                 // The ImageID may be after the ImageLoad
                 if (lastTraceModuleFile != null && lastTraceModuleFileQPC == data.TimeStampQPC && lastTraceModuleFile.timeDateStamp == 0)
                 {
@@ -1156,7 +1151,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             };
             symbolParser.ImageIDFileVersion += delegate (FileVersionTraceData data)
             {
-                noStack = true;
                 // The ImageIDFileVersion may be after the ImageLoad
                 if (lastTraceModuleFile != null && lastTraceModuleFileQPC == data.TimeStampQPC && lastTraceModuleFile.fileVersion == null)
                 {
@@ -1167,18 +1161,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 }
                 else  // Or before (it is handled in ImageGroup callback above)
                     lastFileVersionData = (FileVersionTraceData)data.Clone();
-            };
-            symbolParser.ImageIDOpcode37 += delegate
-            {
-                noStack = true;
-            };
-            symbolParser.ImageIDOpcode38 += delegate
-            {
-                noStack = true;
-            };
-            symbolParser.ImageIDOpcode40 += delegate
-            {
-                noStack = true;
             };
 
             kernelParser.AddCallbackForEvents<FileIONameTraceData>(delegate (FileIONameTraceData data)

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1172,6 +1172,14 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             {
                 noStack = true;
             };
+            symbolParser.ImageIDOpcode38 += delegate
+            {
+                noStack = true;
+            };
+            symbolParser.ImageIDOpcode40 += delegate
+            {
+                noStack = true;
+            };
 
             kernelParser.AddCallbackForEvents<FileIONameTraceData>(delegate (FileIONameTraceData data)
                 {


### PR DESCRIPTION
This change fixes stack association logic when ImageID events with opcode 38 and 40 are present. We are seeing these on traces collected with the Diagnostic Tools collector when gathering VS traces. By setting the noStack flag the stacks get properly associated with the Image/Load event.