### PR TITLE
Fix msbuild break on very clean source trees.

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,4 +6,12 @@
     <None Include="$(AppDesignerFolder)\launchSettings.json" Condition="Exists('$(AppDesignerFolder)\launchSettings.json')" />
   </ItemGroup>
 
+  <!-- This is a patch for the Microsoft.SourceLink.GitHub package.   If you have an old MSBuild 
+       then SourceControlInformationFeatureSupported is not true, but because it sets SourceLink the C# 
+       compiler looks for the *.sourcelink.json and fails.   This patches this until all MSBuilds support
+       source control Information or we fix the sourcelink package -->
+  <PropertyGroup Condition="'$(SourceControlInformationFeatureSupported)' != 'true'">
+    <SourceLink></SourceLink>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
The symptom that we are fixing is that on a very clean build, building from the command line (msbuild.exe) you get build errors about missing *.sourcelink.json files.  

The issue is that if your msbuild is using old components, then it might have SourceControlInformationFeatureSupported not set to true.  When this happens it does not generate a *.sourcelink.json file (which is good), but it LEFT the sourcelink variable set which tells the C# compile to try to attach this file to the resulting EXE and things fail.     
