### PR TITLE
Update the MethodJitTailCallFailed event ID

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -1691,7 +1691,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             add
             {
                 // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-                RegisterTemplate(new MethodJitTailCallFailedTraceData(value, 192, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName));
+                RegisterTemplate(new MethodJitTailCallFailedTraceData(value, 191, 9, "Method", MethodTaskGuid, 86, "TailCallFailed", ProviderGuid, ProviderName));
             }
             remove
             {

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -1695,7 +1695,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             }
             remove
             {
-                source.UnregisterEventTemplate(value, 192, ProviderGuid);
+                source.UnregisterEventTemplate(value, 191, ProviderGuid);
             }
         }
 


### PR DESCRIPTION
This change maps the event to the ID in https://github.com/dotnet/coreclr/blob/2a8529c6130f6c70488e8bace26404b319eed00f/src/vm/ClrEtwAll.man#L3175
The current ID maps the MethodJitInliningFailed event ID, which is wrong.