### PR TITLE
Await time was dropped accidentally.

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4192,6 +4192,7 @@ table {
                 computer.UseTasks = true;
                 computer.GroupByStartStopActivity = true;
                 computer.ExcludeReadyThread = true;
+                computer.NoAwaitTime = streamName.Contains("(CPU ONLY)");
                 computer.GenerateThreadTimeStacks(startStopSource);
 
                 return startStopSource;

--- a/src/TraceEvent/Computers/ThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/ThreadTimeComputer.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Diagnostics.Tracing
         /// LIke the GroupByAspNetRequest but use start-stop activities instead of ASP.NET Requests as the grouping construct. 
         /// </summary>
         public bool GroupByStartStopActivity;
+        /// <summary>
+        /// Don't show AwaitTime.  For CPU only traces showing await time is misleading since
+        /// blocked time will not show up.  
+        /// </summary>
+        public bool NoAwaitTime;
 
         /// <summary>
         /// Generate the thread time stacks, outputting to 'stackSource'.  
@@ -113,7 +118,7 @@ namespace Microsoft.Diagnostics.Tracing
 
                 // We don't do AWAIT_TIME if we don't have blocked time (that is we are CPU ONLY) because it is confusing
                 // since we have SOME blocked time but not all of it.   
-                if (m_traceHasCSwitches)
+                if (!NoAwaitTime)
                 {
                     m_activityComputer.AwaitUnblocks += delegate (TraceActivity activity, TraceEvent data)
                     {

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1374,7 +1374,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 EVENT_TRACE_MERGE_EXTENDED_DATA.EVENT_METADATA |
                 EVENT_TRACE_MERGE_EXTENDED_DATA.VOLUME_MAPPING;
 
-            if ((options & TraceEventMergeOptions.Compress) != 0)
+            if ((options & TraceEventMergeOptions.Compress) != 0 && OperatingSystemVersion.AtLeast(62))
             {
                 flags |= EVENT_TRACE_MERGE_EXTENDED_DATA.COMPRESS_TRACE;
             }


### PR DESCRIPTION
Logic for doing a CPU ONLY start-stop stack view inadvertently turned off 'AWAIT TIME' for all cases
(the intent was to turn of AWAIT time for just CPU ONLY view).    This bug has introduced in early May.

@xiaomi7732  FYI.  