### PR TITLE
Synchronize Access to the Log Inside of SymbolReader

### DIFF
--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
-    <DefineConstants>$(DefineConstants);AUTOANALYSIS_EXTENSIBILITY</DefineConstants>
+    <DefineConstants>$(DefineConstants);AUTOANALYSIS_EXTENSIBILITY;SYNC_SYMBOLREADER_LOG</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1187.

Synchronize access to the log inside of SymbolReader to avoid races caused by async handling of stdout/stderr.

cc: @suprak