### PR TITLE
Grouping: [group CLR/OS entries]: Added System.Xaml namespace to be grouped with WPF

### DIFF
--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -1108,7 +1108,7 @@ namespace PerfViewExtensibility
             else
             {
                 ret.FilterGuiState.GroupRegEx.Value =
-                    @"[group CLR/OS entries] \Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.*!=>LIB;" +
+                    @"[group CLR/OS entries] \Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.Xaml.*!=>WPF;\System.*!=>LIB;" +
                     @"Presentation%=>WPF;WindowsBase%=>WPF;system32\*!=>OS;syswow64\*!=>OS;{%}!=> module $1";
                 ret.FilterGuiState.GroupRegEx.History = new List<string> { ret.FilterGuiState.GroupRegEx.Value,
                      "[group modules]           {%}!->module $1",

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -815,7 +815,7 @@ namespace PerfView
             stackWindow.GroupRegExTextBox.Items.Add(@"[no grouping]");
             if (windows)
             {
-                stackWindow.GroupRegExTextBox.Items.Add(@"[group CLR/OS entries] \Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.*!=>LIB;Presentation%=>WPF;WindowsBase%=>WPF;system32\*!=>OS;syswow64\*!=>OS;{%}!=> module $1");
+                stackWindow.GroupRegExTextBox.Items.Add(@"[group CLR/OS entries] \Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.Xaml.*!=>WPF;\System.*!=>LIB;Presentation%=>WPF;WindowsBase%=>WPF;system32\*!=>OS;syswow64\*!=>OS;{%}!=> module $1");
             }
 
             stackWindow.GroupRegExTextBox.Items.Add(@"[group modules]           {%}!->module $1");

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -1009,7 +1009,7 @@ namespace PerfView
                 stackWindow.GroupRegExTextBox.Items.Insert(0, "[Ignore PID/TID]          ^Process% {%}->$1;^Thread->Thread;");
                 stackWindow.GroupRegExTextBox.Items.Insert(0, "[Ignore Paths]               ^Process% {%}->$1;^Thread->Thread;{%}!{*}->$1!$2");
 
-                var osGroupings = @"^Process% {%}->$1;^Thread->Thread;\Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.*!=>LIB;Presentation%=>WPF;WindowsBase%=>WPF;system32\*!=>OS;syswow64\*!=>OS;{%}!=> module $1";
+                var osGroupings = @"^Process% {%}->$1;^Thread->Thread;\Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.Xaml.*!=>WPF;\System.*!=>LIB;Presentation%=>WPF;WindowsBase%=>WPF;system32\*!=>OS;syswow64\*!=>OS;{%}!=> module $1";
                 stackWindow.GroupRegExTextBox.Items.Insert(0, "[group CLR/OS ignore paths] " + osGroupings + ";{%}!{*}->$1!$2");
 
                 var defaultGroup = "[group CLR/OS entries] " + osGroupings;


### PR DESCRIPTION
Grouping option `[group CLR/OS entries] \Temporary ASP.NET Files\->;v4.0.30319\%!=>CLR;v2.0.50727\%!=>CLR;mscoree=>CLR;\mscorlib.*!=>LIB;\System.*!=>LIB;Presentation%=>WPF;WindowsBase%=>WPF;system32\*!=>OS;syswow64\*!=>OS;{%}!=> module $1` does not consider that `System.Xaml` namespace refers to WPF, but is displayed as `LIB` currently which can lead to extra lines in treeview like WPF->LIB(System.Xaml)->WPF.
Fixed that behaviour in this PR. Added `;\System.Xaml.*!=>WPF` to grouping expression `[group CLR/OS entries] ...`
![perfview-wpf-wrong-grouping](https://user-images.githubusercontent.com/282166/46574615-6c6fc180-c9bf-11e8-820d-78d977b92e2f.PNG)
