### PR TITLE
Use the latest support files versions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,8 +28,8 @@
 
   <!-- versions of dependencies that more than one project use -->
   <PropertyGroup>
-    <PerfViewSupportFilesVersion>1.0.5</PerfViewSupportFilesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.13</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
+    <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.15</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.3.0</XunitVersion>
     <XunitRunnerVisualstudioVersion>2.3.0</XunitRunnerVisualstudioVersion>


### PR DESCRIPTION
This tests the new signed nuget packages.
It also happens to update the DiagnosticHub code (for *.diagsession parsing).