### PR TITLE
add "join all threads" to the list of pre-defined GroupPats, implement Select Process Window for LTTng traces

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -820,6 +820,7 @@ namespace PerfView
             stackWindow.GroupRegExTextBox.Items.Add(@"[group full path module entries]  {*}!=>module $1");
             stackWindow.GroupRegExTextBox.Items.Add(@"[group class entries]     {%!*}.%(=>class $1;{%!*}::=>class $1");
             stackWindow.GroupRegExTextBox.Items.Add(@"[group classes]            {%!*}.%(->class $1;{%!*}::->class $1");
+            stackWindow.GroupRegExTextBox.Items.Add(@"[join all threads]            Thread -> AllThreads");
         }
 
         // ideally this function would not exist.  Does the open logic on the current thread (likely GUI thread)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -820,7 +820,7 @@ namespace PerfView
             stackWindow.GroupRegExTextBox.Items.Add(@"[group full path module entries]  {*}!=>module $1");
             stackWindow.GroupRegExTextBox.Items.Add(@"[group class entries]     {%!*}.%(=>class $1;{%!*}::=>class $1");
             stackWindow.GroupRegExTextBox.Items.Add(@"[group classes]            {%!*}.%(->class $1;{%!*}::->class $1");
-            stackWindow.GroupRegExTextBox.Items.Add(@"[join all threads]            Thread -> AllThreads");
+            stackWindow.GroupRegExTextBox.Items.Add(@"[fold threads]            Thread -> AllThreads");
         }
 
         // ideally this function would not exist.  Does the open logic on the current thread (likely GUI thread)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3908,7 +3908,7 @@ table {
 
                                     incPat += DataFile.GetProcessIncPat(process);
 
-                                    if (process.ProcessID != default) // LTTng trace file lacks process IDs
+                                    if (process.ProcessID != default) // process ID is not always available
                                     {
                                         processIDs.Add(process.ProcessID);
                                     }
@@ -8267,7 +8267,7 @@ table {
         {
             if (!string.IsNullOrEmpty(topCallStackStr))
             {
-                // for the LTTng trace file the top call stack is always process name, the process ID is missing as of today
+                // the top call stack is always process name, the process ID is missing as of today (a perf_events limitation)
                 result = new IProcessForStackSource(topCallStackStr);
                 return true;
             }

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -516,6 +516,7 @@ namespace PerfView
                 }
 
                 GroupRegExTextBox.Text = justMyApp;
+                GroupRegExTextBox.Items.Add(@"[join all threads]            Thread -> AllThreads");
             }
 
 

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -516,7 +516,7 @@ namespace PerfView
                 }
 
                 GroupRegExTextBox.Text = justMyApp;
-                GroupRegExTextBox.Items.Add(@"[join all threads]            Thread -> AllThreads");
+                GroupRegExTextBox.Items.Add(@"[fold threads]            Thread -> AllThreads");
             }
 
 

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -478,7 +478,7 @@ namespace PerfView
 
             // Get tbe name and create the 'justMyApp pattern. 
             string justMyApp = null;
-            string exeName = FindExeName(IncludeRegExTextBox.Text);
+            string exeName = DataSource.DataFile.FindExeName(IncludeRegExTextBox.Text);
             if (exeName != null)
             {
                 if (string.Compare(exeName, "w3wp", StringComparison.OrdinalIgnoreCase) == 0)
@@ -516,7 +516,6 @@ namespace PerfView
                 }
 
                 GroupRegExTextBox.Text = justMyApp;
-                GroupRegExTextBox.Items.Add(@"[fold threads]            Thread -> AllThreads");
             }
 
 
@@ -3569,25 +3568,6 @@ namespace PerfView
                 return false;
             }
             return true;
-        }
-
-        /// <summary>
-        /// This is and ugly routine that scrapes the data to find the full path (without the .exe extension) of the
-        /// exe in the program.   It may fail (return nulls).   
-        /// </summary>
-
-        private static string FindExeName(string incPat)
-        {
-            string procName = null;
-            if (!string.IsNullOrWhiteSpace(incPat))
-            {
-                Match m = Regex.Match(incPat, @"^Process%\s+([^();]+[^(); ])", RegexOptions.IgnoreCase);
-                if (m.Success)
-                {
-                    procName = m.Groups[1].Value;
-                }
-            }
-            return procName;
         }
 
         private static string FindExePath(StackSource stackSource, string procName)


### PR DESCRIPTION
Recently I've been profiling a lot of parallel benchmarks that do the same job on every thread (an example is PlainText TechEmpower benchmark).

I find `Thread -> AllThreads` very useful when working with FlameGraph in such cases:

Before:

![obraz](https://user-images.githubusercontent.com/6011991/62448972-5ced1080-b769-11e9-8515-8cd7da872656.png)

After:

![obraz](https://user-images.githubusercontent.com/6011991/62448997-69716900-b769-11e9-954a-81d0b1297069.png)

my proposal is to add "[join all threads]            Thread -> AllThreads" to the list of predefined GroupPats. Just to make it more accessible for new PerfView users who are not familiar with all grouping capabilities.