### PR TITLE
Tighten the sample aggregation threshold

### DIFF
--- a/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
+++ b/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
@@ -184,8 +184,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             if (left.CallerStackIndex != right.CallerStackIndex)
                 return true;
 
-            // 1.2 is a magic number based on some experiments ;)
-            return left.RelativeTime + (left.Metric * 1.2) < right.RelativeTime;
+            return left.RelativeTime + (left.Metric * 1.1) < right.RelativeTime;
         }
 
         /// <summary>


### PR DESCRIPTION
Improves the speedscope exporter for compatibility with speedscope 1.6.0 or above (https://github.com/jlfwong/speedscope/pull/273).

This is a workaround for https://github.com/microsoft/perfview/issues/1178#issuecomment-638664301. Since I don't know the reason for the original value (1.2), the new value is a simple compromise between 1.0 and 1.2.

@adamsitnik Could you test if you agree with this change?