### PR TITLE
Read cpu number only when it's available in Linux event

### DIFF
--- a/src/PerfView/OtherSources/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/PerfView/OtherSources/Linux/LinuxPerfScriptEventParser.cs
@@ -346,9 +346,13 @@ namespace Diagnostics.Tracing.StackSources
 
                 // CPU
                 source.SkipWhiteSpace();
-                source.MoveNext(); // Move past the "["
-                int cpu = source.ReadInt();
-                source.MoveNext(); // Move past the "]"
+                int cpu = -1;
+                if (source.PeekString(1) == "[")
+                {
+                    source.MoveNext(); // Move past the "["
+                    cpu = source.ReadInt();
+                    source.MoveNext(); // Move past the "]"
+                }
 
                 // Time
                 source.SkipWhiteSpace();


### PR DESCRIPTION
Fixes #806 