### PR TITLE
Add support to BPerf reader for symbols from a different file.

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -197,6 +197,8 @@ namespace PerfView
         public int MaxEventCount;
         public bool ContinueOnError;
         public double SkipMSec;
+        public DateTime StartTime;
+        public DateTime EndTime;
         public bool ForceNgenRundown;
         public bool DumpHeap;
 
@@ -368,6 +370,8 @@ namespace PerfView
                 "Useful for trimming large ETL files. 1M typically yields 300-400 Meg of data considered.");
             parser.DefineOptionalQualifier("SkipMSec", ref SkipMSec, "Skips the first N MSec of the trace.  " +
                 "Useful for trimming large ETL files in conjunction with the /MaxEventCount qualifier.");
+            parser.DefineOptionalQualifier("StartTime", ref StartTime, "The start date and time used to filter events of the input trace for formats that support this.");
+            parser.DefineOptionalQualifier("EndTime", ref EndTime, "The end date and time used to filter events of the input trace for formats that support this.");
             parser.DefineOptionalQualifier("ContinueOnError", ref ContinueOnError, "Processes bad traces as best it can.");
 
             parser.DefineOptionalQualifier("CpuCounters", ref CpuCounters,

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -7225,6 +7225,10 @@ table {
                 options.KeepAllEvents = true;
             }
 
+            var traceEventDispatcherOptions = new TraceEventDispatcherOptions();
+            traceEventDispatcherOptions.StartTime = App.CommandLineArgs.StartTime;
+            traceEventDispatcherOptions.EndTime = App.CommandLineArgs.EndTime;
+
             options.MaxEventCount = App.CommandLineArgs.MaxEventCount;
             options.ContinueOnError = App.CommandLineArgs.ContinueOnError;
             options.SkipMSec = App.CommandLineArgs.SkipMSec;
@@ -7249,7 +7253,7 @@ table {
                 if (!File.Exists(etlxFile))
                 {
                     log.WriteLine("Creating ETLX file {0} from {1}", etlxFile, dataFileName);
-                    TraceLog.CreateFromEventTraceLogFile(dataFileName, etlxFile, options);
+                    TraceLog.CreateFromEventTraceLogFile(dataFileName, etlxFile, options, traceEventDispatcherOptions);
 
                     var dataFileSize = "Unknown";
                     if (File.Exists(dataFileName))

--- a/src/PerfView/Utilities/commandLine.cs
+++ b/src/PerfView/Utilities/commandLine.cs
@@ -1472,6 +1472,10 @@ class CommandLine
 
                     return ParseValue(valueString, type.GetGenericArguments()[0], parameterName);
                 }
+                else if (type == typeof(DateTime))
+                {
+                    return DateTime.Parse(valueString);
+                }
                 else
                 {
                     System.Reflection.MethodInfo parseMethod = type.GetMethod("Parse", new Type[] { typeof(string) });

--- a/src/TraceEvent/TraceEvent.Tests/BPerfTest.cs
+++ b/src/TraceEvent/TraceEvent.Tests/BPerfTest.cs
@@ -63,8 +63,9 @@ namespace TraceEventTests
 
             Output.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", Path.GetFullPath(bperfFileName)));
             var sb = new StringBuilder(1024 * 1024);
+            var traceEventDispatcherOptions = new TraceEventDispatcherOptions();
 
-            using (var traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(Path.GetFullPath(bperfFileName))))
+            using (var traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(Path.GetFullPath(bperfFileName), traceEventDispatcherOptions: traceEventDispatcherOptions)))
             {
                 var traceSource = traceLog.Events.GetSource();
 

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -3070,6 +3070,22 @@ namespace Microsoft.Diagnostics.Tracing
     }
 
     /// <summary>
+    /// An options class for the TraceEventDispatcher
+    /// </summary>
+    public sealed class TraceEventDispatcherOptions
+    {
+        /// <summary>
+        /// StartTime from which you want to start analyzing the events for file formats that support this.
+        /// </summary>
+        public DateTime StartTime { get; set; }
+
+        /// <summary>
+        /// EndTime till when you want to analyze events for file formats that support this.
+        /// </summary>
+        public DateTime EndTime { get; set; }
+    }
+
+    /// <summary>
     /// A TraceEventDispatcher is a TraceEventSource that supports a callback model for dispatching events.  
     /// </summary>
     public abstract unsafe class TraceEventDispatcher : TraceEventSource
@@ -3079,7 +3095,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// </summary>
         /// <param name="traceFileName">A path to a trace file.</param>
         /// <returns>A TraceEventDispatcher for the given trace file.</returns>
-        public static TraceEventDispatcher GetDispatcherFromFileName(string traceFileName)
+        public static TraceEventDispatcher GetDispatcherFromFileName(string traceFileName, TraceEventDispatcherOptions options = null)
         {
 #if !DOTNET_V35
             if (traceFileName.EndsWith(".trace.zip", StringComparison.OrdinalIgnoreCase))
@@ -3103,7 +3119,7 @@ namespace Microsoft.Diagnostics.Tracing
             }
             else if (traceFileName.EndsWith(".btl", StringComparison.OrdinalIgnoreCase))
             {
-                return new BPerfEventSource(traceFileName);
+                return new BPerfEventSource(traceFileName, options);
             }
 #endif
             else

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -56,14 +56,14 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// <para>If etlxFilePath is null the output name is derived from etlFilePath by changing its file extension to .ETLX.</para>
         /// <returns>The name of the ETLX file that was generated.</returns>
         /// </summary>
-        public static string CreateFromEventTraceLogFile(string filePath, string etlxFilePath = null, TraceLogOptions options = null)
+        public static string CreateFromEventTraceLogFile(string filePath, string etlxFilePath = null, TraceLogOptions options = null, TraceEventDispatcherOptions traceEventDispatcherOptions = null)
         {
             if (etlxFilePath == null)
             {
                 etlxFilePath = Path.ChangeExtension(filePath, ".etlx");
             }
 
-            using (TraceEventDispatcher source = TraceEventDispatcher.GetDispatcherFromFileName(filePath))
+            using (TraceEventDispatcher source = TraceEventDispatcher.GetDispatcherFromFileName(filePath, traceEventDispatcherOptions))
             {
                 if (source.EventsLost != 0 && options != null && options.OnLostEvents != null)
                 {
@@ -10379,6 +10379,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// If errors occur during conversion, just assume the traced ended at that point and continue. 
         /// </summary>
         public bool ContinueOnError;
+
         #region private
         private TextWriter m_ConversionLog;
         #endregion


### PR DESCRIPTION
Adds support to BPerf's reader for a side-database for managed method info and image load data. This allows us to enable verbose events like GC in the main session that rotates and a managed method db that doesn't rotate for the application lifetime.

@brianrob @LakshanF this change will allow us to onboard to CAP.