### PR TITLE
Fixes, including adding snupkg support for TraceEvent

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.30</PerfViewVersion>
-    <TraceEventVersion>2.0.30</TraceEventVersion>
+    <PerfViewVersion>2.0.31</PerfViewVersion>
+    <TraceEventVersion>2.0.31</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/EtwClrProfiler/CorProfilerTracer.cpp
+++ b/src/EtwClrProfiler/CorProfilerTracer.cpp
@@ -187,8 +187,8 @@ HRESULT STDMETHODCALLTYPE CorProfilerTracer::InitializeForAttach(
 		// See if we asked for call sampling or not.  
 		DWORD keywords = 0;
 		DWORD keywordsSize = sizeof(keywords);
-		int hr = RegGetValue(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\.NETFramework", L"PerfView_Keywords", RRF_RT_DWORD, NULL, &keywords, &keywordsSize);
-		if (hr == ERROR_SUCCESS)
+		int hrRegGetValue = RegGetValue(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\.NETFramework", L"PerfView_Keywords", RRF_RT_DWORD, NULL, &keywords, &keywordsSize);
+		if (hrRegGetValue == ERROR_SUCCESS)
 		{
 			if ((keywords & DisableInliningKeyword) != 0)
 			{

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -515,7 +515,7 @@ namespace PerfView
             parser.DefineOptionalQualifier("RestartingToElevelate", ref RestartingToElevelate, "Internal: indicates that perfView is restarting to get Admin privileges.");
 
             string sessionName = null;
-            parser.DefineOptionalQualifier("SessionName", ref sessionName, "Define the name for the user mode session, if kernel events are off.");
+            parser.DefineOptionalQualifier("SessionName", ref sessionName, "Define the name for the user mode session (kernel session will also be named analogously) Useful for collecting traces when another ETW profiler (including PerfView) is being used.");
             if (sessionName != null)
             {
                 if (Environment.OSVersion.Version.Major * 10 + Environment.OSVersion.Version.Minor < 62)

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -576,19 +576,19 @@ namespace PerfView
                                 new Guid("B675EC37-BDB6-4648-BC92-F3FDC74D3CA2"), TraceEventLevel.Verbose, 0x70, stacksEnabled);
 
                             // Turn on File Create (open) logging as it is useful for investigations and lightweight. 
-                            // Don't bother if the Kernel FileIOInit evens are on because they are strictly better
+                            // Don't bother if the Kernel FileIOInit events are on because they are strictly better
                             // and you end up with annoying redundancy.  
                             if ((parsedArgs.KernelEvents & KernelTraceEventParser.Keywords.FileIOInit) == 0)
                             {
-                                // 0x10 =  Process  
-                                EnableUserProvider(userModeSession, "Microsoft-Windows-Kernel-Process",
-                                    new Guid("22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716"), TraceEventLevel.Informational, 0x10, stacksEnabled);
+                                // 0x80 = CREATE_FILE (which is any open, including GetFileAttributes etc.   
+                                EnableUserProvider(userModeSession, "Microsoft-Windows-Kernel-File",
+                                    new Guid("EDD08927-9CC4-4E65-B970-C2560FB5C289"), TraceEventLevel.Verbose, 0x80, stacksEnabled);
                             }
 
                             // Turn on the user-mode Process start events.  This allows you to get the stack of create-process calls
-                            // 0x10 = CREATE_FILE (which is any open, including GetFileAttributes etc.   
-                            EnableUserProvider(userModeSession, "Microsoft-Windows-Kernel-File",
-                                new Guid("EDD08927-9CC4-4E65-B970-C2560FB5C289"), TraceEventLevel.Verbose, 0x80, stacksEnabled);
+                            // 0x10 =  Process  
+                            EnableUserProvider(userModeSession, "Microsoft-Windows-Kernel-Process",
+                                new Guid("22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716"), TraceEventLevel.Informational, 0x10, stacksEnabled);
 
                             // Default CLR events also means ASP.NET and private events. 
                             // Turn on ASP.NET at informational by default.
@@ -705,7 +705,11 @@ namespace PerfView
                                 new Guid("adb401e1-5296-51f8-c125-5fda75826144"),
                                 TraceEventLevel.Informational, ulong.MaxValue - IgnoreShortCutKeywords, diagSourceOptions);
 
-                            // TODO should stacks be enabled?
+                            // This is likely redundant with the diagnosticSource above, but is simpler to parse on the reader side.
+
+                            EnableUserProvider(userModeSession, "Microsoft-AspNetCore-Hosting",
+                                new Guid("9e620d2a-55d4-5ade-deb7-c26046d245a8"),TraceEventLevel.Verbose, ulong.MaxValue);
+
                             EnableUserProvider(userModeSession, "Microsoft-ApplicationInsights-Core",
                                 new Guid("74af9f20-af6a-5582-9382-f21f674fb271"),
                                 TraceEventLevel.Verbose, ulong.MaxValue, stacksEnabled);
@@ -762,10 +766,6 @@ namespace PerfView
 
                                 EnableUserProvider(userModeSession, "Microsoft-Windows-RPC",
                                     new Guid("6AD52B32-D609-4BE9-AE07-CE8DAE937E39"), TraceEventLevel.Informational, 0);
-
-                                // TODO FIX NOW how verbose is this?
-                                EnableUserProvider(userModeSession, "Microsoft-Windows-WebIO",
-                                    new Guid("50B3E73C-9370-461D-BB9F-26F32D68887D"), TraceEventLevel.Informational, 0xFFFFFFFF);
 
                                 // This is what WPA turns on in its 'GENERAL' setting  
                                 //Microsoft-Windows-Immersive-Shell: 0x0000000000100000: 0x04

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -136,17 +136,14 @@ namespace PerfView
                                 var template = PerfViewFile.TryGet(filePath);
                                 if (template != null)
                                 {
-                                    // Filter out kernel, rundown files etc. 
-                                    if (Regex.IsMatch(filePath, @"\.(kernel|clr|user)[^.]*\.etl$", RegexOptions.IgnoreCase))
-                                    {
+                                    // Filter out kernel, rundown files etc, if the base file exists.  
+                                    Match m = Regex.Match(filePath, @"^(.*)\.(kernel|clr|user)[^.]*\.etl$", RegexOptions.IgnoreCase);
+                                    if (m.Success && File.Exists(m.Groups[1].Value + ".etl"))
                                         continue;
-                                    }
 
                                     // Filter out any items we were asked to filter out.  
                                     if (m_filter != null && !m_filter.IsMatch(Path.GetFileName(filePath)))
-                                    {
                                         continue;
-                                    }
 
                                     m_Children.Add(PerfViewFile.Get(filePath, template));
                                 }

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -3922,7 +3922,7 @@ namespace PerfView
             PresetMenu.Items.Add(new Separator());
 
             var setDefaultPresetMenuItem = new MenuItem();
-            setDefaultPresetMenuItem.Header = "S_et Startup Preset";
+            setDefaultPresetMenuItem.Header = "S_et As Startup Preset";
             setDefaultPresetMenuItem.Click += DoSetStartupPreset;
             setDefaultPresetMenuItem.ToolTip =
                 "Sets the default values of Group Patterns and Fold Patterns and % to the current values.";

--- a/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tracing
             m_outputStackSource = outputStackSource;
             m_sample = new StackSourceSample(outputStackSource);
             m_nodeNameInternTable = new Dictionary<double, StackSourceFrameIndex>(10);
-            m_blockedFrameIndex = outputStackSource.Interner.FrameIntern("BLOCKED_TIME");
+            m_ExternalFrameIndex = outputStackSource.Interner.FrameIntern("UNMANAGED_CODE_TIME");
             m_cpuFrameIndex = outputStackSource.Interner.FrameIntern("CPU_TIME");
 
             TraceLogEventSource eventSource = traceEvents == null ? m_eventLog.Events.GetSource() :
@@ -527,11 +527,11 @@ namespace Microsoft.Diagnostics.Tracing
                     sample.Metric = (float)(timeRelativeMSec - LastBlockStackRelativeMSec);
                     sample.TimeRelativeMSec = LastBlockStackRelativeMSec;
 
-                    var nodeIndex = computer.m_blockedFrameIndex;
+                    var nodeIndex = computer.m_ExternalFrameIndex;       // BLOCKED_TIME
                     sample.StackIndex = LastBlockCallStack;
 
                     sample.StackIndex = computer.m_outputStackSource.Interner.CallStackIntern(nodeIndex, sample.StackIndex);
-                    computer.m_outputStackSource.AddSample(sample); // BLOCKED_TIME
+                    computer.m_outputStackSource.AddSample(sample);
                 }
             }
 
@@ -586,7 +586,7 @@ namespace Microsoft.Diagnostics.Tracing
 
         // These are boring caches of frame names which speed things up a bit.  
         private Dictionary<double, StackSourceFrameIndex> m_nodeNameInternTable;
-        private StackSourceFrameIndex m_blockedFrameIndex;
+        private StackSourceFrameIndex m_ExternalFrameIndex;
         private StackSourceFrameIndex m_cpuFrameIndex;
         private ActivityComputer m_activityComputer;                        // Used to compute stacks for Tasks 
         #endregion

--- a/src/TraceEvent/Computers/ThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/ThreadTimeComputer.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Diagnostics.Tracing
         #region private
         private void UpdateStartStopActivityOnAwaitComplete(TraceActivity activity, TraceEvent data)
         {
-            // If we are createing 'UNKNOWN_ASYNC nodes, make sure that AWAIT_TIME does not overlap with UNKNOWN_ASYNC time
+            // If we are creating 'UNKNOWN_ASYNC nodes, make sure that AWAIT_TIME does not overlap with UNKNOWN_ASYNC time
 
             var startStopActivity = m_startStopActivities.GetStartStopActivityForActivity(activity);
             if (startStopActivity == null)
@@ -536,6 +536,9 @@ namespace Microsoft.Diagnostics.Tracing
 
         private void AddUnkownAsyncDurationIfNeeded(StartStopActivity startStopActivity, double unknownStartTimeMSec, TraceEvent data)
         {
+            if (NoAwaitTime)
+                return;
+
             Debug.Assert(0 < unknownStartTimeMSec);
             Debug.Assert(unknownStartTimeMSec <= data.TimeStampRelativeMSec);
 

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -20,6 +20,7 @@
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <NuspecFile>Microsoft.Diagnostics.Tracing.TraceEvent.nuspec</NuspecFile>

--- a/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
+++ b/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
@@ -19,7 +19,7 @@
     </None>
 
     <!-- Get the Microsoft.Diagnostics.TraceEvent.*.nuget package we just built -->
-    <None Include="..\TraceEvent\bin\$(Configuration)\Microsoft.Diagnostics.Tracing.TraceEvent.*.nupkg">
+    <None Include="..\TraceEvent\bin\$(Configuration)\Microsoft.Diagnostics.Tracing.TraceEvent.*nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 


### PR DESCRIPTION
Added support for symbol packages using snupkg so that nuget's symbol server works.
Fix issue when looking at Activity time in a CPU-Only Trace.
Changed 'BLOCKED_TIME to 'UNMANAGED_CODE_TIME' in netperf files to be less misleading.
Avoid filtering out *.user.etl files in the GUI when there is no base *.etl file for it.
Fix bug where process start events with stacks were not being logged.
Turn on Microsoft-AspNetCore-Hosting by default.