### PR TITLE
Add start/stop and kernel tracing to perfcollect

### DIFF
--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -1814,7 +1814,7 @@ DoCollect()
         # Pass trace directory and session name to the stop process.
         popd > /dev/null
         usePerf=0
-        declare -p | grep -e lttngTraceDir -e lttngSessionName -e tempDir -e usePerf -e useLttng > $collectInfoFile
+        declare -p | grep -e lttngTraceDir -e lttngSessionName -e tempDir -e usePerf -e useLttng -e logFile > $collectInfoFile
     else
         if [ "$usePerf" == "1" ]
         then
@@ -1944,7 +1944,10 @@ fi
 EnsurePrereqsInstalled
 
 # Initialize the log.
-InitializeLog
+if [ "$1" != "stop" ]
+then
+    InitializeLog
+fi
 
 # Process arguments.
 ProcessArguments $@

--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -15,13 +15,21 @@
 # How to collect a performance trace:
 # 1. Prior to starting the .NET process, set the environment variable COMPlus_PerfMapEnabled=1.
 #    This tells the runtime to emit information that enables perf_event to resolve JIT-compiled code symbols.
+# 
 # 2. Setup your system to reproduce the performance issue you'd like to capture.  Data collection can be
 #    started on already running processes.
-# 2. Run this script: sudo ./perfcollect collect samplePerfTrace
-#    This will start data collection.
-# 3. Let the repro run as long as you need to capture the performance problem.
-# 4. Hit CTRL+C to stop collection.
-#    When collection is stopped, the script will create a trace.zip file matching the name specified on the
+# 
+# 3. [Usage #1] use "collect" command
+#    - Run this script: sudo ./perfcollect collect samplePerfTrace. This will start data collection.
+#    - Let the repro run as long as you need to capture the performance problem.
+#    - Hit CTRL+C to stop collection.
+#
+#    [Usage #2] use "start" and "stop" command
+#    - Run this script: sudo ./perfcollect start samplePerfTrace. This will start data colletion.
+#    - Let the repro run as long as you need to capture the performance problem.
+#    - Run: sudo ./perfcollect stop samplePerfTrace. This will stop collection.
+#
+# 4. When collection is stopped, the script will create a trace.zip file matching the name specified on the
 #    command line.  This file will contain the trace, JIT-compiled symbol information, and all debugging
 #    symbols for binaries referenced by this trace that were available on the machine at collection time.
 #
@@ -1687,13 +1695,19 @@ PrintUsage()
     echo "For detailed collection and viewing steps, view this script in a text editor or viewer."
     echo ""
     echo "./perfcollect <action> <tracename>"
-    echo "Valid Actions: collect view livetrace install"
+    echo "Valid Actions: collect start/stop view livetrace install"
     echo ""
     echo "collect options:"
     echo "By default, collection includes CPU samples collected every ms."
     echo "    -pid          : Only collect data from the specified process id."
     echo "    -threadtime       : Collect context switch events."
     echo "  -hwevents         : Collect (some) hardware counters."
+    echo ""
+    echo "start:"
+    echo "    Start collection, but with Lttng trace ONLY. It needs to be used with 'stop' action."
+    echo ""
+    echo "stop:"
+    echo "    Stop collection if 'start' action is used."
     echo ""
     echo "view options:"
     echo "    -processfilter      : Filter data by the specified process name."

--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -655,16 +655,14 @@ LogAppend()
 
 RunSilent()
 {
-    #HACK 
-    echo $*
-    # if (( $logEnabled == 1 ))
-    # then
-    #     echo "Running \"$*\"" >> $logFile
-    #     $* >> $logFile 2>&1
-    #     echo "" >> $logFile
-    # else
-    #     $* > /dev/null 2>&1
-    # fi
+    if (( $logEnabled == 1 ))
+    then
+        echo "Running \"$*\"" >> $logFile
+        $* >> $logFile 2>&1
+        echo "" >> $logFile
+    else
+        $* > /dev/null 2>&1
+    fi
 }
 
 InitializeLog()
@@ -1140,7 +1138,6 @@ EnsurePrereqsInstalled()
 # Argument Processing
 ######################################
 action=''
-operation=''
 inputTraceName=''
 collectionPid=''
 processFilter=''
@@ -1177,19 +1174,10 @@ ProcessArguments()
     fi
 
     # Validate action name.
-    if [ "$action" != "collect" ] && [ "$action" != "view" ]
+    if [ "$action" != "collect" ] && [ "$action" != "view" ] \
+    && [ "$action" != "start" ] && [ "$action" != "stop" ]
     then
         FatalError "Invalid action specified."
-    fi
-
-    # Validate operation name.
-    if [ "$action" == "collect" ]
-    then
-        if [ "$2" == "start" ] || [ "$2" == "stop" ] 
-        then 
-            operation=$2
-            shift
-        fi
     fi
 
     # Set the data file.
@@ -1378,7 +1366,6 @@ StartLTTngCollection()
 StopLTTngCollection()
 {
     RunSilent "lttng stop $lttngSessionName"
-
     DestroyLTTngSession
 }
 
@@ -1666,7 +1653,7 @@ CTRLC_Handler()
 EndCollect()
 {
     # The user must either use "collect stop" or CTRL+C to stop collection.
-    if [ "$operation" == "stop" ]
+    if [ "$action" == "stop" ]
     then 
         # Recover trace info in the previous program.
         source $collectInfoFile  # TODO: exit and dispose upon missing file
@@ -1813,7 +1800,7 @@ DoCollect()
     if [ "$duration" != "" ]
     then
         WriteStatus "Collection started. Collection will automatically stop in $duration second(s).  Press CTRL+C to stop early."
-    elif [ "$operation" == "start" ]
+    elif [ "$action" == "start" ]
     then
         WriteStatus "Collection started."
     else
@@ -1821,35 +1808,39 @@ DoCollect()
     fi
 
     # Start perf record.
-    if [ "$usePerf" == "1" ]
-    then
-        RunSilent $perfcmd $collectionArgs
-    elif [ "$operation" == "start" ]
+    if [ "$action" == "start" ]
     then 
+        # Skip perf, which can only be stopped by CTRL+C.
         # Pass trace directory and session name to the stop process.
         popd > /dev/null
+        usePerf=0
         declare -p | grep -e lttngTraceDir -e lttngSessionName -e tempDir -e usePerf -e useLttng > $collectInfoFile
     else
-        # Wait here until CTRL+C handler gets called when user types CTRL+C.
-        LogAppend "Waiting for CTRL+C handler to get called."
+        if [ "$usePerf" == "1" ]
+        then
+            RunSilent $perfcmd $collectionArgs
+        else
+            # Wait here until CTRL+C handler gets called when user types CTRL+C.
+            LogAppend "Waiting for CTRL+C handler to get called."
 
-        waitTime=0
-        for (( ; ; ))
-        do
-            if [ "$handlerInvoked" == "1" ]
-            then
-                break;
-            fi
+            waitTime=0
+            for (( ; ; ))
+            do
+                if [ "$handlerInvoked" == "1" ]
+                then
+                    break;
+                fi
 
-            # Wait and then check to see if the handler has been invoked or we've crossed the duration threshold.
-            sleep 1
-            waitTime=$waitTime+1
-            if (( duration > 0 && duration <= waitTime ))
-            then
-                break;
-            fi
-        done
-        # End collection if no operation is set.
+                # Wait and then check to see if the handler has been invoked or we've crossed the duration threshold.
+                sleep 1
+                waitTime=$waitTime+1
+                if (( duration > 0 && duration <= waitTime ))
+                then
+                    break;
+                fi
+            done
+        fi
+        # End collection if action is 'collect'.
         EndCollect
     fi
 }
@@ -1959,15 +1950,12 @@ InitializeLog
 ProcessArguments $@
 
 # Take the appropriate action.
-if [ "$action" == "collect" ]
+if [ "$action" == "collect" ] || [ "$action" == "start" ]
 then
-    if [ "$operation" == "start" ] || [ -z "$operation" ]
-    then
-        DoCollect
-    elif [ "$operation" == "stop" ]
-    then
-        EndCollect
-    fi
+    DoCollect
+elif [ "$action" == "stop" ]
+then
+    EndCollect
 elif [ "$action" == "view" ]
 then
     DoView

--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -607,6 +607,11 @@ declare -a DotNETRuntimePrivate_DynamicTypeUsageKeyword=(
     DotNETRuntimePrivate:ObjectVariantMarshallingToManaged
 )
 
+declare -a Kernel_Default=(
+    sched_process_exec
+    sched_process_exit
+)
+
 ######################################
 ## Global Variables
 ######################################
@@ -633,6 +638,9 @@ handlerInvoked=0
 declare logFile
 logFilePrefix='/tmp/perfcollect'
 logEnabled=1
+
+# Collect info to pass between processes
+collectInfoFile='collectinfo'
 
 ######################################
 ## Logging Functions
@@ -1130,6 +1138,7 @@ EnsurePrereqsInstalled()
 # Argument Processing
 ######################################
 action=''
+operation=''
 inputTraceName=''
 collectionPid=''
 processFilter=''
@@ -1171,12 +1180,30 @@ ProcessArguments()
         FatalError "Invalid action specified."
     fi
 
+    # Validate operation name.
+    if [ "$action" == "collect" ]
+    then
+        if [ "$2" == "start" ] || [ "$2" == "stop" ] 
+        then 
+            operation=$2
+            shift
+        fi
+    fi
+
+    # echo "action: $action"
+    # echo "operation: $operation"
+
     # Set the data file.
     inputTraceName=$2
-    if [ "$inputTraceName" == "" ]
+    echo $inputTraceName
+    if [ "$inputTraceName" == "" ] 
     then
         FatalError "Invalid trace name specified."
     fi
+
+    args=( "$@" )
+    # echo inputTraceName: $inputTraceName
+    # exit
 
     # Process remaining arguments.
     # First copy the args into an array so that we can walk the array.
@@ -1234,6 +1261,9 @@ ProcessArguments()
         elif [ "-nolttng" == "$arg" ]
         then
             useLTTng=0
+        elif [ "-noperf" == "$arg" ]
+        then 
+            usePerf=0
         elif [ "-gccollectonly" == "$arg" ]
         then
             gcCollectOnly=1
@@ -1280,53 +1310,61 @@ CreateLTTngSession()
 
 SetupLTTngSession()
 {
-    # Setup per-event context information.
-    RunSilent "lttng add-context --userspace --type vpid"
-    RunSilent "lttng add-context --userspace --type vtid"
-    RunSilent "lttng add-context --userspace --type procname"
-
-    if [ "$action" == "livetrace" ]
+    # Setup kernel events. 
+    # TODO: enable triggers of different kernel events, instead of a default set of kernel events
+    if [ "$events" == "kernel" ]
     then
-        RunSilent "lttng enable-event --userspace --tracepoint DotNETRuntime:EventSource"
-    elif [ "$gcCollectOnly" == "1" ]
-    then
-        usePerf=0
-        EnableLTTngEvents ${DotNETRuntime_GCKeyword_GCCollectOnly[@]}
-        EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword_GCCollectOnly[@]}
-        EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
-    elif [ "$gcOnly" == "1" ]
-    then
-        usePerf=0
-        EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
-        EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword[@]}
-        EnableLTTngEvents ${DotNETRuntime_JitKeyword[@]}
-        EnableLTTngEvents ${DotNETRuntime_LoaderKeyword[@]}
-        EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
-    elif [ "$gcWithHeap" == "1" ]
-    then
-        usePerf=0
-        EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
-        EnableLTTngEvents ${DotNETRuntime_GCHeapSurvivalAndMovementKeyword[@]}
+        RunSilent "lttng add-context --kernel -t pid -t procname"
+        EnableLTTngKernelEvents ${Kernel_Default[@]}
     else
-        if [ "$events" == "" ]
+        # Setup per-event context information.
+        RunSilent "lttng add-context --userspace --type vpid"
+        RunSilent "lttng add-context --userspace --type vtid"
+        RunSilent "lttng add-context --userspace --type procname"
+
+        if [ "$action" == "livetrace" ]
         then
-            # Enable the default set of events.
-            EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword_ThreadTransferKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_NoKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_ContentionKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_JitKeyword_NGenKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_JitKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_LoaderKeyword[@]}
+            RunSilent "lttng enable-event --userspace --tracepoint DotNETRuntime:EventSource"
+        elif [ "$gcCollectOnly" == "1" ]
+        then
+            usePerf=0
             EnableLTTngEvents ${DotNETRuntime_GCKeyword_GCCollectOnly[@]}
             EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword_GCCollectOnly[@]}
-            EnableLTTngEvents ${DotNETRuntimePrivate_BindingKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntimePrivate_MulticoreJitPrivateKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_CompilationKeyword[@]}
-        elif [ "$events" == "threading" ]
+            EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
+        elif [ "$gcOnly" == "1" ]
         then
-            EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
+            usePerf=0
+            EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_JitKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_LoaderKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
+        elif [ "$gcWithHeap" == "1" ]
+        then
+            usePerf=0
+            EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_GCHeapSurvivalAndMovementKeyword[@]}
+        else
+            if [ "$events" == "" ]
+            then
+                # Enable the default set of events.
+                EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword_ThreadTransferKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_NoKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_ContentionKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_JitKeyword_NGenKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_JitKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_LoaderKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_GCKeyword_GCCollectOnly[@]}
+                EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword_GCCollectOnly[@]}
+                EnableLTTngEvents ${DotNETRuntimePrivate_BindingKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntimePrivate_MulticoreJitPrivateKeyword[@]}
+                EnableLTTngEvents ${DotNETRuntime_CompilationKeyword[@]}
+            elif [ "$events" == "threading" ]
+            then
+                EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
+            fi
         fi
     fi
 }
@@ -1361,6 +1399,15 @@ EnableLTTngEvents()
     done
 }
 
+EnableLTTngKernelEvents()
+{
+    args=( "$@" )
+    for (( i=0; i<${#args[@]}; i++ ))
+    do 
+        RunSilent "lttng enable-event -s $lttngSessionName -k ${args[$i]}"
+    done
+}
+
 ##
 # Helper that processes collected data.
 # This helper is called when the CTRL+C signal is handled.
@@ -1373,7 +1420,6 @@ ProcessCollectedData()
     local directoryName=$traceName$traceSuffix
     mkdir $directoryName
 
-    # Save LTTng trace files.
     if [ "$useLTTng" == "1" ]
     then
         LogAppend "Saving LTTng trace files."
@@ -1581,7 +1627,7 @@ ProcessCollectedData()
     WriteStatus "Compressing trace files"
     
     # Move all collected files to the new directory.
-    RunSilent "mv * $directoryName"
+    RunSilent "mv -f * $directoryName"
 
     # Close the log - this stops all writing to the log, so that we can move it into the archive.
     CloseLog
@@ -1605,7 +1651,7 @@ ProcessCollectedData()
     WriteStatus "Cleaning up artifacts"
 
     # Delete the temp directory.
-    RunSilent "rm -rf $tempDir"
+    RunSilent "rm -rf $tempDir $collectInfoFile"
 
     WriteStatus "...FINISHED"
 
@@ -1625,6 +1671,15 @@ CTRLC_Handler()
 
 EndCollect()
 {
+    # The user must either use "collect stop" or CTRL+C to stop collection.
+    if [ "$operation" == "stop" ]
+    then 
+        # Recover trace info in the previous program.
+        source $collectInfoFile  # TODO: exit and dispose upon missing file
+        # New program started, so go back to the temp directory.
+        pushd $tempDir > /dev/null
+    fi
+
     if [ "$useLTTng" == "1" ]
     then
         StopLTTngCollection
@@ -1637,7 +1692,7 @@ EndCollect()
     WriteStatus "Starting post-processing.  This may take some time."
     WriteStatus
 
-    # The user must CTRL+C to stop collection.
+    # The user used CTRL+C to stop collection.
     # When this happens, we catch the signal and finish our work.
     ProcessCollectedData
 }
@@ -1749,7 +1804,7 @@ DoCollect()
 
     # Create a temp directory to use for collection.
     local tempDir=`mktemp -d`
-        LogAppend "Created temp directory $tempDir"
+    LogAppend "Created temp directory $tempDir"
 
     # Switch to the directory.
     pushd $tempDir > /dev/null
@@ -1765,16 +1820,21 @@ DoCollect()
     then
         WriteStatus "Collection started. Collection will automatically stop in $duration second(s).  Press CTRL+C to stop early."
     else
-            WriteStatus "Collection started. Press CTRL+C to stop."
+        WriteStatus "Collection started."
     fi
 
     # Start perf record.
     if [ "$usePerf" == "1" ]
     then
         RunSilent $perfcmd $collectionArgs
+    elif [ "$operation" == "start" ]
+    then 
+        # Pass trace directory and session name to the stop process.
+        popd > /dev/null
+        declare -p | grep -e lttngTraceDir -e lttngSessionName -e tempDir -e usePerf -e useLttng > $collectInfoFile
     else
         # Wait here until CTRL+C handler gets called when user types CTRL+C.
-                LogAppend "Waiting for CTRL+C handler to get called."
+        LogAppend "Waiting for CTRL+C handler to get called."
 
         waitTime=0
         for (( ; ; ))
@@ -1792,8 +1852,9 @@ DoCollect()
                 break;
             fi
         done
+        # End collection if no operation is set.
+        EndCollect
     fi
-    EndCollect
 }
 
 DoLiveTrace()
@@ -1903,7 +1964,13 @@ ProcessArguments $@
 # Take the appropriate action.
 if [ "$action" == "collect" ]
 then
-    DoCollect
+    if [ "$operation" == "start" ] || [ -z "$operation" ]
+    then
+        DoCollect
+    elif [ "$operation" == "stop" ]
+    then
+        EndCollect
+    fi
 elif [ "$action" == "view" ]
 then
     DoView

--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -1304,61 +1304,60 @@ CreateLTTngSession()
 
 SetupLTTngSession()
 {
-    # Setup kernel events. 
-    # TODO: enable triggers of different kernel events, instead of a default set of kernel events
-    if [ "$events" == "kernel" ]
-    then
-        RunSilent "lttng add-context --kernel -t pid -t procname"
-        EnableLTTngKernelEvents ${LTTng_Kernel_Default[@]}
-    else
-        # Setup per-event context information.
-        RunSilent "lttng add-context --userspace --type vpid"
-        RunSilent "lttng add-context --userspace --type vtid"
-        RunSilent "lttng add-context --userspace --type procname"
+    
+    # Setup per-event context information.
+    RunSilent "lttng add-context --userspace --type vpid"
+    RunSilent "lttng add-context --userspace --type vtid"
+    RunSilent "lttng add-context --userspace --type procname"
+    RunSilent "lttng add-context --kernel -t pid -t procname"
 
-        if [ "$action" == "livetrace" ]
+    if [ "$action" == "livetrace" ]
+    then
+        RunSilent "lttng enable-event --userspace --tracepoint DotNETRuntime:EventSource"
+    elif [ "$gcCollectOnly" == "1" ]
+    then
+        usePerf=0
+        EnableLTTngEvents ${DotNETRuntime_GCKeyword_GCCollectOnly[@]}
+        EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword_GCCollectOnly[@]}
+        EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
+    elif [ "$gcOnly" == "1" ]
+    then
+        usePerf=0
+        EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
+        EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword[@]}
+        EnableLTTngEvents ${DotNETRuntime_JitKeyword[@]}
+        EnableLTTngEvents ${DotNETRuntime_LoaderKeyword[@]}
+        EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
+    elif [ "$gcWithHeap" == "1" ]
+    then
+        usePerf=0
+        EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
+        EnableLTTngEvents ${DotNETRuntime_GCHeapSurvivalAndMovementKeyword[@]}
+    else
+        if [ "$events" == "" ]
         then
-            RunSilent "lttng enable-event --userspace --tracepoint DotNETRuntime:EventSource"
-        elif [ "$gcCollectOnly" == "1" ]
-        then
-            usePerf=0
-            EnableLTTngEvents ${DotNETRuntime_GCKeyword_GCCollectOnly[@]}
-            EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword_GCCollectOnly[@]}
+            # Enable the default set of events.
+            EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword_ThreadTransferKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_NoKeyword[@]}
             EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
-        elif [ "$gcOnly" == "1" ]
-        then
-            usePerf=0
-            EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_ContentionKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_JitKeyword_NGenKeyword[@]}
             EnableLTTngEvents ${DotNETRuntime_JitKeyword[@]}
             EnableLTTngEvents ${DotNETRuntime_LoaderKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
-        elif [ "$gcWithHeap" == "1" ]
+            EnableLTTngEvents ${DotNETRuntime_GCKeyword_GCCollectOnly[@]}
+            EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword_GCCollectOnly[@]}
+            EnableLTTngEvents ${DotNETRuntimePrivate_BindingKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntimePrivate_MulticoreJitPrivateKeyword[@]}
+            EnableLTTngEvents ${DotNETRuntime_CompilationKeyword[@]}
+        elif [ "$events" == "threading" ]
         then
-            usePerf=0
-            EnableLTTngEvents ${DotNETRuntime_GCKeyword[@]}
-            EnableLTTngEvents ${DotNETRuntime_GCHeapSurvivalAndMovementKeyword[@]}
-        else
-            if [ "$events" == "" ]
-            then
-                # Enable the default set of events.
-                EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword_ThreadTransferKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_NoKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_ExceptionKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_ContentionKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_JitKeyword_NGenKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_JitKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_LoaderKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_GCKeyword_GCCollectOnly[@]}
-                EnableLTTngEvents ${DotNETRuntimePrivate_GCPrivateKeyword_GCCollectOnly[@]}
-                EnableLTTngEvents ${DotNETRuntimePrivate_BindingKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntimePrivate_MulticoreJitPrivateKeyword[@]}
-                EnableLTTngEvents ${DotNETRuntime_CompilationKeyword[@]}
-            elif [ "$events" == "threading" ]
-            then
-                EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
-            fi
+            EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
+        elif [ "$events" == "kernel" ]
+        then
+            # Setup kernel events. 
+            # TODO: enable triggers of different kernel events, instead of a default set of kernel events
+            EnableLTTngKernelEvents ${LTTng_Kernel_Default[@]}
         fi
     fi
 }

--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -607,7 +607,7 @@ declare -a DotNETRuntimePrivate_DynamicTypeUsageKeyword=(
     DotNETRuntimePrivate:ObjectVariantMarshallingToManaged
 )
 
-declare -a LTTng_Kernel_Default=(
+declare -a LTTng_Kernel_ProcessLifetime=(
     sched_process_exec
     sched_process_exit
 )
@@ -1341,11 +1341,11 @@ SetupLTTngSession()
         elif [ "$events" == "threading" ]
         then
             EnableLTTngEvents ${DotNETRuntime_ThreadingKeyword[@]}
-        elif [ "$events" == "kernel" ]
+        elif [ "$events" == "processlifetime" ]
         then
             # Setup kernel events. 
             # TODO: enable triggers of different kernel events, instead of a default set of kernel events
-            EnableLTTngKernelEvents ${LTTng_Kernel_Default[@]}
+            EnableLTTngKernelEvents ${LTTng_Kernel_ProcessLifetime[@]}
         fi
     fi
 }

--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -607,7 +607,7 @@ declare -a DotNETRuntimePrivate_DynamicTypeUsageKeyword=(
     DotNETRuntimePrivate:ObjectVariantMarshallingToManaged
 )
 
-declare -a Kernel_Default=(
+declare -a LTTng_Kernel_Default=(
     sched_process_exec
     sched_process_exit
 )
@@ -640,7 +640,7 @@ logFilePrefix='/tmp/perfcollect'
 logEnabled=1
 
 # Collect info to pass between processes
-collectInfoFile='collectinfo'
+collectInfoFile=$(dirname `mktemp -u`)/'perfcollect.sessioninfo'
 
 ######################################
 ## Logging Functions
@@ -655,14 +655,16 @@ LogAppend()
 
 RunSilent()
 {
-    if (( $logEnabled == 1 ))
-    then
-        echo "Running \"$*\"" >> $logFile
-        $* >> $logFile 2>&1
-        echo "" >> $logFile
-    else
-        $* > /dev/null 2>&1
-    fi
+    #HACK 
+    echo $*
+    # if (( $logEnabled == 1 ))
+    # then
+    #     echo "Running \"$*\"" >> $logFile
+    #     $* >> $logFile 2>&1
+    #     echo "" >> $logFile
+    # else
+    #     $* > /dev/null 2>&1
+    # fi
 }
 
 InitializeLog()
@@ -1197,8 +1199,6 @@ ProcessArguments()
         FatalError "Invalid trace name specified."
     fi
 
-    args=( "$@" )
-
     # Process remaining arguments.
     # First copy the args into an array so that we can walk the array.
     args=( "$@" )
@@ -1309,7 +1309,7 @@ SetupLTTngSession()
     if [ "$events" == "kernel" ]
     then
         RunSilent "lttng add-context --kernel -t pid -t procname"
-        EnableLTTngKernelEvents ${Kernel_Default[@]}
+        EnableLTTngKernelEvents ${LTTng_Kernel_Default[@]}
     else
         # Setup per-event context information.
         RunSilent "lttng add-context --userspace --type vpid"
@@ -1414,6 +1414,7 @@ ProcessCollectedData()
     local directoryName=$traceName$traceSuffix
     mkdir $directoryName
 
+    # Save LTTng trace files.
     if [ "$useLTTng" == "1" ]
     then
         LogAppend "Saving LTTng trace files."
@@ -1813,8 +1814,11 @@ DoCollect()
     if [ "$duration" != "" ]
     then
         WriteStatus "Collection started. Collection will automatically stop in $duration second(s).  Press CTRL+C to stop early."
-    else
+    elif [ "$operation" == "start" ]
+    then
         WriteStatus "Collection started."
+    else
+        WriteStatus "Collection started. Press CTRL+C to stop."
     fi
 
     # Start perf record.

--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -1190,20 +1190,14 @@ ProcessArguments()
         fi
     fi
 
-    # echo "action: $action"
-    # echo "operation: $operation"
-
     # Set the data file.
     inputTraceName=$2
-    echo $inputTraceName
     if [ "$inputTraceName" == "" ] 
     then
         FatalError "Invalid trace name specified."
     fi
 
     args=( "$@" )
-    # echo inputTraceName: $inputTraceName
-    # exit
 
     # Process remaining arguments.
     # First copy the args into an array so that we can walk the array.


### PR DESCRIPTION
- Added start/stop to perfcollect
- Added noperf option to turn off perf when necessary
- Enabled lttng tracing of kernel events 

New usage would be:
```./perfcollect collect start <trace_name> -noperf``` to start a lttng-only trace 
```./perfcollect collect stop <trace_name>``` to stop a trace
```./perfcollect collect start <trace_name> -noperf -events kernel``` to start lttng-only kernel trace (currently only process exec/exit events, will add more)


