### PR TITLE
Setting font-family from docs.microsoft.com on all .htm files

### DIFF
--- a/src/PerfView/SupportFiles/EventCounterVisualization.html
+++ b/src/PerfView/SupportFiles/EventCounterVisualization.html
@@ -1,10 +1,23 @@
 ﻿
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
-    <meta charset="utf-8">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Event Counter Visualization</title>
     <style>
+        body {
+            font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
+            font-weight: 400;
+            text-rendering: optimizeLegibility;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        hr {
+            border-top: 3px double gray;
+        }
+
         .line {
             fill: none;
             stroke: steelblue;
@@ -17,7 +30,6 @@
             pointer-events: all;
         }
     </style>
-    <title>Event Counter Visualization</title>
 </head>
 
 <body>

--- a/src/PerfView/SupportFiles/HtmlReportUsersGuide.htm
+++ b/src/PerfView/SupportFiles/HtmlReportUsersGuide.htm
@@ -1,7 +1,22 @@
-﻿<html>
+﻿<!DOCTYPE html>
+<html lang="en">
 <head>
-    <title>Understand Perf Reports</title>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Understand Perf Reports</title>
+    <style>
+        body {
+            font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
+            font-weight: 400;
+            text-rendering: optimizeLegibility;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        hr {
+            border-top: 3px double gray;
+        }
+    </style>
 </head>
 <body lang="en-us">
     <hr />

--- a/src/PerfView/SupportFiles/PerfViewWebVideos.htm
+++ b/src/PerfView/SupportFiles/PerfViewWebVideos.htm
@@ -1,10 +1,20 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <title></title>
-    <style type="text/css">
-        .style1 {
-            font-weight: normal;
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>PerfView Videos</title>
+    <style>
+        body {
+            font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
+            font-weight: 400;
+            text-rendering: optimizeLegibility;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        hr {
+            border-top: 3px double gray;
         }
     </style>
 </head>
@@ -61,9 +71,8 @@
 
     <h3>CPU Investigations.&nbsp; </h3>
     <p>
-        <span class="style1">
-            The most common kind of Time investigation is investigating
-            high CPU usage
+        <span>
+            The most common kind of Time investigation is investigating high CPU usage
         </span>
     </p>
     <ol>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -1,7 +1,22 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>PerfView User's Guide</title>
+    <style>
+        body {
+            font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
+            font-weight: 400;
+            text-rendering: optimizeLegibility;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        hr {
+            border-top: 3px double gray;
+        }
+    </style>
 </head>
 <body>
     <!--  ************************************************************************************* -->
@@ -155,8 +170,7 @@
         <a id="LatestVersion">Getting the latest version of PerfView</a>
     </h3>
     <p>
-        You can get the latest version of PerfView by going to the <a href="http://www.microsoft.com/download">Microsoft Download Center</a>
-        and using the search textbox to search for 'PerfView
+        You can get the latest version of PerfView by going to the <a href="https://github.com/Microsoft/perfview/blob/master/documentation/Downloading.md">PerfView GitHub Download Page</a>
     </p>
     <hr />
     <hr />

--- a/src/TraceParserGen/UsersGuide.htm
+++ b/src/TraceParserGen/UsersGuide.htm
@@ -1,6 +1,22 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>TraceParserGen Users Guide</title>
+    <style>
+        body {
+            font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
+            font-weight: 400;
+            text-rendering: optimizeLegibility;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        hr {
+            border-top: 3px double gray;
+        }
+    </style>
 </head>
 <body>
     <h2> TraceParserGen Users' Guide </h2>

--- a/src/related/EventRegister/UsersGuide.htm
+++ b/src/related/EventRegister/UsersGuide.htm
@@ -1,6 +1,22 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>EventRegister Users Guide</title>
+    <style>
+        body {
+            font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
+            font-weight: 400;
+            text-rendering: optimizeLegibility;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        hr {
+            border-top: 3px double gray;
+        }
+    </style>
 </head>
 <body>
     <h2>


### PR DESCRIPTION
- Serif font makes it hard to read and make the docs _less approachable_. Updated all .htm files to use sans-serif font family (actually copied from docs.microsoft.com).
- style for `hr` tag modified to double lines
- PerfView download link updated on UserGuide.htm