### PR TITLE
Allow RecursionGuard Constants to be Configured

### DIFF
--- a/src/TraceEvent/Stacks/RecursionGuard.cs
+++ b/src/TraceEvent/Stacks/RecursionGuard.cs
@@ -4,19 +4,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 {
     public static class RecursionGuardConfiguration
     {
-        private static ushort _singleThreadRecursionLimit = 400;
         private static ushort _maxResets = 80;
-
-        /// <summary>
-        /// For recursive methods that need to process deep stacks, this value defines the limit for recursion within
-        /// a single thread. After reaching this limit, methods need to trampoline to a new thread before continuing to
-        /// recurse.
-        /// </summary>
-        public static ushort SingleThreadRecursionLimit
-        {
-            get { return _singleThreadRecursionLimit; }
-            set { _singleThreadRecursionLimit = value; }
-        }
 
         /// <summary>
         /// The number of times to trampoline to a new thread before assuming infinite recursion and failing the operation.
@@ -38,6 +26,14 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         private readonly ushort _currentThreadRecursionDepth;
         private readonly ushort _resetCount;
 
+
+        /// <summary>
+        /// For recursive methods that need to process deep stacks, this constant defines the limit for recursion within
+        /// a single thread. After reaching this limit, methods need to trampoline to a new thread before continuing to
+        /// recurse.
+        /// </summary>
+        internal const ushort SingleThreadRecursionLimit = 400;
+
         private RecursionGuard(int currentThreadRecursionDepth, int numResets = 0)
         {
             if (numResets > RecursionGuardConfiguration.MaxResets)
@@ -55,7 +51,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// <summary>
         /// The amount of recursion we have currently done.  
         /// </summary>
-        public int Depth => (_resetCount * RecursionGuardConfiguration.SingleThreadRecursionLimit) + _currentThreadRecursionDepth;
+        public int Depth => (_resetCount * SingleThreadRecursionLimit) + _currentThreadRecursionDepth;
 
         /// <summary>
         /// Gets the recursion guard for entering a recursive method.
@@ -79,6 +75,6 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// Gets a value indicating whether the current operation has exceeded the recursion depth for a single thread,
         /// and needs to continue executing on a new thread.
         /// </summary>
-        public bool RequiresNewThread => _currentThreadRecursionDepth >= RecursionGuardConfiguration.SingleThreadRecursionLimit;
+        public bool RequiresNewThread => _currentThreadRecursionDepth >= SingleThreadRecursionLimit;
     }
 }

--- a/src/TraceEvent/Stacks/RecursionGuard.cs
+++ b/src/TraceEvent/Stacks/RecursionGuard.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     public static class RecursionGuardConfiguration
     {
         private static ushort _singleThreadRecursionLimit = 400;
-        private static ushort _maxResets = 40;
+        private static ushort _maxResets = 80;
 
         /// <summary>
         /// For recursive methods that need to process deep stacks, this value defines the limit for recursion within


### PR DESCRIPTION
There have been some cases recently of extremely deep stack traces that have resulted in `RecursionGuard` throwing a `StackOverflowException`  This change allows the maximum values that trigger a `StackOverflowException` to be configured, and also increases the maximum number of trampoline operations from 20 to 40.