### PR TITLE
Add LowMemoryHostBlocking to GCReason

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -10402,6 +10402,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         InducedCompacting = 0xa,
         LowMemoryHost = 0xb,
         PMFullGC = 0xc,
+        LowMemoryHostBlocking = 0xd
     }
     public enum GCSuspendEEReason
     {


### PR DESCRIPTION
In .NET Framework 4.8, LowMemoryHostBlocking was added to GC_REASON. I am adding this to TraceEvent to keep it consistent with the framework side of GC_REASON. 