### PR TITLE
Make EventSources Consumable from perfcollect

### DIFF
--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -615,6 +615,10 @@ declare -a DotNETRuntimePrivate_DynamicTypeUsageKeyword=(
     DotNETRuntimePrivate:ObjectVariantMarshallingToManaged
 )
 
+declare -a EventSource=(
+    DotNETRuntime:EventSource
+)
+
 declare -a LTTng_Kernel_ProcessLifetimeKeyword=(
     sched_process_exec
     sched_process_exit


### PR DESCRIPTION
Allows `EventSources` to be consumed with the command line `./perfcollect collect sampleTrace -events EventSource`