### PR TITLE
To avoid large allocations create SegmentedStreams and use in graph. 

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.37</PerfViewVersion>
-    <TraceEventVersion>2.0.37</TraceEventVersion>
+    <PerfViewVersion>2.0.38</PerfViewVersion>
+    <TraceEventVersion>2.0.38</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/FastSerialization/MemoryMappedFileStreamReader.cs
+++ b/src/FastSerialization/MemoryMappedFileStreamReader.cs
@@ -16,6 +16,8 @@ namespace FastSerialization
 {
     public class MemoryMappedFileStreamReader : IStreamReader
     {
+        const int BlockCopyCapacity = 10 * 1024 * 1024;
+
         private MemoryMappedFile _file;
         private long _fileLength;
         private bool _leaveOpen;
@@ -39,7 +41,7 @@ namespace FastSerialization
 
             if (IntPtr.Size == 4)
             {
-                _capacity = Math.Min(_fileLength, MemoryMappedFileStreamWriter.BlockCopyCapacity);
+                _capacity = Math.Min(_fileLength, BlockCopyCapacity);
             }
             else
             {
@@ -106,7 +108,7 @@ namespace FastSerialization
             long availableInFile = _fileLength - offset;
             long viewOffset = offset & ~0xFFFF;
             long offsetInView = offset - viewOffset;
-            long viewLength = Math.Min(MemoryMappedFileStreamWriter.BlockCopyCapacity, availableInFile + offsetInView);
+            long viewLength = Math.Min(BlockCopyCapacity, availableInFile + offsetInView);
             _view = _file.CreateViewAccessor(viewOffset, viewLength, MemoryMappedFileAccess.Read);
             _viewAddress = _view.SafeMemoryMappedViewHandle.DangerousGetHandle();
             _viewOffset = viewOffset;
@@ -134,7 +136,7 @@ namespace FastSerialization
             long availableInFile = _fileLength - absoluteOffset;
             long viewOffset = absoluteOffset & ~0xFFFF;
             long offset = absoluteOffset - viewOffset;
-            long viewLength = Math.Min(MemoryMappedFileStreamWriter.BlockCopyCapacity, availableInFile + offset);
+            long viewLength = Math.Min(BlockCopyCapacity, availableInFile + offset);
             _view = _file.CreateViewAccessor(viewOffset, viewLength, MemoryMappedFileAccess.Read);
             _viewAddress = _view.SafeMemoryMappedViewHandle.DangerousGetHandle();
             _viewOffset = viewOffset;
@@ -335,7 +337,7 @@ namespace FastSerialization
 
             long viewOffset = (_viewOffset + _offset) & ~0xFFFF;
             long offset = (_viewOffset + _offset) - viewOffset;
-            long viewLength = Math.Max(Math.Min(MemoryMappedFileStreamWriter.BlockCopyCapacity, availableInFile + offset), capacity + offset);
+            long viewLength = Math.Max(Math.Min(BlockCopyCapacity, availableInFile + offset), capacity + offset);
             _view = _file.CreateViewAccessor(viewOffset, viewLength, MemoryMappedFileAccess.Read);
             _viewAddress = _view.SafeMemoryMappedViewHandle.DangerousGetHandle();
             _viewOffset = viewOffset;

--- a/src/FastSerialization/MemoryMappedFileStreamWriter.cs
+++ b/src/FastSerialization/MemoryMappedFileStreamWriter.cs
@@ -4,6 +4,7 @@
 // This program uses code hyperlinks available as part of the HyperAddin Visual Studio plug-in.
 // It is available from http://www.codeplex.com/hyperAddin 
 // 
+#if false  // This code is currently unused, commented out.  
 using System;
 using System.Text;      // For StringBuilder.
 using System.Threading;
@@ -319,3 +320,4 @@ namespace FastSerialization
         }
     }
 }
+#endif

--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace FastSerialization
+{
+    public class SegmentedMemoryStreamReader
+    {
+         const int BlockCopyCapacity = 10 * 1024 * 1024;
+
+        /// <summary>
+        /// Create a IStreamReader (reads binary data) from a given byte buffer
+        /// </summary>
+        public SegmentedMemoryStreamReader(SegmentedList<byte> data) : this(data, 0, (int)data.Count) { }
+        /// <summary>
+        /// Create a IStreamReader (reads binary data) from a given subregion of a byte buffer 
+        /// </summary>
+        public SegmentedMemoryStreamReader(SegmentedList<byte> data, int start, int length)
+        {
+            bytes = new SegmentedList<byte>(65_536, length);
+            bytes.AppendFrom(data, start, length);
+            position = start;
+            endPosition = length;
+        }
+
+        /// <summary>
+        /// The total length of bytes that this reader can read.  
+        /// </summary>
+        public virtual long Length { get { return endPosition; } }
+
+        #region implemenation of IStreamReader
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public byte ReadByte()
+        {
+            if (position >= endPosition)
+            {
+                Fill(1);
+            }
+
+            return bytes[position++];
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public short ReadInt16()
+        {
+            if (position + sizeof(short) > endPosition)
+            {
+                Fill(sizeof(short));
+            }
+
+            int ret = bytes[position] + (bytes[position + 1] << 8);
+            position += sizeof(short);
+            return (short)ret;
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public int ReadInt32()
+        {
+            if (position + sizeof(int) > endPosition)
+            {
+                Fill(sizeof(int));
+            }
+
+            int ret = bytes[position] + ((bytes[position + 1] + ((bytes[position + 2] + (bytes[position + 3] << 8)) << 8)) << 8);
+            position += sizeof(int);
+            return ret;
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public long ReadInt64()
+        {
+            uint low = (uint)ReadInt32();
+            uint high = (uint)ReadInt32();
+            return (long)((((ulong)high) << 32) + low);        // TODO find the most efficient way of doing this. 
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public string ReadString()
+        {
+            int len = ReadInt32();          // Expect first a character inclusiveCountRet.  -1 means null.
+            if (len < 0)
+            {
+                Debug.Assert(len == -1);
+                return null;
+            }
+
+            if (sb == null)
+            {
+                sb = new StringBuilder(len);
+            }
+
+            sb.Length = 0;
+
+            Debug.Assert(len < Length);
+            while (len > 0)
+            {
+                int b = ReadByte();
+                if (b < 0x80)
+                {
+                    sb.Append((char)b);
+                }
+                else if (b < 0xE0)
+                {
+                    // TODO test this for correctness
+                    b = (b & 0x1F);
+                    b = b << 6 | (ReadByte() & 0x3F);
+                    sb.Append((char)b);
+                }
+                else
+                {
+                    // TODO test this for correctness
+                    b = (b & 0xF);
+                    b = b << 6 | (ReadByte() & 0x3F);
+                    b = b << 6 | (ReadByte() & 0x3F);
+
+                    sb.Append((char)b);
+                }
+                --len;
+            }
+            return sb.ToString();
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public StreamLabel ReadLabel()
+        {
+            return (StreamLabel)ReadInt32();
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public virtual void Goto(StreamLabel label)
+        {
+            Debug.Assert(label != StreamLabel.Invalid);
+            position = (int)label;
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public virtual StreamLabel Current
+        {
+            get
+            {
+                return (StreamLabel)position;
+            }
+        }
+        /// <summary>
+        /// Implementation of IStreamReader
+        /// </summary>
+        public virtual void GotoSuffixLabel()
+        {
+            Goto((StreamLabel)(Length - sizeof(StreamLabel)));
+            Goto(ReadLabel());
+        }
+        /// <summary>
+        /// Dispose pattern
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        /// <summary>
+        /// Dispose pattern
+        /// </summary>
+        protected virtual void Dispose(bool disposing) { }
+        #endregion
+
+        #region private 
+        internal /*protected*/ virtual void Fill(int minBytes)
+        {
+            throw new Exception("Streamreader read past end of buffer");
+        }
+        internal /*protected*/  SegmentedList<byte> bytes;
+        internal /*protected*/  int position;
+        internal /*protected*/  int endPosition;
+        private StringBuilder sb;
+        #endregion
+    }
+}
+

--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace FastSerialization
+{
+    public class SegmentedMemoryStreamWriter
+    {
+        public SegmentedMemoryStreamWriter() : this(64) { }
+        public SegmentedMemoryStreamWriter(int initialSize)
+        {
+            bytes = new SegmentedList<byte>(65_536, initialSize);
+        }
+
+        public virtual long Length { get { return bytes.Count; } }
+        public virtual void Clear() { bytes = new SegmentedList<byte>(131_072); }
+
+        public void Write(byte value)
+        {
+            bytes.Add(value);
+        }
+        public void Write(short value)
+        {
+            int intValue = value;
+            bytes.Add((byte)intValue); intValue = intValue >> 8;
+            bytes.Add((byte)intValue); intValue = intValue >> 8;
+        }
+        public void Write(int value)
+        {
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+        }
+        public void Write(long value)
+        {
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+            bytes.Add((byte)value); value = value >> 8;
+        }
+        public void Write(StreamLabel value)
+        {
+            Write((int)value);
+        }
+        public void Write(string value)
+        {
+            if (value == null)
+            {
+                Write(-1);          // negative charCount means null. 
+            }
+            else
+            {
+                Write(value.Length);
+                for (int i = 0; i < value.Length; i++)
+                {
+                    // TODO do actual UTF8
+                    Write((byte)value[i]);
+                }
+            }
+        }
+        public virtual StreamLabel GetLabel()
+        {
+            return (StreamLabel)Length;
+        }
+        public void WriteSuffixLabel(StreamLabel value)
+        {
+            // This is guaranteed to be uncompressed, but since we are not compressing anything, we can
+            // simply write the value.  
+            Write(value);
+        }
+
+        public void WriteToStream(Stream outputStream)
+        {
+            // TODO really big streams will overflow;
+            outputStream.Write(bytes.ToArray(), 0, (int)Length);
+        }
+        // Note that the returned IMemoryStreamReader is not valid if more writes are done.  
+        public SegmentedMemoryStreamReader GetReader()
+        {
+            var readerBytes = bytes;
+            return new SegmentedMemoryStreamReader(readerBytes, 0, (int)readerBytes.Count);
+        }
+        public void Dispose() { }
+
+        #region private
+        protected virtual void MakeSpace()
+        {
+            // Not necessary
+        }
+
+        public byte[] GetBytes()
+        {
+            return bytes.ToArray();
+        }
+
+        protected SegmentedList<byte> bytes;
+        #endregion
+    }
+}
+


### PR DESCRIPTION
This mostly pulls in code that Marco wrote a while back (some small tweeks).   Bascially instead 
of using MemoryStream we use a new SementedMemoryStream. 

Marco. Please build this locally and test that it performs well and does what you want.  

Note that we don't use MemoryMappedFileStreamWriter anymore so I have #ifdefed it out for now.
Also to avoid dependency of MemoryMappedFileStreamReader on MemoryMappedFileStreamWriter I cloned the BlockCopyCapacity constant into  MemoryMappedFileStreamReader 

@mpeyrotc  @sharwell 