### PR TITLE
Fix dev-time load failure loading KernelTraceControl.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.23</PerfViewVersion>
-    <TraceEventVersion>2.0.23</TraceEventVersion>
+    <PerfViewVersion>2.0.25</PerfViewVersion>
+    <TraceEventVersion>2.0.25</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -28,7 +28,10 @@
     </None>
 
     <!-- There are no static references to these so I need to copy them explicitly.  
-         These are both COM interop assemblies so they are the same for all targets, I pick netstandard1.6 pretty arbitraily -->
+         The first two COM interop assemblies so they are the same for all targets, I pick netstandard1.6 pretty arbitraily 
+         OSExtensions is also the same for all targets.  It needs to be copied for the dev-time case since in that case it runs the DLLs from the .nuget cache
+         by default, and OSExtensions needs to be in the right relative location with respect to the native DLLs (since it loads them via relative path).   
+      -->
     <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll">
       <Link>TraceReloggerLib.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -36,6 +39,11 @@
     </None>
     <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\Dia2Lib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\Dia2Lib.dll">
       <Link>Dia2Lib.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll">
+      <Link>OsExtensions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
OSExtentions needs to be 'next' to the architecture directories where KernelTraceControl.dll lives for it to load
them properly.   This works for published .NET Core apps, but by default 'dotnet run' runs nuget DLLs out of
the nuget cache (it does not copy them to the app directory).   This breaks the loading of KernelTraceControl.dll.

We already manually copy the native files and some interop files to the output directory in the TraceEvent nuget
package.   Here we simply add OSExtentions.dll to that list so it is loaded from the same place even in the dev-time
scenario.