### PR TITLE
make sure that SymbolReader.Dispose closes all opened pdb files

### DIFF
--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -6,16 +6,17 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace Microsoft.Diagnostics.Symbols
 {
-    internal class PortableSymbolModule : ManagedSymbolModule
+    internal class PortableSymbolModule : ManagedSymbolModule, IDisposable
     {
         public PortableSymbolModule(SymbolReader reader, string pdbFileName) : this(reader, File.Open(pdbFileName, FileMode.Open, FileAccess.Read, FileShare.Read), pdbFileName) { }
 
         public PortableSymbolModule(SymbolReader reader, Stream stream, string pdbFileName = "") : base(reader, pdbFileName)
         {
-            _stream = stream;
-            _provider = MetadataReaderProvider.FromPortablePdbStream(_stream);
+            _provider = MetadataReaderProvider.FromPortablePdbStream(stream);
             _metaData = _provider.GetMetadataReader();
         }
+
+        public void Dispose() => _provider.Dispose();
 
         public override Guid PdbGuid
         {
@@ -125,7 +126,6 @@ namespace Microsoft.Diagnostics.Symbols
         // Needed by other things to look up data
         internal MetadataReader _metaData;
         private MetadataReaderProvider _provider;
-        private Stream _stream;
         #endregion
     }
 }

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Diagnostics.Symbols
                 if (firstBytes[0] == 'B' && firstBytes[1] == 'S' && firstBytes[2] == 'J' && firstBytes[3] == 'B')
                 {
                     stream.Seek(0, SeekOrigin.Begin);   // Start over
-                    ret = new PortableSymbolModule(this, pdbFilePath);
+                    ret = new PortableSymbolModule(this, stream, pdbFilePath);
                 }
                 else
                 {

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -912,9 +912,13 @@ namespace Microsoft.Diagnostics.Symbols
         }
 
         /// <summary>
-        ///  Called when you are done with the symbol reader.  Currently does nothing.  
+        ///  Called when you are done with the symbol reader.
+        ///  Closes all opened symbol files.
         /// </summary>
-        public void Dispose() { }
+        public void Dispose()
+        {
+            m_symbolModuleCache.Clear();
+        }
 
         #region private
         /// <summary>

--- a/src/TraceEvent/Utilities/Cache.cs
+++ b/src/TraceEvent/Utilities/Cache.cs
@@ -122,6 +122,10 @@ namespace Utilities
             for (int i = 0; i < m_entries.Length; i++)
             {
                 m_entries[i].Key = default(K);
+                if (m_entries[i].Value != null && m_entries[i].Value is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
                 m_entries[i].Value = null;
             }
             // indicate the free entries. 


### PR DESCRIPTION
I've recently profiled an app using PerfView, opened the trace file, used `Goto Source (Def)`, closed the Source Window, modified the app source code and tried to rebuild the app.

The rebuild has failed with file in use exception:

```log
C:\Program Files\dotnet\sdk\3.0.100-preview9-013617\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(153,5): warning MSB3026: Could not copy "obj\Release\netcoreapp3.0\win-x64\ReportedTime.pdb" to "bin\Release\netcoreapp3.0\win-x64\publish\ReportedTime.pdb". Beginning retry 1 in 1000ms. The process cannot access the file 'C:\Projects\PerfViewDemo\ReportedTime\bin\Release\netcoreapp3.0\win-x64\publish\ReportedTime.pdb' because it is being used by another process.  [C:\Projects\PerfViewDemo\ReportedTime\0_ReportedTime.csproj]
```

This PR helps with that by making sure that when the `SymbolReader.Dispose` is called, it closes all the opened pdb files.

It's still not a perfect solution because `SymbolReader.Dispose` is called on the static symbol reader instance only when a new trace file is opened:

https://github.com/microsoft/perfview/blob/96321f190c292f5f04490092b3111e8ebc136a12/src/PerfView/PerfViewData.cs#L3887

https://github.com/microsoft/perfview/blob/1a14779e5ad890f361b02064b8a69bef18a6bda8/src/PerfView/App.cs#L821

So closing the Source Code window still keeps the .pdf file opened but opening another trace file closes it. A better solution would require much more changes related to symbol reader cache lifetime management but I don't think that it's worth it as of today.

