### PR TITLE
Reduced allocations

### DIFF
--- a/src/FastSerialization/FunctorComparer`1.cs
+++ b/src/FastSerialization/FunctorComparer`1.cs
@@ -1,0 +1,17 @@
+﻿//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// This file is best viewed using outline mode (Ctrl-M Ctrl-O)
+//
+// This program uses code hyperlinks available as part of the HyperAddin Visual Studio plug-in.
+// It is available from http://www.codeplex.com/hyperAddin 
+// 
+
+namespace System.Collections.Generic
+{
+    internal class FunctorComparer<T> : IComparer<T>
+    {
+        public FunctorComparer(Comparison<T> comparison) { this.comparison = comparison; }
+        public int Compare(T x, T y) { return comparison(x, y); }
+
+        private Comparison<T> comparison;
+    }
+}

--- a/src/FastSerialization/GrowableArray.cs
+++ b/src/FastSerialization/GrowableArray.cs
@@ -521,13 +521,4 @@ namespace System.Collections.Generic
             #endregion
         }
     }
-    #region private classes 
-    internal class FunctorComparer<T> : IComparer<T>
-    {
-        public FunctorComparer(Comparison<T> comparison) { this.comparison = comparison; }
-        public int Compare(T x, T y) { return comparison(x, y); }
-
-        private Comparison<T> comparison;
-    };
-    #endregion
 }

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// <summary>
         /// Cause the children of each CallTreeNode in the CallTree to be sorted (accending) based on comparer
         /// </summary>
-        public void Sort(Comparison<CallTreeNode> comparer)
+        public void Sort(IComparer<CallTreeNode> comparer)
         {
             m_root.SortAll(comparer);
         }
@@ -170,7 +170,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// </summary>
         public void SortInclusiveMetricDecending()
         {
-            Sort(delegate (CallTreeNode x, CallTreeNode y)
+            var comparer = new FunctorComparer<CallTreeNode>(delegate (CallTreeNode x, CallTreeNode y)
             {
                 int ret = Math.Abs(y.InclusiveMetric).CompareTo(Math.Abs(x.InclusiveMetric));
                 if (ret != 0)
@@ -180,6 +180,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 // Sort by first sample time (assending) if the counts are the same.  
                 return x.FirstTimeRelativeMSec.CompareTo(y.FirstTimeRelativeMSec);
             });
+
+            Sort(comparer);
         }
 
         /// <summary>
@@ -1181,7 +1183,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// Sort the childre of every node in the te
         /// </summary>
         /// <param name="comparer"></param>
-        internal void SortAll(Comparison<CallTreeNode> comparer, RecursionGuard recursionGuard = default(RecursionGuard))
+        internal void SortAll(IComparer<CallTreeNode> comparer, RecursionGuard recursionGuard = default(RecursionGuard))
         {
             if (recursionGuard.RequiresNewThread)
             {

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -297,8 +297,12 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (recursionGuard.RequiresNewThread)
             {
+                // Avoid capturing method parameters for use in the lambda to reduce fast-path allocation costs
+                var capturedThis = this;
+                var capturedStack = stack;
+                var capturedRecursionGuard = recursionGuard;
                 Task<CallTreeNode> result = Task.Factory.StartNew(
-                    () => FindTreeNode(stack, recursionGuard.ResetOnNewThread),
+                    () => capturedThis.FindTreeNode(capturedStack, capturedRecursionGuard.ResetOnNewThread),
                     TaskCreationOptions.LongRunning);
 
                 return result.GetAwaiter().GetResult();
@@ -433,8 +437,13 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (recursionGuard.RequiresNewThread)
             {
+                // Avoid capturing method parameters for use in the lambda to reduce fast-path allocation costs
+                var capturedThis = this;
+                var capturedTreeNode = treeNode;
+                var capturedCallersOnStack = callersOnStack;
+                var capturedRecursionGuard = recursionGuard;
                 Task result = Task.Factory.StartNew(
-                    () => AccumulateSumByID(treeNode, callersOnStack, recursionGuard.ResetOnNewThread),
+                    () => capturedThis.AccumulateSumByID(capturedTreeNode, capturedCallersOnStack, capturedRecursionGuard.ResetOnNewThread),
                     TaskCreationOptions.LongRunning);
 
                 result.GetAwaiter().GetResult();
@@ -1187,8 +1196,12 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (recursionGuard.RequiresNewThread)
             {
+                // Avoid capturing method parameters for use in the lambda to reduce fast-path allocation costs
+                var capturedThis = this;
+                var capturedComparer = comparer;
+                var capturedRecursionGuard = recursionGuard;
                 Task result = Task.Factory.StartNew(
-                    () => SortAll(comparer, recursionGuard.ResetOnNewThread),
+                    () => capturedThis.SortAll(capturedComparer, capturedRecursionGuard.ResetOnNewThread),
                     TaskCreationOptions.LongRunning);
 
                 result.GetAwaiter().GetResult();
@@ -1754,8 +1767,13 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (recursionGuard.RequiresNewThread)
             {
+                // Avoid capturing method parameters for use in the lambda to reduce fast-path allocation costs
+                var capturedThis = this;
+                var capturedTreeNode = treeNode;
+                var capturedRecursionCount = recursionCount;
+                var capturedRecursionGuard = recursionGuard;
                 Task<AccumulateSamplesResult> result = Task.Factory.StartNew(
-                    () => AccumulateSamplesForNode(treeNode, recursionCount, recursionGuard.ResetOnNewThread),
+                    () => capturedThis.AccumulateSamplesForNode(capturedTreeNode, capturedRecursionCount, capturedRecursionGuard.ResetOnNewThread),
                     TaskCreationOptions.LongRunning);
 
                 return result.GetAwaiter().GetResult();

--- a/src/TraceEvent/Stacks/FilterStacks.cs
+++ b/src/TraceEvent/Stacks/FilterStacks.cs
@@ -514,8 +514,12 @@ namespace Diagnostics.Tracing.StackSources
         {
             if (recursionGuard.RequiresNewThread)
             {
+                // Avoid capturing method parameters for use in the lambda to reduce fast-path allocation costs
+                var capturedThis = this;
+                var capturedStackIndex = stackIndex;
+                var capturedRecursionGuard = recursionGuard;
                 Task<StackInfo> operation = Task.Factory.StartNew(
-                    () => GetStackInfo(stackIndex, recursionGuard.ResetOnNewThread),
+                    () => capturedThis.GetStackInfo(capturedStackIndex, capturedRecursionGuard.ResetOnNewThread),
                     TaskCreationOptions.LongRunning);
 
                 return operation.GetAwaiter().GetResult();

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\FastSerialization\FunctorComparer`1.cs" Link="Utilities\FunctorComparer`1.cs" />
     <Compile Include="..\Utilities\OperatingSystemVersion.cs">
       <Link>Utilities\OperatingSystemVersion.cs</Link>
     </Compile>


### PR DESCRIPTION
Reduces allocations in PerfView when opening certain memory views. Implemented as part of a solution to a 7,000+ second load time for a recent OOM heap.

⚠️ **Please do not rebase or squash this pull request during the merge.** ⚠️ 