### PR TITLE
Fix for Missing Microsoft.Win32.Registry error on Desktop

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -42,8 +42,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll">
-      <Link>OSExtensions.dll</Link>
+
+	<!-- you have to pick the right version of this DLL because it depends on things besides System.Runtime.dll -->
+    <None Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll">
+      <Link>OsExtensions.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\net45\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\net45\OSExtensions.dll">
+      <Link>OsExtensions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
This is a fix for issue #755.   However the issue runs relatively deep and this may be just a quick fix.   I will open another issue to see about a better solution.   