### PR TITLE
Allow building the MemoryGraph and Utilities dlls.

### DIFF
--- a/src/MemoryGraph/MemoryGraph.csproj
+++ b/src/MemoryGraph/MemoryGraph.csproj
@@ -1,66 +1,41 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <PerfLibRootPath>$(MSBuildThisFileDirectory)\..</PerfLibRootPath>
-  </PropertyGroup>
-  <!--Target CLR v2-->
-  <PropertyGroup>
-    <AllowCrossTargeting>true</AllowCrossTargeting>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-  </PropertyGroup>
-  <Import Project="$(PerfLibRootPath)\PerfLib.settings.targets" />
-  <PropertyGroup Condition=" '$(BuildInRazzle)' == 'true' ">
-    <UseVsVersion>true</UseVsVersion>
-    <CreateMetaAssembly>true</CreateMetaAssembly>
-    <PublishMetaAssemblyVisibility>Inter</PublishMetaAssemblyVisibility>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(BuildInRazzle)' != 'true' ">
-    <IgnoreDualBuildAssemblyInfo>false</IgnoreDualBuildAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ProjectGuid>{F1032B5C-568A-4BAD-B253-1B4548389063}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.MemoryGraph</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.MemoryGraph</AssemblyName>
-    <AssemblyAttributeClsCompliant>false</AssemblyAttributeClsCompliant>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE;MULTITHREAD</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="graph.cs" />
-    <Compile Include="MemoryGraph.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\FastSerialization\FastSerialization.csproj">
-      <Project>{e6eacf92-f22d-47dc-8eeb-9bbc4df1e4d5}</Project>
-      <Name>FastSerialization</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Utilities\Utilities.csproj">
-      <Project>{e32c9fc3-8524-4511-8acb-235ac136dc22}</Project>
-      <Name>Utilities</Name>
-    </ProjectReference>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
+    <Company>Microsoft</Company>
+    <Description>MemoryGraph library</Description>
+    <Copyright>Copyright © Microsoft 2010</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FastSerialization\FastSerialization.csproj" />
+    <ProjectReference Include="..\Utilities\Utilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- *** SourceLink Support *** -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
-  <Import Project="$(PerfLibRootPath)\PerfLib.targets" />
+
+  <!-- ******************* Signing Support *********************** -->
+  <ItemGroup>
+    <FilesToSign Include="$(TargetPath)">
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+    </FilesToSign>
+    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+  </ItemGroup>
+
+  <!-- .NET Strong Name Signing -->
+  <PropertyGroup>
+    <SignAssembly Condition="'$(SIGNING_BUILD)'!= ''">true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\MSFT.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
 </Project>
+

--- a/src/Utilities/DirectoryUtilities.cs
+++ b/src/Utilities/DirectoryUtilities.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Utilities
 #if UTILITIES_PUBLIC
     public 
 #endif
-    internal static class DirectoryUtilities
+    static class DirectoryUtilities
     {
         /// <summary>
         /// SafeCopy sourceDirectory to directoryToVersion recursively. The target directory does

--- a/src/Utilities/EnvironmentUtilities.cs
+++ b/src/Utilities/EnvironmentUtilities.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Diagnostics.Utilities
 #if UTILITIES_PUBLIC
     public 
 #endif
-    internal static class EnvironmentUtilities
+    static class EnvironmentUtilities
     {
         public static bool Is64BitProcess
         {

--- a/src/Utilities/FileUtilities.cs
+++ b/src/Utilities/FileUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Utilities
 #if UTILITIES_PUBLIC
     public 
 #endif
-    internal static class FileUtilities
+    static class FileUtilities
     {
         /// <summary>
         /// GetLines works much like File.ReadAllLines, however instead of returning a
@@ -221,7 +221,7 @@ namespace Microsoft.Diagnostics.Utilities
 #if UTILITIES_PUBLIC
     public 
 #endif
-    internal static class PathUtil
+    static class PathUtil
     {
         /// <summary>
         /// Given a path and a superdirectory path relativeToDirectory compute the relative path (the path from) relativeToDirectory

--- a/src/Utilities/StreamUtilities.cs
+++ b/src/Utilities/StreamUtilities.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Utilities
 #if UTILITIES_PUBLIC
     public 
 #endif
-    internal static class StreamUtilities
+    static class StreamUtilities
     {
         /// <summary>
         /// Open the 'fromFilePath' and write its contents to 'toStream'

--- a/src/Utilities/StringUtilities.cs
+++ b/src/Utilities/StringUtilities.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Diagnostics.Utilities
 #if UTILITIES_PUBLIC
     public 
 #endif
-    internal static class StringUtilities
+    static class StringUtilities
     {
         public static bool IsNullOrWhiteSpace(string value)
         {

--- a/src/Utilities/Utilities.csproj
+++ b/src/Utilities/Utilities.csproj
@@ -1,59 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <PerfLibRootPath>$(MSBuildThisFileDirectory)\..</PerfLibRootPath>
-  </PropertyGroup>
-  <!--Target CLR v2-->
-  <PropertyGroup>
-    <AllowCrossTargeting>true</AllowCrossTargeting>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-  </PropertyGroup>
-  <Import Project="$(PerfLibRootPath)\PerfLib.settings.targets" />
-  <PropertyGroup Condition=" '$(BuildInRazzle)' == 'true' ">
-    <UseVsVersion>true</UseVsVersion>
-    <CreateMetaAssembly>true</CreateMetaAssembly>
-    <PublishMetaAssemblyVisibility>Inter</PublishMetaAssemblyVisibility>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(BuildInRazzle)' != 'true' ">
-    <IgnoreDualBuildAssemblyInfo>false</IgnoreDualBuildAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ProjectGuid>{E32C9FC3-8524-4511-8ACB-235AC136DC22}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.Utilities</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.Utilities</AssemblyName>
-    <AssemblyAttributeClsCompliant>false</AssemblyAttributeClsCompliant>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>UTILITIES_PUBLIC;$(DefineConstants)</DefineConstants>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <Company>Microsoft</Company>
+    <Description>Utility library</Description>
+    <Copyright>Copyright © Microsoft 2010</Copyright>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;$(DefineConstants)</DefineConstants>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);UTILITIES_PUBLIC</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <!-- *** SourceLink Support *** -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
+
+  <!-- ******************* Signing Support *********************** -->
   <ItemGroup>
-    <Compile Include="DirectoryUtilities.cs" />
-    <Compile Include="EnvironmentUtilities.cs" />
-    <Compile Include="FileUtilities.cs" />
-    <Compile Include="NativeMethods.cs" />
-    <Compile Include="StreamUtilities.cs" />
-    <Compile Include="StringUtilities.cs" />
-    <Compile Include="XmlUtilities.cs" />
-    <Compile Include="TeeTextWriter.cs" />
+    <FilesToSign Include="$(TargetPath)">
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+    </FilesToSign>
+    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
   </ItemGroup>
-  <Import Project="$(PerfLibRootPath)\PerfLib.targets" />
+
+  <!-- .NET Strong Name Signing -->
+  <PropertyGroup>
+    <SignAssembly Condition="'$(SIGNING_BUILD)'!= ''">true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\MSFT.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
 </Project>
+

--- a/src/Utilities/XmlUtilities.cs
+++ b/src/Utilities/XmlUtilities.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Utilities
 #if UTILITIES_PUBLIC
     public 
 #endif
-    internal class XmlUtilities
+    class XmlUtilities
     {
         /// <summary>
         /// Given an XML element, remove the closing operator for it, so you can add new child elements to it by concatination. 


### PR DESCRIPTION
In the past PerfView code was used to build libraries that were used in Visual Studio.   The
DLLs that were built were Microsoft.Diagnostics.Utilties and Microsoft.Diagnostics.MemoryGraph.

These DLLs are not built as part of perfView (PerfView incorperates the soruce in the the PerfView.exe directly).  The build logic for these two DLLs is still in the repo, but it bit-rotted.
I have updated the MemoryGraph.csproj and Utiltiies.csproj to restore the ability to build these
DLL as the VS MAY find this useful (and it was easy to to do),    This may not turn out to be
useful, but at least this way the CSPROJ files are not completely out of date.

Note that all the changes in *.cs file are simply to removing the unneeded 'internal' specifiers that causes a compile error if UTILITIES_PUBLIC is turned on.

The changes to the *.csproj were to remove what is there and replace with an entirely new *.csproj based on FastSerialziation.csproj as a template.    The result is that MemoryGraph.csproj builds.  