### PR TITLE
include TraceEvent name and version in the exported speedscope and chromium files

### DIFF
--- a/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
             TextWriter writer, string name)
         {
             writer.Write("{");
-            writer.Write($"\"otherData\": {{ \"name\": \"{name}\", \"exporter\": \"{GetExporterName()}\" }}, ");
+            writer.Write($"\"otherData\": {{ \"name\": \"{name}\", \"exporter\": \"{GetExporterInfo()}\" }}, ");
             writer.Write("\"traceEvents\": [");
             bool isFirst = true;
             foreach (var perThread in sortedProfileEventsPerThread.OrderBy(pair => pair.Value.First().RelativeTime))

--- a/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
             TextWriter writer, string name)
         {
             writer.Write("{");
+            writer.Write($"\"otherData\": {{ \"name\": \"{name}\", \"exporter\": \"{GetExporterName()}\" }}, ");
             writer.Write("\"traceEvents\": [");
             bool isFirst = true;
             foreach (var perThread in sortedProfileEventsPerThread.OrderBy(pair => pair.Value.First().RelativeTime))
@@ -97,9 +98,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
                     writer.Write($", \"parent\": {frameInfo.ParentId}");
                 writer.Write("}");
             }
-            writer.Write("}, ");
-            writer.Write($"\"otherData\": {{ \"name\": \"{name}\" }}");
-            writer.Write("}");
+            writer.Write("}}");
         }
         #endregion private
     }

--- a/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
             IReadOnlyList<string> orderedFrameNames, TextWriter writer, string name)
         {
             writer.Write("{");
-            writer.Write($"\"exporter\": \"{GetExporterName()}\", ");
+            writer.Write($"\"exporter\": \"{GetExporterInfo()}\", ");
             writer.Write($"\"name\": \"{name}\", ");
             writer.Write("\"activeProfileIndex\": 0, ");
             writer.Write("\"$schema\": \"https://www.speedscope.app/file-format-schema.json\", ");

--- a/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
             IReadOnlyList<string> orderedFrameNames, TextWriter writer, string name)
         {
             writer.Write("{");
-            writer.Write("\"exporter\": \"speedscope@1.3.2\", ");
+            writer.Write($"\"exporter\": \"{GetExporterName()}\", ");
             writer.Write($"\"name\": \"{name}\", ");
             writer.Write("\"activeProfileIndex\": 0, ");
             writer.Write("\"$schema\": \"https://www.speedscope.app/file-format-schema.json\", ");

--- a/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
+++ b/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
@@ -9,13 +9,6 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 {
     internal static class StackSourceWriterHelper
     {
-        internal static string GetExporterName()
-        {
-            var traceEvent = typeof(StackSourceWriterHelper).GetTypeInfo().Assembly.GetName();
-
-            return $"{traceEvent.Name}@{traceEvent.Version}"; // sth like "Microsoft.Diagnostics.Tracing.TraceEvent@2.0.56.0"
-        }
-
         /// <summary>
         /// we want to identify the thread for every sample to prevent from 
         /// overlaping of samples for the concurrent code so we group the samples by Threads
@@ -170,6 +163,13 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 
             // MUST HAVE!!! the tool expects the profile events in certain order!!
             return OrderForExport(profileEvents).ToArray();
+        }
+
+        internal static string GetExporterInfo()
+        {
+            var traceEvent = typeof(StackSourceWriterHelper).GetTypeInfo().Assembly.GetName();
+
+            return $"{traceEvent.Name}@{traceEvent.Version}"; // sth like "Microsoft.Diagnostics.Tracing.TraceEvent@2.0.56.0"
         }
 
         /// <summary>

--- a/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
+++ b/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
@@ -2,12 +2,20 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Diagnostics.Tracing.Stacks
 {
     internal static class StackSourceWriterHelper
     {
+        internal static string GetExporterName()
+        {
+            var traceEvent = typeof(StackSourceWriterHelper).GetTypeInfo().Assembly.GetName();
+
+            return $"{traceEvent.Name}@{traceEvent.Version}"; // sth like "Microsoft.Diagnostics.Tracing.TraceEvent@2.0.56.0"
+        }
+
         /// <summary>
         /// we want to identify the thread for every sample to prevent from 
         /// overlaping of samples for the concurrent code so we group the samples by Threads


### PR DESCRIPTION
fixes #1178

Sample exporter name: `Microsoft.Diagnostics.Tracing.TraceEvent@2.0.56.0`

@brianrob PTAL