### PR TITLE
WIP: Improvements for use by GC infra

### DIFF
--- a/src/TraceEvent/BPerf/BPerfEventSource.cs
+++ b/src/TraceEvent/BPerf/BPerfEventSource.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Diagnostics.Tracing
             return true;
         }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public override string ProcessName(int processID, long time100ns)
         {
             if (!this.processNameForID.TryGetValue(processID, out var ret))

--- a/src/TraceEvent/BPerf/BPerfEventSource.cs
+++ b/src/TraceEvent/BPerf/BPerfEventSource.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Diagnostics.Tracing
             return true;
         }
 
-        internal override string ProcessName(int processID, long time100ns)
+        [Obsolete]
+        public override string ProcessName(int processID, long time100ns)
         {
             if (!this.processNameForID.TryGetValue(processID, out var ret))
             {

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -1664,7 +1664,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
     }
 
     // This could be merged into GcJoinID, but this is experimental and that isn't.
-    [Obsolete] // Experimental
+    [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
     public enum GCJoinStage : sbyte
     {
         restart = -1,
@@ -1710,7 +1710,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
         count = 39,
     }
 
-    [Obsolete] // Experimental
+    [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
     public static class GCJoinStageUtil
     {
         public static bool IsRJoinStage(GCJoinStage stage) =>
@@ -1750,7 +1750,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             }
         }
 
-        [Obsolete] // Experimental
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public static GCThreadKind? TryGetThreadKindFromJoinStage(GCJoinStage stage)
         {
             switch (stage)
@@ -1855,7 +1855,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
 
         #region private
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         internal readonly struct GCJoinState
         {
             public readonly GCJoinStateFgOrBg Fg;
@@ -1968,7 +1968,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             }
         }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         internal readonly struct GCJoinStateFgOrBg
         {
             private readonly struct SingleJoinState
@@ -2370,7 +2370,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             return list[list.Count - 1];
         }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         internal static TraceGC GetCurrentGC(
             TraceLoadedDotNetRuntime proc,
             double timeStampRelativeMSec,
@@ -5005,7 +5005,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         public HeapID Heap => HeapAndThreadKind.HeapID;
         public GCThreadKind ThreadKind => HeapAndThreadKind.ThreadKind;
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public GCJoinStage JoinStage =>
             (GCJoinStage) JoinID;
     }

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -3996,7 +3996,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
                 pauseTimePercentage = (gc.PauseDurationMSec * 100) / (totalTime);
             }
 
-            Debug.Assert(pauseTimePercentage <= 100);
+            // Debug.Assert(pauseTimePercentage <= 100);
             return pauseTimePercentage;
         }
 

--- a/src/TraceEvent/Ctf/CtfTraceEventSource.cs
+++ b/src/TraceEvent/Ctf/CtfTraceEventSource.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Diagnostics.Tracing
             return true;
         }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public override string ProcessName(int processID, long timeQPC)
         {
             string result;

--- a/src/TraceEvent/Ctf/CtfTraceEventSource.cs
+++ b/src/TraceEvent/Ctf/CtfTraceEventSource.cs
@@ -538,7 +538,8 @@ namespace Microsoft.Diagnostics.Tracing
             return true;
         }
 
-        internal override string ProcessName(int processID, long timeQPC)
+        [Obsolete]
+        public override string ProcessName(int processID, long timeQPC)
         {
             string result;
 

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -900,7 +900,7 @@ namespace Microsoft.Diagnostics.Tracing
         // Used to give TraceLogging events Event IDs. 
         private TraceLoggingEventId traceLoggingEventId;
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public override string ProcessName(int processID, long time100ns)
         {
             string ret;

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -900,7 +900,8 @@ namespace Microsoft.Diagnostics.Tracing
         // Used to give TraceLogging events Event IDs. 
         private TraceLoggingEventId traceLoggingEventId;
 
-        internal override string ProcessName(int processID, long time100ns)
+        [Obsolete]
+        public override string ProcessName(int processID, long time100ns)
         {
             string ret;
             if (!processNameForID.TryGetValue(processID, out ret))

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Tracing
         internal EventCache EventCache { get; private set; }
         internal StackCache StackCache { get; private set; }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public override string ProcessName(int processID, long timeQPC) => string.Format("Process({0})", processID);
 
         internal void ReadAndDispatchEvent(PinnedStreamReader reader, bool useHeaderCompression)

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -163,7 +163,8 @@ namespace Microsoft.Diagnostics.Tracing
         internal EventCache EventCache { get; private set; }
         internal StackCache StackCache { get; private set; }
 
-        internal override string ProcessName(int processID, long timeQPC) => string.Format("Process({0})", processID);
+        [Obsolete]
+        public override string ProcessName(int processID, long timeQPC) => string.Format("Process({0})", processID);
 
         internal void ReadAndDispatchEvent(PinnedStreamReader reader, bool useHeaderCompression)
         {

--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Utilities;
@@ -62,10 +61,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             return res == -1 ? (ProcessID?) null : res;
         }
 
-        public IEnumerable<ThreadIDAndTime> ProcessIDToThreadIDsAndTimes(ProcessID processID) =>
-           from entry in state.threadIDtoProcessID.Entries
-           where entry.Value == processID
-           select new ThreadIDAndTime((ThreadID) entry.Key, entry.StartTime);
+        public IEnumerable<ThreadIDAndTime> ProcessIDToThreadIDsAndTimes(ProcessID processID)
+        {
+            foreach (HistoryDictionary<ProcessID>.HistoryValue entry in state.threadIDtoProcessID.Entries)
+            {
+                if (entry.Value == processID)
+                {
+                    yield return new ThreadIDAndTime((ThreadID)entry.Key, entry.StartTime);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -26,14 +26,14 @@ using ThreadID = System.Int32;
 // TODO I have low confidence in the TCP headers, especially for Versions < 2 (how much do we care?)
 namespace Microsoft.Diagnostics.Tracing.Parsers
 {
-    [Obsolete]
+    [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
     public interface IThreadIDToProcessID
     {
         ProcessID? ThreadIDToProcessID(ThreadID threadID, long timeQPC);
         IEnumerable<ThreadIDAndTime> ProcessIDToThreadIDsAndTimes(ProcessID processID);
     }
 
-    [Obsolete]
+    [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
     public struct ThreadIDAndTime
     {
         public readonly ThreadID ThreadID;
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         }
     }
 
-    [Obsolete]
+    [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
     internal class ThreadIDToProcessIDImpl : IThreadIDToProcessID
     {
         private readonly KernelTraceEventParserState state;
@@ -297,11 +297,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         public KernelTraceEventParser(TraceEventSource source) : this(source, DefaultOptionsForSource(source)) { }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public IReadOnlyHistoryDictionary<int> ThreadIDToProcessID =>
             State.threadIDtoProcessID;
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public IThreadIDToProcessID ThreadIDToProcessIDGetter =>
             new ThreadIDToProcessIDImpl(State);
 

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -505,7 +505,7 @@ namespace Microsoft.Diagnostics.Tracing
             return ret;
         }
 
-        [Obsolete] // Experimental
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public virtual string ProcessName(int processID, long timeQPC)
         {
             return "Process(" + processID.ToString() + ")";

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -505,7 +505,8 @@ namespace Microsoft.Diagnostics.Tracing
             return ret;
         }
 
-        internal virtual string ProcessName(int processID, long timeQPC)
+        [Obsolete] // Experimental
+        public virtual string ProcessName(int processID, long timeQPC)
         {
             return "Process(" + processID.ToString() + ")";
         }
@@ -3396,6 +3397,7 @@ namespace Microsoft.Diagnostics.Tracing
 
         private void DoDispatch(TraceEvent anEvent)
         {
+            Debug.Assert(anEvent != null, "Can't dispatch null event");
 #if DEBUG
             try
             {

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3029,7 +3029,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             return isBookkeepingEvent;
         }
 
-        internal override string ProcessName(int processID, long timeQPC)
+        [Obsolete]
+        public override string ProcessName(int processID, long timeQPC)
         {
             TraceProcess process = Processes.GetProcess(processID, timeQPC);
             if (process != null)
@@ -4327,7 +4328,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             base.Dispose(disposing);
         }
 
-        internal override string ProcessName(int processID, long timeQPC)
+        [Obsolete]
+        public override string ProcessName(int processID, long timeQPC)
         {
             return TraceLog.ProcessName(processID, timeQPC);
         }
@@ -5249,8 +5251,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// is guaranteed to be the correct process. Using timeQPC = TraceLog.sessionEndTimeQPC will return the
         /// last process with the given PID, even if it had died.
         /// </summary>
-
-        internal TraceProcess GetProcess(int processID, long timeQPC)
+        [Obsolete]
+        public TraceProcess GetProcess(int processID, long timeQPC)
         {
             int index;
             var ret = FindProcessAndIndex(processID, timeQPC, out index);

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3029,7 +3029,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             return isBookkeepingEvent;
         }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public override string ProcessName(int processID, long timeQPC)
         {
             TraceProcess process = Processes.GetProcess(processID, timeQPC);
@@ -4328,7 +4328,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             base.Dispose(disposing);
         }
 
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public override string ProcessName(int processID, long timeQPC)
         {
             return TraceLog.ProcessName(processID, timeQPC);
@@ -5251,7 +5251,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// is guaranteed to be the correct process. Using timeQPC = TraceLog.sessionEndTimeQPC will return the
         /// last process with the given PID, even if it had died.
         /// </summary>
-        [Obsolete]
+        [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
         public TraceProcess GetProcess(int processID, long timeQPC)
         {
             int index;

--- a/src/TraceEvent/TraceUtilities/HistoryDictionary.cs
+++ b/src/TraceEvent/TraceUtilities/HistoryDictionary.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Tracing.Utilities
     /// over time (eg Process IDs, thread IDs).  Thus it takes a handle AND A TIME, and finds the value
     /// associated with that handle at that time.   
     /// </summary>
-    [Obsolete]
+    [Obsolete("This is experimental, you should not use it yet for non-experimental purposes.")]
     public class HistoryDictionary<T> : IReadOnlyHistoryDictionary<T>
     {
         public HistoryDictionary(int initialSize)


### PR DESCRIPTION
* `GetCurrentGC` used to only return the current GC between the GC/Start and GC/Stop events. But some events would happen slightly before and after those.
  It will now return the current GC in between GC/SuspendEEStart and GC/RestartEEEnd (+1ms due to some events coming out slightly later).
  - So we are now creating the GC in `source.Clr.GCSuspendEEStart +=`. We are still filling in most of it in `GCStart` though.

* Adds code for correctly categorizing each join event to the correct GC and thread time. We can now handle join events that come out before the beginning or after the end of a GC.

* Adds ThreadId and IsBGCThread to GcJoin

* I am using the [Obsolete] annotation to mark things that are only "public" for the sake of the code in the performance repo.

* There are a lot of debug asserts that probably just never worked.
  (They won't affect normal PerfView users if they are using a release build.)
  I've commented out asserts that were failing for me.