### PR TITLE
Fix non-working URL

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -185,7 +185,7 @@
             repeatedly until it detects that at 5 seconds have gone by. To make this example
             more interesting, it does this using two mutually recursive methods (RecSpin, and
             RecSpinHelper).&nbsp; Each of these helpers spins for a second and then calls the
-            other helper to spin for the rest of the time.&nbsp;&nbsp; See <a href="Tutorial.cs.txt">Tutorial.cs</a>
+            other helper to spin for the rest of the time.&nbsp;&nbsp; See <a href="Tutorial.cs">Tutorial.cs</a>
             for the complete source.&nbsp;
         </li>
     </ol>


### PR DESCRIPTION
For some reason, `Tutorial.cs` link was pointing to `Tutorial.cs.txt` file, which returned `404: Not Found`. Updated the link to point to `Tutorial.cs` instead.