### PR TITLE
Improvements around MinSecForTrigger

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -97,7 +97,7 @@ namespace PerfView
         public int StopOnGCOverMsec;
         public int StopOnBGCFinalPauseOverMsec; // Stop on a BGC whose final pause is over this many ms
         public float DecayToZeroHours;          //causes 'StopOn*OverMSec' timeouts to decay to zero over this time period
-        public int MinSecForTrigger;            // affects StopOnPerfCounter
+        public int MinSecForTrigger = 3;        // affects StopOnPerfCounter and StartOnPerfCounter
         public string StopOnEventLogMessage;    // stop collection on event logs
         public string StopCommand;              // is executed when a stop is triggered.   
         public int StopOnAppFabricOverMsec;

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -6307,9 +6307,15 @@
         <li>PerfView collect "/StopOnPerfCounter:Memory:Committed Bytes: > 50000000000"</li>
     </ul>
     <p>
-        will stop collection of the committed bytes for the entire machine exceed 50GB.  Notice
+        will stop collection when the committed bytes for the entire machine exceed 50GB.  Notice
         that the counter is still CATEGORY:NAME:INSTANCE, but in this case INSTANCE is the
         empty string (the trailing :).
+    </p>
+    <p>
+        The performance counter will trigger when PerfView detects that the
+        counter has satisfied the condition for a certain number of seconds,
+        defaulting to 3 seconds. You can control this with the flag
+        /MinSecForTrigger:N to set the threshold to N seconds.
     </p>
     <p>
         When the performance counter triggers, PerfView actually collects 10 more seconds
@@ -6416,7 +6422,7 @@
         event log, but if you wish to monitor another you can do so by prefixing 'Pattern'
         with the name of the event log following by a @.
     </p>
-    <h5>Using log .NET GCs as as the trigger to stop</h5>
+    <h5>Using long .NET GCs as as the trigger to stop</h5>
     <p>
         Another&nbsp; reasonably common scenario is
         you have some non-HTTP based service that is experiencing pause times and you have a large
@@ -6713,7 +6719,10 @@
         inefficient if the point of interest was well after the performance counter
         triggers.   In this case it makes more sense to <b>not event start</b> collection until the interesting time.
         This is what the /StartOnPerfCounter option is for. Its syntax is identical to <a href="#StopOnPerfCounter">/StopOnPerfCounter</a>
-        however it will not even start collect until this trigger trips.
+        except that it will not even start collecting until this trigger trips. 
+        The flag /MinSecForTrigger:N applies to /StartOnPerfCounter, to
+        control how many seconds the performance counter has to satisfy the
+        condition before triggering collection (the default is 3 seconds).
     </p>
     <p>&nbsp;</p>
     <p>&nbsp;</p>
@@ -7376,7 +7385,7 @@
     </p>
     <hr />
     <!--  ********************************** -->
-    <h2>Command Line Reference</h2>
+    <h2><a id="CommandLineReference">Command Line Reference</a></h2>
     <p>
         Most functionality that is not intimately tied to viewing is available from the
         command line to allow for easy automation of data collection.&nbsp; At the command

--- a/src/PerfView/Triggers.cs
+++ b/src/PerfView/Triggers.cs
@@ -109,6 +109,8 @@ namespace Triggers
 
             m_task = Task.Factory.StartNew(delegate
             {
+                var desiredDirection = IsGreaterThan ? "above" : "below";
+                var otherDirection = IsGreaterThan ? "below" : "above";
                 while (!m_monitoringDone)
                 {
                     var isTriggered = IsCurrentlyTrue();
@@ -116,8 +118,8 @@ namespace Triggers
                     {
                         if (m_wasUntriggered)
                         {
-                            m_log.WriteLine("[Counter is at " + CurrentValue.ToString("f1") + " which is above the trigger for " + m_count + " sec.  Need " + MinSecForTrigger + " sec to trigger.]");
-                            // Perf counters are noisy, only trigger if we get 3 consecutive counts that trigger.  
+                            m_log.WriteLine($"[Counter is at {CurrentValue:n1} which is {desiredDirection} the threshold for {m_count} sec.  Need {MinSecForTrigger} sec to trigger.]");
+                            // Perf counters are noisy, only trigger if we get MinSecForTrigger consecutive counts that are above/below the threshold.
                             m_count++;
                             if (m_count > MinSecForTrigger)
                             {
@@ -128,8 +130,8 @@ namespace Triggers
                         {
                             if (!m_warnedAboutUntriggered)
                             {
-                                m_log.WriteLine("[WARNING: {0}: Counter is above the trigger level already!]", Status);
-                                m_log.WriteLine("[WARNING: PerfView will not trigger until the counter drops below the trigger level.]");
+                                m_log.WriteLine($"[WARNING: {Status}: Counter is {desiredDirection} the trigger level initially!]");
+                                m_log.WriteLine($"[WARNING: PerfView will not trigger until the counter moves from {otherDirection} the trigger level to {desiredDirection} the level.]");
                                 m_warnedAboutUntriggered = true;
                             }
                             m_count = 0;
@@ -144,7 +146,7 @@ namespace Triggers
                             {
                                 m_count = 0;
                                 m_wasUntriggered = true;
-                                m_log.WriteLine("[{0}: Waiting for trigger of {1}, CurVal {2:n1}]", Status, EffectiveThreshold, CurrentValue);
+                                m_log.WriteLine($"[{Status}: Waiting for trigger of {EffectiveThreshold}, CurVal {CurrentValue:n1}]");
                             }
                         }
                         else


### PR DESCRIPTION
Summary:
* Allows the MinSecForTrigger command-line flag to apply to
StartOnPerfCounter (previously only worked with StopOnPerfCounter)
* Improves logging and documentation around StopOnPerfCounter and
StartOnPerfCounter
* Improve log messages around perf counters to be clearer and make
sense for both "greater than" and "less than" scenarios.

Fixes #799