### PR TITLE
Fix Caching Issues in TraceCodeAddresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ src/TraceEvent/EventCounterHandler.cs
 OSExtensions.cs
 password.txt
 documentation/internal/
+*.userosscache

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -7572,9 +7572,15 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
     public sealed class TraceCodeAddresses : IFastSerializable, IEnumerable<TraceCodeAddress>
     {
         /// <summary>
+        /// Chunk size for <see cref="codeAddressObjects"/>
+        /// </summary>
+        private const int ChunkSize = 4096;
+
+        /// <summary>
         /// Returns the count of code address indexes (all code address indexes are strictly less than this).   
         /// </summary>
         public int Count { get { return codeAddresses.Count; } }
+
         /// <summary>
         /// Given a code address index, return the name associated with it (the method name).  It will
         /// have the form MODULE!METHODNAME.   If the module name is unknown a ? is used, and if the
@@ -7587,7 +7593,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 names = new string[Count];
             }
 
-            string name = names[(int)codeAddressIndex];
+            string name = this.names[(int)codeAddressIndex];
+
             if (name == null)
             {
                 string moduleName = "?";
@@ -7608,8 +7615,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     methodName = "0x" + ((ulong)Address(codeAddressIndex)).ToString("x");
                 }
 
-                name = moduleName + "!" + methodName;
+                this.names[(int)codeAddressIndex] = name = moduleName + "!" + methodName;
             }
+
             return name;
         }
         /// <summary>
@@ -7654,6 +7662,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             return ilMap.GetILOffsetForNativeAddress(Address(codeAddressIndex));
         }
+
         /// <summary>
         /// Given a code address index, returns a TraceCodeAddress for it.
         /// </summary>
@@ -7661,22 +7670,38 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             get
             {
-                if (codeAddressObjects == null || (int)codeAddressIndex >= codeAddressObjects.Length)
-                {
-                    codeAddressObjects = new TraceCodeAddress[(int)codeAddressIndex + 16];
-                }
-
                 if (codeAddressIndex == CodeAddressIndex.Invalid)
                 {
                     return null;
                 }
 
-                TraceCodeAddress ret = codeAddressObjects[(int)codeAddressIndex];
+                int chunk = (int)codeAddressIndex / ChunkSize;
+                int offset = (int)codeAddressIndex % ChunkSize;
+
+                if (this.codeAddressObjects == null)
+                {
+                    this.codeAddressObjects = new TraceCodeAddress[chunk + 1][];
+                }
+                else if (chunk >= this.codeAddressObjects.Length)
+                {
+                    Array.Resize(ref this.codeAddressObjects, Math.Max(this.codeAddressObjects.Length * 2, chunk + 1));
+                }
+
+                TraceCodeAddress[] data = this.codeAddressObjects[chunk];
+
+                if (data == null)
+                {
+                    data = this.codeAddressObjects[chunk] = new TraceCodeAddress[ChunkSize];
+                }
+
+                TraceCodeAddress ret = data[offset];
+
                 if (ret == null)
                 {
                     ret = new TraceCodeAddress(this, codeAddressIndex);
-                    codeAddressObjects[(int)codeAddressIndex] = ret;
+                    data[offset] = ret;
                 }
+
                 return ret;
             }
         }
@@ -8999,7 +9024,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         private GrowableArray<ILToNativeMap> ILToNativeMaps;                    // only Jitted code has these, indexed by ILMapIndex 
         private Dictionary<long, ILMapIndex> methodIDToILToNativeMap;
 
-        private TraceCodeAddress[] codeAddressObjects;  // If we were asked for TraceCodeAddresses (instead of indexes) we cache them
+        private TraceCodeAddress[][] codeAddressObjects;  // If we were asked for TraceCodeAddresses (instead of indexes) we cache them, in sparse array
         private string[] names;                         // A cache (one per code address) of the string name of the address
         private int managedMethodRecordCount;           // Remembers how many code addresses are managed methods (currently not serialized)
         internal int totalCodeAddresses;                 // Count of the number of times a code address appears in the log.

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -7588,9 +7588,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </summary>
         public string Name(CodeAddressIndex codeAddressIndex)
         {
-            if (names == null)
+            if (this.names == null)
             {
-                names = new string[Count];
+                this.names = new string[Count];
             }
 
             string name = this.names[(int)codeAddressIndex];


### PR DESCRIPTION
There are two issues with TraceCodeAddresses: 

1) resizing for codeAddressObjects uses linear growth (+ 16) leading to lots of LOH allocations, This is O(N^2) algorithm. Replacing with sparse array.

2) In Name(CodeAddressIndex), there is a cache stored in string array, but no string is ever stored back, causing lots of duplicating string generation. Add write back.