### PR TITLE
Fix small typo in CircularMB docs about how many etl files there are.

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -3913,7 +3913,7 @@
             mode, the file size is limited (to the specified number of megabyte), and when the
             limit is reached the oldest data is overwritten.&nbsp;&nbsp; This keeps file size
             under control.&nbsp; The number in this text box is the file size limit.&nbsp; Note
-            that because the ETW system collects up to etl files (one for kernel events one
+            that because the ETW system collects up to 3 etl files (one for kernel events, one
             for non-kernel, and one for &#39;rundown&#39; events), the file sizes can be bigger
             than this number but it should not be bigger than a factor of 2.   This text box
             corresponds to the /CircularMB=XXX command line parameter.


### PR DESCRIPTION
I believe 3 is what the docs were going for.