### PR TITLE
TraceEvent mods for relogging

### DIFF
--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -605,7 +605,7 @@ namespace ETWManifest
                     case "opcode":
                         m_opcodeId = reader.Value;
                         break;
-                    case "keyword":
+                    case "keywords":
                         m_keywordsId = reader.Value;
                         break;
                     case "level":
@@ -649,7 +649,14 @@ namespace ETWManifest
                 id = m_keywordsId;
                 m_keywordsId = null;
                 if (id != null)
-                    Keywords = m_provider.m_keywordValues[id];
+                    if (m_provider.m_keywordValues != null)
+                    {
+                        var keywordsList = id.Split(' ');
+                        foreach (var currKeyword in keywordsList)
+                        {
+                            Keywords |= m_provider.m_keywordValues[currKeyword];
+                        }
+                    }
 
                 id = TemplateName;
                 if (id != null)

--- a/src/TraceParserGen/TraceParserGen.cs
+++ b/src/TraceParserGen/TraceParserGen.cs
@@ -327,7 +327,7 @@ class TraceParserGen
         {
             var eventName = keyValue.Key;
             var versionsForEvent = keyValue.Value;
-
+     
             // We have to accumulate all the information needed to fetch a field, across all the versions of the event
             // Only then can we emit the code that will work for all fields simultaneously.  
             var fieldVersions = new SortedDictionary<string, List<FieldInfo>>();
@@ -549,6 +549,11 @@ class TraceParserGen
             output.WriteLine("            }");
             output.WriteLine("        }");
             output.WriteLine("");
+
+            // Write out the keywords belonging to this template
+            output.WriteLine("        public static ulong GetKeywords() { return " + versionsForEvent[0].Keywords + "; }");
+            output.WriteLine("        public static string GetProviderName() { return \"" + versionsForEvent[0].Provider.Name + "\"; }");
+            output.WriteLine("        public static Guid GetProviderGuid() { return new Guid(\"" + versionsForEvent[0].Provider.Id + "\"); }");
 
             // Write out the fields specific to this TraceEvent (that are not payload)
             output.WriteLine("        private event Action<" + templateClassName + "> m_target;");


### PR DESCRIPTION
+Add more template data to each class compiled with TraceParserGen (keywords/providername/providerguid)
+Enable TraceRelogger WriteEvents(...) to overwrite specific ETW data
+Modify EnsureScratchBufferSpace so it copies previously filled data when resizing.
+Add UInt64 to list of parsed payload args