### PR TITLE
WIP: Improvements for use by dotnet-gc-infra

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -5419,7 +5419,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             {
                 long ret = SizeAfter - Fragmentation;
 
-                Debug.Assert(ret >= 0);
+                // Debug.Assert(ret >= 0);
                 return ret;
             }
         }


### PR DESCRIPTION
* `GetCurrentGC` used to only return the current GC between the GC/Start and GC/Stop events. But some events would happen slightly before and after those.
  It will now return the current GC in between GC/SuspendEEStart and GC/RestartEEEnd (+1ms due to some events coming out slightly later).

* So we are now creating the GC in `source.Clr.GCSuspendEEStart +=`. We are still filling in most of it in `GCStart` though.

* Commented out `Debug.Assert(_event.PauseDurationMSec == 0);` that was firing.

* New public properties:
	* Adds ExpandMechanisms and CompactMechanisms to GCPerHeapHistory
	* Adds ThreadId and IsBGCThread to GcJoin