### PR TITLE
Add "Open in Browser" option for HTML reports in the TreeView

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -17,6 +17,7 @@
     </Window.Resources>
     <Window.CommandBindings>
         <CommandBinding Command="{x:Static src:MainWindow.ItemHelpCommand}" Executed="DoItemHelp" CanExecute="CanDoItemHelp"/>
+        <CommandBinding Command="{x:Static src:MainWindow.OpenInBrowserCommand}" Executed="OpenInBrowser" CanExecute="CanOpenInBrowser"/>
         <CommandBinding Command="{x:Static src:MainWindow.RunCommand}" Executed="DoRun"/>
         <CommandBinding Command="{x:Static src:MainWindow.CollectCommand}" Executed="DoCollect"/>
         <CommandBinding Command="{x:Static src:MainWindow.AbortCommand}" Executed="DoAbort"/>
@@ -159,7 +160,7 @@
                     </TextBlock>
                     <TextBox Name="FileFilterTextBox" TextChanged="FilterTextChanged" KeyDown="FilterKeyDown" Grid.Column="1" Margin="5,2,2,2" />
                 </Grid>
-                <TreeView x:Name="TreeView" Grid.Column="0" MouseDoubleClick="DoMouseDoubleClickInTreeView" KeyDown="KeyDownInTreeView" SelectedItemChanged="SelectedItemChangedInTreeView"
+                <TreeView x:Name="TreeView" Grid.Column="0" MouseDoubleClick="DoMouseDoubleClickInTreeView" KeyDown="KeyDownInTreeView" SelectedItemChanged="SelectedItemChangedInTreeView" PreviewMouseRightButtonDown="TreeView_PreviewMouseRightButtonDown"
                           ToolTip="Double Click to open.  Right click contains additional help and additional options."
                           IsEnabled="{Binding ElementName=StatusBar, Path=IsNotWorking}" AllowDrop="True" Drop="DoDrop">
                     <TreeView.ItemContainerStyle>
@@ -174,6 +175,7 @@
                                 <StackPanel.ContextMenu>
                                     <ContextMenu>
                                         <MenuItem Command="{x:Static src:MainWindow.ItemHelpCommand}"/>
+                                        <MenuItem Command="{x:Static src:MainWindow.OpenInBrowserCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.RefreshDirCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.OpenCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.CloseCommand}"/>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Navigation;
 using Utilities;
 
@@ -1721,6 +1722,26 @@ namespace PerfView
             StatusBar.Log("Looking up topic " + anchor + " in Users Guide.");
             DisplayUsersGuide(anchor);
         }
+
+        private void OpenInBrowser(object sender, ExecutedRoutedEventArgs e)
+        {
+            var selectedReport = TreeView.SelectedItem as PerfViewHtmlReport;
+            if (selectedReport == null)
+            {
+                throw new ApplicationException("No report selected.");
+            }
+
+            selectedReport.OpenInExternalBrowser(StatusBar);
+        }
+
+        private void CanOpenInBrowser(object sender, CanExecuteRoutedEventArgs e)
+        {
+            if (TreeView.SelectedItem is PerfViewHtmlReport)
+            {
+                e.CanExecute = true;
+            }
+        }
+
         private void DoRefreshDir(object sender, ExecutedRoutedEventArgs e)
         {
             RefreshCurrentDirectory();
@@ -1969,6 +1990,7 @@ namespace PerfView
         public static RoutedUICommand ZipCommand = new RoutedUICommand("Zip", "Zip", typeof(MainWindow));
         public static RoutedUICommand UnZipCommand = new RoutedUICommand("UnZip", "UnZip", typeof(MainWindow));
         public static RoutedUICommand ItemHelpCommand = new RoutedUICommand("Help on Item", "ItemHelp", typeof(MainWindow));
+        public static RoutedUICommand OpenInBrowserCommand = new RoutedUICommand("Open in Browser", "OpenInBrowser", typeof(MainWindow));
         public static RoutedUICommand HideCommand = new RoutedUICommand("Hide", "Hide", typeof(MainWindow),
             new InputGestureCollection() { new KeyGesture(Key.H, ModifierKeys.Alt) });
         public static RoutedUICommand UserCommand = new RoutedUICommand("User Command", "UserCommand", typeof(MainWindow),
@@ -2219,5 +2241,29 @@ namespace PerfView
         }
 
         private string m_openNextFileName;
+
+        // When you right click an item in the TreeView it doesn't automatically change to the TreeViewItem you clicked on.
+        // This helper method changes focus so that the right-click menu items commands are bound to the right TreeViewItem
+        private void TreeView_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            TreeViewItem treeViewItem = FindTreeViewItemInVisualHeirarchy(e.OriginalSource as DependencyObject);
+
+            if (treeViewItem != null)
+            {
+                treeViewItem.Focus();
+                e.Handled = true;
+            }
+        }
+
+        static TreeViewItem FindTreeViewItemInVisualHeirarchy(DependencyObject source)
+        {
+            // Given an item in visual a tree, navigate the parents upwards until we find the TreeViewItem it represents.
+            while (source != null && !(source is TreeViewItem))
+            {
+                source = VisualTreeHelper.GetParent(source);
+            }
+
+            return source as TreeViewItem;
+        }
     }
 }

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -2242,8 +2242,10 @@ namespace PerfView
 
         private string m_openNextFileName;
 
-        // When you right click an item in the TreeView it doesn't automatically change to the TreeViewItem you clicked on.
-        // This helper method changes focus so that the right-click menu items commands are bound to the right TreeViewItem
+        /// <summary>
+        /// When you right click an item in the TreeView it doesn't automatically change to the TreeViewItem you clicked on.
+        /// This helper method changes focus so that the right-click menu items commands are bound to the right TreeViewItem
+        /// </summary>
         private void TreeView_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
             TreeViewItem treeViewItem = FindTreeViewItemInVisualHeirarchy(e.OriginalSource as DependencyObject);
@@ -2255,9 +2257,11 @@ namespace PerfView
             }
         }
 
-        static TreeViewItem FindTreeViewItemInVisualHeirarchy(DependencyObject source)
+        /// <summary>
+        /// Given an item in visual a tree, navigate the parents upwards until we find the TreeViewItem it represents.
+        /// </summary>
+        private static TreeViewItem FindTreeViewItemInVisualHeirarchy(DependencyObject source)
         {
-            // Given an item in visual a tree, navigate the parents upwards until we find the TreeViewItem it represents.
             while (source != null && !(source is TreeViewItem))
             {
                 source = VisualTreeHelper.GetParent(source);

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -1116,6 +1116,10 @@ namespace PerfView
             }
         }
 
+        /// <summary>
+        /// Generates an HTML report and opens it using the machine's default handler .html file paths.
+        /// </summary>
+        /// <param name="worker">The StatusBar that should be updated with progress.</param>
         public void OpenInExternalBrowser(StatusBar worker)
         {
             TraceLog trace = GetTrace(worker);


### PR DESCRIPTION
Scenario: I was opening some pretty large HTML reports in perfview and noticed that the default WebBrowser control was struggling to open large HTML files generated. (I had a particular /GCCollectOnly trace that had captured 180k GCs.)

To be fair, a modern browser also isn't perfect with an HTML file that big, but it is better.

So to address this I added a small feature to the right-click menu on the main TreeView that lets you open the report in your browser instead of the WPF control. Here's a demo:

![OpenInBrowser](https://user-images.githubusercontent.com/578591/79386987-d277c600-7f1f-11ea-9543-9992eb48510d.gif)

To do this I had to fix a second issue - when you right-click an item in the tree view it is not automatically selected before you choose an item in the right-click menu. This meant that you could not reliably use TreeView.SelectedItem in the callback of the command that was chosen in the right-click menu. I fixed this by hooking in to the right-button-down event and navigating the visual tree to find the TreeViewItem related to the visual that was clicked.

Here's the before (notice how CPU Stacks stays selected):

![before](https://user-images.githubusercontent.com/578591/79387111-f6d3a280-7f1f-11ea-9e70-4cfe975d5115.gif)

and after (TraceInfo is selected):

![after](https://user-images.githubusercontent.com/578591/79387125-fc30ed00-7f1f-11ea-8282-3e67920e5bf1.gif)

