### PR TITLE
Allows opt out nested activity id reducing

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.49</PerfViewVersion>
-    <TraceEventVersion>2.0.49</TraceEventVersion>
+    <PerfViewVersion>2.0.48</PerfViewVersion>
+    <TraceEventVersion>2.0.48</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.48</PerfViewVersion>
-    <TraceEventVersion>2.0.48</TraceEventVersion>
+    <PerfViewVersion>2.0.49</PerfViewVersion>
+    <TraceEventVersion>2.0.49</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
@@ -49,6 +49,12 @@ namespace Microsoft.Diagnostics.Tracing
         public bool GroupByStartStopActivity;
 
         /// <summary>
+        /// Reduce nested application insights requests by using related activity id.
+        /// </summary>
+        /// <value></value>
+        public bool ReduceNestedApplicationInsightsRequests { get; set; } = true;
+
+        /// <summary>
         /// Generate the thread time stacks, outputting to 'stackSource'.  
         /// </summary>
         /// <param name="outputStackSource"></param>
@@ -104,7 +110,7 @@ namespace Microsoft.Diagnostics.Tracing
 
             if (GroupByStartStopActivity)
             {
-                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer);
+                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer, ReduceNestedApplicationInsightsRequests);
 
                 // Maps thread Indexes to the start-stop activity that they are executing.  
                 m_threadToStartStopActivity = new StartStopActivity[m_eventLog.Threads.Count];

--- a/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/SampleProfilerThreadTimeComputer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// Reduce nested application insights requests by using related activity id.
         /// </summary>
         /// <value></value>
-        public bool ReduceNestedApplicationInsightsRequests { get; set; } = true;
+        public bool IgnoreApplicationInsightsRequestsWithRelatedActivityId  { get; set; } = true;
 
         /// <summary>
         /// Generate the thread time stacks, outputting to 'stackSource'.  
@@ -110,7 +110,7 @@ namespace Microsoft.Diagnostics.Tracing
 
             if (GroupByStartStopActivity)
             {
-                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer, ReduceNestedApplicationInsightsRequests);
+                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer, IgnoreApplicationInsightsRequestsWithRelatedActivityId);
 
                 // Maps thread Indexes to the start-stop activity that they are executing.  
                 m_threadToStartStopActivity = new StartStopActivity[m_eventLog.Threads.Count];

--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -32,8 +32,9 @@ namespace Microsoft.Diagnostics.Tracing
         /// <summary>
         /// Create a new ServerRequest Computer.
         /// </summary>
-        public StartStopActivityComputer(TraceLogEventSource source, ActivityComputer taskComputer)
+        public StartStopActivityComputer(TraceLogEventSource source, ActivityComputer taskComputer, bool ignoreApplicationInsightsRequestsWithRelatedActivityId = true)
         {
+            m_ignoreApplicationInsightsRequestsWithRelatedActivityId = ignoreApplicationInsightsRequestsWithRelatedActivityId;
             taskComputer.NoCache = true;            // Can't cache start-stops (at the moment)
             m_source = source;
             m_activeStartStopActivities = new Dictionary<StartStopKey, StartStopActivity>();
@@ -708,7 +709,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 uint nibble = (uint)(*bytePtr >> 4);
                 bool secondNibble = false;              // are we reading the second nibble (low order bits) of the byte.
-                NextNibble:
+            NextNibble:
                 if (nibble == (uint)NumberListCodes.End)
                 {
                     break;
@@ -1141,7 +1142,7 @@ namespace Microsoft.Diagnostics.Tracing
                     // If we have a related activity ID, then this start event
                     // is already being tracked by an outer activity (e.g. an
                     // ASP.Net request). Do not process it.
-                    if (!IsTrivialActivityId(data.RelatedActivityID))
+                    if (!IsTrivialActivityId(data.RelatedActivityID) && m_ignoreApplicationInsightsRequestsWithRelatedActivityId)
                     {
                         return;
                     }
@@ -1366,6 +1367,7 @@ namespace Microsoft.Diagnostics.Tracing
         private Dictionary<StartStopKey, StartStopActivity> m_activeStartStopActivities;     // Lookup activities by activityID&ProcessID (we call the start-stop key) at the current time
         private int m_nextIndex;                                                             // Used to create unique indexes for StartStopActivity.Index.  
         private StartStopActivity m_deferredStop;                                            // We defer doing the stop action until the next event.  This is what remembers to do this.  
+        private bool m_ignoreApplicationInsightsRequestsWithRelatedActivityId;               // Until .NET Core 3.0, Application Insights events uses this activity id to de-dupe the rest of the nested activities.
         #endregion
     }
 

--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -709,7 +709,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 uint nibble = (uint)(*bytePtr >> 4);
                 bool secondNibble = false;              // are we reading the second nibble (low order bits) of the byte.
-            NextNibble:
+                NextNibble:
                 if (nibble == (uint)NumberListCodes.End)
                 {
                     break;

--- a/src/TraceEvent/Computers/ThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/ThreadTimeComputer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// Reduce nested application insights requests by using related activity id.
         /// </summary>
         /// <value></value>
-        public bool ReduceNestedApplicationInsightsRequests { get; set; } = true;
+        public bool IgnoreApplicationInsightsRequestsWithRelatedActivityId  { get; set; } = true;
 
         /// <summary>
         /// Don't show AwaitTime.  For CPU only traces showing await time is misleading since
@@ -178,7 +178,7 @@ namespace Microsoft.Diagnostics.Tracing
 
             if (GroupByStartStopActivity)
             {
-                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer, ReduceNestedApplicationInsightsRequests);
+                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer, IgnoreApplicationInsightsRequestsWithRelatedActivityId);
 
                 // Maps thread Indexes to the start-stop activity that they are executing.  
                 m_threadToStartStopActivity = new StartStopActivity[m_eventLog.Threads.Count];

--- a/src/TraceEvent/Computers/ThreadTimeComputer.cs
+++ b/src/TraceEvent/Computers/ThreadTimeComputer.cs
@@ -82,6 +82,13 @@ namespace Microsoft.Diagnostics.Tracing
         /// LIke the GroupByAspNetRequest but use start-stop activities instead of ASP.NET Requests as the grouping construct. 
         /// </summary>
         public bool GroupByStartStopActivity;
+
+        /// <summary>
+        /// Reduce nested application insights requests by using related activity id.
+        /// </summary>
+        /// <value></value>
+        public bool ReduceNestedApplicationInsightsRequests { get; set; } = true;
+
         /// <summary>
         /// Don't show AwaitTime.  For CPU only traces showing await time is misleading since
         /// blocked time will not show up.  
@@ -171,7 +178,7 @@ namespace Microsoft.Diagnostics.Tracing
 
             if (GroupByStartStopActivity)
             {
-                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer);
+                m_startStopActivities = new StartStopActivityComputer(eventSource, m_activityComputer, ReduceNestedApplicationInsightsRequests);
 
                 // Maps thread Indexes to the start-stop activity that they are executing.  
                 m_threadToStartStopActivity = new StartStopActivity[m_eventLog.Threads.Count];


### PR DESCRIPTION
For .NET Core 3.0 trace analysis, we need to have an option to disable application insights activity id filter.