### PR TITLE
Fixed EventSources that use both manifest and self-describing events

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -8142,12 +8142,24 @@
     </li>
     -->
         <li>
+            Version 2.0.16 5/22/18
+            <ul>
+                <li>
+                    Fix bug when parsing 'mixed' EventSources that use both Manifest events and self-describing events
+                    in the same EventSource, leading to the self-descdribing events being parsed as (garbled) manifest
+                    events.    This can happen when using EventCounters pretty easily since EventCounters use the self-decribing
+                    format.  
+                </li>
+            </ul>
+        </li>
+        <li>
             Version 2.0.15 5/14/18
             <ul>
-                <li> Changed the default symbol cache to %TEMP%\SymbolCache.   This aligns PerfView with what Visual Studio does 
-                which saves some space.  Because PerfView remembers the symbol path from invokation to invokation, this change
-                will not affect existing places where PerfView is run.  To use the new cache locaiton you need to use the
-                file -> Clear User Config, and restart.  But mostly you should not care.  
+                <li> 
+                    Changed the default symbol cache to %TEMP%\SymbolCache.   This aligns PerfView with what Visual Studio does
+                    which saves some space.  Because PerfView remembers the symbol path from invokation to invokation, this change
+                    will not affect existing places where PerfView is run.  To use the new cache locaiton you need to use the
+                    file -> Clear User Config, and restart.  But mostly you should not care.
                 </li>
 
             </ul>

--- a/src/TraceEvent/TraceLoggingEventId.cs
+++ b/src/TraceEvent/TraceLoggingEventId.cs
@@ -82,8 +82,9 @@ namespace Microsoft.Diagnostics.Tracing
             if (!m_traceLoggingEventMap.TryGetValue(key, out ret))
             {
                 // No then get the next ID for this particular provider (and allocate a new one)
-                m_nextTraceLoggingIDForProvider.TryGetValue(eventRecord->EventHeader.ProviderId, out ret);
-                ret++;
+                if (!m_nextTraceLoggingIDForProvider.TryGetValue(eventRecord->EventHeader.ProviderId, out ret))
+                    ret = 0xFF00;   // We arbitrarily pick the 'high end' of the event ID range to stay way from user-allocated IDs.   However we also avoid the last 256 ID just in case.  
+                --ret;
                 m_nextTraceLoggingIDForProvider[eventRecord->EventHeader.ProviderId] = ret;
                 if (ret == 0) // means we wrapped around.  We have no more!
                     throw new InvalidOperationException("Error ran out of TraceLogging Event IDs for provider " + eventRecord->EventHeader.ProviderId);


### PR DESCRIPTION

The problem was synthetic ID we generate for self-describing events were overlapping the manifest event IDs.  .   Pick a different range to fix.