### PR TITLE
Display error message when PerfView64 wrapper can't load PerfView.exe

### DIFF
--- a/src/PerfView64/App.cs
+++ b/src/PerfView64/App.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
+using System.Windows;
 
 namespace PerfView64
 {
@@ -15,7 +17,17 @@ namespace PerfView64
         [DebuggerNonUserCode]
         public static int Main(string[] args)
         {
-            return PerfView.App.Main(args);
+            try
+            {
+                return Run(args);
+            }
+            catch (FileNotFoundException ex) when (ex.Message.StartsWith("Could not load file or assembly 'PerfView"))
+            {
+                MessageBox.Show("Failed to run application. Is PerfView.exe present?", "PerfView.exe not found", MessageBoxButton.OK, MessageBoxImage.Error);
+                return 1;
+            }
         }
+
+        private static int Run(string[] args) => PerfView.App.Main(args);
     }
 }

--- a/src/PerfView64/PerfView64.csproj
+++ b/src/PerfView64/PerfView64.csproj
@@ -16,6 +16,7 @@
 
   <PropertyGroup>
     <ApplicationIcon>..\PerfView\performance.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,6 +51,7 @@
         <Authenticode>Microsoft</Authenticode>
     </FilesToSign>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <Reference Include="PresentationFramework" />
   </ItemGroup>
 
 </Project>

--- a/src/PerfView64/app.manifest
+++ b/src/PerfView64/app.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
If you're dumb like me and download the `PerfView64.exe` wrapper and run it without `PerfView.exe` being present, it will silently error (though it will leave an error in the Windows Event Viewer).

This change means an error message will be displayed when `PerfView.exe` is missing.

![2019-04-24 PerfView64 Error](https://user-images.githubusercontent.com/2142963/56643658-5efcf900-66bd-11e9-97f7-e74e4f5492da.png)