### PR TITLE
Add UDP info to ParsedPacket

### DIFF
--- a/src/TraceEvent/Parsers/Microsoft-Windows-NDIS-PacketCapture.cs
+++ b/src/TraceEvent/Parsers/Microsoft-Windows-NDIS-PacketCapture.cs
@@ -318,6 +318,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCaptur
                         if (ip.Protocol == 17)        // UDP
                         {
                             sb.Append(" UDP");
+
+                            UDPHeader udp = new UDPHeader(packetStart + ip.IPHeaderSize);
+                            sb.Append(" SPort=").Append(udp.SourcePort);
+                            sb.Append(" DPort=").Append(udp.DestPort);
+                            sb.Append(" Length=").Append(udp.Length);
+                            sb.Append(" Checksum=").Append(udp.Checksum);
                         }
                         else
                         {
@@ -409,6 +415,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCaptur
             public int CheckSum { get { return (address[10] << 8) + address[11]; } }
 
             private byte* address;
+        }
+
+        private unsafe struct UDPHeader
+        {
+            public UDPHeader(byte* address) { this.address = address; }
+
+            public int SourcePort { get { return (address[0] << 8) + address[1]; } }
+            public int DestPort { get { return (address[2] << 8) + address[3]; } }
+            public int Length { get { return (address[4] << 8) + address[5]; } }
+            public int Checksum { get { return (address[6] << 8) + address[7]; } }
+            public int UDPHeaderSize { get { return 8; } }
+            #region private
+            private byte* address;
+            #endregion
         }
 
         private unsafe struct TCPHeader


### PR DESCRIPTION
This PR adds support for parsing the UDP header in the captured packets and printing the related information in the ParsedPacket output string.

This will show UDP info in PerfView and allows users of the TraceEvent nuget package to get UDP info from ParsedPacket.