### PR TITLE
Fix an infinite loop in the StartStop Actitivities view

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.16</PerfViewVersion>
-    <TraceEventVersion>2.0.16</TraceEventVersion>
+    <PerfViewVersion>2.0.17</PerfViewVersion>
+    <TraceEventVersion>2.0.17</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/TraceEvent/Computers/ActivityComputer.cs
+++ b/src/TraceEvent/Computers/ActivityComputer.cs
@@ -179,10 +179,18 @@ namespace Microsoft.Diagnostics.Tracing
                 // is not running anymore.   
                 if (IsThreadParkedInThreadPool(m_eventLog, data.BlockingStack()))
                 {
+                    int count = 0;
                     while (activity != null)
                     {
                         OnStop(data, activity, thread);
-                        activity = activity.prevActivityOnThread;
+                        TraceActivity newActivity = activity.prevActivityOnThread;
+                        count++;
+                        if (activity == newActivity || count > 1000)
+                        {
+                            m_symbolReader.Log.WriteLine("Error: prevActivityOnThread is recursive {0}", activity.Name);
+                            break;
+                        }
+                        activity = newActivity;
                     }
 
                     // We will make a new activity from the current one then next time we wake up.  

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -2710,18 +2710,24 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             if (!condition)
             {
+                TextWriter writer = null;
+                if (options != null)
+                    writer = options.ConversionLog;
+                bool debugBuild = false;
+#if DEBUG
+                debugBuild = true;
+#endif
+                if (writer == null && !debugBuild)
+                    return;
+
                 Trace.Write("WARNING: ");
                 string prefix = "";
                 if (data != null)
                 {
                     prefix = "Time: " + data.TimeStampRelativeMSec.ToString("f4").PadLeft(12) + " PID: " + data.ProcessID.ToString().PadLeft(4) + ": ";
-                    Trace.Write(prefix);
+                    Debug.Write(prefix);
                 }
                 Trace.WriteLine(message);
-
-                TextWriter writer = null;
-                if (options != null)
-                    writer = options.ConversionLog;
 
                 if (writer == null)
                     return;


### PR DESCRIPTION
Added a max count (1000) to a loop to insure no infinite loops even in bad traces.