### PR TITLE
Improve handling of OutOfMemoryException

### DIFF
--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1461,7 +1461,7 @@ public class GCHeapDumper
             var rootDuration = m_sw.Elapsed.TotalMilliseconds - rootsStartTimeMSec;
             m_log.WriteLine("Scanning UNNAMED GC roots took {0:n1} msec", rootDuration);
         }
-        catch (Exception e)
+        catch (Exception e) when (!(e is OutOfMemoryException))
         {
             m_log.WriteLine("[ERROR while processing roots: {0}", e.Message);
             m_log.WriteLine("Continuing without complete root information");

--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -262,7 +262,7 @@ internal class Program
             }
             else
             {
-                Console.WriteLine("HeapDump Error: {0}", e.ToString());
+                Console.WriteLine("HeapDump Error ({0}): {1}", e.HResult, e.ToString());
             }
 
             if (outputFile != null)


### PR DESCRIPTION
* Don't continue without roots on OutOfMemoryException
* Treat ERROR_NOT_ENOUGH_MEMORY as OutOfMemoryException