### PR TITLE
Replace bool[] sampleSet with HashSet<int>

### DIFF
--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -1245,15 +1245,10 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             var asAgg = this as AggregateCallTreeNode;
             var dir = IsCalleeTree ? RefDirection.From : RefDirection.To;
 
-            bool[] sampleSet = new bool[128];
+            HashSet<int> sampleSet = new HashSet<int>();
             GetSamples(true, delegate (StackSourceSampleIndex sampleIndex)
             {
-                while (sampleSet.Length <= (int)sampleIndex)
-                {
-                    Array.Resize(ref sampleSet, sampleSet.Length * 2);
-                }
-
-                sampleSet[(int)sampleIndex] = true;
+                sampleSet.Add((int)sampleIndex);
                 return true;
             });
 
@@ -1283,7 +1278,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 source.GetReferences(sampleIndex, dir, delegate (StackSourceSampleIndex childIndex)
                 {
                     // Ignore samples to myself.  
-                    if (childIndex < 0 || ((int)childIndex < sampleSet.Length && sampleSet[(int)childIndex]))
+                    if (childIndex < 0 || sampleSet.Contains((int)childIndex))
                     {
                         return;
                     }

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;                        // For TextWriter.  
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing.Utilities;
 
 namespace Microsoft.Diagnostics.Tracing.Stacks
 {
@@ -1245,10 +1246,12 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             var asAgg = this as AggregateCallTreeNode;
             var dir = IsCalleeTree ? RefDirection.From : RefDirection.To;
 
-            HashSet<int> sampleSet = new HashSet<int>();
+            IndexSet sampleSet = new IndexSet();
+
             GetSamples(true, delegate (StackSourceSampleIndex sampleIndex)
             {
-                sampleSet.Add((int)sampleIndex);
+                sampleSet.Add((uint)sampleIndex);
+
                 return true;
             });
 
@@ -1278,7 +1281,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 source.GetReferences(sampleIndex, dir, delegate (StackSourceSampleIndex childIndex)
                 {
                     // Ignore samples to myself.  
-                    if (childIndex < 0 || sampleSet.Contains((int)childIndex))
+                    if (childIndex < 0 || sampleSet.Contains((uint)childIndex))
                     {
                         return;
                     }

--- a/src/TraceEvent/TraceEvent.Tests/IndexSetTest.cs
+++ b/src/TraceEvent/TraceEvent.Tests/IndexSetTest.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using Microsoft.Diagnostics.Tracing.Utilities;
+
+namespace TraceEventTests
+{
+    public class IndexSetTest
+    {
+        [Fact]
+        public void BasicTest()
+        {
+            HashSet<uint> intSet = new HashSet<uint>();
+
+            IndexSet oddSet = new IndexSet();
+
+            int limit = 1024 * 1024;
+
+            Random random = new Random();
+
+            for (int i = 0; i < limit; i++)
+            {
+                int val = random.Next(limit);
+
+                if ((val % 2) == 0)
+                {
+                    val++;
+                }
+
+                intSet.Add((uint)val);
+                oddSet.Add((uint)val);
+            }
+
+            int error = 0;
+
+            for (int i = 0; i < limit; i+= 2)
+            {
+                if (oddSet.Contains((uint)i))
+                {
+                    error++;
+                }
+            }
+
+            Assert.True(error == 0);
+
+            foreach (uint v in intSet)
+            {
+                if (!oddSet.Contains(v))
+                {
+                    error++;
+                }
+            }
+
+            Assert.True(error == 0);
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/IndexSetTest.cs
+++ b/src/TraceEvent/TraceEvent.Tests/IndexSetTest.cs
@@ -7,20 +7,28 @@ namespace TraceEventTests
 {
     public class IndexSetTest
     {
+        public const int Limit = 1000 * 1000;
+
         [Fact]
         public void BasicTest()
+        {
+            Test(0);
+            Test(1);
+            Test(1000);
+            Test(1000 * 1000);
+        }
+
+        private void Test(int count)
         {
             HashSet<uint> intSet = new HashSet<uint>();
 
             IndexSet oddSet = new IndexSet();
 
-            int limit = 1024 * 1024;
-
             Random random = new Random();
 
-            for (int i = 0; i < limit; i++)
+            for (int i = 0; i < count; i++)
             {
-                int val = random.Next(limit);
+                int val = random.Next(Limit);
 
                 if ((val % 2) == 0)
                 {
@@ -33,7 +41,7 @@ namespace TraceEventTests
 
             int error = 0;
 
-            for (int i = 0; i < limit; i+= 2)
+            for (int i = 0; i < Limit; i += 2)
             {
                 if (oddSet.Contains((uint)i))
                 {

--- a/src/TraceEvent/Utilities/IndexSet.cs
+++ b/src/TraceEvent/Utilities/IndexSet.cs
@@ -1,0 +1,144 @@
+﻿//     Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Tracing.Utilities
+{
+    /// <summary>
+    /// Set of unsigned integers, memory optimized for set of indices
+    /// </summary>
+    /// <remarks>This class is designed for set of integer indices of wide range, for example up to 100 million, both for small and large sets.</remarks>
+    /// When there are zeor or single item, data is stored in count + singleValue.
+    /// When there are small number of items, data is stored in <see cref="HashSet{int}"/>, 16 bytes per item.
+    /// When there are lots of items, data is stored in bitset, maxValue / 8 bytes needed.
+    public class IndexSet
+    {
+        /// <summary>
+        /// Single or max value, when bitset is not in use.
+        /// </summary>
+        private uint maxValue;
+
+        /// <summary>
+        /// Hashset
+        /// </summary>
+        private HashSet<uint> hashset;
+
+        /// <summary>
+        /// Bit set
+        /// </summary>
+        private byte[] bitSet;
+
+        /// <summary>
+        /// integer count, when bitset is not in use.
+        /// </summary>
+        private int count;
+
+        /// <summary>
+        /// Add an integer
+        /// </summary>
+        /// <param name="value">Integer to add</param>
+        public void Add(uint value)
+        {
+            if (this.count == 0)
+            {
+                this.maxValue = value;
+                this.count = 1;
+            }
+            else if (this.bitSet  != null)
+            {
+                uint index = value / 8;
+
+                int len = this.bitSet.Length;
+
+                if (index >= len)
+                {
+                    while (value >= len * 8)
+                    {
+                        len *= 2;
+                    }
+
+                    Array.Resize(ref this.bitSet, len);
+                }
+
+                this.bitSet[index] |= (byte)(1 << (int)(value % 8));
+            }
+            else
+            {
+                if (this.count == 1)
+                {
+                    this.hashset = new HashSet<uint>();
+
+                    this.hashset.Add(this.maxValue);
+                }
+
+                if (this.hashset.Add(value))
+                {
+                    this.count++;
+                }
+
+                if (value > this.maxValue)
+                {
+                    this.maxValue = value;
+                }
+
+                // Check for conversion to bit set every 2048 elements
+                if (((this.count % 2048) == 2047) && ((this.count * (16 * 8)) >= this.maxValue))
+                {
+                    this.ConvertoBitSet();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check if the value is in the set
+        /// </summary>
+        /// <param name="value">Integer to check</param>
+        /// <returns>True if in the set</returns>
+        public bool Contains(uint value)
+        {
+            if (this.count == 0)
+            {
+                return false;
+            }
+            else if (this.count == 1)
+            {
+                return this.maxValue == value;
+            }
+            else if (this.bitSet != null)
+            {
+                uint index = value / 8;
+
+                if (index < this.bitSet.Length)
+                {
+                    return (this.bitSet[index] & ((1 << (int)(value % 8)))) != 0;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return this.hashset.Contains(value);
+            }
+        }
+
+        /// <summary>
+        /// Convert to bitset
+        /// </summary>
+        private void ConvertoBitSet()
+        {
+            uint len = (this.maxValue + 7) / 8;
+
+            this.bitSet = new byte[len];
+
+            foreach (uint v in this.hashset)
+            {
+                this.bitSet[v / 8] |= (byte)((1 << (int)(v % 8)));
+            }
+
+            this.hashset = null;
+        }
+    }
+}


### PR DESCRIPTION
Found while analyzing a .gcDump, there are 858 bool[] arrays in LOH, largest are 4 mb each, taking total 950 mb of space, almost empty, mostly not rooted. Replace with HashSet<int>. Managed heap much smaller afterwards.