### PR TITLE
Fix dll naming for linux

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -43,7 +43,7 @@
       <Visible>False</Visible>
     </None>
     <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll">
-      <Link>OsExtensions.dll</Link>
+      <Link>OSExtensions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
We have a project that references TraceEvent Nuget package. When building that project, MSBuild generates the deps.json file for the executable and will copy/paste all TraceEvent dependencies in the output dir.
The deps.json will contain the original name of all assemblies needed to launch the executable.
The Microsoft.Diagnostics.Tracing.TraceEvent.props file instructs to copy OSExtensions.dll (original name) to the output directory and rename it to OsExtensions.dll.

When running the project on Linux, it won't start because it won't be able to find the OSExtensions.dll, because it has been renamed to OsExtensions.dll.