### PR TITLE
Avoid ArgumentNullException when HeapDump encounters a type with no name

### DIFF
--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -2501,7 +2501,7 @@ public class GCHeapDumper
         }
         else
         {
-            ret = GetTypeIndexForName(name, type.Module.FileName, 0);
+            ret = GetTypeIndexForName(name ?? "<Unnamed "+ type.MetadataToken.ToString("x8") + ">", type.Module.FileName, 0);
             m_typeIdxToGraphIdx[idx] = (int)ret + 1;
         }
         return ret;


### PR DESCRIPTION
I encountered ArgumentNullException when running HeapDump on a snapshot memory dump of a 64-bit ASP.NET Core application. There were some types with null names.
I think they came from dynamically generated types in a DI container.
This fixes the ArgumentNullException by generating names for them based on their metadata token.