### PR TITLE
Various changes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.21</PerfViewVersion>
-    <TraceEventVersion>2.0.21</TraceEventVersion>
+    <PerfViewVersion>2.0.22</PerfViewVersion>
+    <TraceEventVersion>2.0.22</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/EtwClrProfiler/CorProfilerTracer.cpp
+++ b/src/EtwClrProfiler/CorProfilerTracer.cpp
@@ -106,64 +106,51 @@ void WINAPI ProfilerControlCallback(
 // TODO presently unused.   Only needed if the callback needs the TracerState
 // static CorProfilerTracer* s_tracer = NULL;
 
+//************************
+EXTERN_C int CallSampleCount = 1;	// This counts down to 0 for sampling 
+int CallSamplingRate = 1;			// The number of calls to skip before taking a sample.  
+
 EXTERN_C void __stdcall EnterMethod(FunctionID functionID)
 {
-	EventWriteCallEnterEvent(functionID);
-}
-
-EXTERN_C void __stdcall TailcallMethod(FunctionID functionID)
-{
-	EnterMethod(functionID);
+	EventWriteCallEnterEvent(functionID, CallSamplingRate);
+	CallSampleCount = CallSamplingRate;
 }
 
 #if defined(_M_IX86)
 // see http://msdn.microsoft.com/en-us/library/4ks26t93.aspx  for inline assembly.   Not supported on X64.   
 
-void __declspec(naked) __stdcall EnterMethodNaked(FunctionID funcID)
+void __declspec(naked) __stdcall EnterMethodNaked(FunctionIDOrClientID funcID)
 {
 	__asm
 	{
-		push eax
-		push ecx
-		push edx
-		push[esp + 16]		// Push the function ID
-		call EnterMethod
-		pop edx
-		pop ecx
-		pop eax
+		lock dec[CallSampleCount]
+		jle TakeSample
 		ret 4
+
+		TakeSample:
+		push eax
+			push ecx
+			push edx
+			push[esp + 16]		// Push the function ID
+			call EnterMethod
+			pop edx
+			pop ecx
+			pop eax
+			ret 4
 	}
 } // EnterNaked
 
-// Currently we don't care about the leave method (can we avoid making the call?
-void __declspec(naked) __stdcall LeaveMethodNaked(FunctionID funcID)
+void __declspec(naked) __stdcall TailcallMethodNaked(FunctionIDOrClientID funcID)
 {
 	__asm
 	{
-		ret 4
-	}
-}
-
-void __declspec(naked) __stdcall TailcallMethodNaked(FunctionID funcID)
-{
-	__asm
-	{
-		push eax
-		push ecx
-		push edx
-		push[esp + 16]
-		call TailcallMethod
-		pop edx
-		pop ecx
-		pop eax
-		ret 4
+		jmp EnterMethodNaked
 	}
 }
 
 #else
-EXTERN_C void __stdcall EnterMethodNaked(FunctionID functionID);
-EXTERN_C void __stdcall LeaveMethodNaked(FunctionID functionID);
-EXTERN_C void __stdcall TailcallMethodNaked(FunctionID functionID);
+EXTERN_C void __stdcall EnterMethodNaked(FunctionIDOrClientID functionID);
+EXTERN_C void __stdcall TailcallMethodNaked(FunctionIDOrClientID functionID);
 #endif 
 
 //==========================================================================
@@ -201,15 +188,28 @@ HRESULT STDMETHODCALLTYPE CorProfilerTracer::InitializeForAttach(
 		DWORD keywords = 0;
 		DWORD keywordsSize = sizeof(keywords);
 		int hr = RegGetValue(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\.NETFramework", L"PerfView_Keywords", RRF_RT_DWORD, NULL, &keywords, &keywordsSize);
-		if (hr == ERROR_SUCCESS && (keywords & (CallKeyword | CallSampledKeyword)) != 0)
+		if (hr == ERROR_SUCCESS)
 		{
-			// assert(s_tracer == NULL);	// Don't need any information passed around so I don't need this.  
-			// s_tracer = this;
+			if ((keywords & DisableInliningKeyword) != 0)
+			{
+				CALL_N_LOGONBADHR(m_info->GetEventMask(&oldFlags));
+				CALL_N_LOGONBADHR(m_info->SetEventMask(oldFlags | COR_PRF_DISABLE_INLINING));
+			}
 
-			// Turn on the Call entry and leave hooks.  
-			CALL_N_LOGONBADHR(m_info->SetEnterLeaveFunctionHooks(EnterMethodNaked, LeaveMethodNaked, TailcallMethodNaked));
-			CALL_N_LOGONBADHR(m_info->GetEventMask(&oldFlags));
-			CALL_N_LOGONBADHR(m_info->SetEventMask(oldFlags | COR_PRF_MONITOR_ENTERLEAVE));
+			if ((keywords & (CallKeyword | CallSampledKeyword)) != 0)
+			{
+				// assert(s_tracer == NULL);	// Don't need any information passed around so I don't need this.  
+				// s_tracer = this;
+
+				// Turn on the Call entry and leave hooks.  
+				CALL_N_LOGONBADHR(m_info->SetEnterLeaveFunctionHooks3(EnterMethodNaked, 0, TailcallMethodNaked));
+				CALL_N_LOGONBADHR(m_info->GetEventMask(&oldFlags));
+				CALL_N_LOGONBADHR(m_info->SetEventMask(oldFlags | COR_PRF_MONITOR_ENTERLEAVE));
+
+
+				if ((keywords & CallSampledKeyword) != 0)
+					CallSamplingRate = 997;		// TODO make it configurable.    We choose 997 because it is prime and thus likely to be uncorrelated with things.  
+			}
 		}
 	}
 exit:

--- a/src/EtwClrProfiler/CorProfilerTracer.cpp
+++ b/src/EtwClrProfiler/CorProfilerTracer.cpp
@@ -208,7 +208,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerTracer::InitializeForAttach(
 
 
 				if ((keywords & CallSampledKeyword) != 0)
-					CallSamplingRate = 997;		// TODO make it configurable.    We choose 997 because it is prime and thus likely to be uncorrelated with things.  
+					CallSamplingRate = 97;		// TODO make it configurable.    We choose 97 because it is prime and thus likely to be uncorrelated with things.  
 			}
 		}
 	}

--- a/src/EtwClrProfiler/ETWClrProfiler.h
+++ b/src/EtwClrProfiler/ETWClrProfiler.h
@@ -18,178 +18,266 @@
 extern "C" {
 #endif
 
-	//
-	// Allow Diasabling of code generation
-	//
+//
+// Allow disabling of code generation
+//
 #ifndef MCGEN_DISABLE_PROVIDER_CODE_GENERATION
 #if  !defined(McGenDebug)
 #define McGenDebug(a,b)
-#endif 
+#endif
+#ifndef MCGEN_EVENT_ENABLED
+#define MCGEN_EVENT_ENABLED(EventName) EventEnabled##EventName()
+#endif
 
 
 #if !defined(MCGEN_TRACE_CONTEXT_DEF)
 #define MCGEN_TRACE_CONTEXT_DEF
-	typedef struct _MCGEN_TRACE_CONTEXT
-	{
-		TRACEHANDLE     RegistrationHandle;
-		TRACEHANDLE     Logger;
-		ULONGLONG       MatchAnyKeyword;
-		ULONGLONG       MatchAllKeyword;
-		ULONG           Flags;
-		ULONG           IsEnabled;
-		UCHAR           Level;
-		UCHAR           Reserve;
-	} MCGEN_TRACE_CONTEXT, *PMCGEN_TRACE_CONTEXT;
+typedef struct _MCGEN_TRACE_CONTEXT
+{
+    TRACEHANDLE            RegistrationHandle;
+    TRACEHANDLE            Logger;
+    ULONGLONG              MatchAnyKeyword;
+    ULONGLONG              MatchAllKeyword;
+    ULONG                  Flags;
+    ULONG                  IsEnabled;
+    UCHAR                  Level;
+    UCHAR                  Reserve;
+    USHORT                 EnableBitsCount;
+    PULONG                 EnableBitMask;
+    const ULONGLONG*       EnableKeyWords;
+    const UCHAR*           EnableLevel;
+} MCGEN_TRACE_CONTEXT, *PMCGEN_TRACE_CONTEXT;
+#endif
+
+#if !defined(MCGEN_LEVEL_KEYWORD_ENABLED_DEF)
+#define MCGEN_LEVEL_KEYWORD_ENABLED_DEF
+FORCEINLINE
+BOOLEAN
+McGenLevelKeywordEnabled(
+    _In_ PMCGEN_TRACE_CONTEXT EnableInfo,
+    _In_ UCHAR Level,
+    _In_ ULONGLONG Keyword
+    )
+{
+    //
+    // Check if the event Level is lower than the level at which
+    // the channel is enabled.
+    // If the event Level is 0 or the channel is enabled at level 0,
+    // all levels are enabled.
+    //
+
+    if ((Level <= EnableInfo->Level) || // This also covers the case of Level == 0.
+        (EnableInfo->Level == 0)) {
+
+        //
+        // Check if Keyword is enabled
+        //
+
+        if ((Keyword == (ULONGLONG)0) ||
+            ((Keyword & EnableInfo->MatchAnyKeyword) &&
+             ((Keyword & EnableInfo->MatchAllKeyword) == EnableInfo->MatchAllKeyword))) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+
+}
 #endif
 
 #if !defined(MCGEN_EVENT_ENABLED_DEF)
 #define MCGEN_EVENT_ENABLED_DEF
-	FORCEINLINE
-		BOOLEAN
-		McGenEventEnabled(
-			__in PMCGEN_TRACE_CONTEXT EnableInfo,
-			__in PCEVENT_DESCRIPTOR EventDescriptor
-		)
-	{
-		//
-		// Check if the event Level is lower than the level at which
-		// the channel is enabled.
-		// If the event Level is 0 or the channel is enabled at level 0,
-		// all levels are enabled.
-		//
+FORCEINLINE
+BOOLEAN
+McGenEventEnabled(
+    _In_ PMCGEN_TRACE_CONTEXT EnableInfo,
+    _In_ PCEVENT_DESCRIPTOR EventDescriptor
+    )
+{
 
-		if ((EventDescriptor->Level <= EnableInfo->Level) || // This also covers the case of Level == 0.
-			(EnableInfo->Level == 0)) {
+    return McGenLevelKeywordEnabled(EnableInfo, EventDescriptor->Level, EventDescriptor->Keyword);
 
-			//
-			// Check if Keyword is enabled
-			//
-
-			if ((EventDescriptor->Keyword == (ULONGLONG)0) ||
-				((EventDescriptor->Keyword & EnableInfo->MatchAnyKeyword) &&
-				((EventDescriptor->Keyword & EnableInfo->MatchAllKeyword) == EnableInfo->MatchAllKeyword))) {
-				return TRUE;
-			}
-		}
-
-		return FALSE;
-
-	}
+}
 #endif
 
 
-	//
-	// EnableCheckMacro
-	//
+//
+// EnableCheckMacro
+//
 #ifndef MCGEN_ENABLE_CHECK
 #define MCGEN_ENABLE_CHECK(Context, Descriptor) (Context.IsEnabled &&  McGenEventEnabled(&Context, &Descriptor))
+#endif
+
+#ifndef MCGEN_EVENTWRITE_UM
+#define MCGEN_EVENTWRITE_UM EventWrite
+#endif
+#ifndef MCGEN_EVENTREGISTER_UM
+#define MCGEN_EVENTREGISTER_UM EventRegister
+#endif
+#ifndef MCGEN_EVENTUNREGISTER_UM
+#define MCGEN_EVENTUNREGISTER_UM EventUnregister
 #endif
 
 #if !defined(MCGEN_CONTROL_CALLBACK)
 #define MCGEN_CONTROL_CALLBACK
 
-	DECLSPEC_NOINLINE __inline
-		VOID
-		__stdcall
-		McGenControlCallbackV2(
-			__in LPCGUID SourceId,
-			__in ULONG ControlCode,
-			__in UCHAR Level,
-			__in ULONGLONG MatchAnyKeyword,
-			__in ULONGLONG MatchAllKeyword,
-			__in_opt PEVENT_FILTER_DESCRIPTOR FilterData,
-			__in_opt PVOID CallbackContext
-		)
-		/*++
+DECLSPEC_NOINLINE __inline
+VOID
+__stdcall
+McGenControlCallbackV2(
+    _In_ LPCGUID SourceId,
+    _In_ ULONG ControlCode,
+    _In_ UCHAR Level,
+    _In_ ULONGLONG MatchAnyKeyword,
+    _In_ ULONGLONG MatchAllKeyword,
+    _In_opt_ PEVENT_FILTER_DESCRIPTOR FilterData,
+    _Inout_opt_ PVOID CallbackContext
+    )
+/*++
 
-		Routine Description:
+Routine Description:
 
-			This is the notification callback for Vista.
+    This is the notification callback for Windows Vista and later.
 
-		Arguments:
+Arguments:
 
-			SourceId - The GUID that identifies the session that enabled the provider.
+    SourceId - The GUID that identifies the session that enabled the provider.
 
-			ControlCode - The parameter indicates whether the provider
-						  is being enabled or disabled.
+    ControlCode - The parameter indicates whether the provider
+                  is being enabled or disabled.
 
-			Level - The level at which the event is enabled.
+    Level - The level at which the event is enabled.
 
-			MatchAnyKeyword - The bitmask of keywords that the provider uses to
-							  determine the category of events that it writes.
+    MatchAnyKeyword - The bitmask of keywords that the provider uses to
+                      determine the category of events that it writes.
 
-			MatchAllKeyword - This bitmask additionally restricts the category
-							  of events that the provider writes.
+    MatchAllKeyword - This bitmask additionally restricts the category
+                      of events that the provider writes.
 
-			FilterData - The provider-defined data.
+    FilterData - The provider-defined data.
 
-			CallbackContext - The context of the callback that is defined when the provider
-							  called EtwRegister to register itself.
+    CallbackContext - The context of the callback that is defined when the provider
+                      called EtwRegister to register itself.
 
-		Remarks:
+Remarks:
 
-			ETW calls this function to notify provider of enable/disable
+    ETW calls this function to notify provider of enable/disable
 
-		--*/
-	{
-		PMCGEN_TRACE_CONTEXT Ctx = (PMCGEN_TRACE_CONTEXT)CallbackContext;
+--*/
+{
+    PMCGEN_TRACE_CONTEXT Ctx = (PMCGEN_TRACE_CONTEXT)CallbackContext;
+    ULONG Ix;
 #ifndef MCGEN_PRIVATE_ENABLE_CALLBACK_V2
-		UNREFERENCED_PARAMETER(SourceId);
-		UNREFERENCED_PARAMETER(FilterData);
+    UNREFERENCED_PARAMETER(SourceId);
+    UNREFERENCED_PARAMETER(FilterData);
 #endif
 
-		if (Ctx == NULL) {
-			return;
-		}
+    if (Ctx == NULL) {
+        return;
+    }
 
-		switch (ControlCode) {
+    switch (ControlCode) {
 
-		case EVENT_CONTROL_CODE_ENABLE_PROVIDER:
-			Ctx->Level = Level;
-			Ctx->MatchAnyKeyword = MatchAnyKeyword;
-			Ctx->MatchAllKeyword = MatchAllKeyword;
-			Ctx->IsEnabled = EVENT_CONTROL_CODE_ENABLE_PROVIDER;
-			break;
+        case EVENT_CONTROL_CODE_ENABLE_PROVIDER:
+            Ctx->Level = Level;
+            Ctx->MatchAnyKeyword = MatchAnyKeyword;
+            Ctx->MatchAllKeyword = MatchAllKeyword;
+            Ctx->IsEnabled = EVENT_CONTROL_CODE_ENABLE_PROVIDER;
 
-		case EVENT_CONTROL_CODE_DISABLE_PROVIDER:
-			Ctx->IsEnabled = EVENT_CONTROL_CODE_DISABLE_PROVIDER;
-			Ctx->Level = 0;
-			Ctx->MatchAnyKeyword = 0;
-			Ctx->MatchAllKeyword = 0;
-			break;
+            for (Ix = 0; Ix < Ctx->EnableBitsCount; Ix += 1) {
+                if (McGenLevelKeywordEnabled(Ctx, Ctx->EnableLevel[Ix], Ctx->EnableKeyWords[Ix]) != FALSE) {
+                    Ctx->EnableBitMask[Ix >> 5] |= (1 << (Ix % 32));
+                } else {
+                    Ctx->EnableBitMask[Ix >> 5] &= ~(1 << (Ix % 32));
+                }
+            }
+            break;
 
-		default:
-			break;
-		}
+        case EVENT_CONTROL_CODE_DISABLE_PROVIDER:
+            Ctx->IsEnabled = EVENT_CONTROL_CODE_DISABLE_PROVIDER;
+            Ctx->Level = 0;
+            Ctx->MatchAnyKeyword = 0;
+            Ctx->MatchAllKeyword = 0;
+            if (Ctx->EnableBitsCount > 0) {
+                RtlZeroMemory(Ctx->EnableBitMask, (((Ctx->EnableBitsCount - 1) / 32) + 1) * sizeof(ULONG));
+            }
+            break;
+
+        default:
+            break;
+    }
 
 #ifdef MCGEN_PRIVATE_ENABLE_CALLBACK_V2
-		//
-		// Call user defined callback
-		//
-		MCGEN_PRIVATE_ENABLE_CALLBACK_V2(
-			SourceId,
-			ControlCode,
-			Level,
-			MatchAnyKeyword,
-			MatchAllKeyword,
-			FilterData,
-			CallbackContext
-		);
+    //
+    // Call user defined callback
+    //
+    MCGEN_PRIVATE_ENABLE_CALLBACK_V2(
+        SourceId,
+        ControlCode,
+        Level,
+        MatchAnyKeyword,
+        MatchAllKeyword,
+        FilterData,
+        CallbackContext
+        );
 #endif
 
-		return;
-	}
+    return;
+}
 
 #endif
+
+#ifndef McGenEventWriteUM_def
+#define McGenEventWriteUM_def
+DECLSPEC_NOINLINE __inline
+ULONG __stdcall
+McGenEventWriteUM(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_range_(1, 128) ULONG EventDataCount,
+    _Inout_updates_(EventDataCount) EVENT_DATA_DESCRIPTOR* EventData
+    )
+{
+    const USHORT UNALIGNED* Traits;
+    UCHAR DisallowedChannel;
+    ULONGLONG DescriptorCopy[2]; // ULONGLONG to suppress unnecessary cookie.
+
+    Traits = (const USHORT UNALIGNED*)(UINT_PTR)Context->Logger;
+
+    if (Traits == NULL) {
+        EventDataCount -= 1;
+        EventData += 1;
+        if (EventDataCount == 0) {
+            EventData = NULL;
+        }
+        DisallowedChannel = 12; // WINEVENT_CHANNEL_PROVIDERMETADATA
+    } else {
+        EventData[0].Ptr = (ULONG_PTR)Traits;
+        EventData[0].Size = *Traits;
+        EventData[0].Reserved = 2; // EVENT_DATA_DESCRIPTOR_TYPE_PROVIDER_METADATA
+        DisallowedChannel = 0;
+    }
+
+    if (Descriptor->Channel == DisallowedChannel) {
+        *(EVENT_DESCRIPTOR*)DescriptorCopy = *Descriptor;
+        ((EVENT_DESCRIPTOR*)DescriptorCopy)->Channel = (UCHAR)((Traits == NULL) ? 0 : 12);
+        Descriptor = (EVENT_DESCRIPTOR*)DescriptorCopy;
+    }
+
+    return MCGEN_EVENTWRITE_UM(Context->RegistrationHandle, Descriptor, EventDataCount, EventData);
+}
+#endif // McGenEventWriteUM_def
+
 #endif // MCGEN_DISABLE_PROVIDER_CODE_GENERATION
-	//+
-	// Provider ETWClrProfiler Event Count 19
-	//+
-	EXTERN_C __declspec(selectany) const GUID ETWClrProfiler = { 0x6652970f, 0x1756, 0x5d8d, {0x08, 0x05, 0xe9, 0xaa, 0xd1, 0x52, 0xaa, 0x84} };
 
-	//
-	// Tasks
-	//
+//+
+// Provider ETWClrProfiler Event Count 19
+//+
+EXTERN_C __declspec(selectany) const GUID ETWClrProfiler = {0x6652970f, 0x1756, 0x5d8d, {0x08, 0x05, 0xe9, 0xaa, 0xd1, 0x52, 0xaa, 0x84}};
+
+//
+// Tasks
+//
 #define ETWClrProfiler_TASK_GC 0x1
 #define ETWClrProfiler_TASK_ClassIDDefintion 0xa
 #define ETWClrProfiler_TASK_ModuleIDDefintion 0xb
@@ -217,322 +305,454 @@ extern "C" {
 #define GCAllocSampledKeyword 0x8
 #define CallKeyword 0x10
 #define CallSampledKeyword 0x20
+#define DisableInliningKeyword 0x40
 
 //
 // Event Descriptors
 //
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ClassIDDefintionEvent = { 0x1, 0x0, 0x0, 0x4, 0x0, 0xa, 0xf };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ClassIDDefintionEvent = {0x1, 0x0, 0x0, 0x4, 0x0, 0xa, 0xf};
 #define ClassIDDefintionEvent_value 0x1
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ModuleIDDefintionEvent = { 0x2, 0x0, 0x0, 0x4, 0x0, 0xb, 0xf };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ModuleIDDefintionEvent = {0x2, 0x0, 0x0, 0x4, 0x0, 0xb, 0xf};
 #define ModuleIDDefintionEvent_value 0x2
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectAllocatedEvent = { 0xa, 0x0, 0x0, 0x5, 0x0, 0xc, 0xc };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectAllocatedEvent = {0xa, 0x0, 0x0, 0x5, 0x0, 0xc, 0xc};
 #define ObjectAllocatedEvent_value 0xa
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR FinalizeableObjectQueuedEvent = { 0xb, 0x0, 0x0, 0x4, 0x0, 0xd, 0xd };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR FinalizeableObjectQueuedEvent = {0xb, 0x0, 0x0, 0x4, 0x0, 0xd, 0xd};
 #define FinalizeableObjectQueuedEvent_value 0xb
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR HandleCreatedEvent = { 0xc, 0x0, 0x0, 0x4, 0x0, 0xe, 0xe };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR HandleCreatedEvent = {0xc, 0x0, 0x0, 0x4, 0x0, 0xe, 0xe};
 #define HandleCreatedEvent_value 0xc
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR HandleDestroyedEvent = { 0xd, 0x0, 0x0, 0x4, 0x0, 0xf, 0xe };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR HandleDestroyedEvent = {0xd, 0x0, 0x0, 0x4, 0x0, 0xf, 0xe};
 #define HandleDestroyedEvent_value 0xd
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR RootReferencesEvent = { 0xf, 0x0, 0x0, 0x5, 0x0, 0x16, 0x2 };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR RootReferencesEvent = {0xf, 0x0, 0x0, 0x5, 0x0, 0x16, 0x2};
 #define RootReferencesEvent_value 0xf
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectReferencesEvent = { 0x10, 0x0, 0x0, 0x5, 0x0, 0x17, 0x2 };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectReferencesEvent = {0x10, 0x0, 0x0, 0x5, 0x0, 0x17, 0x2};
 #define ObjectReferencesEvent_value 0x10
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR GCStartEvent = { 0x14, 0x0, 0x0, 0x4, 0x1, 0x1, 0xf };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR GCStartEvent = {0x14, 0x0, 0x0, 0x4, 0x1, 0x1, 0xf};
 #define GCStartEvent_value 0x14
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR GCStopEvent = { 0x15, 0x0, 0x0, 0x4, 0x2, 0x1, 0xf };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR GCStopEvent = {0x15, 0x0, 0x0, 0x4, 0x2, 0x1, 0xf};
 #define GCStopEvent_value 0x15
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectsMovedEvent = { 0x16, 0x0, 0x0, 0x4, 0x0, 0x14, 0xf };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectsMovedEvent = {0x16, 0x0, 0x0, 0x4, 0x0, 0x14, 0xf};
 #define ObjectsMovedEvent_value 0x16
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectsSurvivedEvent = { 0x17, 0x0, 0x0, 0x4, 0x0, 0x15, 0xf };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ObjectsSurvivedEvent = {0x17, 0x0, 0x0, 0x4, 0x0, 0x15, 0xf};
 #define ObjectsSurvivedEvent_value 0x17
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR CaptureStateStart = { 0x18, 0x0, 0x0, 0x3, 0x1, 0x18, 0x80000000000f };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR CaptureStateStart = {0x18, 0x0, 0x0, 0x3, 0x1, 0x18, 0x80000000000f};
 #define CaptureStateStart_value 0x18
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR CaptureStateStop = { 0x19, 0x0, 0x0, 0x3, 0x2, 0x18, 0x80000000000f };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR CaptureStateStop = {0x19, 0x0, 0x0, 0x3, 0x2, 0x18, 0x80000000000f};
 #define CaptureStateStop_value 0x19
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ProfilerError = { 0x1a, 0x0, 0x0, 0x2, 0x0, 0x1a, 0x80000000000f };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ProfilerError = {0x1a, 0x0, 0x0, 0x2, 0x0, 0x1a, 0x80000000000f};
 #define ProfilerError_value 0x1a
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ProfilerShutdown = { 0x1b, 0x0, 0x0, 0x2, 0x0, 0x1b, 0x80000000000f };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR ProfilerShutdown = {0x1b, 0x0, 0x0, 0x2, 0x0, 0x1b, 0x80000000000f};
 #define ProfilerShutdown_value 0x1b
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR SamplingRateChange = { 0x1c, 0x0, 0x0, 0x5, 0x0, 0x1c, 0x8 };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR SamplingRateChange = {0x1c, 0x0, 0x0, 0x5, 0x0, 0x1c, 0x8};
 #define SamplingRateChange_value 0x1c
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR CallEnterEvent = { 0x1d, 0x0, 0x0, 0x5, 0x0, 0x1d, 0x30 };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR CallEnterEvent = {0x1d, 0x0, 0x0, 0x5, 0x0, 0x1d, 0x30};
 #define CallEnterEvent_value 0x1d
-	EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR SendManifestEvent = { 0xfffe, 0x0, 0x0, 0x0, 0x0, 0xfffe, 0x80000000000f };
+EXTERN_C __declspec(selectany) const EVENT_DESCRIPTOR SendManifestEvent = {0xfffe, 0x0, 0x0, 0x0, 0x0, 0xfffe, 0x80000000000f};
 #define SendManifestEvent_value 0xfffe
 
-	//
-	// Note on Generate Code from Manifest Windows Vista and above
-	//
-	//Structures :  are handled as a size and pointer pairs. The macro for the event will have an extra 
-	//parameter for the size in bytes of the structure. Make sure that your structures have no extra padding.
-	//
-	//Strings: There are several cases that can be described in the manifest. For array of variable length 
-	//strings, the generated code will take the count of characters for the whole array as an input parameter. 
-	//
-	//SID No support for array of SIDs, the macro will take a pointer to the SID and use appropriate 
-	//GetLengthSid function to get the length.
-	//
+//
+// Note on Generate Code from Manifest for Windows Vista and above
+//
+//Structures :  are handled as a size and pointer pairs. The macro for the event will have an extra
+//parameter for the size in bytes of the structure. Make sure that your structures have no extra padding.
+//
+//Strings: There are several cases that can be described in the manifest. For array of variable length
+//strings, the generated code will take the count of characters for the whole array as an input parameter.
+//
+//SID No support for array of SIDs, the macro will take a pointer to the SID and use appropriate
+//GetLengthSid function to get the length.
+//
 
-	//
-	// Allow Diasabling of code generation
-	//
+//
+// Allow disabling of code generation
+//
 #ifndef MCGEN_DISABLE_PROVIDER_CODE_GENERATION
 
 //
-// Globals 
+// Globals
 //
 
+#ifndef ETWClrProfiler_Traits
+#define ETWClrProfiler_Traits NULL
+#endif
 #ifndef _ClassDefinitionFlags_def
 #define _ClassDefinitionFlags_def
-	typedef enum _ClassDefinitionFlags
-	{
-	}ClassDefinitionFlags;
+typedef enum _ClassDefinitionFlags
+{
+}ClassDefinitionFlags;
 #endif
 
-	EXTERN_C __declspec(selectany) REGHANDLE ETWClrProfilerHandle = (REGHANDLE)0;
 
-	EXTERN_C __declspec(selectany) MCGEN_TRACE_CONTEXT ETWClrProfiler_Context = { 0 };
+//
+// Event Enablement Bits
+//
+
+EXTERN_C __declspec(selectany) DECLSPEC_CACHEALIGN ULONG ETWClrProfilerEnableBits[1];
+EXTERN_C __declspec(selectany) const ULONGLONG ETWClrProfilerKeywords[10] = {0xf, 0xc, 0xd, 0xe, 0x2, 0x80000000000f, 0x80000000000f, 0x8, 0x30, 0x80000000000f};
+EXTERN_C __declspec(selectany) const UCHAR ETWClrProfilerLevels[10] = {4, 5, 4, 4, 5, 3, 2, 5, 5, 0};
+EXTERN_C __declspec(selectany) MCGEN_TRACE_CONTEXT ETWClrProfiler_Context = {0, (ULONG_PTR)ETWClrProfiler_Traits, 0, 0, 0, 0, 0, 0, 10, ETWClrProfilerEnableBits, ETWClrProfilerKeywords, ETWClrProfilerLevels};
+
+#define ETWClrProfilerHandle (ETWClrProfiler_Context.RegistrationHandle)
 
 #if !defined(McGenEventRegisterUnregister)
 #define McGenEventRegisterUnregister
-	DECLSPEC_NOINLINE __inline
-		ULONG __stdcall
-		McGenEventRegister(
-			__in LPCGUID ProviderId,
-			__in_opt PENABLECALLBACK EnableCallback,
-			__in_opt PVOID CallbackContext,
-			__out PREGHANDLE RegHandle
-		)
-		/*++
+#pragma warning(push)
+#pragma warning(disable:6103)
+DECLSPEC_NOINLINE __inline
+ULONG __stdcall
+McGenEventRegister(
+    _In_ LPCGUID ProviderId,
+    _In_opt_ PENABLECALLBACK EnableCallback,
+    _In_opt_ PVOID CallbackContext,
+    _Inout_ PREGHANDLE RegHandle
+    )
+/*++
 
-		Routine Description:
+Routine Description:
 
-			This function register the provider with ETW USER mode
+    This function registers the provider with ETW USER mode.
 
-		Arguments:
-			ProviderId      - Provider Id to be register with ETW
-			EnableCallback  - Callback to be used
-			CallbackContext - Context for this provider
-			RegHandle       - Pointer to Registration handle
+Arguments:
+    ProviderId - Provider ID to register with ETW.
 
-		Remarks:
+    EnableCallback - Callback to be used.
 
-			If the handle != NULL will return ERROR_SUCCESS
+    CallbackContext - Context for this provider.
 
-		--*/
-	{
-		ULONG Error;
+    RegHandle - Pointer to registration handle.
 
+Remarks:
 
-		if (*RegHandle) {
-			//
-			// already registered
-			//
-			return ERROR_SUCCESS;
-		}
+    If the handle != NULL will return ERROR_SUCCESS
 
-		Error = EventRegister(ProviderId, EnableCallback, CallbackContext, RegHandle);
-
-		return Error;
-	}
+--*/
+{
+    ULONG Error;
 
 
-	DECLSPEC_NOINLINE __inline
-		ULONG __stdcall
-		McGenEventUnregister(__inout PREGHANDLE RegHandle)
-		/*++
+    if (*RegHandle) {
+        //
+        // already registered
+        //
+        return ERROR_SUCCESS;
+    }
 
-		Routine Description:
+    Error = MCGEN_EVENTREGISTER_UM( ProviderId, EnableCallback, CallbackContext, RegHandle);
 
-			Unregister from ETW USER mode
-
-		Arguments:
-					RegHandle this is the pointer to the provider context
-		Remarks:
-					If Provider has not register RegHandle = NULL,
-					return ERROR_SUCCESS
-		--*/
-	{
-		ULONG Error;
+    return Error;
+}
+#pragma warning(pop)
 
 
-		if (!(*RegHandle)) {
-			//
-			// Provider has not registerd
-			//
-			return ERROR_SUCCESS;
-		}
+DECLSPEC_NOINLINE __inline
+ULONG __stdcall
+McGenEventUnregister(_Inout_ PREGHANDLE RegHandle)
+/*++
 
-		Error = EventUnregister(*RegHandle);
-		*RegHandle = (REGHANDLE)0;
+Routine Description:
 
-		return Error;
-	}
+    Unregister from ETW USER mode
+
+Arguments:
+            RegHandle this is the pointer to the provider context
+Remarks:
+            If provider has not been registered, RegHandle == NULL,
+            return ERROR_SUCCESS
+--*/
+{
+    ULONG Error;
+
+
+    if(!(*RegHandle)) {
+        //
+        // Provider has not registerd
+        //
+        return ERROR_SUCCESS;
+    }
+
+    Error = MCGEN_EVENTUNREGISTER_UM(*RegHandle);
+    *RegHandle = (REGHANDLE)0;
+
+    return Error;
+}
 #endif
-	//
-	// Register with ETW Vista +
-	//
+//
+// Register with ETW (Vista or later) using provider GUID determined from manifest
+//
 #ifndef EventRegisterETWClrProfiler
-#define EventRegisterETWClrProfiler() McGenEventRegister(&ETWClrProfiler, McGenControlCallbackV2, &ETWClrProfiler_Context, &ETWClrProfilerHandle) 
+#define EventRegisterETWClrProfiler() McGenEventRegister(&ETWClrProfiler, McGenControlCallbackV2, &ETWClrProfiler_Context, &ETWClrProfilerHandle)
 #endif
 
 //
-// UnRegister with ETW
+// Unregister with ETW
 //
 #ifndef EventUnregisterETWClrProfiler
-#define EventUnregisterETWClrProfiler() McGenEventUnregister(&ETWClrProfilerHandle) 
+#define EventUnregisterETWClrProfiler() McGenEventUnregister(&ETWClrProfilerHandle)
 #endif
+
+//
+// Enablement check macro for ClassIDDefintionEvent
+//
+
+#define EventEnabledClassIDDefintionEvent() ((ETWClrProfilerEnableBits[0] & 0x00000001) != 0)
 
 //
 // Event Macro for ClassIDDefintionEvent
 //
 #define EventWriteClassIDDefintionEvent(ClassID, Token, Flags, ModuleID, Name)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ClassIDDefintionEvent) ?\
-        Template_xqqxz(ETWClrProfilerHandle, &ClassIDDefintionEvent, ClassID, Token, Flags, ModuleID, Name)\
+        MCGEN_EVENT_ENABLED(ClassIDDefintionEvent) ?\
+        McTemplateU0xqqxz(&ETWClrProfiler_Context, &ClassIDDefintionEvent, ClassID, Token, Flags, ModuleID, Name)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for ModuleIDDefintionEvent
+//
+
+#define EventEnabledModuleIDDefintionEvent() ((ETWClrProfilerEnableBits[0] & 0x00000001) != 0)
 
 //
 // Event Macro for ModuleIDDefintionEvent
 //
 #define EventWriteModuleIDDefintionEvent(ModuleID, AssemblyID, Path)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ModuleIDDefintionEvent) ?\
-        Template_xxz(ETWClrProfilerHandle, &ModuleIDDefintionEvent, ModuleID, AssemblyID, Path)\
+        MCGEN_EVENT_ENABLED(ModuleIDDefintionEvent) ?\
+        McTemplateU0xxz(&ETWClrProfiler_Context, &ModuleIDDefintionEvent, ModuleID, AssemblyID, Path)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for ObjectAllocatedEvent
+//
+
+#define EventEnabledObjectAllocatedEvent() ((ETWClrProfilerEnableBits[0] & 0x00000002) != 0)
 
 //
 // Event Macro for ObjectAllocatedEvent
 //
 #define EventWriteObjectAllocatedEvent(ObjectID, ClassID, Size, RepresentativeSize)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ObjectAllocatedEvent) ?\
-        Template_xxxx(ETWClrProfilerHandle, &ObjectAllocatedEvent, ObjectID, ClassID, Size, RepresentativeSize)\
+        MCGEN_EVENT_ENABLED(ObjectAllocatedEvent) ?\
+        McTemplateU0xxxx(&ETWClrProfiler_Context, &ObjectAllocatedEvent, ObjectID, ClassID, Size, RepresentativeSize)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for FinalizeableObjectQueuedEvent
+//
+
+#define EventEnabledFinalizeableObjectQueuedEvent() ((ETWClrProfilerEnableBits[0] & 0x00000004) != 0)
 
 //
 // Event Macro for FinalizeableObjectQueuedEvent
 //
 #define EventWriteFinalizeableObjectQueuedEvent(ObjectID, ClassID)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, FinalizeableObjectQueuedEvent) ?\
-        Template_xx(ETWClrProfilerHandle, &FinalizeableObjectQueuedEvent, ObjectID, ClassID)\
+        MCGEN_EVENT_ENABLED(FinalizeableObjectQueuedEvent) ?\
+        McTemplateU0xx(&ETWClrProfiler_Context, &FinalizeableObjectQueuedEvent, ObjectID, ClassID)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for HandleCreatedEvent
+//
+
+#define EventEnabledHandleCreatedEvent() ((ETWClrProfilerEnableBits[0] & 0x00000008) != 0)
 
 //
 // Event Macro for HandleCreatedEvent
 //
 #define EventWriteHandleCreatedEvent(HandleID, InitialObjectID)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, HandleCreatedEvent) ?\
-        Template_xx(ETWClrProfilerHandle, &HandleCreatedEvent, HandleID, InitialObjectID)\
+        MCGEN_EVENT_ENABLED(HandleCreatedEvent) ?\
+        McTemplateU0xx(&ETWClrProfiler_Context, &HandleCreatedEvent, HandleID, InitialObjectID)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for HandleDestroyedEvent
+//
+
+#define EventEnabledHandleDestroyedEvent() ((ETWClrProfilerEnableBits[0] & 0x00000008) != 0)
 
 //
 // Event Macro for HandleDestroyedEvent
 //
 #define EventWriteHandleDestroyedEvent(HandleID)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, HandleDestroyedEvent) ?\
-        Template_x(ETWClrProfilerHandle, &HandleDestroyedEvent, HandleID)\
+        MCGEN_EVENT_ENABLED(HandleDestroyedEvent) ?\
+        McTemplateU0x(&ETWClrProfiler_Context, &HandleDestroyedEvent, HandleID)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for RootReferencesEvent
+//
+
+#define EventEnabledRootReferencesEvent() ((ETWClrProfilerEnableBits[0] & 0x00000010) != 0)
 
 //
 // Event Macro for RootReferencesEvent
 //
 #define EventWriteRootReferencesEvent(Count, ObjectIDs, GCRootKinds, GCRootFlags, RootIDs)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, RootReferencesEvent) ?\
-        Template_qPR0QR0QR0PR0(ETWClrProfilerHandle, &RootReferencesEvent, Count, ObjectIDs, GCRootKinds, GCRootFlags, RootIDs)\
+        MCGEN_EVENT_ENABLED(RootReferencesEvent) ?\
+        McTemplateU0qPR0QR0QR0PR0(&ETWClrProfiler_Context, &RootReferencesEvent, Count, ObjectIDs, GCRootKinds, GCRootFlags, RootIDs)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for ObjectReferencesEvent
+//
+
+#define EventEnabledObjectReferencesEvent() ((ETWClrProfilerEnableBits[0] & 0x00000010) != 0)
 
 //
 // Event Macro for ObjectReferencesEvent
 //
 #define EventWriteObjectReferencesEvent(ObjectID, ClassID, Size, ObjectRefCount, ObjectRefs)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ObjectReferencesEvent) ?\
-        Template_xxxqPR3(ETWClrProfilerHandle, &ObjectReferencesEvent, ObjectID, ClassID, Size, ObjectRefCount, ObjectRefs)\
+        MCGEN_EVENT_ENABLED(ObjectReferencesEvent) ?\
+        McTemplateU0xxxqPR3(&ETWClrProfiler_Context, &ObjectReferencesEvent, ObjectID, ClassID, Size, ObjectRefCount, ObjectRefs)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for GCStartEvent
+//
+
+#define EventEnabledGCStartEvent() ((ETWClrProfilerEnableBits[0] & 0x00000001) != 0)
 
 //
 // Event Macro for GCStartEvent
 //
 #define EventWriteGCStartEvent(GCID, Generation, Induced)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, GCStartEvent) ?\
-        Template_ddt(ETWClrProfilerHandle, &GCStartEvent, GCID, Generation, Induced)\
+        MCGEN_EVENT_ENABLED(GCStartEvent) ?\
+        McTemplateU0ddt(&ETWClrProfiler_Context, &GCStartEvent, GCID, Generation, Induced)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for GCStopEvent
+//
+
+#define EventEnabledGCStopEvent() ((ETWClrProfilerEnableBits[0] & 0x00000001) != 0)
 
 //
 // Event Macro for GCStopEvent
 //
 #define EventWriteGCStopEvent(GCID)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, GCStopEvent) ?\
-        Template_d(ETWClrProfilerHandle, &GCStopEvent, GCID)\
+        MCGEN_EVENT_ENABLED(GCStopEvent) ?\
+        McTemplateU0d(&ETWClrProfiler_Context, &GCStopEvent, GCID)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for ObjectsMovedEvent
+//
+
+#define EventEnabledObjectsMovedEvent() ((ETWClrProfilerEnableBits[0] & 0x00000001) != 0)
 
 //
 // Event Macro for ObjectsMovedEvent
 //
 #define EventWriteObjectsMovedEvent(Count, RangeBases, TargetBases, Lengths)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ObjectsMovedEvent) ?\
-        Template_qPR0PR0QR0(ETWClrProfilerHandle, &ObjectsMovedEvent, Count, RangeBases, TargetBases, Lengths)\
+        MCGEN_EVENT_ENABLED(ObjectsMovedEvent) ?\
+        McTemplateU0qPR0PR0QR0(&ETWClrProfiler_Context, &ObjectsMovedEvent, Count, RangeBases, TargetBases, Lengths)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for ObjectsSurvivedEvent
+//
+
+#define EventEnabledObjectsSurvivedEvent() ((ETWClrProfilerEnableBits[0] & 0x00000001) != 0)
 
 //
 // Event Macro for ObjectsSurvivedEvent
 //
 #define EventWriteObjectsSurvivedEvent(Count, RangeBases, Lengths)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ObjectsSurvivedEvent) ?\
-        Template_qPR0QR0(ETWClrProfilerHandle, &ObjectsSurvivedEvent, Count, RangeBases, Lengths)\
+        MCGEN_EVENT_ENABLED(ObjectsSurvivedEvent) ?\
+        McTemplateU0qPR0QR0(&ETWClrProfiler_Context, &ObjectsSurvivedEvent, Count, RangeBases, Lengths)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for CaptureStateStart
+//
+
+#define EventEnabledCaptureStateStart() ((ETWClrProfilerEnableBits[0] & 0x00000020) != 0)
 
 //
 // Event Macro for CaptureStateStart
 //
 #define EventWriteCaptureStateStart()\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, CaptureStateStart) ?\
-        TemplateEventDescriptor(ETWClrProfilerHandle, &CaptureStateStart)\
+        MCGEN_EVENT_ENABLED(CaptureStateStart) ?\
+        McTemplateU0(&ETWClrProfiler_Context, &CaptureStateStart)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for CaptureStateStop
+//
+
+#define EventEnabledCaptureStateStop() ((ETWClrProfilerEnableBits[0] & 0x00000020) != 0)
 
 //
 // Event Macro for CaptureStateStop
 //
 #define EventWriteCaptureStateStop()\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, CaptureStateStop) ?\
-        TemplateEventDescriptor(ETWClrProfilerHandle, &CaptureStateStop)\
+        MCGEN_EVENT_ENABLED(CaptureStateStop) ?\
+        McTemplateU0(&ETWClrProfiler_Context, &CaptureStateStop)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for ProfilerError
+//
+
+#define EventEnabledProfilerError() ((ETWClrProfilerEnableBits[0] & 0x00000040) != 0)
 
 //
 // Event Macro for ProfilerError
 //
 #define EventWriteProfilerError(ErrorCode, Message)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ProfilerError) ?\
-        Template_xz(ETWClrProfilerHandle, &ProfilerError, ErrorCode, Message)\
+        MCGEN_EVENT_ENABLED(ProfilerError) ?\
+        McTemplateU0xz(&ETWClrProfiler_Context, &ProfilerError, ErrorCode, Message)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for ProfilerShutdown
+//
+
+#define EventEnabledProfilerShutdown() ((ETWClrProfilerEnableBits[0] & 0x00000040) != 0)
 
 //
 // Event Macro for ProfilerShutdown
 //
 #define EventWriteProfilerShutdown()\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, ProfilerShutdown) ?\
-        TemplateEventDescriptor(ETWClrProfilerHandle, &ProfilerShutdown)\
+        MCGEN_EVENT_ENABLED(ProfilerShutdown) ?\
+        McTemplateU0(&ETWClrProfiler_Context, &ProfilerShutdown)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for SamplingRateChange
+//
+
+#define EventEnabledSamplingRateChange() ((ETWClrProfilerEnableBits[0] & 0x00000080) != 0)
 
 //
 // Event Macro for SamplingRateChange
 //
 #define EventWriteSamplingRateChange(ClassID, ClassName, MSecDelta, MinAllocPerMSec, NewAllocPerMSec, AllocPerMSec, SampleRate)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, SamplingRateChange) ?\
-        Template_xzddffd(ETWClrProfilerHandle, &SamplingRateChange, ClassID, ClassName, MSecDelta, MinAllocPerMSec, NewAllocPerMSec, AllocPerMSec, SampleRate)\
+        MCGEN_EVENT_ENABLED(SamplingRateChange) ?\
+        McTemplateU0xzddffd(&ETWClrProfiler_Context, &SamplingRateChange, ClassID, ClassName, MSecDelta, MinAllocPerMSec, NewAllocPerMSec, AllocPerMSec, SampleRate)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for CallEnterEvent
+//
+
+#define EventEnabledCallEnterEvent() ((ETWClrProfilerEnableBits[0] & 0x00000100) != 0)
 
 //
 // Event Macro for CallEnterEvent
 //
-#define EventWriteCallEnterEvent(FunctionID)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, CallEnterEvent) ?\
-        Template_x(ETWClrProfilerHandle, &CallEnterEvent, FunctionID)\
+#define EventWriteCallEnterEvent(FunctionID, SampleRate)\
+        MCGEN_EVENT_ENABLED(CallEnterEvent) ?\
+        McTemplateU0xq(&ETWClrProfiler_Context, &CallEnterEvent, FunctionID, SampleRate)\
         : ERROR_SUCCESS\
+
+//
+// Enablement check macro for SendManifestEvent
+//
+
+#define EventEnabledSendManifestEvent() ((ETWClrProfilerEnableBits[0] & 0x00000200) != 0)
 
 //
 // Event Macro for SendManifestEvent
 //
 #define EventWriteSendManifestEvent(Format, MajorVersion, MinorVersion, Magic, TotalChunks, ChunkNumger, Data)\
-        MCGEN_ENABLE_CHECK(ETWClrProfiler_Context, SendManifestEvent) ?\
-        Template_cccchhs(ETWClrProfilerHandle, &SendManifestEvent, Format, MajorVersion, MinorVersion, Magic, TotalChunks, ChunkNumger, Data)\
+        MCGEN_EVENT_ENABLED(SendManifestEvent) ?\
+        McTemplateU0cccchhs(&ETWClrProfiler_Context, &SendManifestEvent, Format, MajorVersion, MinorVersion, Magic, TotalChunks, ChunkNumger, Data)\
         : ERROR_SUCCESS\
 
 #endif // MCGEN_DISABLE_PROVIDER_CODE_GENERATION
@@ -544,470 +764,498 @@ extern "C" {
 #ifndef MCGEN_DISABLE_PROVIDER_CODE_GENERATION
 
 //
-// Template Functions 
+// Template Functions
 //
 //
 //Template from manifest : ClassIDDefintionArgs
 //
-#ifndef Template_xqqxz_def
-#define Template_xqqxz_def
-	ETW_INLINE
-		ULONG
-		Template_xqqxz(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  ClassID,
-			__in const unsigned int  Token,
-			__in const unsigned int  Flags,
-			__in unsigned __int64  ModuleID,
-			__in_opt PCWSTR  Name
-		)
-	{
-#define ARGUMENT_COUNT_xqqxz 5
+#ifndef McTemplateU0xqqxz_def
+#define McTemplateU0xqqxz_def
+ETW_INLINE
+ULONG
+McTemplateU0xqqxz(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_ const unsigned int  _Arg1,
+    _In_ const unsigned int  _Arg2,
+    _In_ unsigned __int64  _Arg3,
+    _In_opt_ PCWSTR  _Arg4
+    )
+{
+#define McTemplateU0xqqxz_ARGCOUNT 5
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_xqqxz];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xqqxz_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &ClassID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1], &Token, sizeof(const unsigned int));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(const unsigned int)  );
 
-		EventDataDescCreate(&EventData[2], &Flags, sizeof(const unsigned int));
+    EventDataDescCreate(&EventData[3],&_Arg2, sizeof(const unsigned int)  );
 
-		EventDataDescCreate(&EventData[3], &ModuleID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[4],&_Arg3, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[4],
-			(Name != NULL) ? Name : L"NULL",
-			(Name != NULL) ? (ULONG)((wcslen(Name) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
+    EventDataDescCreate(&EventData[5],
+                        (_Arg4 != NULL) ? _Arg4 : L"NULL",
+                        (_Arg4 != NULL) ? (ULONG)((wcslen(_Arg4) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_xqqxz, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xqqxz_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : ModuleIDDefintionArgs
-	//
-#ifndef Template_xxz_def
-#define Template_xxz_def
-	ETW_INLINE
-		ULONG
-		Template_xxz(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  ModuleID,
-			__in unsigned __int64  AssemblyID,
-			__in_opt PCWSTR  Path
-		)
-	{
-#define ARGUMENT_COUNT_xxz 3
+//
+//Template from manifest : ModuleIDDefintionArgs
+//
+#ifndef McTemplateU0xxz_def
+#define McTemplateU0xxz_def
+ETW_INLINE
+ULONG
+McTemplateU0xxz(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_ unsigned __int64  _Arg1,
+    _In_opt_ PCWSTR  _Arg2
+    )
+{
+#define McTemplateU0xxz_ARGCOUNT 3
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_xxz];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xxz_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &ModuleID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1], &AssemblyID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[2],
-			(Path != NULL) ? Path : L"NULL",
-			(Path != NULL) ? (ULONG)((wcslen(Path) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
+    EventDataDescCreate(&EventData[3],
+                        (_Arg2 != NULL) ? _Arg2 : L"NULL",
+                        (_Arg2 != NULL) ? (ULONG)((wcslen(_Arg2) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_xxz, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xxz_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : ObjectAllocatedArgs
-	//
-#ifndef Template_xxxx_def
-#define Template_xxxx_def
-	ETW_INLINE
-		ULONG
-		Template_xxxx(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  ObjectID,
-			__in unsigned __int64  ClassID,
-			__in unsigned __int64  Size,
-			__in unsigned __int64  RepresentativeSize
-		)
-	{
-#define ARGUMENT_COUNT_xxxx 4
+//
+//Template from manifest : ObjectAllocatedArgs
+//
+#ifndef McTemplateU0xxxx_def
+#define McTemplateU0xxxx_def
+ETW_INLINE
+ULONG
+McTemplateU0xxxx(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_ unsigned __int64  _Arg1,
+    _In_ unsigned __int64  _Arg2,
+    _In_ unsigned __int64  _Arg3
+    )
+{
+#define McTemplateU0xxxx_ARGCOUNT 4
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_xxxx];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xxxx_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &ObjectID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1], &ClassID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[2], &Size, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[3],&_Arg2, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[3], &RepresentativeSize, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[4],&_Arg3, sizeof(unsigned __int64)  );
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_xxxx, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xxxx_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : FinalizeableObjectQueuedArgs
-	//
-#ifndef Template_xx_def
-#define Template_xx_def
-	ETW_INLINE
-		ULONG
-		Template_xx(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  ObjectID,
-			__in unsigned __int64  ClassID
-		)
-	{
-#define ARGUMENT_COUNT_xx 2
+//
+//Template from manifest : FinalizeableObjectQueuedArgs
+//
+#ifndef McTemplateU0xx_def
+#define McTemplateU0xx_def
+ETW_INLINE
+ULONG
+McTemplateU0xx(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_ unsigned __int64  _Arg1
+    )
+{
+#define McTemplateU0xx_ARGCOUNT 2
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_xx];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xx_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &ObjectID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1], &ClassID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(unsigned __int64)  );
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_xx, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xx_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : HandleDestroyedArgs
-	//
-#ifndef Template_x_def
-#define Template_x_def
-	ETW_INLINE
-		ULONG
-		Template_x(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  HandleID
-		)
-	{
-#define ARGUMENT_COUNT_x 1
+//
+//Template from manifest : HandleDestroyedArgs
+//
+#ifndef McTemplateU0x_def
+#define McTemplateU0x_def
+ETW_INLINE
+ULONG
+McTemplateU0x(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0
+    )
+{
+#define McTemplateU0x_ARGCOUNT 1
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_x];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0x_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &HandleID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_x, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0x_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : RootReferencesArgs
-	//
-#ifndef Template_qPR0QR0QR0PR0_def
-#define Template_qPR0QR0QR0PR0_def
-	ETW_INLINE
-		ULONG
-		Template_qPR0QR0QR0PR0(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in const unsigned int  Count,
-			__in_ecount(Count) const void * *ObjectIDs,
-			__in_ecount(Count) const unsigned int *GCRootKinds,
-			__in_ecount(Count) const unsigned int *GCRootFlags,
-			__in_ecount(Count) const void * *RootIDs
-		)
-	{
-#define ARGUMENT_COUNT_qPR0QR0QR0PR0 5
+//
+//Template from manifest : RootReferencesArgs
+//
+#ifndef McTemplateU0qPR0QR0QR0PR0_def
+#define McTemplateU0qPR0QR0QR0PR0_def
+ETW_INLINE
+ULONG
+McTemplateU0qPR0QR0QR0PR0(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ const unsigned int  _Arg0,
+    _In_reads_(_Arg0) const void * *_Arg1,
+    _In_reads_(_Arg0) const unsigned int *_Arg2,
+    _In_reads_(_Arg0) const unsigned int *_Arg3,
+    _In_reads_(_Arg0) const void * *_Arg4
+    )
+{
+#define McTemplateU0qPR0QR0QR0PR0_ARGCOUNT 5
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_qPR0QR0QR0PR0];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0qPR0QR0QR0PR0_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &Count, sizeof(const unsigned int));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(const unsigned int)  );
 
-		EventDataDescCreate(&EventData[1], ObjectIDs, sizeof(PVOID)*Count);
+    EventDataDescCreate(&EventData[2], _Arg1, sizeof(PVOID)*_Arg0);
 
-		EventDataDescCreate(&EventData[2], GCRootKinds, sizeof(const unsigned int)*Count);
+    EventDataDescCreate(&EventData[3], _Arg2, sizeof(const unsigned int)*_Arg0);
 
-		EventDataDescCreate(&EventData[3], GCRootFlags, sizeof(const unsigned int)*Count);
+    EventDataDescCreate(&EventData[4], _Arg3, sizeof(const unsigned int)*_Arg0);
 
-		EventDataDescCreate(&EventData[4], RootIDs, sizeof(PVOID)*Count);
+    EventDataDescCreate(&EventData[5], _Arg4, sizeof(PVOID)*_Arg0);
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_qPR0QR0QR0PR0, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0qPR0QR0QR0PR0_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : ObjectReferencesArgs
-	//
-#ifndef Template_xxxqPR3_def
-#define Template_xxxqPR3_def
-	ETW_INLINE
-		ULONG
-		Template_xxxqPR3(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  ObjectID,
-			__in unsigned __int64  ClassID,
-			__in unsigned __int64  Size,
-			__in const unsigned int  ObjectRefCount,
-			__in_ecount(ObjectRefCount) const void * *ObjectRefs
-		)
-	{
-#define ARGUMENT_COUNT_xxxqPR3 5
+//
+//Template from manifest : ObjectReferencesArgs
+//
+#ifndef McTemplateU0xxxqPR3_def
+#define McTemplateU0xxxqPR3_def
+ETW_INLINE
+ULONG
+McTemplateU0xxxqPR3(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_ unsigned __int64  _Arg1,
+    _In_ unsigned __int64  _Arg2,
+    _In_ const unsigned int  _Arg3,
+    _In_reads_(_Arg3) const void * *_Arg4
+    )
+{
+#define McTemplateU0xxxqPR3_ARGCOUNT 5
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_xxxqPR3];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xxxqPR3_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &ObjectID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1], &ClassID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[2], &Size, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[3],&_Arg2, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[3], &ObjectRefCount, sizeof(const unsigned int));
+    EventDataDescCreate(&EventData[4],&_Arg3, sizeof(const unsigned int)  );
 
-		EventDataDescCreate(&EventData[4], ObjectRefs, sizeof(PVOID)*ObjectRefCount);
+    EventDataDescCreate(&EventData[5], _Arg4, sizeof(PVOID)*_Arg3);
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_xxxqPR3, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xxxqPR3_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : GCStartArgs
-	//
-#ifndef Template_ddt_def
-#define Template_ddt_def
-	ETW_INLINE
-		ULONG
-		Template_ddt(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in const signed int  GCID,
-			__in const signed int  Generation,
-			__in const BOOL  Induced
-		)
-	{
-#define ARGUMENT_COUNT_ddt 3
+//
+//Template from manifest : GCStartArgs
+//
+#ifndef McTemplateU0ddt_def
+#define McTemplateU0ddt_def
+ETW_INLINE
+ULONG
+McTemplateU0ddt(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ const signed int  _Arg0,
+    _In_ const signed int  _Arg1,
+    _In_ const BOOL  _Arg2
+    )
+{
+#define McTemplateU0ddt_ARGCOUNT 3
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_ddt];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0ddt_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &GCID, sizeof(const signed int));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(const signed int)  );
 
-		EventDataDescCreate(&EventData[1], &Generation, sizeof(const signed int));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(const signed int)  );
 
-		EventDataDescCreate(&EventData[2], &Induced, sizeof(const BOOL));
+    EventDataDescCreate(&EventData[3],&_Arg2, sizeof(const BOOL)  );
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_ddt, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0ddt_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : GCStopArgs
-	//
-#ifndef Template_d_def
-#define Template_d_def
-	ETW_INLINE
-		ULONG
-		Template_d(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in const signed int  GCID
-		)
-	{
-#define ARGUMENT_COUNT_d 1
+//
+//Template from manifest : GCStopArgs
+//
+#ifndef McTemplateU0d_def
+#define McTemplateU0d_def
+ETW_INLINE
+ULONG
+McTemplateU0d(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ const signed int  _Arg0
+    )
+{
+#define McTemplateU0d_ARGCOUNT 1
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_d];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0d_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &GCID, sizeof(const signed int));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(const signed int)  );
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_d, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0d_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : ObjectsMovedArgs
-	//
-#ifndef Template_qPR0PR0QR0_def
-#define Template_qPR0PR0QR0_def
-	ETW_INLINE
-		ULONG
-		Template_qPR0PR0QR0(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in const unsigned int  Count,
-			__in_ecount(Count) const void * *RangeBases,
-			__in_ecount(Count) const void * *TargetBases,
-			__in_ecount(Count) const unsigned int *Lengths
-		)
-	{
-#define ARGUMENT_COUNT_qPR0PR0QR0 4
+//
+//Template from manifest : ObjectsMovedArgs
+//
+#ifndef McTemplateU0qPR0PR0QR0_def
+#define McTemplateU0qPR0PR0QR0_def
+ETW_INLINE
+ULONG
+McTemplateU0qPR0PR0QR0(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ const unsigned int  _Arg0,
+    _In_reads_(_Arg0) const void * *_Arg1,
+    _In_reads_(_Arg0) const void * *_Arg2,
+    _In_reads_(_Arg0) const unsigned int *_Arg3
+    )
+{
+#define McTemplateU0qPR0PR0QR0_ARGCOUNT 4
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_qPR0PR0QR0];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0qPR0PR0QR0_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &Count, sizeof(const unsigned int));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(const unsigned int)  );
 
-		EventDataDescCreate(&EventData[1], RangeBases, sizeof(PVOID)*Count);
+    EventDataDescCreate(&EventData[2], _Arg1, sizeof(PVOID)*_Arg0);
 
-		EventDataDescCreate(&EventData[2], TargetBases, sizeof(PVOID)*Count);
+    EventDataDescCreate(&EventData[3], _Arg2, sizeof(PVOID)*_Arg0);
 
-		EventDataDescCreate(&EventData[3], Lengths, sizeof(const unsigned int)*Count);
+    EventDataDescCreate(&EventData[4], _Arg3, sizeof(const unsigned int)*_Arg0);
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_qPR0PR0QR0, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0qPR0PR0QR0_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : ObjectsSurvivedArgs
-	//
-#ifndef Template_qPR0QR0_def
-#define Template_qPR0QR0_def
-	ETW_INLINE
-		ULONG
-		Template_qPR0QR0(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in const unsigned int  Count,
-			__in_ecount(Count) const void * *RangeBases,
-			__in_ecount(Count) const unsigned int *Lengths
-		)
-	{
-#define ARGUMENT_COUNT_qPR0QR0 3
+//
+//Template from manifest : ObjectsSurvivedArgs
+//
+#ifndef McTemplateU0qPR0QR0_def
+#define McTemplateU0qPR0QR0_def
+ETW_INLINE
+ULONG
+McTemplateU0qPR0QR0(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ const unsigned int  _Arg0,
+    _In_reads_(_Arg0) const void * *_Arg1,
+    _In_reads_(_Arg0) const unsigned int *_Arg2
+    )
+{
+#define McTemplateU0qPR0QR0_ARGCOUNT 3
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_qPR0QR0];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0qPR0QR0_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &Count, sizeof(const unsigned int));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(const unsigned int)  );
 
-		EventDataDescCreate(&EventData[1], RangeBases, sizeof(PVOID)*Count);
+    EventDataDescCreate(&EventData[2], _Arg1, sizeof(PVOID)*_Arg0);
 
-		EventDataDescCreate(&EventData[2], Lengths, sizeof(const unsigned int)*Count);
+    EventDataDescCreate(&EventData[3], _Arg2, sizeof(const unsigned int)*_Arg0);
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_qPR0QR0, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0qPR0QR0_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : (null)
-	//
-#ifndef TemplateEventDescriptor_def
-#define TemplateEventDescriptor_def
+//
+//Template from manifest : (null)
+//
+#ifndef McTemplateU0_def
+#define McTemplateU0_def
+ETW_INLINE
+ULONG
+McTemplateU0(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor
+    )
+{
+#define McTemplateU0_ARGCOUNT 0
 
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0_ARGCOUNT + 1];
 
-	ETW_INLINE
-		ULONG
-		TemplateEventDescriptor(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor
-		)
-	{
-		return EventWrite(RegHandle, Descriptor, 0, NULL);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : ProfilerErrorArgs
-	//
-#ifndef Template_xz_def
-#define Template_xz_def
-	ETW_INLINE
-		ULONG
-		Template_xz(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  ErrorCode,
-			__in_opt PCWSTR  Message
-		)
-	{
-#define ARGUMENT_COUNT_xz 2
+//
+//Template from manifest : ProfilerErrorArgs
+//
+#ifndef McTemplateU0xz_def
+#define McTemplateU0xz_def
+ETW_INLINE
+ULONG
+McTemplateU0xz(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_opt_ PCWSTR  _Arg1
+    )
+{
+#define McTemplateU0xz_ARGCOUNT 2
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_xz];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xz_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &ErrorCode, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1],
-			(Message != NULL) ? Message : L"NULL",
-			(Message != NULL) ? (ULONG)((wcslen(Message) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
+    EventDataDescCreate(&EventData[2],
+                        (_Arg1 != NULL) ? _Arg1 : L"NULL",
+                        (_Arg1 != NULL) ? (ULONG)((wcslen(_Arg1) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_xz, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xz_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : SamplingRateChangeArgs
-	//
-#ifndef Template_xzddffd_def
-#define Template_xzddffd_def
-	ETW_INLINE
-		ULONG
-		Template_xzddffd(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in unsigned __int64  ClassID,
-			__in_opt PCWSTR  ClassName,
-			__in const signed int  MSecDelta,
-			__in const signed int  MinAllocPerMSec,
-			__in const float  NewAllocPerMSec,
-			__in const float  AllocPerMSec,
-			__in const signed int  SampleRate
-		)
-	{
-#define ARGUMENT_COUNT_xzddffd 7
+//
+//Template from manifest : SamplingRateChangeArgs
+//
+#ifndef McTemplateU0xzddffd_def
+#define McTemplateU0xzddffd_def
+ETW_INLINE
+ULONG
+McTemplateU0xzddffd(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_opt_ PCWSTR  _Arg1,
+    _In_ const signed int  _Arg2,
+    _In_ const signed int  _Arg3,
+    _In_ const float  _Arg4,
+    _In_ const float  _Arg5,
+    _In_ const signed int  _Arg6
+    )
+{
+#define McTemplateU0xzddffd_ARGCOUNT 7
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_xzddffd];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xzddffd_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &ClassID, sizeof(unsigned __int64));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1],
-			(ClassName != NULL) ? ClassName : L"NULL",
-			(ClassName != NULL) ? (ULONG)((wcslen(ClassName) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
+    EventDataDescCreate(&EventData[2],
+                        (_Arg1 != NULL) ? _Arg1 : L"NULL",
+                        (_Arg1 != NULL) ? (ULONG)((wcslen(_Arg1) + 1) * sizeof(WCHAR)) : (ULONG)sizeof(L"NULL"));
 
-		EventDataDescCreate(&EventData[2], &MSecDelta, sizeof(const signed int));
+    EventDataDescCreate(&EventData[3],&_Arg2, sizeof(const signed int)  );
 
-		EventDataDescCreate(&EventData[3], &MinAllocPerMSec, sizeof(const signed int));
+    EventDataDescCreate(&EventData[4],&_Arg3, sizeof(const signed int)  );
 
-		EventDataDescCreate(&EventData[4], &NewAllocPerMSec, sizeof(const float));
+    EventDataDescCreate(&EventData[5],&_Arg4, sizeof(const float)  );
 
-		EventDataDescCreate(&EventData[5], &AllocPerMSec, sizeof(const float));
+    EventDataDescCreate(&EventData[6],&_Arg5, sizeof(const float)  );
 
-		EventDataDescCreate(&EventData[6], &SampleRate, sizeof(const signed int));
+    EventDataDescCreate(&EventData[7],&_Arg6, sizeof(const signed int)  );
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_xzddffd, EventData);
-	}
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xzddffd_ARGCOUNT + 1, EventData);
+}
 #endif
 
-	//
-	//Template from manifest : SendManifestArgs
-	//
-#ifndef Template_cccchhs_def
-#define Template_cccchhs_def
-	ETW_INLINE
-		ULONG
-		Template_cccchhs(
-			__in REGHANDLE RegHandle,
-			__in PCEVENT_DESCRIPTOR Descriptor,
-			__in const UCHAR  Format,
-			__in const UCHAR  MajorVersion,
-			__in const UCHAR  MinorVersion,
-			__in const UCHAR  Magic,
-			__in const unsigned short  TotalChunks,
-			__in const unsigned short  ChunkNumger,
-			__in_opt LPCSTR  Data
-		)
-	{
-#define ARGUMENT_COUNT_cccchhs 7
+//
+//Template from manifest : CallEnterArgs
+//
+#ifndef McTemplateU0xq_def
+#define McTemplateU0xq_def
+ETW_INLINE
+ULONG
+McTemplateU0xq(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ unsigned __int64  _Arg0,
+    _In_ const unsigned int  _Arg1
+    )
+{
+#define McTemplateU0xq_ARGCOUNT 2
 
-		EVENT_DATA_DESCRIPTOR EventData[ARGUMENT_COUNT_cccchhs];
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0xq_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[0], &Format, sizeof(const UCHAR));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(unsigned __int64)  );
 
-		EventDataDescCreate(&EventData[1], &MajorVersion, sizeof(const UCHAR));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(const unsigned int)  );
 
-		EventDataDescCreate(&EventData[2], &MinorVersion, sizeof(const UCHAR));
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0xq_ARGCOUNT + 1, EventData);
+}
+#endif
 
-		EventDataDescCreate(&EventData[3], &Magic, sizeof(const UCHAR));
+//
+//Template from manifest : SendManifestArgs
+//
+#ifndef McTemplateU0cccchhs_def
+#define McTemplateU0cccchhs_def
+ETW_INLINE
+ULONG
+McTemplateU0cccchhs(
+    _In_ PMCGEN_TRACE_CONTEXT Context,
+    _In_ PCEVENT_DESCRIPTOR Descriptor,
+    _In_ const UCHAR  _Arg0,
+    _In_ const UCHAR  _Arg1,
+    _In_ const UCHAR  _Arg2,
+    _In_ const UCHAR  _Arg3,
+    _In_ const unsigned short  _Arg4,
+    _In_ const unsigned short  _Arg5,
+    _In_opt_ LPCSTR  _Arg6
+    )
+{
+#define McTemplateU0cccchhs_ARGCOUNT 7
 
-		EventDataDescCreate(&EventData[4], &TotalChunks, sizeof(const unsigned short));
+    EVENT_DATA_DESCRIPTOR EventData[McTemplateU0cccchhs_ARGCOUNT + 1];
 
-		EventDataDescCreate(&EventData[5], &ChunkNumger, sizeof(const unsigned short));
+    EventDataDescCreate(&EventData[1],&_Arg0, sizeof(const UCHAR)  );
 
-		EventDataDescCreate(&EventData[6],
-			(Data != NULL) ? Data : "NULL",
-			(Data != NULL) ? (ULONG)((strlen(Data) + 1) * sizeof(CHAR)) : (ULONG)sizeof("NULL"));
+    EventDataDescCreate(&EventData[2],&_Arg1, sizeof(const UCHAR)  );
 
-		return EventWrite(RegHandle, Descriptor, ARGUMENT_COUNT_cccchhs, EventData);
-	}
+    EventDataDescCreate(&EventData[3],&_Arg2, sizeof(const UCHAR)  );
+
+    EventDataDescCreate(&EventData[4],&_Arg3, sizeof(const UCHAR)  );
+
+    EventDataDescCreate(&EventData[5],&_Arg4, sizeof(const unsigned short)  );
+
+    EventDataDescCreate(&EventData[6],&_Arg5, sizeof(const unsigned short)  );
+
+    EventDataDescCreate(&EventData[7],
+                        (_Arg6 != NULL) ? _Arg6 : "NULL",
+                        (_Arg6 != NULL) ? (ULONG)((strlen(_Arg6) + 1) * sizeof(CHAR)) : (ULONG)sizeof("NULL"));
+
+    return McGenEventWriteUM(Context, Descriptor, McTemplateU0cccchhs_ARGCOUNT + 1, EventData);
+}
 #endif
 
 #endif // MCGEN_DISABLE_PROVIDER_CODE_GENERATION

--- a/src/EtwClrProfiler/ETWClrProfiler.man
+++ b/src/EtwClrProfiler/ETWClrProfiler.man
@@ -14,6 +14,7 @@
           <keyword name="GCAllocSampled"  mask="0x000000000008" symbol="GCAllocSampledKeyword"/>
           <keyword name="Call"            mask="0x000000000010" symbol="CallKeyword"/>
           <keyword name="CallSampled"     mask="0x000000000020" symbol="CallSampledKeyword"/>
+          <keyword name="DisableInlining" mask="0x000000000040" symbol="DisableInliningKeyword"/>
         </keywords>
         <tasks>
           <task name="GC" value="1" message="$(string.task_GC)" />
@@ -182,6 +183,7 @@
 
           <template tid="CallEnterArgs">
             <data name="FunctionID" inType="win:UInt64" />
+            <data name="SampleRate" inType="win:UInt32" />
           </template>
           
           <template tid="SendManifestArgs">

--- a/src/EtwClrProfiler/compileManifest.bat
+++ b/src/EtwClrProfiler/compileManifest.bat
@@ -1,2 +1,2 @@
 REM This generates a ETWClrProfiler.h file
-.\MC.exe -W winmeta.xml -um -b ETWClrProfiler.man 
+MC.exe -W winmeta.xml -um -b ETWClrProfiler.man 

--- a/src/EtwHeapDump/DotNetHeapDumper.cs
+++ b/src/EtwHeapDump/DotNetHeapDumper.cs
@@ -82,7 +82,7 @@ public class DotNetHeapDumper
                 string sessionName = "PerfViewGCHeapSession";
                 session = new TraceEventSession(sessionName, null);
                 int gcNum = -1;
-                session.BufferSizeMB = 256;         // Events come pretty fast, so make the buffer bigger. 
+                session.BufferSizeMB = 1024;         // Events come pretty fast, so make the buffer bigger. 
 
                 // Start the providers and trigger the GCs.  
                 log.WriteLine("{0,5:n1}s: Requesting a .NET Heap Dump", sw.Elapsed.TotalSeconds);

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.Diagnostics.FastSerialization</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.FastSerialization</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <Company>Microsoft</Company>
     <Description>Serialization library for TraceEvent.</Description>
@@ -15,6 +16,11 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);GROWABLEARRAY_PUBLIC;STREAMREADER_PUBLIC;FASTSERIALIZATION_PUBLIC</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- *** SourceLink Support *** -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
+  </ItemGroup>
 
   <!-- ******************* Signing Support *********************** -->
   <ItemGroup>

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Prefer32Bit>true</Prefer32Bit>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <RootNamespace>HeapDump</RootNamespace>
     <AssemblyName>HeapDump</AssemblyName>
@@ -34,6 +35,8 @@
   <ItemGroup>
     <ProjectReference Include="..\FastSerialization\FastSerialization.csproj" />
     <ProjectReference Include="..\TraceEvent\TraceEvent.csproj" />
+    <!-- *** SourceLink Support *** -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MemoryGraph/MemoryGraph.csproj
+++ b/src/MemoryGraph/MemoryGraph.csproj
@@ -6,6 +6,7 @@
   <!--Target CLR v2-->
   <PropertyGroup>
     <AllowCrossTargeting>true</AllowCrossTargeting>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -57,6 +58,9 @@
       <Project>{e32c9fc3-8524-4511-8acb-235ac136dc22}</Project>
       <Name>Utilities</Name>
     </ProjectReference>
+
+    <!-- *** SourceLink Support *** -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
   <Import Project="$(PerfLibRootPath)\PerfLib.targets" />
 </Project>

--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -51,7 +51,9 @@ namespace PerfView
 
                 // If we need to install, display the splash screen early, otherwise wait
                 if (!Directory.Exists(SupportFiles.SupportFileDir) && !noGui)
+                {
                     DisplaySplashScreen();
+                }
 #endif
                 App.Unpack();                   // Install the program if it is not done already 
                 App.RelaunchIfNeeded(args);     // If we are running from a a network share, relaunch locally. 
@@ -123,7 +125,9 @@ namespace PerfView
 #if !PERFVIEW_COLLECT
             // On ARM we don't have a GUI
             if (SupportFiles.ProcessArch == ProcessorArchitecture.Arm)
+            {
                 CommandLineArgs.NoGui = true;
+            }
 #else
             // We never support GUI in PerfViewCollect
             CommandLineArgs.NoGui = true;
@@ -185,8 +189,10 @@ namespace PerfView
                 using (var correctFile = new PEFile.PEFile(correctTraceEventDll))
                 {
                     if (fileInUse.Header.TimeDateStampSec != correctFile.Header.TimeDateStampSec)
+                    {
                         throw new ApplicationException("Error using the wrong Microsoft.Diagnostics.Tracing.TraceEvent.dll.\r\n" +
                             "   You cannot place a version of Microsoft.Diagnostics.Tracing.TraceEvent.dll next to PerfView.exe.");
+                    }
                 }
             }
 #endif
@@ -236,9 +242,13 @@ namespace PerfView
                 {
 #if !PERFVIEW_COLLECT // THese messages are confusing for PerfViewCollect given that it does not support View.  
                     if (CommandLineArgs.DataFile != null)
+                    {
                         CommandProcessor.LogFile.WriteLine("Trying to view {0}", CommandLineArgs.DataFile);
+                    }
                     else
+                    {
                         CommandProcessor.LogFile.WriteLine("No command given, Trying to open viewer.");
+                    }
 #endif
                     CommandProcessor.LogFile.WriteLine("Use 'PerfView collect' or 'PerfView HeapSnapshot' to collect data.");
                     return -4;
@@ -942,7 +952,9 @@ namespace PerfView
                 var splashScreen = (System.Windows.SplashScreen)s_splashScreen.Target;
                 s_splashScreen = null;
                 if (splashScreen != null)
+                {
                     splashScreen.Close(new TimeSpan(0));
+                }
             }
 #endif
         }
@@ -966,7 +978,9 @@ namespace PerfView
             var done = false;
             var ret = false;
             if (GuiApp.MainWindow == null || GuiApp.MainWindow.Dispatcher == null)
+            {
                 return ret;
+            }
 
             // We are on the GUI thread, we can just open the dialog 
             if (GuiApp.MainWindow.Dispatcher.CheckAccess())
@@ -998,7 +1012,9 @@ namespace PerfView
 
                 // Yuk, spin until the dialog box is closed.  
                 while (!done)
+                {
                     System.Threading.Thread.Sleep(100);
+                }
             }
             return ret;
 #else
@@ -1096,8 +1112,8 @@ namespace PerfView
         }
 
 #if !DOTNET_CORE
-        static Thread s_threadToInterrupt;
-        static int s_controlCPressed = 0;
+        private static Thread s_threadToInterrupt;
+        private static int s_controlCPressed = 0;
 #endif
 
         #endregion

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -121,6 +121,7 @@ namespace PerfView
         public bool DotNetAllocSampled;     // Turn on .NET Allocation profiling, but only sampled (in a smart way)
         public bool DotNetCalls;            // Turn on logging of every .NET call
         public bool DotNetCallsSampled;     // Sampling of .NET calls.  
+        public bool DisableInlining;        // Force inlining to be disabled. (useful for DotNetCalls).  
         public bool JITInlining;            // Turn on logging of successful and failed JIT inlining
         public int OSHeapProcess;           // Turn on OS Heap tracing for the process with the given process ID.
         public string OSHeapExe;            // Turn on OS heap tracing for any process with the given EXE
@@ -483,6 +484,7 @@ namespace PerfView
             parser.DefineOptionalQualifier("DotNetAllocSampled", ref DotNetAllocSampled, "Turns on per-allocation .NET profiling, sampling types in a smart way to keep overhead low.");
             parser.DefineOptionalQualifier("DotNetCalls", ref DotNetCalls, "Turns on per-call .NET profiling.");
             parser.DefineOptionalQualifier("DotNetCallsSampled", ref DotNetCallsSampled, "Turns on per-call .NET profiling, sampling types in a smart way to keep overhead low.");
+            parser.DefineOptionalQualifier("DisableInlining", ref DisableInlining, "Turns off inlining (but only affects processes that start after trace start.");
             parser.DefineOptionalQualifier("JITInlining", ref JITInlining, "Turns on logging of successful and failed JIT inlining attempts.");
             parser.DefineOptionalQualifier("CCWRefCount", ref CCWRefCount, "Turns on logging of information about .NET Native CCW reference counting.");
             parser.DefineOptionalQualifier("OSHeapProcess", ref OSHeapProcess, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given process ID.");

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml
@@ -4,7 +4,7 @@
         xmlns:src="clr-namespace:PerfView"
         Background="#FFA7A7A7" 
         Title="Collecting Memory Data" 
-        Width="730" MinWidth="500" Height="399">
+        Width="900" MinWidth="500" Height="400">
     <Window.CommandBindings>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp"/>
     </Window.CommandBindings>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Prefer32Bit>True</Prefer32Bit>
     <StartupObject>PerfView.App</StartupObject>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <Description>PerfView</Description>
     <Company>Microsoft</Company>
@@ -47,6 +48,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" PrivateAssets="all" />
     <PackageReference Include="PerfView.SupportFiles" Version="$(PerfViewSupportFilesVersion)" PrivateAssets="all" />
+
+    <!-- *** SourceLink Support *** -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -8172,21 +8172,35 @@
     </h2>
     <ul>
         <!--
-        <li>Version 1.4.1 - 1/XX/2013
+    <li>Version 1.4.1 - 1/XX/2013
+        <ul>
+        <li>XXX</li>
+          <li>Improved the performance of the stack-view substantially by building a simplified regular expression matcher
+                instead of using System.Text.RegularExpressions.  This should improve 'update' speeds in the stack viewer
+                in common scenarios by of 2 </li>
+            <li>Allowed the stack-view to parallelize much of the activity, improving performance by probably another factor
+                of about 2 or more in many cases.   More can be done here to take advantage of Quad procs etc </li>
+            <li>Because it would be very easy for the above two features to cause the code to break, I have added a /safeMode
+                command qualifier that turns them off.   If you get a crash when updating the stack viewer, you should retry
+                with /safemode</li>
+        </ul>
+    </li>
+    -->
+        <li>
+            Version 2.0.22 8/15/18
             <ul>
-            <li>XXX</li>
-              <li>Improved the performance of the stack-view substantially by building a simplified regular expression matcher
-                    instead of using System.Text.RegularExpressions.  This should improve 'update' speeds in the stack viewer
-                    in common scenarios by of 2 </li>
-                <li>Allowed the stack-view to parallelize much of the activity, improving performance by probably another factor
-                    of about 2 or more in many cases.   More can be done here to take advantage of Quad procs etc </li>
-                <li>Because it would be very easy for the above two features to cause the code to break, I have added a /safeMode
-                    command qualifier that turns them off.   If you get a crash when updating the stack viewer, you should retry
-                    with /safemode</li>
+                <li> Added the /DotNetCallsSampled command line option that does call instrumentation
+                but samples every 97 calls (to keep overhead low)
+                 </li>
+                <li>Added the /DisableInlining command line option that tells the runtime not to
+                inline (used with the /DotNetCalls or /DotNetCallsSampled options)</li>
+                <li>Minor bug fixes so that things work inside windows docker containers.  
+                This works on windowsServerCore Version RS3 or beyond.  PerfViewCollect can 
+                be used on windowsNano OS
+                </li>
+                <li>fixed build to support SourceLink for the PerfVIew/TraceEvent source itself.</li>
             </ul>
         </li>
-        -->
-
         <li>
             Version 2.0.17 5/25/18
             <ul>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -4052,6 +4052,17 @@
                 /BufferSize qualifier very large (e.g. 1000Meg).  and even that may not be enough
                 This option is really only meant for small isolated tests.
             </p>
+            <p>
+                There is an command line option /DotNetCallsSampled which works like /DotNetCalls, however it
+                samples every 97 calls rather than every call.  This cuts the overhead (and file size)
+                by a factor of ~100 which is better if overhead is a concern. 
+            </p>
+            <p>
+                By default the runtime does not disable inlining of methods.  Thus you will not see 
+                inlined calls in your trace.   There is also a command line option /DisableInlining 
+                which disables inlining so you will see every call.  This slows things down even more
+                so should only be used in 'small' scenarios.  
+            </p>
         </li>
         <li>
             The <strong><a id="JITInliningCheckBox">JIT Inlining Checkbox</a></strong> - Causes
@@ -6096,6 +6107,19 @@
         few minutes of data that lead up to the 'bad perf' (in this case high GC time).
     </p>
     <p>
+        Some counters (like the system global counters 'Memory:Committed Bytes' do not have
+        an instance because there is only one for the whole machine.  For these specify
+        an emtpy string.   For example
+    </p>
+    <ul>
+        <li>PerfView collect "/StopOnPerfCounter:Memory:Committed Bytes: > 50000000000"</li>
+    </ul>
+    <p>
+        will stop collection of the committed bytes for the entire machine exceed 50GB.  Notice
+        that the counter is still CATEGORY:NAME:INSTANCE, but in this case INSTANCE is the 
+        empty string (the trailing :).     
+    </p>
+    <p>
         When the performance counter triggers, PerfView actually collects 10 more seconds
         of trace before stopping. This way you get both the conditions up to and slightly
         after the event that you are interested in. PerfView logs an event called StopReason
@@ -6114,6 +6138,16 @@
         will then show you all the instances (processes) that have those counters. These
         three names (category, counter, instance) are the values you need to give to the
         '/StopOnPerfCounter qualifier.
+    </p>
+    <p>
+        You will want to test your /StopOn* specfication before waiting a long time to see
+        if it catpures a trace properly.   If you open the log (or use /MaxCollectSec=XXX to
+        force it to stop quickly and then look at the file specified by /LogFile or look for
+        this captured log file in the 'TraceInfo view of the '*.etl.zip'), you will find 
+        diagnostic messages as it monitors the perf counter.  You should see messages that
+        show it setting up the perf counter as well as the values it sees every few seconds. 
+        This can give you confidence that you did not misspell the counter, that you have
+        the correct instance, and you picked a reasonable threshold.
     </p>
     <p>
         You can specify the /StopOnPerfCounter qualifier more than once and each acts as a trigger.

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -10,6 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);PERFVIEW_COLLECT;DOTNET_CORE</DefineConstants>
     <NoWarn>$(NoWarn),0649,0618</NoWarn>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,6 +44,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
 
   <!-- Ensure that the native components of TraceEvent are restored into the target and publish directories so that TraceEvent can pinvoke into them. -->

--- a/src/TraceEvent/Computers/ActivityComputer.cs
+++ b/src/TraceEvent/Computers/ActivityComputer.cs
@@ -133,6 +133,23 @@ namespace Microsoft.Diagnostics.Tracing
                 OnStart(data, id);
             };
 
+            // System.Threading.ThreadPool.QueueUserWorkItem support.  
+            fxParser.ThreadPoolEnqueueWork += delegate (ThreadPoolEnqueueWorkArgs data)
+            {
+                OnCreated(data, GetClrRawID(data, data.WorkID), TraceActivity.ActivityKind.ClrThreadPool);
+            };
+            fxParser.ThreadPoolDequeueWork += delegate (ThreadPoolDequeueWorkArgs data)
+            {
+                OnStart(data, GetClrRawID(data, data.WorkID));
+            };
+
+            // With this event, we should not need the hack below that looks at context switches
+            // because we fire this before we go to sleep.  
+            m_source.Clr.ThreadPoolWorkerThreadWait += delegate (ThreadPoolWorkerThreadTraceData data)
+            {
+                AutoRestart(data, data.Thread());
+            };
+
             // .NET Network thread pool support 
             m_source.Clr.ThreadPoolIOEnqueue += delegate (ThreadPoolIOWorkEnqueueTraceData data)
             {

--- a/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
@@ -206,6 +206,10 @@ namespace Microsoft.Diagnostics.Tracing
                         }
                     }
 
+                    // We don't care about EventPipe sample profiler events.  
+                    if (data.ProviderGuid == SampleProfilerTraceEventParser.ProviderGuid)
+                        return;
+
                     // We don't care about the TPL provider.  Too many events.  
                     if (data.ProviderGuid == TplEtwProviderTraceEventParser.ProviderGuid)
                     {

--- a/src/TraceEvent/Parsers/FrameworkTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/FrameworkTraceEventParser.cs
@@ -9089,7 +9089,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
     }
     public sealed class ThreadPoolDequeueWorkArgs : TraceEvent
     {
-        public long workID { get { return GetInt64At(0); } }
+        public Address WorkID { get { return (Address)GetInt64At(0); } }
 
         #region Private
         internal ThreadPoolDequeueWorkArgs(Action<ThreadPoolDequeueWorkArgs> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -9114,7 +9114,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
-            XmlAttrib(sb, "workID", workID);
+            XmlAttrib(sb, "WorkID", WorkID);
             sb.Append("/>");
             return sb;
         }
@@ -9125,7 +9125,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
             {
                 if (payloadNames == null)
                 {
-                    payloadNames = new string[] { "workID" };
+                    payloadNames = new string[] { "WorkID" };
                 }
 
                 return payloadNames;
@@ -9137,7 +9137,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
             switch (index)
             {
                 case 0:
-                    return workID;
+                    return WorkID;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
@@ -9149,7 +9149,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
     }
     public sealed class ThreadPoolEnqueueWorkArgs : TraceEvent
     {
-        public long workID { get { return GetInt64At(0); } }
+        public Address WorkID { get { return (Address)GetInt64At(0); } }
 
         #region Private
         internal ThreadPoolEnqueueWorkArgs(Action<ThreadPoolEnqueueWorkArgs> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -9174,7 +9174,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
-            XmlAttrib(sb, "workID", workID);
+            XmlAttrib(sb, "WorkID", WorkID);
             sb.Append("/>");
             return sb;
         }
@@ -9185,7 +9185,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
             {
                 if (payloadNames == null)
                 {
-                    payloadNames = new string[] { "workID" };
+                    payloadNames = new string[] { "WorkID" };
                 }
 
                 return payloadNames;
@@ -9197,7 +9197,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource
             switch (index)
             {
                 case 0:
-                    return workID;
+                    return WorkID;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;

--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -3463,20 +3463,22 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
 #if !CONTAINER_WORKAROUND_NOT_NEEDED
                 // Currently ETW shows paths from the HOST not the CLIENT for some files.   We recognise them 
-                // because they have have the form of a GUID path \Files and then the client path.   We only
-                // need to fix this for windows (OS) files, so we use \Files\Windows\as the key that this is
-                // happening, and we morph the name to fix it.
-
+                // because they have have the form of a GUID path \OS or \File and then the client path.   It is enough
+                // to fix this for files in the \windows directory so we use \OS\Windows\ or \Files\Windows as the key 
+                // to tell if we have a HOST file path and we morph the name to fix it.
                 // We can pull this out when the OS fixes ETW to show client names.  
-                var filesIdx = kernelName.IndexOf(@"\Files\Windows\", StringComparison.OrdinalIgnoreCase);
-                if (16 < filesIdx)
+                var filesIdx = kernelName.IndexOf(@"\OS\Windows\", StringComparison.OrdinalIgnoreCase);
+                if (0 <= filesIdx && filesIdx + 3 < kernelName.Length)
                 {
-                    var ret = systemDrive + kernelName.Substring(filesIdx + 6);
-                    return ret;
+                    return systemDrive + kernelName.Substring(filesIdx + 3);
                 }
 
-#endif 
-
+                filesIdx = kernelName.IndexOf(@"\Files\Windows\", StringComparison.OrdinalIgnoreCase);
+                if (0 <= filesIdx && filesIdx + 6 < kernelName.Length)
+                {
+                    return systemDrive + kernelName.Substring(filesIdx + 6);
+                }
+#endif
                 for (int i = 0; i < kernelToDriveMap.Count; i++)
                 {
                     Debug.Assert(kernelToDriveMap[i].Key.EndsWith(@"\"));

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -1895,9 +1895,11 @@ namespace Microsoft.Diagnostics.Tracing
         }
         /// <summary>
         /// Returns the Timestamp for the event using Query Performance Counter (QPC) ticks.   
-        /// The start time for the QPC tick counter is unknown
+        /// The start time for the QPC tick counter is arbitrary and the units  also vary.  
         /// </summary>
-        internal long TimeStampQPC { get { return eventRecord->EventHeader.TimeStamp; } }
+        [Obsolete("Not Obsolete but Discouraged.  Please use TimeStampRelativeMSec.")]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public long TimeStampQPC { get { return eventRecord->EventHeader.TimeStamp; } }
 
         /// <summary>
         /// A standard way for events to are that certain addresses are addresses in code and ideally have
@@ -3369,42 +3371,42 @@ namespace Microsoft.Diagnostics.Tracing
             try
             {
 #endif
-            if (anEvent.Target != null)
-            {
-                anEvent.Dispatch();
-            }
-
-            if (anEvent.next != null)
-            {
-                TraceEvent nextEvent = anEvent;
-                for (; ; )
+                if (anEvent.Target != null)
                 {
-                    nextEvent = nextEvent.next;
-                    if (nextEvent == null)
-                    {
-                        break;
-                    }
-
-                    if (nextEvent.Target != null)
-                    {
-                        nextEvent.eventRecord = anEvent.eventRecord;
-                        nextEvent.userData = anEvent.userData;
-                        nextEvent.eventIndex = anEvent.eventIndex;
-                        nextEvent.Dispatch();
-                        nextEvent.eventRecord = null;
-                    }
-                }
-            }
-            if (AllEvents != null)
-            {
-                if (unhandledEventTemplate == anEvent)
-                {
-                    unhandledEventTemplate.PrepForCallback();
+                    anEvent.Dispatch();
                 }
 
-                AllEvents(anEvent);
-            }
-            anEvent.eventRecord = null;
+                if (anEvent.next != null)
+                {
+                    TraceEvent nextEvent = anEvent;
+                    for (; ; )
+                    {
+                        nextEvent = nextEvent.next;
+                        if (nextEvent == null)
+                        {
+                            break;
+                        }
+
+                        if (nextEvent.Target != null)
+                        {
+                            nextEvent.eventRecord = anEvent.eventRecord;
+                            nextEvent.userData = anEvent.userData;
+                            nextEvent.eventIndex = anEvent.eventIndex;
+                            nextEvent.Dispatch();
+                            nextEvent.eventRecord = null;
+                        }
+                    }
+                }
+                if (AllEvents != null)
+                {
+                    if (unhandledEventTemplate == anEvent)
+                    {
+                        unhandledEventTemplate.PrepForCallback();
+                    }
+
+                    AllEvents(anEvent);
+                }
+                anEvent.eventRecord = null;
 #if DEBUG
             }
             catch (Exception e)

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -20,6 +20,8 @@
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
     <NuspecFile>Microsoft.Diagnostics.Tracing.TraceEvent.nuspec</NuspecFile>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);SetNuspecProperties</GenerateNuspecDependsOn>
   </PropertyGroup>
@@ -65,6 +67,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+
+  <!-- *** SourceLink Support *** -->
+  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TraceEvent/TraceUtilities/PEFile.cs
+++ b/src/TraceEvent/TraceUtilities/PEFile.cs
@@ -955,7 +955,7 @@ namespace PEFile
         {
             // Convert seconds from Jan 1 1970 to DateTime ticks.  
             // The 621356004000000000L represents Jan 1 1970 as DateTime 100ns ticks.  
-            DateTime ret = new DateTime(((long)timeDateStampSec) * 10000000 + 621356004000000000L, DateTimeKind.Utc).ToLocalTime();
+            DateTime ret = new DateTime(((long)(uint)timeDateStampSec) * 10000000 + 621356004000000000L, DateTimeKind.Utc).ToLocalTime();
 
             // Calculation above seems to be off by an hour  Don't know why 
             ret = ret.AddHours(-1.0);


### PR DESCRIPTION
1. Added SourceLink Support (PDBs now have URLs)
2. Added TimeStampQPC (however it is marked as Discouraged, it is for unusual scenarios)
3. Added /DotNetCallsSampled which samples every ~1000 calls (which is enough that it does not slow things down too much
4.  Added /DisableInlining for /DotNetCalls* so that you can see every call whether it was inlined or not.
5. Windows now routinle does not log the machine name.  Fix logic that depended on knowing the machine name.