### PR TITLE
Use compiled shared instances of commonly used regex in event view filtering

### DIFF
--- a/src/PerfView/EtwEventSource.cs
+++ b/src/PerfView/EtwEventSource.cs
@@ -646,6 +646,8 @@ namespace PerfView
 
             #region private
 
+            private static readonly Regex specialCharRemover = new Regex(" *[\r\n\t]+ *", RegexOptions.Compiled);
+
             /// <summary>
             /// Adds 'fieldName' with value 'fieldValue' to the output.  It either goes into a column (based on columnOrder) or it goes into
             /// 'rest' as a fieldName="fieldValue" string.   It also updates 'columnSums' for the fieldValue for any in a true column 
@@ -658,7 +660,7 @@ namespace PerfView
                 }
                 // If the field value has to many newlines in it, the GUI gets confused because the text block is larger than
                 // the vertical size.   WPF may fix this at some point, but in the mean time this is a work around. 
-                fieldValue = Regex.Replace(fieldValue, " *[\r\n\t]+ *", " ");
+                fieldValue = specialCharRemover.Replace(fieldValue, " ");
 
                 var putInRest = true;
                 if (columnOrder != null)

--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -1018,6 +1018,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             }
         }
 
+        private static readonly Regex paramReplacer = new Regex(@"%(\d+)", RegexOptions.Compiled);
+
         public override string GetFormattedMessage(IFormatProvider formatProvider)
         {
             if (MessageFormat == null)
@@ -1027,7 +1029,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
             // TODO is this error handling OK?  
             // Replace all %N with the string value for that parameter.  
-            return Regex.Replace(MessageFormat, @"%(\d+)", delegate (Match m)
+            return paramReplacer.Replace(MessageFormat, delegate (Match m)
             {
                 int targetIndex = int.Parse(m.Groups[1].Value) - 1;
 


### PR DESCRIPTION
When filter through "large" collections of events the performance can be rather lackluster.

From profiling this scenario of PerfView it is apparent that most time is spent replacing characters in strings with Regex:
![image](https://user-images.githubusercontent.com/6630421/78392208-201f3500-75e8-11ea-804c-f91ae8cb184a.png)

Just based on a quick glance this change was the least intrusive change possible.

A filtering through a collection of ~1_000_000 events here is the measurements from the PerfView logs:

Before:
```
Started: Scanning Events
Completed: Scanning Events   (Elapsed Time: 105.203 sec)
WARNING, returned the maximum 10000 records.
Histogram: ___o_________o0003011222365324442222424467A7453559546441001000000o__________________________________ Time Bucket 28,382.8 MSec
[Found 10000 (TRUNCATED. Set MaxRet for more) Records.  11,260 total events. ColumnSums: tag=510,000.000]
```

After:
```
Started: Scanning Events
Completed: Scanning Events   (Elapsed Time: 74.308 sec)
WARNING, returned the maximum 10000 records.
Histogram: ___o_________o0003011222365324442222424467A7453559546441001000000o__________________________________ Time Bucket 28,382.8 MSec
[Found 10000 (TRUNCATED. Set MaxRet for more) Records.  11,260 total events. ColumnSums: tag=510,000.000]
```




 