### PR TITLE
fixed compile error:  error CS1566: Error reading resource '.\x86\Microsoft.Diagnostics.Runtime.dll' 

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -265,7 +265,7 @@
       <Link>Microsoft.Diagnostics.Tracing.TraceEvent.xml</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)Microsoft.Diagnostics.Runtime\$(MicrosoftDiagnosticsRuntimeVersion)\lib\net40\Microsoft.Diagnostics.Runtime.dll">
+    <EmbeddedResource Include="$(NuGetPackageRoot)\Microsoft.Diagnostics.Runtime\$(MicrosoftDiagnosticsRuntimeVersion)\lib\net40\Microsoft.Diagnostics.Runtime.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\x86\Microsoft.Diagnostics.Runtime.dll</LogicalName>


### PR DESCRIPTION
I tried to compile Perfview and got an error:

>  error CS1566: Error reading resource '.\x86\Microsoft.Diagnostics.Runtime.dll' 'Could not find a part of the path 'C:\Users\Andre\.nuget\packagesMicrosoft.Diagnostics.Runtime\0.8.31-beta\lib\net40\Microsoft.Diagnostics.Runtime.dll'.'

packagesMicrosoft.Diagnostics.Runtime is wrong, there is a missing `\`