### PR TITLE
Fixed typo with .NGENPDB #1019 

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -157,7 +157,7 @@ namespace PerfView
                                     continue;
                                 }
                                 // We know that .NGENPDB directories are uninteresting, filter them out.  
-                                if (dir.EndsWith(".NENPDB", StringComparison.OrdinalIgnoreCase))
+                                if (dir.EndsWith(".NGENPDB", StringComparison.OrdinalIgnoreCase))
                                 {
                                     continue;
                                 }


### PR DESCRIPTION
Fixed typo with .NGENPDB #1019 
.NENPDB -> .N**G**ENPDB