### PR TITLE
Fix double value parsing in trigger expressions

### DIFF
--- a/src/PerfView/Triggers.cs
+++ b/src/PerfView/Triggers.cs
@@ -1410,7 +1410,7 @@ namespace Triggers
                         var expressionValue = Convert.ToInt64(Value);
                         result = -expressionValue.CompareTo(longValue);     // negated because the x and y arguments are swapped.  
                     }
-                    else if (double.TryParse(fieldValue, System.Globalization.NumberStyles.Integer | System.Globalization.NumberStyles.AllowDecimalPoint, null, out double doubleValue))
+                    else if (double.TryParse(fieldValue, System.Globalization.NumberStyles.Number, null, out double doubleValue))
                     {
                         var expressionValue = Convert.ToDouble(Value);
                         result = -expressionValue.CompareTo(doubleValue);   // negated because the x and y arguments are swapped.


### PR DESCRIPTION
High values with a thousands separator were not parsed correctly and that caused trigger expression evaluation to use the value as a string. Ex: 7,664.722 in expression TimeMS >= 10000 evaluated to true.