### PR TITLE
Small fixes

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3742,9 +3742,14 @@ namespace PerfView
             else
             {
                 providerGuid = TraceEventProviders.GetProviderGuidByName(providerSpec);
-                // Look it up by name 
+                // Look it up as an EventSource 
                 if (providerGuid == Guid.Empty)
-                    TraceEventProviders.GetEventSourceGuidFromName(providerSpec);
+                {
+                    providerGuid = TraceEventProviders.GetEventSourceGuidFromName(providerSpec);
+                    log.WriteLine("Provider named '{0}' was unknown to the operating system, assuming it is an EventSource with GUID '{1}'",
+                        providerSpec, providerGuid);
+                    log.WriteLine("If the provider name  is misspelled we are simply using the wrong GUID and the provider will be ignored.");
+                }
             }
 
             retList.Add(new ParsedProvider()

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3748,7 +3748,7 @@ namespace PerfView
                     providerGuid = TraceEventProviders.GetEventSourceGuidFromName(providerSpec);
                     log.WriteLine("Provider named '{0}' was unknown to the operating system, assuming it is an EventSource with GUID '{1}'",
                         providerSpec, providerGuid);
-                    log.WriteLine("If the provider name  is misspelled we are simply using the wrong GUID and the provider will be ignored.");
+                    log.WriteLine("WARNING: If {0} is misspelled we are simply using the wrong GUID and the provider will be ignored.", providerSpec);
                 }
             }
 

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -1402,7 +1402,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
                     {
                         MethodBeingCompiled = data.MethodBeingCompiledNamespace + "." + data.MethodBeingCompiledName,
                         Inliner = data.InlinerNamespace + "." + data.InlinerName,
-                        Inlinee = data.InlinerNamespace + "." + data.InlineeName
+                        Inlinee = data.InlineeNamespace + "." + data.InlineeName
                     });
                 };
                 source.Clr.MethodInliningFailedAnsi += delegate (MethodJitInliningFailedAnsiTraceData data)

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                     throw new NotSupportedException("Can only enable kernel events on a kernel session.");
                 }
 
-                InsureStarted();
+                EnsureStarted();
 
                 // If we have provider data we add some predefined key-value pairs for infrastructure purposes. 
                 ulong matchAllKeywords = 0;
@@ -676,7 +676,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 if (systemTraceProvider)
                 {
                     properties->LogFileMode |= TraceEventNativeMethods.EVENT_TRACE_SYSTEM_LOGGER_MODE;
-                    InsureStarted(properties);
+                    EnsureStarted(properties);
 
                     dwErr = TraceEventNativeMethods.TraceSetInformation(m_SessionHandle,
                                                                         TraceEventNativeMethods.TRACE_INFO_CLASS.TraceStackTracingInfo,
@@ -1012,7 +1012,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                     throw new NotSupportedException("Can only capture state on user mode sessions.");
                 }
 
-                InsureStarted();
+                EnsureStarted();
                 var parameters = new TraceEventNativeMethods.ENABLE_TRACE_PARAMETERS();
                 var filter = new TraceEventNativeMethods.EVENT_FILTER_DESCRIPTOR();
                 parameters.Version = TraceEventNativeMethods.ENABLE_TRACE_PARAMETERS_VERSION;
@@ -1262,7 +1262,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                             throw new NotSupportedException("Kernel sessions must be started (EnableKernelProvider called) before accessing the source.");
                         }
 
-                        InsureStarted();
+                        EnsureStarted();
                     }
                     m_source = new ETWTraceEventSource(SessionName, TraceEventSourceType.Session);
                 }
@@ -2065,7 +2065,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
             Debug.Assert(curID <= stackTracingIdsMax);
             return curID;
         }
-        private void InsureStarted(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES* properties = null)
+        private void EnsureStarted(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES* properties = null)
         {
             if (!m_Create)
             {


### PR DESCRIPTION
Fix logic that allows EventSources to skip the * syntax (e.g. /ProviderName=XXX will assume XXX is
and eventSource (with a warning in the log), if it could not find it in the OS table).    This was the
intent of code added long ago but it was broken.

Renamed Insure->Ensure

Small fix in inlining processing logic.