### PR TITLE
Fix official build break.

### DIFF
--- a/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.nuspec
@@ -6,7 +6,12 @@
     <title>Non-Source files needed to Build TraceEvent</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
+    <licenseUrl>https://github.com/Microsoft/perfview/blob/master/LICENSE.TXT</licenseUrl>
+    <!--  *************************************** 
+     4/2/2019 When the official builds support the 'license' element we should upgrade to use the that (shown below)  
+
     <license type="expression">MIT</license>
+     *************************************** -->
     <projectUrl>https://github.com/Microsoft/perfview</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/NugetSupportFiles/PerfView.SupportFiles/PerfView.SupportFiles.nuspec
+++ b/src/NugetSupportFiles/PerfView.SupportFiles/PerfView.SupportFiles.nuspec
@@ -6,7 +6,11 @@
     <title>Non-Source files needed to Build PerfView</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
+    <!--  *************************************** 
+     4/2/2019 When the official builds support the 'license' element we should upgrade to use the that (shown below)  
+
     <license type="expression">MIT</license>
+     *************************************** -->
     <projectUrl>https://github.com/Microsoft/perfview</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -7,7 +7,12 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Microsoft/perfview</projectUrl>
+    <licenseUrl>https://github.com/Microsoft/perfview/blob/master/LICENSE.TXT</licenseUrl>
+    <!--  *************************************** 
+     4/2/2019 When the official builds support the 'license' element we should upgrade to use the that (shown below)  
+
     <license type="expression">MIT</license>
+     *************************************** -->
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>


### PR DESCRIPTION
Offical builds don't support the license nuget element.   Fall back to licenseUrl for now.