### PR TITLE
Fixes lookup of system32 symbols in the unmerged case.

### DIFF
--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -1517,21 +1517,24 @@ namespace Microsoft.Diagnostics.Symbols
         /// We may be a 32 bit app which has File system redirection turned on
         /// Morph System32 to SysNative in that case to bypass file system redirection         
         /// </summary>
-        private static string BypassSystem32FileRedirection(string path)
+        internal static string BypassSystem32FileRedirection(string path)
         {
-            var winDir = Environment.GetEnvironmentVariable("WinDir");
-            if (winDir != null)
+            if (0 <= path.IndexOf("System32\\", StringComparison.OrdinalIgnoreCase))
             {
-                var system32 = Path.Combine(winDir, "System32");
-                if (path.StartsWith(system32, StringComparison.OrdinalIgnoreCase))
+                var winDir = Environment.GetEnvironmentVariable("WinDir");
+                if (winDir != null)
                 {
-                    if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432") != null)
+                    var system32 = Path.Combine(winDir, "System32");
+                    if (path.StartsWith(system32, StringComparison.OrdinalIgnoreCase))
                     {
-                        var sysNative = Path.Combine(winDir, "Sysnative");
-                        var newPath = Path.Combine(sysNative, path.Substring(system32.Length + 1));
-                        if (File.Exists(newPath))
+                        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432") != null)
                         {
-                            path = newPath;
+                            var sysNative = Path.Combine(winDir, "Sysnative");
+                            var newPath = Path.Combine(sysNative, path.Substring(system32.Length + 1));
+                            if (File.Exists(newPath))
+                            {
+                                path = newPath;
+                            }
                         }
                     }
                 }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -8458,7 +8458,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         symReader.m_log.WriteLine("The /UnsafePdbMatch option will force an ambiguous match, but this is not recommended.");
                     }
                 }
-                symReader.m_log.WriteLine("Failed to to find PDB for {0}", moduleFile.FilePath);
+                symReader.m_log.WriteLine("Failed to find PDB for {0}", moduleFile.FilePath);
                 return null;
             }
 
@@ -8496,13 +8496,14 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </summary>
         private bool TraceModuleUnchanged(TraceModuleFile moduleFile, TextWriter log)
         {
-            if (!File.Exists(moduleFile.FilePath))
+            string moduleFilePath = SymbolReader.BypassSystem32FileRedirection(moduleFile.FilePath);
+            if (!File.Exists(moduleFilePath))
             {
                 log.WriteLine("The file {0} does not exist on the local machine", moduleFile.FilePath);
                 return false;
             }
 
-            using (var file = new PEFile.PEFile(moduleFile.FilePath))
+            using (var file = new PEFile.PEFile(moduleFilePath))
             {
                 if (file.Header.CheckSum != (uint)moduleFile.ImageChecksum)
                 {


### PR DESCRIPTION
Basically PerfView is a 32 bit app, and system file redirection had to be
bypassed one more place.