### PR TITLE
Update to support signing Nuget support packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.18</PerfViewVersion>
-    <TraceEventVersion>2.0.18</TraceEventVersion>
+    <PerfViewVersion>2.0.19</PerfViewVersion>
+    <TraceEventVersion>2.0.19</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
@@ -3,7 +3,7 @@ REM
 REM *** This is mostly a template for doing the copy.      ****  
 REM *** Most likey you want this to be the current version ****
 REM *** PLEASE MODIFY THE VERSION NUMBER TO BE CURRENT!    ****
-xcopy /s /Y %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.12\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
+xcopy /s /Y %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.14\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
 
 REM Overwrite OSExtensions.dll with the latest built versions.
 xcopy /s /Y ..\OSExtensions\bin\Release\net45\OSExtensions.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\lib\net45

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.5">
     <id>Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles</id>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     <title>Non-Source files needed to Build TraceEvent</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <description> Basically this package contains DLLs that TraceEvent depends on but does not build itself.</description>
-    <releaseNotes>This package is a refresh with signing for the 2.0 release of TraceEvent.  It fixes the KernelTraceControl.win61.dll that was not signed properly. </releaseNotes>
+    <releaseNotes>Move to signed nuget packages.</releaseNotes>
     <tags>TraceEvent</tags>
   </metadata>
 </package>

--- a/src/NugetSupportFiles/PerfView.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/PerfView.SupportFiles.Populate.bat
@@ -4,8 +4,8 @@ REM *** This is mostly a template for doing the copy.      ****
 REM *** Most likey you want this to be the current version ****
 REM *** PLEASE MODIFY THE VERSION NUMBER TO BE CURRENT!    ****
 REM 
-xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\PerfView.SupportFiles\1.0.5\*.dll PerfView.SupportFiles
-xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\PerfView.SupportFiles\1.0.5\*.exe PerfView.SupportFiles
+xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\PerfView.SupportFiles\1.0.6\*.dll PerfView.SupportFiles
+xcopy /s %HOMEDRIVE%%HOMEPATH%\.nuget\packages\PerfView.SupportFiles\1.0.6\*.exe PerfView.SupportFiles
 
 @REM These are the binary files we need from somewhere to for the support package
 @REM lib\native\x86\DiagnosticsHub.Packaging.dll

--- a/src/NugetSupportFiles/PerfView.SupportFiles/PerfView.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/PerfView.SupportFiles/PerfView.SupportFiles.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.5">
     <id>PerfView.SupportFiles</id>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <title>Non-Source files needed to Build PerfView</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -11,6 +11,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <description> Basically this package contains DLLs that PerfView depends on but does not build itself.</description>
+    <releaseNotes>Move to signed nuget packages.</releaseNotes>
     <tags>PerfView</tags>
   </metadata>
 </package>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -240,6 +240,13 @@
       <Link>System.Runtime.InteropServices.RuntimeInformation.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Collections.Immutable.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\System.Collections.Immutable.dll</LogicalName>
+      <Link>System.Collections.Immutable.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Reflection.Metadata.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -4138,8 +4138,8 @@
         </li>
         <li>
             The <strong><a id="AdditionalProvidersTextBox">Additional Providers TextBox</a></strong>
-            - A comma separated list of specifications for providers.&nbsp;&nbsp; This can be specified by using the
-            (the ... button) or by the following textual specification.  Each provider
+            - A comma separated list of specifications for providers cooresponding to the /providers comand line qualifier.
+            This can be specified by using the ... button or by the following textual specification.  Each provider
             specification has the general form of <em>provider</em>:<em>keywords</em>:<em>level:values</em>.
             The keyword and levels specification parts are optional and can be omitted (For example <em>provider:keywords:values</em> or <em>provider:values </em>is legal).&nbsp;&nbsp;
             <ul>

--- a/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
+++ b/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
@@ -13,26 +13,24 @@
   </PropertyGroup>
    
   <ItemGroup>
-    <None Include="..\TraceEvent\bin\$(Configuration)\*.nupkg">
+    <!-- To support Signing new SupportFile packages, look for any packages in the NugetSupportFiles directory -->
+    <None Include="..\NugetSupportFiles\*.SupportFiles.*.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+
+    <!-- Get the Microsoft.Diagnostics.TraceEvent.*.nuget package we just built -->
+    <None Include="..\TraceEvent\bin\$(Configuration)\Microsoft.Diagnostics.Tracing.TraceEvent.*.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <FilesToSign Include="$(OutDir)\Microsoft.Diagnostics.Tracing.TraceEvent.$(TraceEventVersion).nupkg">
-       <Authenticode>Nuget</Authenticode>
-    </FilesToSign>
-    <FilesToSign Include="$(OutDir)\Microsoft.Diagnostics.Tracing.TraceEvent.$(TraceEventVersion).symbols.nupkg">
-       <Authenticode>Nuget</Authenticode>
-    </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
-  </ItemGroup>
-
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Message Importance="High" Text="Done with attempt to Sign '%(FilesToSign.Identity)'" /> 
-  </Target>
-
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Message Importance="High" Text="Attempting to sign package '%(FilesToSign.Identity)'" /> 
+    <ItemGroup>
+      <!-- Sign any nuget packages that made it to our output directory -->
+      <FilesToSign Include="$(OutDir)*.nupkg">
+	 <Authenticode>Nuget</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+    <Message Importance="High" Text="Package Sign '%(FilesToSign.Identity)'" /> 
   </Target>
 </Project>


### PR DESCRIPTION
A month ago Nuget requires microsoft packages to be signed.
Update TraceEventPackageSigning to support signing nuget packages that are checked in to NugetSupportFiles.
Also fixed a missing DLL problem (PerfView.csproj).