### PR TITLE
TraceParserGen: fix GetTemplateNameForEvent for empty evnt fields

### DIFF
--- a/src/TraceParserGen/TraceParserGen.cs
+++ b/src/TraceParserGen/TraceParserGen.cs
@@ -674,7 +674,7 @@ class TraceParserGen
     private static string GetTemplateNameForEvent(Event evnt, string eventName)
     {
         var ret = "EmptyTraceData";
-        if (evnt.Fields != null)
+        if (evnt.Fields != null && evnt.Fields.Count > 0)
         {
             ret = TraceParserGen.ToCSharpName(evnt.TemplateName);
             if (ret == null || ret.StartsWith("tid_"))


### PR DESCRIPTION
Fixing an issue that happen when the evnt.Fields is not null but empty. Without this fix, if the evnt.Fields is empty, it will generate this kind of event:
```csharp
public event Action<Template_0> AddAnnotationStart
```
instead of:
```csharp
public event Action<EmptyTraceData> AddAnnotationStart
```

This can be easily observe by trying to generate a parser for the **wpf-etw.man**.

I just added a check on the count of evnt.Fields. Let me know if you prefer the null conditional form `if (evnt.Fields?.Count > 0 )`, I can change that.