### PR TITLE
Cleanup background bindings and more colors

### DIFF
--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -4,8 +4,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     xmlns:src="clr-namespace:PerfView"
     xmlns:src1="clr-namespace:PerfView"
-    xmlns:controls="clr-namespace:Controls" xmlns:drawing="clr-namespace:System.Drawing;assembly=System.Drawing"
-                Title="PerfView Stacks"
+    xmlns:controls="clr-namespace:Controls"
+    xmlns:drawing="clr-namespace:System.Drawing;assembly=System.Drawing"
+    Title="PerfView Stacks"
     Width="919" Height="605"
     >
     <Window.Resources>

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -4,8 +4,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     xmlns:src="clr-namespace:PerfView"
     xmlns:src1="clr-namespace:PerfView"
-    xmlns:controls="clr-namespace:Controls"
-    Title="PerfView Stacks"
+    xmlns:controls="clr-namespace:Controls" xmlns:drawing="clr-namespace:System.Drawing;assembly=System.Drawing"
+                Title="PerfView Stacks"
     Width="919" Height="605"
     >
     <Window.Resources>
@@ -86,9 +86,7 @@
             <CommandBinding Command="{x:Static src:StackWindow.ExpandCommand}" Executed="DoExpand" CanExecute="CanExpand"/>
             <CommandBinding Command="{x:Static src:StackWindow.CollapseCommand}" Executed="DoCollapse" CanExecute="CanExpand"/>
             <CommandBinding Command="{x:Static src:StackWindow.ExpandAllCommand}" Executed="DoExpandAll" CanExecute="CanExpand"/>
-            <CommandBinding Command="{x:Static src:StackWindow.SetBrownBackgroundColorCommand}" Executed="DoSetBrownBackgroundColor" CanExecute="CanSetBackgroundColor"/>
-            <CommandBinding Command="{x:Static src:StackWindow.SetBlueBackgroundColorCommand}" Executed="DoSetBlueBackgroundColor" CanExecute="CanSetBackgroundColor"/>
-            <CommandBinding Command="{x:Static src:StackWindow.SetRedBackgroundColorCommand}" Executed="DoSetRedBackgroundColor" CanExecute="CanSetBackgroundColor"/>
+            <CommandBinding Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" Executed="DoSetBackgroundColor" CanExecute="CanSetBackgroundColor"/>
             <CommandBinding Command="{x:Static src:StackWindow.FoldPercentCommand}" Executed="DoFoldPercent" />
             <CommandBinding Command="{x:Static src:StackWindow.IncreaseFoldPercentCommand}" Executed="DoIncreaseFoldPercent" />
             <CommandBinding Command="{x:Static src:StackWindow.DecreaseFoldPercentCommand}" Executed="DoDecreaseFoldPercent" />
@@ -163,9 +161,13 @@
                 <MenuItem Command="{x:Static src:StackWindow.ExpandCommand}" />
                 <MenuItem Command="{x:Static src:StackWindow.CollapseCommand}" />
                 <MenuItem Header="Set Background Color">
-                    <MenuItem Command="{x:Static src:StackWindow.SetBrownBackgroundColorCommand}" />
-                    <MenuItem Command="{x:Static src:StackWindow.SetBlueBackgroundColorCommand}" />
-                    <MenuItem Command="{x:Static src:StackWindow.SetRedBackgroundColorCommand}" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" CommandParameter="{x:Static drawing:Color.LightSkyBlue}" Header="Set Background Blue" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" CommandParameter="{x:Static drawing:Color.BurlyWood}" Header="Set Background Brown" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" CommandParameter="{x:Static drawing:Color.LightGreen}" Header="Set Background Green" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" CommandParameter="{x:Static drawing:Color.Gainsboro}" Header="Set Background Gray" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" CommandParameter="{x:Static drawing:Color.Lavender}" Header="Set Background Purple" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" CommandParameter="{x:Static drawing:Color.LightPink}" Header="Set Background Pink" />
+                    <MenuItem Command="{x:Static src:StackWindow.SetBackgroundColorCommand}" CommandParameter="{x:Static drawing:Color.Coral}" Header="Set Background Red" />
                 </MenuItem>
                 <Separator/>
                 <MenuItem Header="FilterParams">

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2660,23 +2660,9 @@ namespace PerfView
                            (CalleesTab.IsSelected && m_calleesView.SelectedNode != null);
         }
 
-        private void DoSetBrownBackgroundColor(object sender, ExecutedRoutedEventArgs e)
+        private void DoSetBackgroundColor(object sender, ExecutedRoutedEventArgs e)
         {
-            DoSetBackgroundColor(sender, e, System.Drawing.Color.BurlyWood);
-        }
-
-        private void DoSetBlueBackgroundColor(object sender, ExecutedRoutedEventArgs e)
-        {
-            DoSetBackgroundColor(sender, e, System.Drawing.Color.LightSkyBlue);
-        }
-
-        private void DoSetRedBackgroundColor(object sender, ExecutedRoutedEventArgs e)
-        {
-            DoSetBackgroundColor(sender, e, System.Drawing.Color.Coral);
-        }
-
-        private void DoSetBackgroundColor(object sender, ExecutedRoutedEventArgs e, System.Drawing.Color color)
-        {
+            System.Drawing.Color color = (System.Drawing.Color)e.Parameter;
             CallTreeViewNode selectedNode = null;
             CallTreeView view = null;
             if (CallTreeTab.IsSelected)
@@ -3261,9 +3247,7 @@ namespace PerfView
             new InputGestureCollection() { new KeyGesture(Key.Space) });
         public static RoutedUICommand CollapseCommand = new RoutedUICommand("Collapse", "Collapse", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.Space, ModifierKeys.Shift) });
-        public static RoutedUICommand SetBrownBackgroundColorCommand = new RoutedUICommand("Set Brown Background Color", "SetBrownBackgroundColor", typeof(StackWindow));
-        public static RoutedUICommand SetBlueBackgroundColorCommand = new RoutedUICommand("Set Blue Background Color", "SetBlueBackgroundColor", typeof(StackWindow));
-        public static RoutedUICommand SetRedBackgroundColorCommand = new RoutedUICommand("Set Red Background Color", "SetRedBackgroundColor", typeof(StackWindow));
+        public static RoutedUICommand SetBackgroundColorCommand = new RoutedUICommand("Set Background Color", "SetBackgroundColor", typeof(StackWindow));
         public static RoutedUICommand FoldPercentCommand = new RoutedUICommand("Fold %", "FoldPercent", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.F6) });
         public static RoutedUICommand IncreaseFoldPercentCommand = new RoutedUICommand("Increase Fold %", "Increase FoldPercent", typeof(StackWindow),


### PR DESCRIPTION
This PR cleans up how background colors are set with bindings and adds
purple, green, gray and pink.

This is the new UI update:
![image](https://user-images.githubusercontent.com/3953714/90079517-05a74780-dcbd-11ea-8a8e-6f77b7fde50a.png)

Here are all the colors:
![image](https://user-images.githubusercontent.com/3953714/90079546-135ccd00-dcbd-11ea-9fc7-7d235c1a7311.png)


@mpeyrotc 