### PR TITLE
Add processor stacks

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -1,15 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Windows;
-using System.Windows.Media;
-using System.Xml;
 using Diagnostics.Tracing.StackSources;
 using global::DiagnosticsHub.Packaging.Interop;
 using Graphs;
@@ -34,6 +22,19 @@ using Microsoft.DiagnosticsHub.Packaging.InteropEx;
 using PerfView.GuiUtilities;
 using PerfViewExtensibility;
 using PerfViewModel;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows;
+using System.Windows.Media;
+using System.Xml;
 using Utilities;
 using Address = System.UInt64;
 using EventSource = EventSources.EventSource;
@@ -5112,10 +5113,8 @@ table {
                     var asSampledProfile = data as SampledProfileTraceData;
                     if (asSampledProfile != null)
                     {
-                        stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern("Priority (" + asSampledProfile.Priority + ")"), stackIndex);
-                        stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern("Processor (" + asSampledProfile.ProcessorNumber + ")"), stackIndex);
-//                        var processorPriority = "Processor (" + asSampledProfile.ProcessorNumber + ") Priority (" + asSampledProfile.Priority + ")";
-//                        stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern(processorPriority), stackIndex);
+                        var processorPriority = "Processor (" + asSampledProfile.ProcessorNumber + ") Priority (" + asSampledProfile.Priority + ")";
+                        stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern(processorPriority), stackIndex);
 
                         sample.StackIndex = stackIndex;
                         sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
@@ -6696,6 +6695,12 @@ table {
                 {
                     stackWindow.FoldPercentTextBox.Text = stackWindow.GetDefaultFoldPercentage();
                 }
+            }
+
+            if (stackSourceName.StartsWith("Processor"))
+            {
+                stackWindow.GroupRegExTextBox.Items.Insert(0, "Processor ({%}) Priority ({%})->Priority ($2)");
+                stackWindow.GroupRegExTextBox.Items.Insert(0, "Processor ({%}) Priority ({%})->Processor ($1)");
             }
 
             if (stackSourceName == "Net OS Heap Alloc" || stackSourceName == "Image Load" || stackSourceName == "Disk I/O" ||

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -5099,7 +5099,7 @@ table {
             }
             else if (streamName.StartsWith("Processor"))
             {
-                eventSource.AllEvents += delegate (TraceEvent data)
+                eventSource.Kernel.PerfInfoSample += delegate (SampledProfileTraceData data)
                 {
                     StackSourceCallStackIndex stackIndex;
                     var callStackIdx = data.CallStackIndex();
@@ -5110,17 +5110,13 @@ table {
 
                     stackIndex = stackSource.GetCallStack(callStackIdx, data);
 
-                    var asSampledProfile = data as SampledProfileTraceData;
-                    if (asSampledProfile != null)
-                    {
-                        var processorPriority = "Processor (" + asSampledProfile.ProcessorNumber + ") Priority (" + asSampledProfile.Priority + ")";
-                        stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern(processorPriority), stackIndex);
+                    var processorPriority = "Processor (" + data.ProcessorNumber + ") Priority (" + data.Priority + ")";
+                    stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern(processorPriority), stackIndex);
 
-                        sample.StackIndex = stackIndex;
-                        sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
-                        sample.Metric = 1;
-                        stackSource.AddSample(sample);
-                    }
+                    sample.StackIndex = stackIndex;
+                    sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
+                    sample.Metric = 1;
+                    stackSource.AddSample(sample);
                 };
                 eventSource.Process();
             }

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -2297,7 +2297,7 @@
                     <ul>
                         <li>
                             <strong><a id="ProcessorStacks">Processor Stacks</a></strong> - Shows what every
-                            processor is doing, including at what priority. Use the 
+                            processor is doing, including at what priority. Use GroupPats to focus on Processor or Priority.
                         </li>
                         <li>
                             <strong><a id="ThreadTimeStacks">Thread Time Stacks</a></strong> - Shows what every

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -2296,6 +2296,10 @@
                     wall clock time, and memory investigations.
                     <ul>
                         <li>
+                            <strong><a id="ProcessorStacks">Processor Stacks</a></strong> - Shows what every
+                            processor is doing, including at what priority. Use the 
+                        </li>
+                        <li>
                             <strong><a id="ThreadTimeStacks">Thread Time Stacks</a></strong> - Shows what every
                             thread is doing whether it is consuming CPU, disk, network or blocked on something
                             else.  It does not include the 'ReadyThread' information.

--- a/src/TraceEvent/Parsers/Microsoft-Windows-NDIS-PacketCapture.cs
+++ b/src/TraceEvent/Parsers/Microsoft-Windows-NDIS-PacketCapture.cs
@@ -560,8 +560,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCaptur
         }
         protected internal override void Validate()
         {
-            Debug.Assert(!(Version == 0 && EventDataLength != FragmentSize + 12));
-            Debug.Assert(!(Version > 0 && EventDataLength < FragmentSize + 12));
+            //Debug.Assert(!(Version == 0 && EventDataLength != FragmentSize + 12));
+            //Debug.Assert(!(Version > 0 && EventDataLength < FragmentSize + 12));
         }
         protected internal override Delegate Target
         {

--- a/src/TraceEvent/Parsers/Microsoft-Windows-NDIS-PacketCapture.cs
+++ b/src/TraceEvent/Parsers/Microsoft-Windows-NDIS-PacketCapture.cs
@@ -560,8 +560,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCaptur
         }
         protected internal override void Validate()
         {
-            //Debug.Assert(!(Version == 0 && EventDataLength != FragmentSize + 12));
-            //Debug.Assert(!(Version > 0 && EventDataLength < FragmentSize + 12));
+            Debug.Assert(!(Version == 0 && EventDataLength != FragmentSize + 12));
+            Debug.Assert(!(Version > 0 && EventDataLength < FragmentSize + 12));
         }
         protected internal override Delegate Target
         {


### PR DESCRIPTION
Adds "Processor Stacks" advanced view if CPU stacks are available.
"Processor (x) Priority (y)" is added as the top frame to every stack, which allows per processor / priority analysis.
For convenience two grouping regexes are added to the view "Processor ({%}) Priority ({%})->Processor ($1)" and "Processor ({%}) Priority ({%})->Processor ($2)" that allow grouping by Processor and Priority respectively.
@Maoni0 , let me know if you have other thoughts around the view.