### PR TITLE
Update TraceEvent parsers to match CoreCLR manifest changes

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4429,6 +4429,35 @@ table {
                     sample.StackIndex = stackIndex;
                     stackSource.AddSample(sample);
                 }
+                foreach (var data in events.ByEventType<CCWRefCountChangeAnsiTraceData>())
+                {
+                    sample.Metric = 1;
+                    sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
+                    var stackIndex = stackSource.GetCallStack(data.CallStackIndex(), data);
+
+                    var operation = data.Operation;
+                    if (operation.StartsWith("Release", StringComparison.OrdinalIgnoreCase))
+                        sample.Metric = -1;
+
+                    var ccwRefKindName = "CCW " + operation;
+                    var ccwRefKindIndex = stackSource.Interner.FrameIntern(ccwRefKindName);
+                    stackIndex = stackSource.Interner.CallStackIntern(ccwRefKindIndex, stackIndex);
+
+                    var ccwRefCountName = "CCW NewRefCnt " + data.NewRefCount.ToString();
+                    var ccwRefCountIndex = stackSource.Interner.FrameIntern(ccwRefCountName);
+                    stackIndex = stackSource.Interner.CallStackIntern(ccwRefCountIndex, stackIndex);
+
+                    var ccwInstanceName = "CCW Instance 0x" + data.COMInterfacePointer.ToString("x");
+                    var ccwInstanceIndex = stackSource.Interner.FrameIntern(ccwInstanceName);
+                    stackIndex = stackSource.Interner.CallStackIntern(ccwInstanceIndex, stackIndex);
+
+                    var ccwTypeName = "CCW Type " + data.NameSpace + "." + data.ClassName;
+                    var ccwTypeIndex = stackSource.Interner.FrameIntern(ccwTypeName);
+                    stackIndex = stackSource.Interner.CallStackIntern(ccwTypeIndex, stackIndex);
+
+                    sample.StackIndex = stackIndex;
+                    stackSource.AddSample(sample);
+                }
             }
             else if (streamName == ".NET Native CCW Ref Count")
             {

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -1296,6 +1296,17 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
                         Inlinee = data.InlinerNamespace + "." + data.InlineeName
                     });
                 };
+                source.Clr.MethodInliningFailedAnsi += delegate (MethodJitInliningFailedAnsiTraceData data)
+                {
+                    var stats = currentManagedProcess(data);
+                    stats.JIT.m_stats.InliningFailures.Add(new InliningFailureResult
+                    {
+                        MethodBeingCompiled = data.MethodBeingCompiledNamespace + "." + data.MethodBeingCompiledName,
+                        Inliner = data.InlinerNamespace + "." + data.InlinerName,
+                        Inlinee = data.InlineeNamespace + "." + data.InlineeName,
+                        Reason = data.FailReason
+                    });
+                };
                 source.Clr.MethodInliningFailed += delegate (MethodJitInliningFailedTraceData data)
                 {
                     var stats = currentManagedProcess(data);

--- a/src/TraceEvent/Parsers/ClrPrivateTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrPrivateTraceEventParser.cs
@@ -1402,7 +1402,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                RegisterTemplate(new CCWRefCountChangeAnsiTraceData(value, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName));
+                RegisterTemplate(new CCWRefCountChangeAnsiTraceData(value, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChangeAnsi", ProviderGuid, ProviderName));
             }
             remove
             {
@@ -1420,7 +1420,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             remove
             {
                 source.UnregisterEventTemplate(value, 200, ProviderGuid);
-                source.UnregisterEventTemplate(value, 40, GCTaskGuid);
             }
         }
         public event Action<SetGCHandleTraceData> GCSetGCHandle
@@ -2012,7 +2011,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[100] = new NgenBindEventTraceData(null, 188, 13, "NgenBinder", NgenBinderTaskGuid, 69, "NgenBind", ProviderGuid, ProviderName);
                 templates[101] = new FailFastTraceData(null, 191, 2, "FailFast", FailFastTaskGuid, 52, "", ProviderGuid, ProviderName);
                 templates[102] = new FinalizeObjectTraceData(null, 192, 1, "GC", GCTaskGuid, 39, "FinalizeObject", ProviderGuid, ProviderName);
-                templates[103] = new CCWRefCountChangeAnsiTraceData(null, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName);
+                templates[103] = new CCWRefCountChangeAnsiTraceData(null, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChangeAnsi", ProviderGuid, ProviderName);
                 templates[104] = new SetGCHandleTraceData(null, 194, 1, "GC", GCTaskGuid, 42, "SetGCHandle", ProviderGuid, ProviderName);
                 templates[105] = new DestroyGCHandleTraceData(null, 195, 1, "GC", GCTaskGuid, 43, "DestroyGCHandle", ProviderGuid, ProviderName);
                 templates[106] = new FusionMessageTraceData(null, 196, 10, "Binding", BindingTaskGuid, 70, "FusionMessage", ProviderGuid, ProviderName);

--- a/src/TraceEvent/Parsers/ClrPrivateTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrPrivateTraceEventParser.cs
@@ -1397,16 +1397,29 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 source.UnregisterEventTemplate(value, 39, GCTaskGuid);
             }
         }
+        public event Action<CCWRefCountChangeAnsiTraceData> GCCCWRefCountChangeAnsi
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                RegisterTemplate(new CCWRefCountChangeAnsiTraceData(value, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 193, ProviderGuid);
+                source.UnregisterEventTemplate(value, 40, GCTaskGuid);
+            }
+        }
         public event Action<CCWRefCountChangeTraceData> GCCCWRefCountChange
         {
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                RegisterTemplate(new CCWRefCountChangeTraceData(value, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName));
+                RegisterTemplate(new CCWRefCountChangeTraceData(value, 200, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 193, ProviderGuid);
+                source.UnregisterEventTemplate(value, 200, ProviderGuid);
                 source.UnregisterEventTemplate(value, 40, GCTaskGuid);
             }
         }
@@ -1895,7 +1908,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[132];
+                var templates = new TraceEvent[133];
                 templates[0] = new GCDecisionTraceData(null, 1, 1, "GC", GCTaskGuid, 132, "Decision", ProviderGuid, ProviderName);
                 templates[1] = new GCSettingsTraceData(null, 2, 1, "GC", GCTaskGuid, 14, "Settings", ProviderGuid, ProviderName);
                 templates[2] = new GCOptimizedTraceData(null, 3, 1, "GC", GCTaskGuid, 16, "Optimized", ProviderGuid, ProviderName);
@@ -1999,7 +2012,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[100] = new NgenBindEventTraceData(null, 188, 13, "NgenBinder", NgenBinderTaskGuid, 69, "NgenBind", ProviderGuid, ProviderName);
                 templates[101] = new FailFastTraceData(null, 191, 2, "FailFast", FailFastTaskGuid, 52, "", ProviderGuid, ProviderName);
                 templates[102] = new FinalizeObjectTraceData(null, 192, 1, "GC", GCTaskGuid, 39, "FinalizeObject", ProviderGuid, ProviderName);
-                templates[103] = new CCWRefCountChangeTraceData(null, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName);
+                templates[103] = new CCWRefCountChangeAnsiTraceData(null, 193, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName);
                 templates[104] = new SetGCHandleTraceData(null, 194, 1, "GC", GCTaskGuid, 42, "SetGCHandle", ProviderGuid, ProviderName);
                 templates[105] = new DestroyGCHandleTraceData(null, 195, 1, "GC", GCTaskGuid, 43, "DestroyGCHandle", ProviderGuid, ProviderName);
                 templates[106] = new FusionMessageTraceData(null, 196, 10, "Binding", BindingTaskGuid, 70, "FusionMessage", ProviderGuid, ProviderName);
@@ -2028,6 +2041,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[129] = new DynamicTypeUseNoParametersPrivateTraceData(null, 411, 22, "ClrDynamicTypeUsage", ClrDynamicTypeUsageTaskGuid, 22, "BeginCreateManagedReference", ProviderGuid, ProviderName);
                 templates[130] = new DynamicTypeUseNoParametersPrivateTraceData(null, 412, 22, "ClrDynamicTypeUsage", ClrDynamicTypeUsageTaskGuid, 23, "EndCreateManagedReference", ProviderGuid, ProviderName);
                 templates[131] = new DynamicTypeUseStringAndIntPrivateTraceData(null, 413, 22, "ClrDynamicTypeUsage", ClrDynamicTypeUsageTaskGuid, 24, "ObjectVariantMarshallingToManaged", ProviderGuid, ProviderName);
+                templates[132] = new CCWRefCountChangeTraceData(null, 200, 1, "GC", GCTaskGuid, 40, "CCWRefCountChange", ProviderGuid, ProviderName);
 
                 s_templates = templates;
             }
@@ -3874,7 +3888,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate
         private event Action<FinalizeObjectTraceData> Action;
         #endregion
     }
-    public sealed class CCWRefCountChangeTraceData : TraceEvent
+    public sealed class CCWRefCountChangeAnsiTraceData : TraceEvent
     {
         public Address HandleID { get { return GetAddressAt(0); } }
         public Address ObjectID { get { return GetAddressAt(HostOffset(4, 1)); } }
@@ -3885,6 +3899,95 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate
         public string NameSpace { get { return GetUTF8StringAt(SkipUTF8String(HostOffset(24, 3))); } }
         public string Operation { get { return GetUnicodeStringAt(SkipUTF8String(SkipUTF8String(HostOffset(24, 3)))); } }
         public int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(SkipUTF8String(SkipUTF8String(HostOffset(24, 3))))); } }
+
+        #region Private
+        internal CCWRefCountChangeAnsiTraceData(Action<CCWRefCountChangeAnsiTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.Action = action;
+        }
+        internal protected override void Dispatch()
+        {
+            Action(this);
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<CCWRefCountChangeAnsiTraceData>)value; }
+        }
+        internal protected override void Validate()
+        {
+            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(SkipUTF8String(SkipUTF8String(HostOffset(24, 3)))) + 2));
+            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(SkipUTF8String(SkipUTF8String(HostOffset(24, 3)))) + 2));
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttribHex(sb, "HandleID", HandleID);
+            XmlAttribHex(sb, "ObjectID", ObjectID);
+            XmlAttribHex(sb, "COMInterfacePointer", COMInterfacePointer);
+            XmlAttrib(sb, "NewRefCount", NewRefCount);
+            XmlAttribHex(sb, "AppDomainID", AppDomainID);
+            XmlAttrib(sb, "ClassName", ClassName);
+            XmlAttrib(sb, "NameSpace", NameSpace);
+            XmlAttrib(sb, "Operation", Operation);
+            XmlAttrib(sb, "ClrInstanceID", ClrInstanceID);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "HandleID", "ObjectID", "COMInterfacePointer", "NewRefCount", "AppDomainID", "ClassName", "NameSpace", "Operation", "ClrInstanceID" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return HandleID;
+                case 1:
+                    return ObjectID;
+                case 2:
+                    return COMInterfacePointer;
+                case 3:
+                    return NewRefCount;
+                case 4:
+                    return AppDomainID;
+                case 5:
+                    return ClassName;
+                case 6:
+                    return NameSpace;
+                case 7:
+                    return Operation;
+                case 8:
+                    return ClrInstanceID;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<CCWRefCountChangeAnsiTraceData> Action;
+        #endregion
+    }
+    public sealed class CCWRefCountChangeTraceData : TraceEvent
+    {
+        public Address HandleID { get { return GetAddressAt(0); } }
+        public Address ObjectID { get { return GetAddressAt(HostOffset(4, 1)); } }
+        public Address COMInterfacePointer { get { return GetAddressAt(HostOffset(8, 2)); } }
+        public int NewRefCount { get { return GetInt32At(HostOffset(12, 3)); } }
+        public long AppDomainID { get { return GetInt64At(HostOffset(16, 3)); } }
+        public string ClassName { get { return GetUnicodeStringAt(HostOffset(24, 3)); } }
+        public string NameSpace { get { return GetUnicodeStringAt(SkipUnicodeString(HostOffset(24, 3))); } }
+        public string Operation { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(HostOffset(24, 3)))); } }
+        public int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(HostOffset(24, 3))))); } }
 
         #region Private
         internal CCWRefCountChangeTraceData(Action<CCWRefCountChangeTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -3903,8 +4006,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate
         }
         internal protected override void Validate()
         {
-            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(SkipUTF8String(SkipUTF8String(HostOffset(24, 3)))) + 2));
-            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(SkipUTF8String(SkipUTF8String(HostOffset(24, 3)))) + 2));
+            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(HostOffset(24, 3)))) + 2));
+            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(HostOffset(24, 3)))) + 2));
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -1600,7 +1600,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             remove
             {
                 source.UnregisterEventTemplate(value, 192, ProviderGuid);
-                source.UnregisterEventTemplate(value, 84, MethodTaskGuid);
             }
         }
         public event Action<MethodJitInliningFailedAnsiTraceData> MethodInliningFailedAnsi
@@ -1608,7 +1607,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                RegisterTemplate(new MethodJitInliningFailedAnsiTraceData(value, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName));
+                RegisterTemplate(new MethodJitInliningFailedAnsiTraceData(value, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailedAnsi", ProviderGuid, ProviderName));
             }
             remove
             {
@@ -1647,7 +1646,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                RegisterTemplate(new MethodJitTailCallFailedAnsiTraceData(value, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName));
+                RegisterTemplate(new MethodJitTailCallFailedAnsiTraceData(value, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailedAnsi", ProviderGuid, ProviderName));
             }
             remove
             {
@@ -1665,7 +1664,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             remove
             {
                 source.UnregisterEventTemplate(value, 192, ProviderGuid);
-                source.UnregisterEventTemplate(value, 86, MethodTaskGuid);
             }
         }
 
@@ -1829,8 +1827,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[111] = new ThreadPoolIOWorkEnqueueTraceData(null, 63, 23, "ThreadPool", ThreadPoolTaskGuid, 13, "IOEnqueue", ProviderGuid, ProviderName);
                 templates[112] = new ThreadPoolIOWorkTraceData(null, 64, 23, "ThreadPool", ThreadPoolTaskGuid, 14, "IODequeue", ProviderGuid, ProviderName);
                 templates[113] = new ThreadPoolIOWorkTraceData(null, 65, 23, "ThreadPool", ThreadPoolTaskGuid, 15, "IOPack", ProviderGuid, ProviderName);
-                templates[114] = new MethodJitInliningFailedAnsiTraceData(null, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName);
-                templates[115] = new MethodJitTailCallFailedAnsiTraceData(null, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName);
+                templates[114] = new MethodJitInliningFailedAnsiTraceData(null, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailedAnsi", ProviderGuid, ProviderName);
+                templates[115] = new MethodJitTailCallFailedAnsiTraceData(null, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailedAnsi", ProviderGuid, ProviderName);
 
                 s_templates = templates;
             }

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -1595,7 +1595,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                RegisterTemplate(new MethodJitInliningFailedTraceData(value, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName));
+                RegisterTemplate(new MethodJitInliningFailedTraceData(value, 192, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 192, ProviderGuid);
+                source.UnregisterEventTemplate(value, 84, MethodTaskGuid);
+            }
+        }
+        public event Action<MethodJitInliningFailedAnsiTraceData> MethodInliningFailedAnsi
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                RegisterTemplate(new MethodJitInliningFailedAnsiTraceData(value, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName));
             }
             remove
             {
@@ -1629,16 +1642,29 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 source.UnregisterEventTemplate(value, 85, MethodTaskGuid);
             }
         }
+        public event Action<MethodJitTailCallFailedAnsiTraceData> MethodTailCallFailedAnsi
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                RegisterTemplate(new MethodJitTailCallFailedAnsiTraceData(value, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 189, ProviderGuid);
+                source.UnregisterEventTemplate(value, 86, MethodTaskGuid);
+            }
+        }
         public event Action<MethodJitTailCallFailedTraceData> MethodTailCallFailed
         {
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                RegisterTemplate(new MethodJitTailCallFailedTraceData(value, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName));
+                RegisterTemplate(new MethodJitTailCallFailedTraceData(value, 192, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName));
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 189, ProviderGuid);
+                source.UnregisterEventTemplate(value, 192, ProviderGuid);
                 source.UnregisterEventTemplate(value, 86, MethodTaskGuid);
             }
         }
@@ -1684,7 +1710,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[114];
+                var templates = new TraceEvent[116];
                 templates[0] = new GCStartTraceData(null, 1, 1, "GC", GCTaskGuid, 1, "Start", ProviderGuid, ProviderName);
                 templates[1] = new GCEndTraceData(null, 2, 1, "GC", GCTaskGuid, 2, "Stop", ProviderGuid, ProviderName);
                 templates[2] = new GCNoUserDataTraceData(null, 3, 1, "GC", GCTaskGuid, 132, "RestartEEStop", ProviderGuid, ProviderName);
@@ -1771,7 +1797,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[83] = new AuthenticodeVerificationTraceData(null, 183, 13, "AuthenticodeVerification", AuthenticodeVerificationTaskGuid, 1, "Start", ProviderGuid, ProviderName);
                 templates[84] = new AuthenticodeVerificationTraceData(null, 184, 13, "AuthenticodeVerification", AuthenticodeVerificationTaskGuid, 2, "Stop", ProviderGuid, ProviderName);
                 templates[85] = new MethodJitInliningSucceededTraceData(null, 185, 9, "Method", MethodTaskGuid, 83, "InliningSucceeded", ProviderGuid, ProviderName);
-                templates[86] = new MethodJitInliningFailedTraceData(null, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName);
+                templates[86] = new MethodJitInliningFailedTraceData(null, 192, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName);
                 templates[87] = new RuntimeInformationTraceData(null, 187, 19, "Runtime", RuntimeTaskGuid, 1, "Start", ProviderGuid, ProviderName);
                 templates[88] = new MethodJitTailCallSucceededTraceData(null, 188, 9, "Method", MethodTaskGuid, 85, "TailCallSucceeded", ProviderGuid, ProviderName);
                 templates[89] = new MethodJitTailCallFailedTraceData(null, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName);
@@ -1803,6 +1829,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[111] = new ThreadPoolIOWorkEnqueueTraceData(null, 63, 23, "ThreadPool", ThreadPoolTaskGuid, 13, "IOEnqueue", ProviderGuid, ProviderName);
                 templates[112] = new ThreadPoolIOWorkTraceData(null, 64, 23, "ThreadPool", ThreadPoolTaskGuid, 14, "IODequeue", ProviderGuid, ProviderName);
                 templates[113] = new ThreadPoolIOWorkTraceData(null, 65, 23, "ThreadPool", ThreadPoolTaskGuid, 15, "IOPack", ProviderGuid, ProviderName);
+                templates[114] = new MethodJitInliningFailedAnsiTraceData(null, 186, 9, "Method", MethodTaskGuid, 84, "InliningFailed", ProviderGuid, ProviderName);
+                templates[115] = new MethodJitTailCallFailedAnsiTraceData(null, 189, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName);
 
                 s_templates = templates;
             }
@@ -8694,7 +8722,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         private event Action<MethodJitInliningSucceededTraceData> Action;
         #endregion
     }
-    public sealed class MethodJitInliningFailedTraceData : TraceEvent
+    public sealed class MethodJitInliningFailedAnsiTraceData : TraceEvent
     {
         public string MethodBeingCompiledNamespace { get { return GetUnicodeStringAt(0); } }
         public string MethodBeingCompiledName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
@@ -8708,6 +8736,108 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         public bool FailAlways { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))))))) != 0; } }
         public string FailReason { get { return GetUTF8StringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4); } }
         public int ClrInstanceID { get { return GetInt16At(SkipUTF8String(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4)); } }
+
+        #region Private
+        internal MethodJitInliningFailedAnsiTraceData(Action<MethodJitInliningFailedAnsiTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<MethodJitInliningFailedAnsiTraceData>)value; }
+        }
+        protected internal override void Validate()
+        {
+            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
+            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "MethodBeingCompiledNamespace", MethodBeingCompiledNamespace);
+            XmlAttrib(sb, "MethodBeingCompiledName", MethodBeingCompiledName);
+            XmlAttrib(sb, "MethodBeingCompiledNameSignature", MethodBeingCompiledNameSignature);
+            XmlAttrib(sb, "InlinerNamespace", InlinerNamespace);
+            XmlAttrib(sb, "InlinerName", InlinerName);
+            XmlAttrib(sb, "InlinerNameSignature", InlinerNameSignature);
+            XmlAttrib(sb, "InlineeNamespace", InlineeNamespace);
+            XmlAttrib(sb, "InlineeName", InlineeName);
+            XmlAttrib(sb, "InlineeNameSignature", InlineeNameSignature);
+            XmlAttrib(sb, "FailAlways", FailAlways);
+            XmlAttrib(sb, "FailReason", FailReason);
+            XmlAttrib(sb, "ClrInstanceID", ClrInstanceID);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "MethodBeingCompiledNamespace", "MethodBeingCompiledName", "MethodBeingCompiledNameSignature", "InlinerNamespace", "InlinerName", "InlinerNameSignature", "InlineeNamespace", "InlineeName", "InlineeNameSignature", "FailAlways", "FailReason", "ClrInstanceID" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return MethodBeingCompiledNamespace;
+                case 1:
+                    return MethodBeingCompiledName;
+                case 2:
+                    return MethodBeingCompiledNameSignature;
+                case 3:
+                    return InlinerNamespace;
+                case 4:
+                    return InlinerName;
+                case 5:
+                    return InlinerNameSignature;
+                case 6:
+                    return InlineeNamespace;
+                case 7:
+                    return InlineeName;
+                case 8:
+                    return InlineeNameSignature;
+                case 9:
+                    return FailAlways;
+                case 10:
+                    return FailReason;
+                case 11:
+                    return ClrInstanceID;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<MethodJitInliningFailedAnsiTraceData> Action;
+        #endregion
+    }
+
+    public sealed class MethodJitInliningFailedTraceData : TraceEvent
+    {
+        public string MethodBeingCompiledNamespace { get { return GetUnicodeStringAt(0); } }
+        public string MethodBeingCompiledName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
+        public string MethodBeingCompiledNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(0))); } }
+        public string InlinerNamespace { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))); } }
+        public string InlinerName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))); } }
+        public string InlinerNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))); } }
+        public string InlineeNamespace { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))); } }
+        public string InlineeName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))))); } }
+        public string InlineeNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))); } }
+        public bool FailAlways { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))))))) != 0; } }
+        public string FailReason { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4); } }
+        public int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4)); } }
 
         #region Private
         internal MethodJitInliningFailedTraceData(Action<MethodJitInliningFailedTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -8795,6 +8925,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         private event Action<MethodJitInliningFailedTraceData> Action;
         #endregion
     }
+
     public sealed class RuntimeInformationTraceData : TraceEvent
     {
         public int ClrInstanceID { get { return GetInt16At(0); } }
@@ -9009,7 +9140,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         private event Action<MethodJitTailCallSucceededTraceData> Action;
         #endregion
     }
-    public sealed class MethodJitTailCallFailedTraceData : TraceEvent
+
+    public sealed class MethodJitTailCallFailedAnsiTraceData : TraceEvent
     {
         public string MethodBeingCompiledNamespace { get { return GetUnicodeStringAt(0); } }
         public string MethodBeingCompiledName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
@@ -9023,6 +9155,108 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         public bool TailPrefix { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))))))) != 0; } }
         public string FailReason { get { return GetUTF8StringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4); } }
         public int ClrInstanceID { get { return GetInt16At(SkipUTF8String(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4)); } }
+
+        #region Private
+        internal MethodJitTailCallFailedAnsiTraceData(Action<MethodJitTailCallFailedAnsiTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            this.Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<MethodJitTailCallFailedAnsiTraceData>)value; }
+        }
+        protected internal override void Validate()
+        {
+            Debug.Assert(!(Version == 0 && EventDataLength != SkipUTF8String(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
+            Debug.Assert(!(Version > 0 && EventDataLength < SkipUTF8String(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "MethodBeingCompiledNamespace", MethodBeingCompiledNamespace);
+            XmlAttrib(sb, "MethodBeingCompiledName", MethodBeingCompiledName);
+            XmlAttrib(sb, "MethodBeingCompiledNameSignature", MethodBeingCompiledNameSignature);
+            XmlAttrib(sb, "CallerNamespace", CallerNamespace);
+            XmlAttrib(sb, "CallerName", CallerName);
+            XmlAttrib(sb, "CallerNameSignature", CallerNameSignature);
+            XmlAttrib(sb, "CalleeNamespace", CalleeNamespace);
+            XmlAttrib(sb, "CalleeName", CalleeName);
+            XmlAttrib(sb, "CalleeNameSignature", CalleeNameSignature);
+            XmlAttrib(sb, "TailPrefix", TailPrefix);
+            XmlAttrib(sb, "FailReason", FailReason);
+            XmlAttrib(sb, "ClrInstanceID", ClrInstanceID);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "MethodBeingCompiledNamespace", "MethodBeingCompiledName", "MethodBeingCompiledNameSignature", "CallerNamespace", "CallerName", "CallerNameSignature", "CalleeNamespace", "CalleeName", "CalleeNameSignature", "TailPrefix", "FailReason", "ClrInstanceID" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return MethodBeingCompiledNamespace;
+                case 1:
+                    return MethodBeingCompiledName;
+                case 2:
+                    return MethodBeingCompiledNameSignature;
+                case 3:
+                    return CallerNamespace;
+                case 4:
+                    return CallerName;
+                case 5:
+                    return CallerNameSignature;
+                case 6:
+                    return CalleeNamespace;
+                case 7:
+                    return CalleeName;
+                case 8:
+                    return CalleeNameSignature;
+                case 9:
+                    return TailPrefix;
+                case 10:
+                    return FailReason;
+                case 11:
+                    return ClrInstanceID;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<MethodJitTailCallFailedAnsiTraceData> Action;
+        #endregion
+    }
+
+    public sealed class MethodJitTailCallFailedTraceData : TraceEvent
+    {
+        public string MethodBeingCompiledNamespace { get { return GetUnicodeStringAt(0); } }
+        public string MethodBeingCompiledName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
+        public string MethodBeingCompiledNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(0))); } }
+        public string CallerNamespace { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))); } }
+        public string CallerName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))); } }
+        public string CallerNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))); } }
+        public string CalleeNamespace { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))); } }
+        public string CalleeName { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))))); } }
+        public string CalleeNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))); } }
+        public bool TailPrefix { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))))))))) != 0; } }
+        public string FailReason { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4); } }
+        public int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4)); } }
 
         #region Private
         internal MethodJitTailCallFailedTraceData(Action<MethodJitTailCallFailedTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -9041,8 +9275,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         }
         protected internal override void Validate()
         {
-            Debug.Assert(!(Version == 0 && EventDataLength != SkipUTF8String(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
-            Debug.Assert(!(Version > 0 && EventDataLength < SkipUTF8String(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
+            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
+            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))))))))) + 4) + 2));
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {


### PR DESCRIPTION
This update corresponds to https://github.com/dotnet/coreclr/pull/17989.