### PR TITLE
Fix a typo and stale link

### DIFF
--- a/documentation/Downloading.md
+++ b/documentation/Downloading.md
@@ -16,12 +16,12 @@ care about specific bug fixes or features go there.
 In the common case, you only need one file, PerfView.exe, to use the tool.  The most recent copy of
 this file can be downloaded here
 
-* [Download Version 2.0.39 of PerfView.exe](https://github.com/Microsoft/perfview/releases/download/P2.0.39/PerfView.exe)
+* [Download Version 2.0.42 of PerfView.exe](https://github.com/Microsoft/perfview/releases/download/P2.0.42/PerfView.exe)
 
 Once you click the above link in your browser it will start downloading, the details of which vary from browser to browser.
 In some cases it will prompt for more information (IE) and in others (Chrome) it may not be obvious that
 you clicked on anything (look at the bottom of the pane for changes).  The result, however will be a PerfView.exe on your
-local machine.   
+local machine.
 
 Once downloaded you you can simply double click on the downloaded EXE to launch PerfView.
 While Github itself and your browser do some validation, to be extra careful you can

--- a/src/TraceEvent/BPerf/BPerfEventSource.cs
+++ b/src/TraceEvent/BPerf/BPerfEventSource.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Diagnostics.Tracing
 
         public override bool Process()
         {
-            this.utcOffsetMinutes = 480;
             this.ProcessInner();
             return true;
         }


### PR DESCRIPTION
Fixes the updated release link
A stray line from my previous change is there. It is harmless because we always overwrite it but confusing and not what I intended to do. No need to update release for it.