### PR TITLE
Increase StackInfoCacheSize to 128K

### DIFF
--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         // This keeps track of stacks that I have used in the past
-        private const int StackInfoCacheSize = 128;          // Must be a power of 2
+        private const int StackInfoCacheSize = 128 * 1024;          // Must be a power of 2
         private TreeCacheEntry[] m_TreeForStack;
 
         // Maps frame IDs to their canonical one (we group all frame IDs)


### PR DESCRIPTION
Reduces the number of cases where `AddSample` falls back to searching for nodes.