### PR TITLE
Added CTRL+L command to focus the Directory (HistoryComboBox).

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -39,7 +39,11 @@
         <CommandBinding Command="{x:Static src:MainWindow.ILSizeCommand}" Executed="DoILSize"/>
         <CommandBinding Command="{x:Static src:MainWindow.HeapSnapshotFromDumpCommand}" Executed="DoTakeHeapShapshotFromProcessDump"/>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp"/>
+        <CommandBinding Command="{x:Static src:MainWindow.FocusDirectoryCommand}" Executed="DoFocusDirectory"/>
     </Window.CommandBindings>
+    <Window.InputBindings>
+        <KeyBinding Gesture="CTRL+L" Command="{x:Static src:MainWindow.FocusDirectoryCommand}" />
+    </Window.InputBindings>
     <DockPanel>
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1856,6 +1856,10 @@ namespace PerfView
             StatusBar.Log("Displaying the reference guide.");
             DisplayUsersGuide("ReferenceGuide");
         }
+        private void DoFocusDirectory(object sender, RoutedEventArgs e)
+        {
+            Directory.Focus();
+        }
 
         private void UpdateFileFilter()
         {
@@ -1958,6 +1962,8 @@ namespace PerfView
 
         public static RoutedUICommand HeapSnapshotFromDumpCommand = new RoutedUICommand("Take Heap Snapshot from Process Dump", "HeapSnapshotFromDump",
             typeof(MainWindow));
+        public static RoutedUICommand FocusDirectoryCommand = new RoutedUICommand("Focus Directory", "FocusDirectory", typeof(MainWindow),
+            new InputGestureCollection() { new KeyGesture(Key.L, ModifierKeys.Control) });
         #region private
         internal static List<string> ParseWordsOrQuotedStrings(string commandAndArgs)
         {


### PR DESCRIPTION
Fixes #132 
The only issue is when you focus the RichTextBox. As it has its own commands and bindings, the CTRL+L will not work. You would have to press TAB to lose focus and then CTRL+L should work again.
I tested adding Focused=False on RichTextBox to avoid firing up the commands. As this RTB is always disabled, no need to listen to the editing commands, but, another issue I found is after clicking on a link inside RTB. It somehow gives the RTB focus again and CTRL+L doesn't work.

If adding focused false is fine, let me know so I can add that change as well.
