### PR TITLE
Changes window ownership for better z-ordering

### DIFF
--- a/src/PerfView/GuiUtilities/WindowBase.cs
+++ b/src/PerfView/GuiUtilities/WindowBase.cs
@@ -21,8 +21,7 @@ namespace PerfView
                 // give up setting the owner in that case (it is not critical to have an owner)  
                 try
                 {
-                    Owner = parentWindow;
-                    WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                    WindowStartupLocation = WindowStartupLocation.CenterScreen;
                 }
                 catch (System.Exception) { }
             }


### PR DESCRIPTION
Previous #758 fixed window creation so that child windows would be on the same monitor as their parents. This change has the side effect of making it impossible to put parent windows on top of child windows.

This change instead puts the window on the screen where the mouse cursor is at the time the window is created. This isn't perfect; if you double click something and quickly move the mouse you can wind up with the window on the "wrong" monitor. I think this is a better compromise than the current situation.

Fixes #865