### PR TITLE
Fix parsing of ETLX files larger than 2GB

### DIFF
--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -132,7 +132,7 @@ namespace FastSerialization
         /// </summary>
         public StreamLabel ReadLabel()
         {
-            return (StreamLabel)ReadInt32();
+            return (StreamLabel)(uint)ReadInt32();
         }
         /// <summary>
         /// Implementation of IStreamReader
@@ -150,7 +150,7 @@ namespace FastSerialization
         {
             get
             {
-                return (StreamLabel)position;
+                return (StreamLabel)(uint)position;
             }
         }
         /// <summary>

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -150,7 +150,7 @@ namespace FastSerialization
         /// </summary>
         public StreamLabel ReadLabel()
         {
-            return (StreamLabel)ReadInt32();
+            return (StreamLabel)(uint)ReadInt32();
         }
         /// <summary>
         /// Implementation of IStreamReader
@@ -168,7 +168,7 @@ namespace FastSerialization
         {
             get
             {
-                return (StreamLabel)position;
+                return (StreamLabel)(uint)position;
             }
         }
         /// <summary>
@@ -950,7 +950,7 @@ namespace FastSerialization
                             int position = r.Next(0, origData.Length);
                             int size = r.Next(0, bufferSize) + 1;
 
-                            reader.Goto((StreamLabel)position);
+                            reader.Goto((StreamLabel)(uint)position);
                             Compare(reader, origData, position, size);
                         }
                         reader.Close();

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -576,7 +576,7 @@ namespace Graphs
 
             for (int i = 0; i < nodeCount; i++)
             {
-                m_nodes.Add((StreamLabel)deserializer.ReadInt());
+                m_nodes.Add((StreamLabel)(uint)deserializer.ReadInt());
             }
 
             // Read in the Blob stream.  

--- a/src/TraceEvent/TraceEvent.Tests/FastSerializerTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/FastSerializerTests.cs
@@ -1,0 +1,39 @@
+﻿using FastSerialization;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class FastSerializerTests
+    {
+        [Fact]
+        public void ParseStreamLabel()
+        {
+            MemoryStream ms = new MemoryStream();
+            BinaryWriter writer = new BinaryWriter(ms);
+            WriteString(writer, "!FastSerialization.1");
+            writer.Write(0);
+            writer.Write(19);
+            writer.Write(1_000_000);
+            writer.Write(0xf1234567);
+
+            ms.Position = 0;
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms), "name");
+            Assert.Equal((StreamLabel)0, d.ReadLabel());
+            Assert.Equal((StreamLabel)19, d.ReadLabel());
+            Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
+            Assert.Equal((StreamLabel)0xf1234567, d.ReadLabel());
+        }
+
+        private void WriteString(BinaryWriter writer, string val)
+        {
+            writer.Write(val.Length);
+            writer.Write(Encoding.UTF8.GetBytes(val));
+        }
+    }
+}


### PR DESCRIPTION
This fixes issue #958 

StreamLabels serialized in the FastSerialization format are 4 byte unsigned integers, but the FastSerialization library reads them using ReadInt32() so values above 2GB appear negative. Prior to PR #952 StreamLabel was a uint so (StreamLabel)ReadInt32() restored the correct unsigned semantics to the value. In PR #952 StreamLabel became a long which meant values above 2GB remained negative. Attempting to Goto() a negative StreamLabel put the reader in a bad state which lead to the observed error later in Fill().

The fix casts the int first to a uint, then assigns to the StreamLabel as before. The problematic trace was only manifesting an issue at StreamReaderWriter.cs:153, but I searched for all locations where an int was being assigned to a StreamLabel in case any of them were following the same convention of using a signed type to represent unsigned data. SegmentedMemoryStreamReader.cs:135 and graph.cs:579 strongly appear to follow that pattern, I think it is unlikely in the other cases but the uint cast is a no-op in that case and does no harm.

The issue wasn't caught in testing because we don't have any ETW tests with sample inputs larger than 2GB. I added a unit test for parsing StreamLabel with a test case larger than 2GB to prevent regressions.