### PR TITLE
Fix Issue with Colons in Perf Counter Instance Names

### DIFF
--- a/src/PerfView/Triggers.cs
+++ b/src/PerfView/Triggers.cs
@@ -73,11 +73,11 @@ namespace Triggers
             DecayToZeroHours = decayToZeroHours;
             MinSecForTrigger = 3;
 
-            var m = Regex.Match(spec, @"^\s*(.*):(.*?):(.*?)\s*([<>])\s*(\d+\.?\d*)\s*$");
+            var m = Regex.Match(spec, @"^\s*(.*?):(.*?):(.*?)\s*([<>])\s*(\d+\.?\d*)\s*$");
             if (!m.Success)
             {
                 throw new ApplicationException(
-                    "Performance monitor specification '" + spec + "' does not match syntax CATEGORY:COUNTER:INSTANCE [<>] NUM");
+                    "Performance monitor specification '" + spec + "' does not match syntax CATEGORY:COUNTER:INSTANCE [<>] NUM (i.e. 0.12 or 12)");
             }
 
             var categoryName = m.Groups[1].Value;


### PR DESCRIPTION
When using a performance counter trigger, if the instance name contains a colon ":" it will not match the regex and instead error out.  One example is the below counter which should be allowed: 

PhysicalDisk:Avg. Disk sec/Write:0 C:>0.01

I also noticed that when specifying a threshold, its required to have a leading digit (0.02 instead of .02) so I updated the error message to help anyone who might run into that.

This PR fixes the colon issue and updates the error message.