### PR TITLE
Fix unaligned memory access errors in TraceEvent

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -254,6 +254,13 @@
       <Link>System.Reflection.Metadata.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Runtime.CompilerServices.Unsafe.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\System.Runtime.CompilerServices.Unsafe.dll</LogicalName>
+      <Link>System.Runtime.CompilerServices.Unsafe.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\TraceEvent\$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.xml">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -4368,19 +4368,21 @@ namespace Microsoft.Diagnostics.Tracing
         }
         internal static unsafe double ReadDouble(IntPtr pointer, int offset)
         {
-            return *((double*)((byte*)pointer.ToPointer() + offset));
+            var val = Marshal.ReadInt64(pointer, offset);
+            return *(double*)&val;
         }
         internal static unsafe float ReadSingle(IntPtr pointer, int offset)
         {
-            return *((float*)((byte*)pointer.ToPointer() + offset));
+            var val = Marshal.ReadInt32(pointer, offset);
+            return *(float*)&val;
         }
-        internal static unsafe long ReadInt64(IntPtr pointer, int offset)
+        internal static long ReadInt64(IntPtr pointer, int offset)
         {
-            return *((long*)((byte*)pointer.ToPointer() + offset));
+            return Marshal.ReadInt64(pointer, offset);
         }
-        internal static unsafe int ReadInt32(IntPtr pointer, int offset)
+        internal static int ReadInt32(IntPtr pointer, int offset)
         {
-            return *((int*)((byte*)pointer.ToPointer() + offset));
+            return Marshal.ReadInt32(pointer, offset);
         }
         internal static unsafe short ReadInt16(IntPtr pointer, int offset)
         {

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -15,6 +15,7 @@ using System.Dynamic;
 #endif
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Address = System.UInt64;
@@ -4368,21 +4369,19 @@ namespace Microsoft.Diagnostics.Tracing
         }
         internal static unsafe double ReadDouble(IntPtr pointer, int offset)
         {
-            var val = Marshal.ReadInt64(pointer, offset);
-            return *(double*)&val;
+            return Unsafe.ReadUnaligned<double>((byte*)pointer.ToPointer() + offset);
         }
         internal static unsafe float ReadSingle(IntPtr pointer, int offset)
         {
-            var val = Marshal.ReadInt32(pointer, offset);
-            return *(float*)&val;
+            return Unsafe.ReadUnaligned<float>((byte*)pointer.ToPointer() + offset);
         }
-        internal static long ReadInt64(IntPtr pointer, int offset)
+        internal static unsafe long ReadInt64(IntPtr pointer, int offset)
         {
-            return Marshal.ReadInt64(pointer, offset);
+            return Unsafe.ReadUnaligned<long>((byte*)pointer.ToPointer() + offset);
         }
-        internal static int ReadInt32(IntPtr pointer, int offset)
+        internal static unsafe int ReadInt32(IntPtr pointer, int offset)
         {
-            return Marshal.ReadInt32(pointer, offset);
+            return Unsafe.ReadUnaligned<int>((byte*)pointer.ToPointer() + offset);
         }
         internal static unsafe short ReadInt16(IntPtr pointer, int offset)
         {

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
 
   <!-- *** SourceLink Support *** -->
   <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />


### PR DESCRIPTION
This fixes unaligned read errors (SIGBUS) caused by unmanaged pointer operations on ARM platforms. The [`Marshal.Read*()`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.readint64?view=netcore-3.1) operations are portable and have little performance impacts.