### PR TITLE
Fix an issue caused by unexpected stop of trace sessions when TraceEventSession is just created and attached to check if a session is active.

### DIFF
--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -867,7 +867,14 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 if (m_StopOnDispose)
                 {
                     m_StopOnDispose = false;
-                    Stop(true);
+
+                    // Only dispose session and source when required.
+                    // For session just attached to check if it's active, we must not call dispose.
+                    // Otherwise, it will caused unexpected stop of trace sessions.
+                    if (m_Create)
+                    {
+                        Stop(true);
+                    }
                 }
 
                 // TODO need safe handles
@@ -1447,13 +1454,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// </summary>
         ~TraceEventSession()
         {
-            // Only dispose session and source when required.
-            // For session just attached to check if it's active, we must not call dispose.
-            // Otherwise, it will caused unexpected stop of trace sessions.
-            if (m_Create)
-            {
-                Dispose();
-            }
+            Dispose();
         }
 
         /// <summary>

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1447,7 +1447,13 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// </summary>
         ~TraceEventSession()
         {
-            Dispose();
+            // Only dispose session and source when required.
+            // For session just attached to check if it's active, we must not call dispose.
+            // Otherwise, it will caused unexpected stop of trace sessions.
+            if (m_Create)
+            {
+                Dispose();
+            }
         }
 
         /// <summary>

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -868,8 +868,8 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 {
                     m_StopOnDispose = false;
 
-                    // Only dispose session and source when required.
-                    // For session just attached to check if it's active, we must not call dispose.
+                    // Only stop the session when we were the original creator of it and not for cases where we attach.
+                    // For session just attached to check if it's active, we must not call stop method.
                     // Otherwise, it will caused unexpected stop of trace sessions.
                     if (m_Create)
                     {


### PR DESCRIPTION
Fix an issue caused by unexpected stop of trace sessions when TraceEventSession is just created and attached to check if a session is active.