### PR TITLE
Intern Stack Definitions Once Per Usage Instead of Once Per Definition

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -2509,11 +2509,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     Debug.Assert(!stackInfo.WaitingToLeaveKernel);
                     userStackKeyToInfo.Remove(data.StackKey);
 
-                    // User mode stacks we can convert immediately.  
-                    CallStackIndex callStack = callStacks.GetStackIndexForStackEvent(
-                         data.InstructionPointers, data.FrameCount, data.PointerSize, stackInfo.Thread, stackInfo.UserModeStackIndex);
                     while (stackInfo != null)
                     {
+                        // User mode stacks we can convert immediately.
+                        CallStackIndex callStack = callStacks.GetStackIndexForStackEvent(
+                             data.InstructionPointers, data.FrameCount, data.PointerSize, stackInfo.Thread, stackInfo.UserModeStackIndex);
+
                         Debug.Assert(!stackInfo.IsDead);
                         Debug.Assert(stackInfo.UserModeStackKey == data.StackKey);
                         Debug.Assert(stackInfo.UserModeStackIndex == CallStackIndex.Invalid);


### PR DESCRIPTION
ETW stacks are logged as a set of separate events which are then correlated with the data events that they correspond to.  Construction of stacks and correlation with their data events occurs during `TraceLog` creation.  There are "stack definition" events, and then references to the stack definitions.  Stack references are 1:1 with their data events.  Stack definitions are 1:N where N is the number of references to the stack.  It is also important to know that stack definitions are not specific to a thread and do not contain the thread information as part of the stack.  This is done during construction of the `TraceLog`.

Prior to this change, the data structure that holds stack references assumed that all usages of a single reference came from the same thread.  It appears this may have been true at one point, but is no longer true.  To solve this problem, this change interns the stack for each entry in the list, which allows us to ensure that the stack frame that represents the thread is correct on each intern operation, and is then property correlated with its data event.