### PR TITLE
Fix bug where PerfView fails to launch.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,14 +22,14 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.34</PerfViewVersion>
-    <TraceEventVersion>2.0.34</TraceEventVersion>
+    <PerfViewVersion>2.0.35</PerfViewVersion>
+    <TraceEventVersion>2.0.35</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->
   <PropertyGroup>
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.16</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.17</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>1.0.2</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.3.0</XunitVersion>
     <XunitRunnerVisualstudioVersion>2.3.0</XunitRunnerVisualstudioVersion>

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.Populate.bat
@@ -8,6 +8,7 @@ REM *** PLEASE MODIFY THE VERSION NUMBER TO BE CURRENT!    ****
 	exit /b 1
 )
 xcopy /s /Y %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.%1\*.dll Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
+xcopy /s /Y %HOMEDRIVE%%HOMEPATH%\.nuget\packages\Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles\1.0.%1\*.pdb Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles
 @if NOT "%ERRORLEVEL%" == "0" (
     echo *****  Bad Version Number %1.  ******
 	exit /b 1
@@ -26,7 +27,9 @@ REM Overwrite OSExtensions.dll with the latest built versions.  However you want
 @REM lib\native\x86\msdia140.dll
 @REM lib\net45\Dia2Lib.dll
 @REM lib\net45\OSExtensions.dll
+@REM lib\net45\OSExtensions.pdb
 @REM lib\net45\TraceReloggerLib.dll
 @REM lib\netstandard1.6\Dia2Lib.dll
 @REM lib\netstandard1.6\OSExtensions.dll
+@REM lib\netstandard1.6\OSExtensions.pdb
 @REM lib\netstandard1.6\TraceReloggerLib.dll

--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.5">
     <id>Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles</id>
-    <version>1.0.16</version>
+    <version>1.0.18</version>
     <title>Non-Source files needed to Build TraceEvent</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/PerfView/GuiUtilities/WindowBase.cs
+++ b/src/PerfView/GuiUtilities/WindowBase.cs
@@ -17,7 +17,7 @@ namespace PerfView
         {
             if (parentWindow != null)
             {
-                // Try to set the owner, but it might fail (if the window has never been displayed)
+                // Try to set the owner, but it might fail (e.g. if parentWindow has never been displayed)
                 // give up setting the owner in that case (it is not critical to have an owner)  
                 try
                 {

--- a/src/PerfView/GuiUtilities/WindowBase.cs
+++ b/src/PerfView/GuiUtilities/WindowBase.cs
@@ -15,8 +15,17 @@ namespace PerfView
 
         public WindowBase(Window parentWindow)
         {
-            Owner = parentWindow;
-            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            if (parentWindow != null)
+            {
+                // Try to set the owner, but it might fail (if the window has never been displayed)
+                // give up setting the owner in that case (it is not critical to have an owner)  
+                try
+                {
+                    Owner = parentWindow;
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                }
+                catch (System.Exception) { }
+            }
         }
     }
 }


### PR DESCRIPTION
We added code to give windows owners (so that windows end up on a related screen when using multiple screens)
However it turns out you can't give a window an owner if the owner was never display, and we do precisely this
when we pop a EULA dialog on startup.  This causes a silent crash (because the normal windows to display errors
also fail).    Fix this by catching errors and proceeding without setting owners.

Also updated to use a newer SupportFiles (this just adds a PDB), and update the PerfView version number.