### PR TITLE
Added horizontal scrolling of PerfGrids

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@ root=true
 [*.cs]
 indent_style = space
 indent_size = 4
+
+[*.xaml]
+indent_style = space
+indent_size = 4

--- a/src/PerfView.Tests/StackViewer/StackWindowTests.cs
+++ b/src/PerfView.Tests/StackViewer/StackWindowTests.cs
@@ -133,6 +133,33 @@ namespace PerfViewTests.StackViewer
             return RunUITestAsync(setupAsync, testDriverAsync, cleanupAsync);
         }
 
+        private static T FindChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            if (parent == null)
+            {
+                return default(T);
+            }
+
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                // Try child itself
+                DependencyObject child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T)
+                {
+                    return (T)child;
+                }
+
+                // If not - try grandchild
+                var result = FindChild<T>(child);
+                if (result != null)
+                {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+            
         private static async Task<PerfDataGrid> SelectTabAsync(StackWindow stackWindow, KnownDataGrid grid, CancellationToken cancellationToken)
         {
             Assert.Same(stackWindow.Dispatcher.Thread, Thread.CurrentThread);
@@ -204,7 +231,12 @@ namespace PerfViewTests.StackViewer
                     var cellToDoubleClick = (DataGridCell)gridToDoubleClick.DisplayNameColumn.GetCellContent(itemToDoubleClick).Parent;
 
                     var border = (Border)VisualTreeHelper.GetChild(cellToDoubleClick, 0);
-                    var textBlock = (TextBlock)VisualTreeHelper.GetChild(VisualTreeHelper.GetChild(VisualTreeHelper.GetChild(border, 0), 0), 0);
+                    var scrollViewer = (ScrollViewer)VisualTreeHelper.GetChild(
+                        VisualTreeHelper.GetChild(VisualTreeHelper.GetChild(border, 0), 0), 0);
+                    var cellGrid = FindChild<Grid>(scrollViewer);
+                    var scrollContentPresenter = FindChild<ScrollContentPresenter>(cellGrid);
+                    var internalGrid = FindChild<Grid>(scrollContentPresenter);
+                    var textBlock = (TextBlock)internalGrid.Children.Cast<UIElement>().First(i => Grid.GetRow(i) == 0);
                     Point controlCenter = new Point(textBlock.ActualWidth / 2, textBlock.ActualHeight / 2);
                     Point controlCenterOnView = textBlock.TranslatePoint(controlCenter, (UIElement)Helpers.RootVisual(textBlock));
                     Point controlCenterOnDevice = PresentationSource.FromDependencyObject(Helpers.RootVisual(textBlock)).CompositionTarget.TransformToDevice.Transform(controlCenterOnView);

--- a/src/PerfView/GuiUtilities/ScrollSynchronizer.cs
+++ b/src/PerfView/GuiUtilities/ScrollSynchronizer.cs
@@ -1,0 +1,395 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace Utilities
+{
+    public class ScrollSynchronizer : DependencyObject
+    {
+        // Variables
+        public static DependencyProperty ScrollGroupProperty;
+        static Dictionary<object, string> m_Scrollers;
+        static Dictionary<string, List<object>> m_GroupScrollers;
+        static Dictionary<string, double> m_HorizontalScrollPositions;
+        static Dictionary<string, double> m_HorizontalScrollLengths;
+        static Dictionary<string, double> m_VerticalScrollPositions;
+        static Dictionary<string, double> m_VerticalScrollLengths;
+
+        // Properties
+        public string ScrollGroup
+        {
+            get { return (string)GetValue(ScrollGroupProperty); }
+            set { SetValue(ScrollGroupProperty, value); }
+        }
+
+        // Constructors
+        static ScrollSynchronizer()
+        {
+            ScrollGroupProperty = DependencyProperty.RegisterAttached(
+                "ScrollGroup",
+                typeof(string),
+                typeof(ScrollSynchronizer),
+                new PropertyMetadata(new PropertyChangedCallback(OnScrollGroupChanged)));
+            m_Scrollers = new Dictionary<object, string>();
+            m_GroupScrollers = new Dictionary<string, List<object>>();
+            m_HorizontalScrollPositions = new Dictionary<string, double>();
+            m_HorizontalScrollLengths = new Dictionary<string, double>();
+            m_VerticalScrollPositions = new Dictionary<string, double>();
+            m_VerticalScrollLengths = new Dictionary<string, double>();
+        }
+
+        // Get/Set
+        public static void SetScrollGroup(DependencyObject obj, string nScrollGroup)
+        {
+            obj.SetValue(ScrollGroupProperty, nScrollGroup);
+        }
+
+        public static string GetScrollGroup(DependencyObject obj)
+        {
+            return (string)obj.GetValue(ScrollGroupProperty);
+        }
+
+        static void OnScrollGroupChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+        {
+            ScrollViewer sv = obj as ScrollViewer;
+            ScrollBar sb = obj as ScrollBar;
+            if ((sv == null) && (sb == null))
+                return;
+
+            string ov = (string)e.OldValue;
+            string nv = (string)e.NewValue;
+
+            if (!string.IsNullOrEmpty(ov))
+            {
+                if ((sv != null) && (m_Scrollers.ContainsKey(sv)))
+                {
+                    sv.ScrollChanged -= new ScrollChangedEventHandler(ScrollViewer_ScrollChanged);
+                    m_Scrollers.Remove(sv);
+                    m_GroupScrollers[ov].Remove(sv);
+                }
+
+                if ((sb != null) && (m_Scrollers.ContainsKey(sb)))
+                {
+                    sb.IsEnabled = false;
+                    sb.Scroll -= new ScrollEventHandler(ScrollBar_Scroll);
+                    m_Scrollers.Remove(sb);
+                    m_GroupScrollers[ov].Remove(sb);
+                }
+
+                // Kill off if nobody left in the group
+                if (m_GroupScrollers[ov].Count == 0)
+                {
+                    m_GroupScrollers.Remove(ov);
+                    m_HorizontalScrollPositions.Remove(ov);
+                    m_HorizontalScrollLengths.Remove(ov);
+                    m_VerticalScrollPositions.Remove(ov);
+                    m_VerticalScrollLengths.Remove(ov);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(nv))
+            {
+                // Prepare the group
+                if (!m_GroupScrollers.ContainsKey(nv))
+                    m_GroupScrollers.Add(nv, new List<object>());
+
+                if (sv != null)
+                {
+                    if (sv.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled)
+                    {
+                        if (m_HorizontalScrollPositions.ContainsKey(nv))
+                            SetScrollViewerHorizontalPosition(sv, m_HorizontalScrollPositions[nv]);
+                        else
+                        {
+                            m_HorizontalScrollPositions.Add(nv, GetScrollViewerHorizontalPosition(sv));
+                            m_HorizontalScrollLengths.Add(nv, GetScrollViewerHorizontalLength(sv));
+                        }
+                    }
+
+                    if (sv.VerticalScrollBarVisibility != ScrollBarVisibility.Disabled)
+                    {
+                        if (m_VerticalScrollPositions.ContainsKey(nv))
+                            SetScrollViewerVerticalPosition(sv, m_VerticalScrollPositions[nv]);
+                        else
+                        {
+                            m_VerticalScrollPositions.Add(nv, GetScrollViewerVerticalPosition(sv));
+                            m_VerticalScrollLengths.Add(nv, GetScrollViewerVerticalLength(sv));
+                        }
+                    }
+
+                    m_Scrollers.Add(sv, nv);
+                    m_GroupScrollers[nv].Add(sv);
+
+                    sv.ScrollChanged += new ScrollChangedEventHandler(ScrollViewer_ScrollChanged);
+                }
+
+                if (sb != null)
+                {
+                    sb.IsEnabled = true;
+
+                    if (sb.Orientation == Orientation.Horizontal)
+                    {
+                        if (m_HorizontalScrollPositions.ContainsKey(nv))
+                        {
+                            SetScrollBarPosition(sb, m_HorizontalScrollPositions[nv]);
+                            SetScrollBarLength(sb, m_HorizontalScrollLengths[nv]);
+                        }
+                        else
+                        {
+                            m_HorizontalScrollPositions.Add(nv, GetScrollBarPosition(sb));
+                            m_HorizontalScrollLengths.Add(nv, GetScrollBarLength(sb));
+                        }
+                    }
+                    else
+                    {
+                        if (m_VerticalScrollPositions.ContainsKey(nv))
+                        {
+                            SetScrollBarPosition(sb, m_VerticalScrollPositions[nv]);
+                            SetScrollBarLength(sb, m_VerticalScrollLengths[nv]);
+                        }
+                        else
+                        {
+                            m_VerticalScrollPositions.Add(nv, GetScrollBarPosition(sb));
+                            m_VerticalScrollLengths.Add(nv, GetScrollBarLength(sb));
+                        }
+                    }
+
+                    m_Scrollers.Add(sb, nv);
+                    m_GroupScrollers[nv].Add(sb);
+
+                    sb.Scroll += new ScrollEventHandler(ScrollBar_Scroll);
+                }
+            }
+        }
+
+        static void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            Scroll(sender as ScrollViewer, (e.HorizontalChange != 0), (e.VerticalChange != 0));
+
+            // Hide scroll bar under the grid if no need to scroll.
+            // Only iterating over ScrollBars since ScrollViewer items inside grid are already hidden.
+            Visibility v = e.ExtentWidth <= e.ViewportWidth ? Visibility.Collapsed : Visibility.Visible;
+            foreach (object obj in m_GroupScrollers[m_Scrollers[sender]])
+            {
+                var sb = obj as ScrollBar;
+                if (sb != null)
+                {
+                    sb.Visibility = v;
+                }
+            }
+        }
+
+        static void ScrollBar_Scroll(object sender, ScrollEventArgs e)
+        {
+            Scroll(sender as ScrollBar, false, false);
+        }
+
+        static void Scroll(object nChangeScroller, bool nHorzChange, bool nVertChange)
+        {
+            string group = m_Scrollers[nChangeScroller];
+
+            ScrollViewer svc = nChangeScroller as ScrollViewer;
+            ScrollBar sbc = nChangeScroller as ScrollBar;
+
+            // Record the position and length
+            if (svc != null)
+            {
+                if (svc.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled)
+                {
+                    m_HorizontalScrollPositions[group] = GetScrollViewerHorizontalPosition(svc);
+                    m_HorizontalScrollLengths[group] = GetScrollViewerHorizontalLength(svc);
+                }
+
+                if (svc.VerticalScrollBarVisibility != ScrollBarVisibility.Disabled)
+                {
+                    m_VerticalScrollPositions[group] = GetScrollViewerVerticalPosition(svc);
+                    m_VerticalScrollLengths[group] = GetScrollViewerVerticalLength(svc);
+                }
+            }
+
+            if (sbc != null)
+            {
+                if (sbc.Orientation == Orientation.Horizontal)
+                {
+                    m_HorizontalScrollPositions[group] = GetScrollBarPosition(sbc);
+                    m_HorizontalScrollLengths[group] = GetScrollBarLength(sbc);
+                }
+                else
+                {
+                    m_VerticalScrollPositions[group] = GetScrollBarPosition(sbc);
+                    m_VerticalScrollLengths[group] = GetScrollBarLength(sbc);
+                }
+            }
+
+            // Modify each scroller in the group
+            foreach (object obj in m_GroupScrollers[group])
+            {
+                ScrollViewer sv = obj as ScrollViewer;
+                ScrollBar sb = obj as ScrollBar;
+
+                // Skip changing myself
+                if ((sv == nChangeScroller) || (sb == nChangeScroller))
+                    continue;
+
+                // Modify an existing scrollviewer
+                if (sv != null)
+                {
+                    // Modify from a scrollviewer (scrollviewer -> scrollviewer)
+                    if (svc != null)
+                    {
+                        // Modify horizontal
+                        if ((sv.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled) &&
+                            nHorzChange && (svc.HorizontalScrollBarVisibility !=
+                                            ScrollBarVisibility.Disabled))
+                            SetScrollViewerHorizontalPosition(
+                                sv,
+                                GetScrollViewerHorizontalPosition(svc));
+
+                        // Modify vertical
+                        if ((sv.VerticalScrollBarVisibility != ScrollBarVisibility.Disabled) &&
+                            nVertChange && (svc.VerticalScrollBarVisibility !=
+                                            ScrollBarVisibility.Disabled))
+                            SetScrollViewerVerticalPosition(sv, GetScrollViewerVerticalPosition(svc));
+                    }
+
+                    // Modify from a scrollbar (scrollbar -> scrollviewer)
+                    if (sbc != null)
+                    {
+                        // Modify horizontal
+                        if ((sv.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled) &&
+                            (sbc.Orientation == Orientation.Horizontal))
+                            SetScrollViewerHorizontalPosition(sv, GetScrollBarPosition(sbc));
+
+                        // Modify vertical
+                        if ((sv.VerticalScrollBarVisibility != ScrollBarVisibility.Disabled) &&
+                            (sbc.Orientation == Orientation.Vertical))
+                            SetScrollViewerVerticalPosition(sv, GetScrollBarPosition(sbc));
+                    }
+                }
+
+                // Modify an existing scrollbar
+                if (sb != null)
+                {
+                    // Modify from a scrollviewer (scrollviewer -> scrollbar)
+                    if (svc != null)
+                    {
+                        // Modify horizontal
+                        if ((sb.Orientation == Orientation.Horizontal) &&
+                            (svc.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled))
+                        {
+                            SetScrollBarPosition(sb, GetScrollViewerHorizontalPosition(svc));
+                            SetScrollBarLength(sb, GetScrollViewerHorizontalLength(svc));
+                        }
+
+                        // Modify vertical
+                        if ((sb.Orientation == Orientation.Vertical) &&
+                            (svc.VerticalScrollBarVisibility != ScrollBarVisibility.Disabled))
+                        {
+                            SetScrollBarPosition(sb, GetScrollViewerVerticalPosition(svc));
+                            SetScrollBarLength(sb, GetScrollViewerVerticalLength(svc));
+                        }
+                    }
+
+                    // Modify from a scrollbar (scrollbar -> scrollbar)
+                    if (sbc != null)
+                    {
+                        // Modify same orientation
+                        if (sb.Orientation == sbc.Orientation)
+                        {
+                            SetScrollBarPosition(sb, GetScrollBarPosition(sbc));
+                            SetScrollBarLength(sb, GetScrollBarLength(sbc));
+                        }
+                    }
+                }
+            }
+        }
+
+        static double GetScrollViewerHorizontalPosition(ScrollViewer nScrollViewer)
+        {
+            if (nScrollViewer.ViewportWidth >= nScrollViewer.ExtentWidth)
+                return 0;
+
+            return nScrollViewer.HorizontalOffset / nScrollViewer.ScrollableWidth;
+        }
+
+        static double GetScrollViewerHorizontalLength(ScrollViewer nScrollViewer)
+        {
+            if (nScrollViewer.ViewportWidth >= nScrollViewer.ExtentWidth)
+                return 1;
+
+            if (nScrollViewer.ExtentWidth <= 0)
+                return 0;
+
+            return nScrollViewer.ViewportWidth / nScrollViewer.ExtentWidth;
+        }
+
+        static double GetScrollViewerVerticalPosition(ScrollViewer nScrollViewer)
+        {
+            if (nScrollViewer.ViewportHeight >= nScrollViewer.ExtentHeight)
+                return 0;
+
+            return nScrollViewer.VerticalOffset / nScrollViewer.ScrollableHeight;
+        }
+
+        static double GetScrollViewerVerticalLength(ScrollViewer nScrollViewer)
+        {
+            if (nScrollViewer.ViewportHeight >= nScrollViewer.ExtentHeight)
+                return 1;
+
+            if (nScrollViewer.ExtentHeight <= 0)
+                return 0;
+
+            return nScrollViewer.ViewportHeight / nScrollViewer.ExtentHeight;
+        }
+
+        static double GetScrollBarPosition(ScrollBar nScrollBar)
+        {
+            double tracklen = nScrollBar.Maximum - nScrollBar.Minimum;
+
+            return (nScrollBar.Value - nScrollBar.Minimum) / tracklen;
+        }
+
+        static double GetScrollBarLength(ScrollBar nScrollBar)
+        {
+            double tracklen = nScrollBar.Maximum - nScrollBar.Minimum;
+
+            return nScrollBar.ViewportSize / (tracklen + nScrollBar.ViewportSize);
+        }
+
+        static void SetScrollViewerHorizontalPosition(ScrollViewer nScrollViewer, double nPosition)
+        {
+            nScrollViewer.ScrollToHorizontalOffset(nPosition * nScrollViewer.ScrollableWidth);
+        }
+
+        static void SetScrollViewerVerticalPosition(ScrollViewer nScrollViewer, double nPosition)
+        {
+            nScrollViewer.ScrollToVerticalOffset(nPosition * nScrollViewer.ScrollableHeight);
+        }
+
+        static void SetScrollBarPosition(ScrollBar nScrollBar, double nPosition)
+        {
+            double tracklen = nScrollBar.Maximum - nScrollBar.Minimum;
+
+            nScrollBar.Value = nPosition * tracklen + nScrollBar.Minimum;
+        }
+
+        static void SetScrollBarLength(ScrollBar nScrollBar, double nLength)
+        {
+            double tracklen = nScrollBar.Maximum - nScrollBar.Minimum;
+
+            if (nLength < 1)
+            {
+                nScrollBar.ViewportSize = nLength * tracklen / (1 - nLength);
+                nScrollBar.LargeChange = nScrollBar.ViewportSize;
+                nScrollBar.IsEnabled = true;
+            }
+            else
+            {
+                nScrollBar.ViewportSize = double.MaxValue;
+                nScrollBar.IsEnabled = false;
+            }
+        }
+    }
+}

--- a/src/PerfView/GuiUtilities/ScrollViewerMouseFix.cs
+++ b/src/PerfView/GuiUtilities/ScrollViewerMouseFix.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Utilities
+{
+    /// <summary>
+    /// Helper class to prevent ScrollViewer handling MouseWheel event.
+    /// It allows vertical mouse wheel scrolling while mouse is over hidden horizontal ScrollViewers in the grid
+    /// </summary>
+    public class ScrollViewerMouseFix
+    {
+        public static bool GetDisableMouseScroll(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(DisableMouseScrollProperty);
+        }
+
+        public static void SetDisableMouseScroll(DependencyObject obj, bool value)
+        {
+            obj.SetValue(DisableMouseScrollProperty, value);
+        }
+
+        public static readonly DependencyProperty DisableMouseScrollProperty =
+            DependencyProperty.RegisterAttached("DisableMouseScroll", typeof(bool), typeof(ScrollViewerMouseFix), new FrameworkPropertyMetadata(false,ScrollViewerMouseFix.OnDisableMouseScrollPropertyChanged));
+
+        public static void OnDisableMouseScrollPropertyChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            ScrollViewer viewer = sender as ScrollViewer;
+            if (viewer == null)
+            {
+                throw new ArgumentException("The dependency property can only be attached to a ScrollViewer", "sender");
+            }
+
+            if ((bool)e.NewValue)
+            {
+                viewer.PreviewMouseWheel += HandlePreviewMouseWheel;
+            }
+            else if (!(bool)e.NewValue)
+            {
+                viewer.PreviewMouseWheel -= HandlePreviewMouseWheel;
+            }
+        }
+
+        private static void HandlePreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (!e.Handled && sender != null)
+            {
+                e.Handled = true;
+                var eventArg = new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta);
+                eventArg.RoutedEvent = UIElement.MouseWheelEvent;
+                eventArg.Source = sender;
+                var parent = VisualTreeHelper.GetParent((DependencyObject)sender) as UIElement;
+                parent?.RaiseEvent(eventArg);            }
+        }
+    }
+}

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml
@@ -6,6 +6,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:WPFToolKit="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
         xmlns:converter="clr-namespace:PerfView.StackViewer"
+        xmlns:scroll="clr-namespace:Utilities"
         mc:Ignorable="d" 
         d:DesignHeight="223" d:DesignWidth="600">
     <UserControl.Resources>
@@ -38,305 +39,327 @@
             <Setter Property="AutoGenerateColumns" Value="False"/>
         </Style>
     </UserControl.Resources>
-    <WPFToolKit:DataGrid Name="Grid" 
-        Style="{StaticResource dataGridStyle}"
-        RowStyle ="{StaticResource customDataGridRowStyle}"
-        SelectionMode="Extended" SelectionUnit="CellOrRowHeader" 
-        SelectedCellsChanged="SelectedCellsChanged" 
-        CanUserSortColumns="False" 
-        ClipboardCopyMode="IncludeHeader" 
-        Margin="0,0,-23,0" PreparingCellForEdit="Grid_PreparingCellForEdit" >
-        <WPFToolKit:DataGrid.Columns>
-            <WPFToolKit:DataGridTemplateColumn 
-                x:Name="DisplayNameColumn"
-                HeaderStyle="{StaticResource CenterAlign}"
-                IsReadOnly="True"
-                Width="*" 
-                ClipboardContentBinding="{Binding Name}">
-                <WPFToolKit:DataGridTemplateColumn.CellTemplate>
-                    <DataTemplate>
-                        <TextBlock Name="Name" Text="{Binding DisplayName}" ToolTip="{Binding Name}"/>
-                    </DataTemplate>
-                </WPFToolKit:DataGridTemplateColumn.CellTemplate>
-                <WPFToolKit:DataGridTemplateColumn.Header>
-                    <TextBlock Name="NameColumn">
-                        Name <Hyperlink Click="DoHyperlinkHelp" Tag="NameColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                      The name of the method or group (see GroupPat dialog box).    
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTemplateColumn.Header>
-            </WPFToolKit:DataGridTemplateColumn>
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding InclusiveMetricPercent, StringFormat={}{0:n1}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="IncPercentColumn">
-                       Inc % <Hyperlink  Click="DoHyperlinkHelp" Tag="IncPercentColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                     The % of the total sample metric that occured in this item or any of its callees.   
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding InclusiveMetric, StringFormat={}{0:n1}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header >
-                    <TextBlock Margin="0,0,5,0" Name="IncColumn">
-                        Inc <Hyperlink Click="DoHyperlinkHelp" Tag="IncColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                     The sum of the sample metric that occured in this item or any of its callees.   
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
+    <Grid IsSharedSizeScope="true">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
-            <WPFToolKit:DataGridTextColumn 
-                CanUserSort="False"
-                IsReadOnly="True"
-                Binding="{Binding AverageInclusiveMetric, StringFormat={}{0:n1}}"
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="IncAvgColumn">
-                        Inc Avg <Hyperlink Click="DoHyperlinkHelp" Tag="IncAvgColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                            <TextBlock>
-                                     The average of the sample metric that occured in this item or any of its callees.
-                            </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
+        <WPFToolKit:DataGrid Name="Grid"  Grid.Row="0"
+            Style="{StaticResource dataGridStyle}"
+            RowStyle ="{StaticResource customDataGridRowStyle}"
+            SelectionMode="Extended" SelectionUnit="CellOrRowHeader" 
+            SelectedCellsChanged="SelectedCellsChanged" 
+            CanUserSortColumns="False" 
+            ClipboardCopyMode="IncludeHeader" 
+            Margin="0,0,-23,0" PreparingCellForEdit="Grid_PreparingCellForEdit">
+            <WPFToolKit:DataGrid.Columns>
+                <WPFToolKit:DataGridTemplateColumn 
+                    x:Name="DisplayNameColumn"
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    IsReadOnly="True"
+                    Width="*" 
+                    ClipboardContentBinding="{Binding Name}">
+                    <WPFToolKit:DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <ScrollViewer HorizontalScrollBarVisibility="Hidden"
+                                VerticalScrollBarVisibility="Disabled"
+                                scroll:ScrollSynchronizer.ScrollGroup="{Binding Path=ScrollGroup, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}"
+                                scroll:ScrollViewerMouseFix.DisableMouseScroll="True">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="NameColumn"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Name="Name" Text="{Binding DisplayName}" ToolTip="{Binding Name}" Grid.Column="0"/>
+                                </Grid>
+                            </ScrollViewer>
+                        </DataTemplate>
+                    </WPFToolKit:DataGridTemplateColumn.CellTemplate>
+                    <WPFToolKit:DataGridTemplateColumn.Header>
+                        <TextBlock Name="NameColumn">
+                            Name <Hyperlink Click="DoHyperlinkHelp" Tag="NameColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                          The name of the method or group (see GroupPat dialog box).    
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTemplateColumn.Header>
+                </WPFToolKit:DataGridTemplateColumn>
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding InclusiveMetricPercent, StringFormat={}{0:n1}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="IncPercentColumn">
+                           Inc % <Hyperlink  Click="DoHyperlinkHelp" Tag="IncPercentColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                         The % of the total sample metric that occured in this item or any of its callees.   
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding InclusiveMetric, StringFormat={}{0:n1}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header >
+                        <TextBlock Margin="0,0,5,0" Name="IncColumn">
+                            Inc <Hyperlink Click="DoHyperlinkHelp" Tag="IncColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                         The sum of the sample metric that occured in this item or any of its callees.   
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
 
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding InclusiveCount, StringFormat={}{0:n0}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="IncCountColumn">
-                        Inc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="IncCountColumn ">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                            <TextBlock>
-                                    The count of the instances in item or its children.
-                            </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveMetricPercent, StringFormat={}{0:n1}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="ExcPercentColumn">
-                        Exc % <Hyperlink Click="DoHyperlinkHelp" Tag="ExcPercentColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
+                <WPFToolKit:DataGridTextColumn 
+                    CanUserSort="False"
+                    IsReadOnly="True"
+                    Binding="{Binding AverageInclusiveMetric, StringFormat={}{0:n1}}"
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="IncAvgColumn">
+                            Inc Avg <Hyperlink Click="DoHyperlinkHelp" Tag="IncAvgColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
                                 <TextBlock>
-                                    The % of the total sample metric that occured in this item exclusively (not its children, does include folding).  
+                                         The average of the sample metric that occured in this item or any of its callees.
                                 </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding InclusiveCount, StringFormat={}{0:n0}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="IncCountColumn">
+                            Inc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="IncCountColumn ">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                <TextBlock>
+                                        The count of the instances in item or its children.
+                                </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding ExclusiveMetricPercent, StringFormat={}{0:n1}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="ExcPercentColumn">
+                            Exc % <Hyperlink Click="DoHyperlinkHelp" Tag="ExcPercentColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                        The % of the total sample metric that occured in this item exclusively (not its children, does include folding).  
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
             
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveMetric, StringFormat={}{0:n0}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="ExcColumn">
-                        Exc <Hyperlink Click="DoHyperlinkHelp" Tag="ExcColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The sum of the sample metric that occured in this item exclusively (not its children, does include folding).  
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding ExclusiveMetric, StringFormat={}{0:n0}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="ExcColumn">
+                            Exc <Hyperlink Click="DoHyperlinkHelp" Tag="ExcColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                        The sum of the sample metric that occured in this item exclusively (not its children, does include folding).  
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
 
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveCount, StringFormat={}{0:n0}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="ExcCountColumn">
-                        Exc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="ExcCountColumn ">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The count of the instances in item (excluding its children, does include folding) 
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding ExclusiveCount, StringFormat={}{0:n0}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="ExcCountColumn">
+                            Exc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="ExcCountColumn ">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                        The count of the instances in item (excluding its children, does include folding) 
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
 
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveFoldedMetric, StringFormat={}{0:n0}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="FoldColumn">
-                        Fold <Hyperlink Click="DoHyperlinkHelp" Tag="FoldColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The exclusive metric that have been folded into this node (by FoldPat or Fold %).  
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding ExclusiveFoldedMetric, StringFormat={}{0:n0}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="FoldColumn">
+                            Fold <Hyperlink Click="DoHyperlinkHelp" Tag="FoldColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                        The exclusive metric that have been folded into this node (by FoldPat or Fold %).  
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
 
-            <WPFToolKit:DataGridTextColumn 
-                IsReadOnly="True"
-                Binding="{Binding ExclusiveFoldedCount, StringFormat={}{0:n0}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="FoldCountColumn">
-                        Fold Ct <Hyperlink Click="DoHyperlinkHelp" Tag="FoldCountColumn ">?</Hyperlink>
+                <WPFToolKit:DataGridTextColumn 
+                    IsReadOnly="True"
+                    Binding="{Binding ExclusiveFoldedCount, StringFormat={}{0:n0}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="FoldCountColumn">
+                            Fold Ct <Hyperlink Click="DoHyperlinkHelp" Tag="FoldCountColumn ">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                        The count that have been folded into this node (by FoldPat or Fold %). 
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+                <!-- TODO promote ReadOnly to the table as a whole -->
+                <WPFToolKit:DataGridTextColumn
+                    x:Name="TimeHistogramColumn"
+                    IsReadOnly="False"  
+                    Binding="{Binding InclusiveMetricByTimeString}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource HistogramCell}"
+                    EditingElementStyle="{StaticResource HistogramEditCell}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="WhenColumn">
+                        When <Hyperlink Click="DoHyperlinkHelp" Tag="WhenColumn">?</Hyperlink>
                         <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The count that have been folded into this node (by FoldPat or Fold %). 
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-            <!-- TODO promote ReadOnly to the table as a whole -->
-            <WPFToolKit:DataGridTextColumn
-                x:Name="TimeHistogramColumn"
-                IsReadOnly="False"  
-                Binding="{Binding InclusiveMetricByTimeString}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource HistogramCell}"
-                EditingElementStyle="{StaticResource HistogramEditCell}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="WhenColumn">
-                    When <Hyperlink Click="DoHyperlinkHelp" Tag="WhenColumn">?</Hyperlink>
-                    <TextBlock.ToolTip>
+                                    <TextBlock TextAlignment="Left">
+                                        The time interval (from Start to End) is divided up into 32 buckets.<LineBreak/>
+                                        The buckets are normalized to a 100% value.<LineBreak/>
+                                        For CPU (and other metrics that naturally represent time like disk time)<LineBreak/>
+                                        100% represents the use of 1 CPU (or disk, or thread ...)<LineBreak/>
+                                        For all other 100% represents half the maximum. <LineBreak/>
+                                        _ = No samples<LineBreak/>
+                                        . =  0% &lt; X &lt; .1%<LineBreak/>
+                                        o =  .1% &lt; X &lt; 1%<LineBreak/>
+                                        0 =  1% &lt; X &lt; 10%<LineBreak/> 
+                                        1 = 10% &lt; X &lt; 20%<LineBreak/>
+                                        2 = 20% &lt; X &lt; 30%<LineBreak/>
+                                        ... <LineBreak/>
+                                        9 = 90% &lt; X &lt; 100%<LineBreak/>
+                                        A = 100% &lt; X &lt; 110%<LineBreak/>
+                                        ... <LineBreak/>
+                                        Z = 350% &lt; X &lt; 360%<LineBreak/>
+                                        * = 360% &lt; X of 1 CPU<LineBreak/>
+                                        a =  -10% &lt; X &lt; 0%<LineBreak/>
+                                        b =  -20% &lt; X &lt; -10%<LineBreak/>
+                                        ... <LineBreak/>
+                                        z = -260% &lt; X &lt; -250%<LineBreak/>
+                                        @ = X &lt; -260%<LineBreak/>
+                                        <LineBreak/>
+                                        Selecting this text in the status window and use SetRange (Alt-R) to set range. 
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+                <WPFToolKit:DataGridTextColumn
+                    x:Name="ScenarioHistogramColumn"
+                    IsReadOnly="False"  
+                    Binding="{Binding InclusiveMetricByScenarioString}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource HistogramCell}"
+                    EditingElementStyle="{StaticResource HistogramEditCell}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="WhichColumn">
+                        Which <Hyperlink Click="DoHyperlinkHelp" Tag="WhichColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                <!-- TODO: update this tooltip help -->
                                 <TextBlock TextAlignment="Left">
-                                    The time interval (from Start to End) is divided up into 32 buckets.<LineBreak/>
-                                    The buckets are normalized to a 100% value.<LineBreak/>
-                                    For CPU (and other metrics that naturally represent time like disk time)<LineBreak/>
-                                    100% represents the use of 1 CPU (or disk, or thread ...)<LineBreak/>
-                                    For all other 100% represents half the maximum. <LineBreak/>
-                                    _ = No samples<LineBreak/>
-                                    . =  0% &lt; X &lt; .1%<LineBreak/>
-                                    o =  .1% &lt; X &lt; 1%<LineBreak/>
-                                    0 =  1% &lt; X &lt; 10%<LineBreak/> 
-                                    1 = 10% &lt; X &lt; 20%<LineBreak/>
-                                    2 = 20% &lt; X &lt; 30%<LineBreak/>
-                                    ... <LineBreak/>
-                                    9 = 90% &lt; X &lt; 100%<LineBreak/>
-                                    A = 100% &lt; X &lt; 110%<LineBreak/>
-                                    ... <LineBreak/>
-                                    Z = 350% &lt; X &lt; 360%<LineBreak/>
-                                    * = 360% &lt; X of 1 CPU<LineBreak/>
-                                    a =  -10% &lt; X &lt; 0%<LineBreak/>
-                                    b =  -20% &lt; X &lt; -10%<LineBreak/>
-                                    ... <LineBreak/>
-                                    z = -260% &lt; X &lt; -250%<LineBreak/>
-                                    @ = X &lt; -260%<LineBreak/>
-                                    <LineBreak/>
-                                    Selecting this text in the status window and use SetRange (Alt-R) to set range. 
+                                        The scenarios are divided into up to 32 buckets.<LineBreak/>
+                                        The buckets are normalized to a 100% value.<LineBreak/>
+                                        100% represents half of the maximum across all buckets. <LineBreak/>
+                                        _ = No samples<LineBreak/>
+                                        . =  0% &lt; X &lt; .1%<LineBreak/>
+                                        o =  .1% &lt; X &lt; 1%<LineBreak/>
+                                        0 =  1% &lt; X &lt; 10%<LineBreak/> 
+                                        1 = 10% &lt; X &lt; 20%<LineBreak/>
+                                        2 = 20% &lt; X &lt; 30%<LineBreak/>
+                                        ... <LineBreak/>
+                                        9 = 90% &lt; X &lt; 100%<LineBreak/>
+                                        A = 100% &lt; X &lt; 110%<LineBreak/>
+                                        ... <LineBreak/>
+                                        Z = 350% &lt; X &lt; 360%<LineBreak/>
+                                        * = 360% &lt; X<LineBreak/>
+                                        a =  -10% &lt; X &lt; 0%<LineBreak/>
+                                        b =  -20% &lt; X &lt; -10%<LineBreak/>
+                                        ... <LineBreak/>
+                                        z = -260% &lt; X &lt; -250%<LineBreak/>
+                                        @ = X &lt; -260%<LineBreak/>
+                                        <LineBreak/>
+                                        Double-click to enter select mode. Select text and use "Set Scenario List" to limit the view to a set of scenarios.
                                 </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-            <WPFToolKit:DataGridTextColumn
-                x:Name="ScenarioHistogramColumn"
-                IsReadOnly="False"  
-                Binding="{Binding InclusiveMetricByScenarioString}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource HistogramCell}"
-                EditingElementStyle="{StaticResource HistogramEditCell}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="WhichColumn">
-                    Which <Hyperlink Click="DoHyperlinkHelp" Tag="WhichColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                            <!-- TODO: update this tooltip help -->
-                            <TextBlock TextAlignment="Left">
-                                    The scenarios are divided into up to 32 buckets.<LineBreak/>
-                                    The buckets are normalized to a 100% value.<LineBreak/>
-                                    100% represents half of the maximum across all buckets. <LineBreak/>
-                                    _ = No samples<LineBreak/>
-                                    . =  0% &lt; X &lt; .1%<LineBreak/>
-                                    o =  .1% &lt; X &lt; 1%<LineBreak/>
-                                    0 =  1% &lt; X &lt; 10%<LineBreak/> 
-                                    1 = 10% &lt; X &lt; 20%<LineBreak/>
-                                    2 = 20% &lt; X &lt; 30%<LineBreak/>
-                                    ... <LineBreak/>
-                                    9 = 90% &lt; X &lt; 100%<LineBreak/>
-                                    A = 100% &lt; X &lt; 110%<LineBreak/>
-                                    ... <LineBreak/>
-                                    Z = 350% &lt; X &lt; 360%<LineBreak/>
-                                    * = 360% &lt; X<LineBreak/>
-                                    a =  -10% &lt; X &lt; 0%<LineBreak/>
-                                    b =  -20% &lt; X &lt; -10%<LineBreak/>
-                                    ... <LineBreak/>
-                                    z = -260% &lt; X &lt; -250%<LineBreak/>
-                                    @ = X &lt; -260%<LineBreak/>
-                                    <LineBreak/>
-                                    Double-click to enter select mode. Select text and use "Set Scenario List" to limit the view to a set of scenarios.
-                            </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-            <WPFToolKit:DataGridTextColumn 
-                x:Name="FirstTimeColumn"
-                IsReadOnly="True"
-                Binding="{Binding FirstTimeRelativeMSec, StringFormat={}{0:n3}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="FirstColumn">
-                        First <Hyperlink Click="DoHyperlinkHelp" Tag="FirstColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The time in of the first sample (msec from start of trace).
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-            <WPFToolKit:DataGridTextColumn 
-                x:Name="LastTimeColumn"
-                IsReadOnly="True"
-                Binding="{Binding LastTimeRelativeMSec, StringFormat={}{0:n3}}" 
-                HeaderStyle="{StaticResource CenterAlign}"
-                ElementStyle="{StaticResource RightAlign}">
-                <WPFToolKit:DataGridTextColumn.Header>
-                    <TextBlock Margin="0,0,5,0" Name="LastColumn">
-                        Last <Hyperlink Click="DoHyperlinkHelp" Tag="LastColumn">?</Hyperlink>
-                        <TextBlock.ToolTip>
-                                <TextBlock>
-                                    The time in of the last sample (msec from start of trace).
-                                </TextBlock>
-                        </TextBlock.ToolTip>
-                    </TextBlock>
-                </WPFToolKit:DataGridTextColumn.Header>
-            </WPFToolKit:DataGridTextColumn>
-        </WPFToolKit:DataGrid.Columns>
-    </WPFToolKit:DataGrid>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+                <WPFToolKit:DataGridTextColumn 
+                    x:Name="FirstTimeColumn"
+                    IsReadOnly="True"
+                    Binding="{Binding FirstTimeRelativeMSec, StringFormat={}{0:n3}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="FirstColumn">
+                            First <Hyperlink Click="DoHyperlinkHelp" Tag="FirstColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                        The time in of the first sample (msec from start of trace).
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+                <WPFToolKit:DataGridTextColumn 
+                    x:Name="LastTimeColumn"
+                    IsReadOnly="True"
+                    Binding="{Binding LastTimeRelativeMSec, StringFormat={}{0:n3}}" 
+                    HeaderStyle="{StaticResource CenterAlign}"
+                    ElementStyle="{StaticResource RightAlign}">
+                    <WPFToolKit:DataGridTextColumn.Header>
+                        <TextBlock Margin="0,0,5,0" Name="LastColumn">
+                            Last <Hyperlink Click="DoHyperlinkHelp" Tag="LastColumn">?</Hyperlink>
+                            <TextBlock.ToolTip>
+                                    <TextBlock>
+                                        The time in of the last sample (msec from start of trace).
+                                    </TextBlock>
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                    </WPFToolKit:DataGridTextColumn.Header>
+                </WPFToolKit:DataGridTextColumn>
+            </WPFToolKit:DataGrid.Columns>
+        </WPFToolKit:DataGrid>
+        <ScrollBar 
+            Grid.Row="1"
+            scroll:ScrollSynchronizer.ScrollGroup="{Binding Path=ScrollGroup, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}"
+            Orientation="Horizontal"/>
+    </Grid>
+
 </UserControl>

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
@@ -19,9 +19,12 @@ namespace PerfView
     {
         public static bool NoPadOnCopyToClipboard = false;
 
+        public string ScrollGroup { get; }
+
         public PerfDataGrid()
         {
             InitializeComponent();
+            ScrollGroup = Guid.NewGuid().ToString();
             Grid.CopyingRowClipboardContent += delegate (object sender, DataGridRowClipboardEventArgs e)
             {
                 for (int i = 0; i < e.ClipboardRowContent.Count; i++)

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -5,20 +5,31 @@
     xmlns:src="clr-namespace:PerfView"
     xmlns:src1="clr-namespace:PerfView"
     xmlns:controls="clr-namespace:Controls"
+    xmlns:scroll="clr-namespace:Utilities"
     Title="PerfView Stacks"
     Width="919" Height="605"
     >
     <Window.Resources>
         <!-- DataContext for this template is a CallTreeViewNode -->
         <DataTemplate x:Key="TreeControlCell">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="{Binding IndentString}" FontFamily="Courier New"/>
-                <CheckBox IsChecked="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding HasChildren}"/>
-                <TextBlock Name="Name" Text="{Binding Name}" FontWeight="{Binding FontWeight}"/>
-                <TextBlock Margin="5,0,0,0" Visibility="{Binding VisibleIfDisplayingSecondary}">
-                    <Hyperlink Command="Help" CommandParameter="PrimaryAndSecondaryNodes">?</Hyperlink>
-                </TextBlock>
-            </StackPanel>
+            <ScrollViewer HorizontalScrollBarVisibility="Hidden"
+                          VerticalScrollBarVisibility="Hidden"
+                          scroll:ScrollSynchronizer.ScrollGroup="{Binding Path=ScrollGroup, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}"
+                          scroll:ScrollViewerMouseFix.DisableMouseScroll="True">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="NameColumn"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal" Grid.Column="0">
+                        <TextBlock Text="{Binding IndentString}" FontFamily="Courier New"/>
+                        <CheckBox IsChecked="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding HasChildren}"/>
+                        <TextBlock Name="Name" Text="{Binding Name}" FontWeight="{Binding FontWeight}"/>
+                        <TextBlock Margin="5,0,0,0" Visibility="{Binding VisibleIfDisplayingSecondary}">
+                            <Hyperlink Command="Help" CommandParameter="PrimaryAndSecondaryNodes">?</Hyperlink>
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
+            </ScrollViewer>
         </DataTemplate>
         <Style x:Key="HeaderStyle">
             <Setter Property="TextBlock.FontSize" Value="14" />


### PR DESCRIPTION
As an attempt to make better solution for #300 I've implemented horizontal scrolling within first column of the grid.
The scrollbar appears below grid when necessary.

Works fine for me for few months already. There are some issues (like resetting to the leftmost position after expanding/collapsing nodes, but it does not affect overall better UI experience).

GitHub shows .xaml file contains lots of changes, but this is primarily because of changed nesting, thus indentation.

It is better to see diff ignoring whitespace differences.