### PR TITLE
Cleanup ClrTraceEventParser.cs file generation

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -9,14 +9,10 @@ using Address = System.UInt64;
 
 #pragma warning disable 1591        // disable warnings on XML comments not being present
 
-/* This file was generated with the command */
-// traceParserGen /merge CLREtwAll.man CLRTraceEventParser.cs
-/* And then modified by hand to add functionality (handle to name lookup, fixup of evenMethodLoadUnloadTraceDMOatats ...) */
-// The version before any hand modifications is kept as KernelTraceEventParser.base.cs, and a 3
-// way diff is done when traceParserGen is rerun.  This allows the 'by-hand' modifications to be
-// applied again if the mof or the traceParserGen transformation changes. 
-// 
-// See traceParserGen /usersGuide for more on the /merge option 
+// This file was generated with the following command:
+//    traceParserGen CLREtwAll.man CLRTraceEventParser.cs
+// And then modified by hand to add functionality (handle to name lookup, fixup of evenMethodLoadUnloadTraceDMOatats ...)
+// Note: /merge option is no more available (does not even compile)
 namespace Microsoft.Diagnostics.Tracing.Parsers
 {
     using Microsoft.Diagnostics.Tracing.Parsers.Clr;

--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -605,9 +605,10 @@ namespace ETWManifest
                     return Capitalize(OpcodeName);
                 }
 
-                if (TaskName.EndsWith(OpcodeName, StringComparison.OrdinalIgnoreCase))
+                // could be that the task name is the prefix of the Opcode name
+                if (OpcodeName.StartsWith(TaskName, StringComparison.OrdinalIgnoreCase))
                 {
-                    return TaskName;
+                    return Capitalize(OpcodeName);
                 }
 
                 return TaskName + Capitalize(OpcodeName);
@@ -793,7 +794,7 @@ namespace ETWManifest
                     }
                 }
             }
-            catch
+            catch(Exception e)
             {
                 if (fileName == null)
                 {


### PR DESCRIPTION
Cleanup TraceParserGen to generate a .cs file from which it is possible to copy/paste valid new CLR events related code intothe TraceEvent ClrTraceEventParser.cs file.

Before this change, the generated C# code was not valid and needed careful manual merge operations when new events are added to ClrEtwAll.man in CoreClr repo.