### PR TITLE
Fix Missing NuGet Package Dependency

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.50</PerfViewVersion>
-    <TraceEventVersion>2.0.50</TraceEventVersion>
+    <PerfViewVersion>2.0.51</PerfViewVersion>
+    <TraceEventVersion>2.0.51</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -33,6 +33,10 @@
     <releaseNotes>https://github.com/Microsoft/perfview/releases/tag/T$version$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>TraceEvent EventSource Microsoft ETW Event Tracing for Windows</tags>
+
+    <dependencies>
+      <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" />
+    </dependencies>
   </metadata>
 
   <files>


### PR DESCRIPTION
#1104 adds a new package dependency to TraceEvent, but the nuspec was not updated.  This results in exceptions such as this: https://github.com/dotnet/diagnostics/pull/894?email_token=ABPMGEWPZW742HDCRXCKNXLRG5VOZA5CNFSM4LFCQFJ2YY3PNVWWK3TUL52HS4DFVREXG43VMVBW63LNMVXHJKTDN5WW2ZLOORPWSZGOEOPC2ZQ#discussion_r390837979.