### PR TITLE
Fix problem where classic ASP.NET activities nest when they should not.

### DIFF
--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -1,4 +1,4 @@
-using FastSerialization;    // Fore IStreamReader
+using FastSerialization;    // For IStreamReader
 using Graphs;
 using Microsoft.Diagnostics.Utilities;
 using System;

--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Diagnostics.Tracing
                 }
 
                 Guid activityId = data.ContextId;
-                OnStart(data, data.Path, &activityId, null, creator);
+                OnStart(data, data.Path, &activityId, null, creator, null, false);
             };
             aspNetParser.AspNetReqStop += delegate (AspNetStopTraceData data)
             {


### PR DESCRIPTION
Basically OnStart already has a option (but it is not the default) that says 'don't use the current thread's activity as the parent activity.   This is just what we need to fix this issue (since classic ASP.NET Events really should not nest, if you see two starts in a row, you should not make the second activity the child of the first.   