### PR TITLE
Short-circuit DynamicTraceEventParser::GetPayloadValueAt for arrays of bytes

### DIFF
--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -570,8 +570,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             {
                 var arrayCount = GetCountForArray(payloadFetch, arrayInfo, ref offset);
 
-                // TODO this is very inefficient for blitable types.   Optimize that.  
+                // TODO this is very inefficient for blitable types. Optimize that.
                 var elementType = arrayInfo.Element.Type;
+
+                // Byte array short-circuit.
+                if (elementType == typeof(byte))
+                {
+                    return this.GetByteArrayAt(offset, arrayCount);
+                }
+
                 var ret = Array.CreateInstance(elementType, arrayCount);
                 for (int i = 0; i < arrayCount; i++)
                 {


### PR DESCRIPTION
For reasons I'm not going to get into, we are using the DynamicTraceEventParser class (as opposed to a strongly typed parser from traceparsergen) to retrieve a payload value of type byte array. Its very inefficient; there is already a TODO in the codebase to handle arrays of blittable types more efficiently. I did some brief testing where I emited a single event, captured and opened up that file using the DynamicTraceEventParser, cloned the event, then read a single 2000 byte payload value 10000 times from that clone. Using perfview I can see a 5x reduction in CPU from before and after.

My change looks a little hackish, but seems safe enough until that existing TODO is properly addressed. Existing tests pass.