### PR TITLE
EventCounter data visualization

### DIFF
--- a/src/PerfView/EventViewer/EventWindow.xaml
+++ b/src/PerfView/EventViewer/EventWindow.xaml
@@ -27,6 +27,7 @@
             <CommandBinding Command="{x:Static src:EventWindow.OpenAnyStartStopStacksCommand}" Executed="DoOpenAnyStartStopStacks"/>
             <CommandBinding Command="{x:Static src:EventWindow.OpenAnyTaskTreeStacksCommand}" Executed="DoOpenAnyTaskTreeStacks"/>
             <CommandBinding Command="{x:Static src:EventWindow.SetProcessFilterCommand}" Executed="DoProcessFilter"/>
+            <CommandBinding Command="{x:Static src:EventWindow.ShowEventCounterGraphCommand}" Executed="DoShowEventCounterGraph"/>
             <CommandBinding Command="{x:Static src:EventWindow.SetRangeFilterCommand}" Executed="DoRangeFilter"/>
             <CommandBinding Command="{x:Static src:EventWindow.NewWindowCommand}" Executed="DoNewWindow"/>
             <CommandBinding Command="{x:Static src:EventWindow.CancelCommand}" Executed="DoCancel"/>
@@ -41,6 +42,8 @@
             <ContextMenu>
                 <MenuItem Command="{x:Static src:EventWindow.NewWindowCommand}" />
                 <MenuItem Command="{x:Static src:EventWindow.UpdateCommand}" />
+                <Separator/>
+                <MenuItem Command="{x:Static src:EventWindow.ShowEventCounterGraphCommand}" />
                 <Separator/>
                 <MenuItem Command="{x:Static src:EventWindow.SetProcessFilterCommand}" />
                 <MenuItem Command="{x:Static src:EventWindow.SetRangeFilterCommand}" />

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -501,6 +502,110 @@ namespace PerfView
             ProcessFilterTextBox.Text = GetCellStringValue(selectedCells[0]);
             Update();
         }
+        private void DoShowEventCounterGraph(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (EventTypes.SelectedItems.Count != 1)
+            {
+                return;
+            }
+            if (!((string)EventTypes.SelectedItems[0]).EndsWith("/EventCounters"))
+            {
+                return;
+            }
+            Update();
+            
+            string templatePath = Path.Combine(SupportFiles.SupportFileDir, "EventCounterVisualization.html");
+            string template = File.ReadAllText(templatePath);
+
+            double t = 0;
+           
+            var counters = new Dictionary<string, List<Tuple<double, double>>>();
+            string pattern = @"Name:""([^""]*)"", Mean:([^,]*).*IntervalSec:([^}]*)";
+            m_source.ForEach(delegate (EventRecord event_)
+            {
+                string rest = event_.Rest;
+                if (rest == null)
+                {
+                    return false;
+                }
+                MatchCollection matches = Regex.Matches(rest, pattern);
+                if (matches.Count != 1 || matches[0].Groups.Count != 4)
+                {
+                    return false;
+                }
+
+                string namePart = matches[0].Groups[1].Captures[0].Value;
+                string meanPart = matches[0].Groups[2].Captures[0].Value;
+                string intervalSecPart = matches[0].Groups[3].Captures[0].Value;
+
+                double mean;
+                double intervalSec;
+                if (!double.TryParse(meanPart, out mean))
+                {
+                    return false;
+                }
+                if (!double.TryParse(intervalSecPart, out intervalSec))
+                {
+                    return false;
+                }
+
+                List<Tuple<Double, Double>> points;
+                if (!counters.TryGetValue(namePart, out points))
+                {
+                    points = new List<Tuple<double, double>>();
+                    counters.Add(namePart, points);
+                }
+                points.Add(Tuple.Create(t, mean));
+
+                t += intervalSec;
+
+                return true;
+            });
+
+            var firstCounter = true;
+            var sb = new StringBuilder();
+            sb.Append("var data = [");
+            foreach (var counter in counters)
+            {
+                if (firstCounter)
+                {
+                    firstCounter = false;
+                }
+                else
+                {
+                    sb.Append(",");
+                }
+                sb.Append("{");
+                sb.Append(@"name:""");
+                sb.Append(counter.Key);
+                sb.Append(@""", points:[");
+                var firstPoint = true;
+                foreach (var point in counter.Value)
+                {
+                    if (firstPoint)
+                    {
+                        firstPoint = false;
+                    }
+                    else
+                    {
+                        sb.Append(",");
+                    }
+                    sb.Append("{ X:");
+                    sb.Append(point.Item1);
+                    sb.Append(", Y:");
+                    sb.Append(point.Item2);
+                    sb.Append("}");
+                }
+                sb.Append("]}");
+            }
+            sb.Append("];");
+            string html = Path.GetTempFileName() + ".html";
+            File.WriteAllText(html, template.Replace("// REPLACE-DATA-HERE", sb.ToString()));
+
+            string uri = "file:///" + html.Replace('\\', '/').Replace(" ", "%20");
+            Process.Start(uri);
+        }
+            
         private void DoRangeFilter(object sender, ExecutedRoutedEventArgs e)
         {
             if (Histogram.IsFocused)
@@ -1265,6 +1370,10 @@ namespace PerfView
             typeof(EventWindow), new InputGestureCollection() { new KeyGesture(Key.S, ModifierKeys.Alt) });
         public static RoutedUICommand OpenAnyStartStopStacksCommand = new RoutedUICommand("Open Any Start Stop Stacks", "OpenAnyStartStopStacks", typeof(EventWindow));
         public static RoutedUICommand OpenAnyTaskTreeStacksCommand = new RoutedUICommand("Open Any TaskTree Stacks", "OpenAnyTaskTreeStacks", typeof(EventWindow));
+
+        public static RoutedUICommand ShowEventCounterGraphCommand = new RoutedUICommand("Show EventCounter Graph", "ShowEventCounterGraph",
+            typeof(EventWindow), new InputGestureCollection() { new KeyGesture(Key.G, ModifierKeys.Control) });
+
         public static RoutedUICommand SetProcessFilterCommand = new RoutedUICommand("Set Process Filter", "SetProcessFilter",
             typeof(EventWindow), new InputGestureCollection() { new KeyGesture(Key.P, ModifierKeys.Control) });
         public static RoutedUICommand SetRangeFilterCommand = new RoutedUICommand("Set Range Filter", "SetRangeFilter",

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -350,6 +350,11 @@
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\UsersGuide.htm</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SupportFiles\EventCounterVisualization.html">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\EventCounterVisualization.html</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="SupportFiles\PerfViewWebVideos.htm">
       <Type>Non-Resx</Type>

--- a/src/PerfView/SupportFiles/EventCounterVisualization.html
+++ b/src/PerfView/SupportFiles/EventCounterVisualization.html
@@ -1,0 +1,215 @@
+﻿
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        .line {
+            fill: none;
+            stroke: steelblue;
+            stroke-width: 1.5px;
+        }
+
+        .zoom {
+            cursor: move;
+            fill: none;
+            pointer-events: all;
+        }
+    </style>
+    <title>Event Counter Visualization</title>
+</head>
+
+<body>
+    <div id="content">
+    </div>
+    <script src="https://d3js.org/d3.v4.min.js"></script>
+    <script>
+
+        // REPLACE-DATA-HERE
+
+        var content = document.getElementById("content");
+
+
+        for (i = 0; i < data.length; i++) {
+            var xmlns = "http://www.w3.org/2000/svg";
+
+            var blockElement = document.createElement("div");
+            blockElement.style.margin = "20px 20px 20px 20px";
+
+            var textElement = document.createElement("div");
+            textElement.style.width = "960px";
+            textElement.style.textAlign = "center";
+
+            var svgElem = document.createElementNS(xmlns, "svg");
+            svgElem.setAttributeNS(null, "width", 960);
+            svgElem.setAttributeNS(null, "height", 500);
+
+            textElement.appendChild(document.createTextNode(data[i].name));
+            content.appendChild(blockElement);
+            blockElement.appendChild(textElement);
+            blockElement.appendChild(svgElem);
+
+            plot(d3.select(svgElem), data[i].points);
+        }
+
+        function plot(svg, data) {
+            var margin = {
+                top: 20,
+                right: 20,
+                bottom: 110,
+                left: 40
+            },
+                margin2 = {
+                    top: 430,
+                    right: 20,
+                    bottom: 30,
+                    left: 40
+                },
+                width = +svg.attr("width") - margin.left - margin.right,
+                height = +svg.attr("height") - margin.top - margin.bottom,
+                height2 = +svg.attr("height") - margin2.top - margin2.bottom;
+
+            var x = d3.scaleTime().range([0, width]),
+                x2 = d3.scaleTime().range([0, width]),
+                y = d3.scaleLinear().range([height, 0]),
+                y2 = d3.scaleLinear().range([height2, 0]);
+
+            var xAxis = d3.axisBottom(x),
+                xAxis2 = d3.axisBottom(x2),
+                yAxis = d3.axisLeft(y);
+
+            var brush = d3.brushX()
+                .extent([
+                    [0, 0],
+                    [width, height2]
+                ])
+                .on("brush end", brushed);
+
+            var zoom = d3.zoom()
+                .scaleExtent([1, Infinity])
+                .translateExtent([
+                    [0, 0],
+                    [width, height]
+                ])
+                .extent([
+                    [0, 0],
+                    [width, height]
+                ])
+                .on("zoom", zoomed);
+
+            var line = d3.line()
+                .x(function (d) {
+                    return x(d.X);
+                })
+                .y(function (d) {
+                    return y(d.Y);
+                });
+
+            var line2 = d3.line()
+                .x(function (d) {
+                    return x2(d.X);
+                })
+                .y(function (d) {
+                    return y2(d.Y);
+                });
+
+            var clip = svg.append("defs").append("svg:clipPath")
+                .attr("id", "clip")
+                .append("svg:rect")
+                .attr("width", width)
+                .attr("height", height)
+                .attr("x", 0)
+                .attr("y", 0);
+
+            var Line_chart = svg.append("g")
+                .attr("class", "focus")
+                .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+                .attr("clip-path", "url(#clip)");
+
+
+            var focus = svg.append("g")
+                .attr("class", "focus")
+                .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+            var context = svg.append("g")
+                .attr("class", "context")
+                .attr("transform", "translate(" + margin2.left + "," + margin2.top + ")");
+
+            x.domain(d3.extent(data, function (d) {
+                return d.X;
+            }));
+            y.domain([0, d3.max(data, function (d) {
+                return d.Y;
+            })]);
+            x2.domain(x.domain());
+            y2.domain(y.domain());
+
+
+            focus.append("g")
+                .attr("class", "axis axis--x")
+                .attr("transform", "translate(0," + height + ")")
+                .call(xAxis);
+
+            focus.append("g")
+                .attr("class", "axis axis--y")
+                .call(yAxis);
+
+            Line_chart.append("path")
+                .datum(data)
+                .attr("class", "line")
+                .attr("d", line);
+
+            context.append("path")
+                .datum(data)
+                .attr("class", "line")
+                .attr("d", line2);
+
+
+            context.append("g")
+                .attr("class", "axis axis--x")
+                .attr("transform", "translate(0," + height2 + ")")
+                .call(xAxis2);
+
+            context.append("g")
+                .attr("class", "brush")
+                .call(brush)
+                .call(brush.move, x.range());
+
+            svg.append("rect")
+                .attr("class", "zoom")
+                .attr("width", width)
+                .attr("height", height)
+                .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+                .call(zoom);
+
+            function brushed() {
+                if (d3.event.sourceEvent && d3.event.sourceEvent.type === "zoom") return; // ignore brush-by-zoom
+                var s = d3.event.selection || x2.range();
+                x.domain(s.map(x2.invert, x2));
+                Line_chart.select(".line").attr("d", line);
+                focus.select(".axis--x").call(xAxis);
+                svg.select(".zoom").call(zoom.transform, d3.zoomIdentity
+                    .scale(width / (s[1] - s[0]))
+                    .translate(-s[0], 0));
+            }
+
+            function zoomed() {
+                if (d3.event.sourceEvent && d3.event.sourceEvent.type === "brush") return; // ignore zoom-by-brush
+                var t = d3.event.transform;
+                x.domain(t.rescaleX(x2).domain());
+                Line_chart.select(".line").attr("d", line);
+                focus.select(".axis--x").call(xAxis);
+                context.select(".brush").call(brush.move, x.range().map(t.invertX, t));
+            }
+
+            function type(d) {
+                d.X = d.X;
+                d.Y = +d.Y;
+                return d;
+            }
+        }
+    </script>
+</body>
+
+</html>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -3629,6 +3629,12 @@
             <strong>Tab instead of Enter </strong>- If you wish to change several filter textboxes
             use Tab instead of return to complete the entry so that you don&#39;t cause a refresh.&nbsp;
         </li>
+        <li>
+            <strong>Visualize Event Counters</strong>- Right click the event name, you can choose 
+            the option to Show EventCounter graph, and it will popup a HTML based line graph for 
+            the data. The visualization will respect the text filter so you can choose to display
+            a particular subset of the counters.
+        </li>
     </ul>
     <hr />
     <!--  ****************** -->


### PR DESCRIPTION
Here is a pull request for the issue #839

We used to be able to view the EventCounter traces as indivdual events.

![raweventcounterview](https://user-images.githubusercontent.com/3410332/50721486-11f50880-1075-11e9-8ce0-3f1522b58310.png)

Now you can pull up the context menu

![eventcountercontextmenu](https://user-images.githubusercontent.com/3410332/50721507-69937400-1075-11e9-8174-9d13a43eac34.png)

and open the graph view:

![graphbrowser](https://user-images.githubusercontent.com/3410332/50721517-95aef500-1075-11e9-9d70-adca2ea09fbb.png)

You can double-click to zoom and drag to pan the graph to see the details.

![graphbrowserzoomed](https://user-images.githubusercontent.com/3410332/50721525-c000b280-1075-11e9-9c72-13ca2bde3ba8.png)

@vancem 