### PR TITLE
Microsoft symbol server now defaults to SSL site.

### DIFF
--- a/src/TraceEvent/Symbols/SymbolPath.cs
+++ b/src/TraceEvent/Symbols/SymbolPath.cs
@@ -70,9 +70,9 @@ namespace Microsoft.Diagnostics.Symbols
                 if (s_MicrosoftSymbolServerPath == null)
                 {
                     s_MicrosoftSymbolServerPath = s_MicrosoftSymbolServerPath +
-                        ";" + @"SRV*http://msdl.microsoft.com/download/symbols" +     // Operatig system Symbols
+                        ";" + @"SRV*https://msdl.microsoft.com/download/symbols" +     // Operatig system Symbols
                         ";" + @"SRV*https://nuget.smbsrc.net" +                       // Nuget symbols
-                        ";" + @"SRV*http://referencesource.microsoft.com/symbols" +   // .NET Runtime desktop symbols 
+                        ";" + @"SRV*https://referencesource.microsoft.com/symbols" +   // .NET Runtime desktop symbols 
                         ";" + @"SRV*https://dotnet.myget.org/F/dotnet-core/symbols";  // Pre-release Nuget symbols.  
                 }
                 return s_MicrosoftSymbolServerPath;


### PR DESCRIPTION
Microsoft symbol server and reference sources' symbol server defaults to SSL site. #698