### PR TITLE
Get Perfview.csproj building in VS2019 and F5

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -437,7 +437,7 @@
 
   <!-- Work around CoreCompile doesn't exist error -->
   <PropertyGroup>
-    <LanguageTargets>$(MSBuildExtensionsPath)\$(VisualStudioVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
+    <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
   </PropertyGroup>
 
   <!--

--- a/src/PerfView/Properties/launchSettings.json
+++ b/src/PerfView/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
     "PerfView": {
-      "executablePath": "$(OutDir)$(AssemblyName)$(TargetExt)"
+      "commandName": "Project"
     }
   }
 }


### PR DESCRIPTION
These changes find the correct MSBuildToolsPath to use in order to find the Microsoft.CSharp.Targets file with only VS2019 installed. 

Also has been validated to build and launch in VS2017by @mpeyrotc