### PR TITLE
Add configure to bypass assert dialogs

### DIFF
--- a/src/PerfView/app.config
+++ b/src/PerfView/app.config
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <configuration>
+  <system.diagnostics>
+    <!-- Set the value to false to avoid poping up dialogs when assert fails. -->
+    <assert assertuienabled="true"/>
+  </system.diagnostics>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
   </startup>


### PR DESCRIPTION
Set the value to false will allow build debug binaries while not showing the assertion failure dialogs. Just to make the debugging easier.