### PR TITLE
Update link to most recent version of PerfView in docs

### DIFF
--- a/documentation/Downloading.md
+++ b/documentation/Downloading.md
@@ -16,7 +16,7 @@ care about specific bug fixes or features go there.
 In the common case, you only need one file, PerfView.exe, to use the tool.  The most recent copy of
 this file can be downloaded here
 
-* [Download Version 2.0.43 of PerfView.exe](https://github.com/Microsoft/perfview/releases/download/P2.0.42/PerfView.exe)
+* [Download Version 2.0.43 of PerfView.exe](https://github.com/Microsoft/perfview/releases/download/P2.0.43/PerfView.exe)
 
 Once you click the above link in your browser it will start downloading, the details of which vary from browser to browser.
 In some cases it will prompt for more information (IE) and in others (Chrome) it may not be obvious that

--- a/documentation/Downloading.md
+++ b/documentation/Downloading.md
@@ -16,7 +16,7 @@ care about specific bug fixes or features go there.
 In the common case, you only need one file, PerfView.exe, to use the tool.  The most recent copy of
 this file can be downloaded here
 
-* [Download Version 2.0.42 of PerfView.exe](https://github.com/Microsoft/perfview/releases/download/P2.0.42/PerfView.exe)
+* [Download Version 2.0.43 of PerfView.exe](https://github.com/Microsoft/perfview/releases/download/P2.0.42/PerfView.exe)
 
 Once you click the above link in your browser it will start downloading, the details of which vary from browser to browser.
 In some cases it will prompt for more information (IE) and in others (Chrome) it may not be obvious that


### PR DESCRIPTION
With the recent .nettrace format change, people will need new version of PerfView to open them - This doc is the one of the first thing that pops up on search engines but it only has link to 2.0.42, so I'm updating the documentation here for whoever else clicks this and finds that it can't open .nettrace files :-)