### PR TITLE
Add the CompilationVerbose keyword to CLRTraceEventParser

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -176,6 +176,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             /// Events that will dump PDBs of dynamically generated assemblies to the ETW stream.  
             /// </summary>
             Codesymbols = 0x400000000,
+            /// <summary>
+            /// Verbose events for diagnosing compilation and pre-compilation features.
+            /// </summary>
+            CompilationVerbose = 0x2000000000,
 
             /// <summary>
             /// Recommend default flags (good compromise on verbosity).  

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -177,9 +177,9 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             /// </summary>
             Codesymbols = 0x400000000,
             /// <summary>
-            /// Verbose events for diagnosing compilation and pre-compilation features.
+            /// Diagnostic events for diagnosing compilation and pre-compilation features.
             /// </summary>
-            CompilationVerbose = 0x2000000000,
+            CompilationDiagnostic = 0x2000000000,
 
             /// <summary>
             /// Recommend default flags (good compromise on verbosity).  


### PR DESCRIPTION
Add support for enabling the CompilationVerbose keyword via /ClrEvents.  This is in reaction to https://github.com/dotnet/coreclr/pull/25544.