### PR TITLE
Update GCCollectOnly to not include CLR exception events.

### DIFF
--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -696,11 +696,8 @@ namespace PerfView
                 {
                     m_args.GCCollectOnly = true;
 
-                    // The process events are so we get process names.  The ImageLoad events are so that we get version information about the DLLs 
-                    m_args.KernelEvents = KernelTraceEventParser.Keywords.Process | KernelTraceEventParser.Keywords.ImageLoad;
-                    m_args.ClrEvents = ClrTraceEventParser.Keywords.GC | ClrTraceEventParser.Keywords.Exception;
-                    m_args.ClrEventLevel = TraceEventLevel.Informational;
-                    m_args.NoRundown = true;
+                    CommandLineArgs.ConfigureForGCCollectOnly(m_args);
+
                     if (!m_args.Merge.HasValue)
                     {
                         m_args.Merge = false;


### PR DESCRIPTION
This is a proposed fix for issue #1200 

The logic for configuring GCCollectOnly is split for command line runs vs UI collect runs. I took this opportunity to share the logic between the two through a static method in CommandLineArgs. (Is there a better place to put that logic?)

One difference between the two was that UI collection was not setting TplEvents to None - it does now.

I tested/verified that both the UI collection checkbox and command line runs no longer collect exception events and they still collect GC events shown in the GCStats report.

CC: @Maoni0 , @brianrob 