### PR TITLE
update for loop in perfcollect

### DIFF
--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -1371,9 +1371,8 @@ SetupLTTngSession()
         else     
             # Enable other keywords
             events=(${events//","/" "})
-            for (( i=0; i<${#events[@]}; i++ ))
+            for event in ${events[@]}
             do 
-                local event=${events[$i]}
                 if [ "${!event}" == "" ] || [ "$( echo `declare -p $event | grep -- -a` )" == "" ]
                 then
                     echo Invalid keyword $event, skipped...


### PR DESCRIPTION
Current for loop expression will allow any possible inner loop to change ```$i``` randomly and result in early-exit or infinite loop. ( If there's no specific reason to use ```$i``` for loop,  recommending to get rid of this value completely to avoid similar bugs in the future )