### PR TITLE
fix SpeedScope exporter bug

### DIFF
--- a/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
@@ -230,8 +230,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
         {
             if (openSample.Depth != closeSample.Depth)
                 throw new ArgumentException("Invalid arguments, both samples must be of the same depth");
-            if (closeSample.Metric == 0.0)
-                throw new ArgumentException("Invalid sample, the metric must NOT be equal zero.", nameof(closeSample));
+            if (openSample.RelativeTime == closeSample.RelativeTime + closeSample.Metric)
+                throw new ArgumentException("Invalid samples, two samples can not happen at the same time.");
 
             profileEvents.Add(new ProfileEvent(ProfileEventType.Open, frameId, openSample.RelativeTime, openSample.Depth));
             profileEvents.Add(new ProfileEvent(ProfileEventType.Close, frameId, closeSample.RelativeTime + closeSample.Metric, closeSample.Depth));


### PR DESCRIPTION
The SpeedScope file format represents every profile as a list of sorted open and close events.

An example: method Main lasts from 0.0s to 1.0s. Such a profile would be represented as:

```json
"frames": [ { "name": "Main" } ]
events:
[
  { "type": "O", "frame": 0, "at": 0.0 },
  { "type": "C", "frame": 0, "at": 1.0 },
]
```

If two samples happen at the same time, the closing sample must be exported first, then the opening sample should be exported. Descending by call stack depth:

```cs
void Main()
{ 
  A(); 
  B();
}

void A() => C();
void B() => C();
```

```json
"frames": 
[ 
 { "name": "Main" }, 
 { "name": "A" },
 { "name": "B" }, 
 { "name": "C" } 
]
events:
[
  { "type": "O", "frame": 0, "at": 0.0 }, // open Main
  { "type": "O", "frame": 1, "at": 0.0 }, // open A
  { "type": "O", "frame": 3, "at": 0.0 }, // open C
  { "type": "C", "frame": 3, "at": 0.5 }, // close C
  { "type": "C", "frame": 1, "at": 0.5 }, // close A
  { "type": "O", "frame": 2, "at": 0.5 }, // open B
  { "type": "O", "frame": 3, "at": 0.5 }, // open C
  { "type": "C", "frame": 3, "at": 1.0 }, // close C
  { "type": "C", "frame": 2, "at": 1.0 }, // close B
  { "type": "C", "frame": 0, "at": 1.0 }, // close Main
]
```

The method that sorts the events in the right order assumes that a single event can not start and end at the exact same moment (it would break the sort which would close and then open it and later break speescope ;) ).

https://github.com/microsoft/perfview/blob/e8307efc8d903e9a87784861563819baed799451/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs#L252

When I was implementing it I've introduced a condition that was not checking that but rather if metric of the close sample equals 0.

This PR fixes #917 and #956 

