### PR TITLE
Implement Linux Tracing Improvements

### DIFF
--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
+using System.Linq.Expressions;
 
 namespace LinuxTracing.Tests
 {
@@ -89,7 +90,7 @@ namespace LinuxTracing.Tests
         {
             string path = Constants.GetTestingPerfDumpPath("onegeneric");
             DoStackTraceTest(path, doBlockedTime: false, callerStacks: new List<List<string>> {
-                new List<string>{ "module!symbol", "Thread (0)", "comm", null }
+                new List<string>{ "module!symbol", "Thread (0)", "Process comm (0)", null }
             });
         }
 
@@ -99,7 +100,7 @@ namespace LinuxTracing.Tests
         {
             string path = Constants.GetTestingPerfDumpPath("onegeneric");
             DoStackTraceTest(path, doBlockedTime: false, callerStacks: new List<List<string>> {
-                new List<string>{ "module!symbol", "Thread (0)", "comm", null }
+                new List<string>{ "module!symbol", "Thread (0)", "Process comm (0)", null }
             });
         }
 
@@ -122,8 +123,8 @@ namespace LinuxTracing.Tests
             string path = Constants.GetTestingPerfDumpPath("two_small_generic");
             DoStackTraceTest(path, doBlockedTime: false, callerStacks: new List<List<string>>
             {
-                new List<string> { "module!symbol", "module2!symbol2", "main!main", "Thread (0)", "comm" },
-                new List<string> { "module3!symbol3", "module4!symbol4", "main!main", "Thread (0)", "comm2" }
+                new List<string> { "module!symbol", "module2!symbol2", "main!main", "Thread (0)", "Process comm (0)" },
+                new List<string> { "module3!symbol3", "module4!symbol4", "main!main", "Thread (1)", "Process comm2 (1)" }
             });
         }
 
@@ -133,7 +134,7 @@ namespace LinuxTracing.Tests
             string path = Constants.GetTestingPerfDumpPath("ms_stack");
             DoStackTraceTest(path, doBlockedTime: false, callerStacks: new List<List<string>>
             {
-                new List<string> { "module!symbol(param[])", "Thread (0)", "comm" },
+                new List<string> { "module!symbol(param[])", "Thread (0)", "Process comm (0)" },
             });
         }
 
@@ -143,8 +144,8 @@ namespace LinuxTracing.Tests
             string path = Constants.GetTestingPerfDumpPath("one_complete_switch");
             DoStackTraceTest(path, doBlockedTime: true, callerStacks: new List<List<string>>
             {
-                new List<string> { "BLOCKED_TIME", "module!symbol", "Thread (0)", "comm1"},
-                new List<string> { "BLOCKED_TIME", "module!symbol", "Thread (1)", "comm2"},
+                new List<string> { "BLOCKED_TIME", "module!symbol", "Thread (0)", "Process comm1 (0)"},
+                new List<string> { "BLOCKED_TIME", "module!symbol", "Thread (1)", "Process comm2 (1)"},
             });
         }
 
@@ -155,8 +156,8 @@ namespace LinuxTracing.Tests
             DoStackTraceTest(path, doBlockedTime: false,
                 callerStacks: new List<List<string>>
                 {
-                    new List<string> { "Thread (0)", "comm" },
-                    new List<string> { "module!symbol", "Thread (0)", "comm" },
+                    new List<string> { "Thread (0)", "Process comm (0)" },
+                    new List<string> { "module!symbol", "Thread (0)", "Process comm (0)" },
                 });
         }
 

--- a/src/LinuxEvent.Tests/Sources/two_small_generic.perf.data.dump
+++ b/src/LinuxEvent.Tests/Sources/two_small_generic.perf.data.dump
@@ -3,7 +3,7 @@
 	address symbol2 (module2)
 	address main (main)
 
-comm2	0/0		[000] 0.0:			1 event_name: event_properties
+comm2	1/1		[000] 0.0:			1 event_name: event_properties
 	address symbol3 (module3)
 	address symbol4 (module4)
 	address main (main)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -8299,7 +8299,7 @@ table {
         {
             "CPU",
             "CPU (with Optimization Tiers)",
-            "Thread Time (experimental)"
+            "Thread Time"
         };
 
         public override string FormatName { get { return "Perf"; } }
@@ -8320,7 +8320,7 @@ table {
                 string xmlPath;
                 bool doThreadTime = false;
 
-                if (streamName == "Thread Time (experimental)")
+                if (streamName == "Thread Time")
                 {
                     xmlPath = CacheFiles.FindFile(FilePath, ".perfscript.threadtime.xml.zip");
                     doThreadTime = true;
@@ -8330,10 +8330,12 @@ table {
                     xmlPath = CacheFiles.FindFile(FilePath, ".perfscript.cpu.xml.zip");
                 }
 
+#if !DEBUG
                 if (!CacheFiles.UpToDate(xmlPath, FilePath))
+#endif
                 {
                     XmlStackSourceWriter.WriteStackViewAsZippedXml(
-                        new ParallelLinuxPerfScriptStackSource(FilePath, doThreadTime), xmlPath);
+                        new LinuxPerfScriptStackSource(FilePath, doThreadTime), xmlPath);
                 }
 
                 bool showOptimizationTiers =
@@ -8369,6 +8371,7 @@ table {
             m_Children = new List<PerfViewTreeItem>();
             var advanced = new PerfViewTreeGroup("Advanced Group");
             var memory = new PerfViewTreeGroup("Memory Group");
+            var experimental = new PerfViewTreeGroup("Experimental Group");
 
             m_Children.Add(new PerfViewStackSource(this, "CPU"));
 
@@ -8380,10 +8383,7 @@ table {
                 advanced.AddChild(new PerfViewStackSource(this, "CPU (with Optimization Tiers)"));
             }
 
-            if (AppLog.InternalUser)
-            {
-                advanced.AddChild(new PerfViewStackSource(this, "Thread Time (experimental)"));
-            }
+            experimental.AddChild(new PerfViewStackSource(this, "Thread Time"));
 
             if (m_traceLog != null)
             {
@@ -8409,6 +8409,11 @@ table {
             if (advanced.Children.Count > 0)
             {
                 m_Children.Add(advanced);
+            }
+
+            if(AppLog.InternalUser && experimental.Children.Count > 0)
+            {
+                m_Children.Add(experimental);
             }
 
             return null;

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -8302,27 +8302,11 @@ table {
             "Thread Time (experimental)"
         };
 
-        public override string FormatName { get { return "LTTng"; } }
+        public override string FormatName { get { return "Perf"; } }
 
         public override string[] FileExtensions { get { return new string[] { ".trace.zip" }; } }
 
         public override bool SupportsProcesses => true;
-
-        internal override string GetProcessIncPat(IProcess process) => process.Name;
-
-        internal override string FindExeName(string incPat) => string.IsNullOrEmpty(incPat) ? incPat : incPat.Split('|').FirstOrDefault();
-
-        internal override bool GetProcessForStackSourceFromTopCallStackFrame(string topCallStackStr, out IProcessForStackSource result)
-        {
-            if (!string.IsNullOrEmpty(topCallStackStr))
-            {
-                // the top call stack is always process name, the process ID is missing as of today (a perf_events limitation)
-                result = new IProcessForStackSource(topCallStackStr);
-                return true;
-            }
-            result = null;
-            return false;
-        }
 
         protected internal override EventSource OpenEventSourceImpl(TextWriter log)
         {

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -11680,6 +11680,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
 
         // Pregenerated code, not sent by the runtime
         ReadyToRun,
+
+        // This value is not sent by the runtime through this parser, but
+        // does get sent through Linux traces.  Set the value to byte.MaxValue
+        // to avoid clobbering a real value.
+        PreJIT = byte.MaxValue
     }
     [Flags]
     public enum StartupMode

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             }
 
             frames.Add(new ThreadFrame(threadID, "Thread"));
-            frames.Add(new ProcessFrame(command));
+            frames.Add(new ProcessFrame(processID, command));
 
             return frames;
         }
@@ -1126,11 +1126,13 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
     public struct ProcessFrame : Frame
     {
         public FrameKind Kind { get { return FrameKind.ProcessFrame; } }
-        public string DisplayName { get { return Name; } }
+        public string DisplayName { get { return string.Format("Process {0} ({1})", Name, ID); } }
         public string Name { get; }
+        public int ID { get; }
 
-        public ProcessFrame(string name)
+        public ProcessFrame(int id, string name)
         {
+            ID = id;
             Name = name;
         }
     }

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
@@ -74,7 +74,11 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                                 blockedTimeAnalyzer?.UpdateThreadState(linuxEvent);
 
                                 StackSourceSample sample = CreateSampleFor(linuxEvent, blockedTimeAnalyzer);
-                                threadSamples[(int)givenArrayIndex].Add(sample);
+
+                                if (linuxEvent.Kind == EventKind.Cpu)
+                                {
+                                    threadSamples[(int)givenArrayIndex].Add(sample);
+                                }
 
                                 blockedTimeAnalyzer?.LinuxEventSampleAssociation(linuxEvent, sample);
                             }
@@ -296,7 +300,6 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             StackSourceCallStackIndex stackIndex = currentStackIndex;
 
             var sample = new StackSourceSample(this);
-            Debug.Assert(StartTimeStampMSec != 0);
             sample.TimeRelativeMSec = linuxEvent.TimeMSec - StartTimeStampMSec;
             if (linuxEvent.Kind == EventKind.Cpu)
             {

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
@@ -3,6 +3,7 @@ using Microsoft.Diagnostics.Tracing.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.IO.Compression;
@@ -63,7 +64,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                             BlockedTimeAnalyzer blockedTimeAnalyzer = null;
                             if (threadBlockedTimeAnalyzers != null)
                             {
-                                blockedTimeAnalyzer = new BlockedTimeAnalyzer();
+                                blockedTimeAnalyzer = new BlockedTimeAnalyzer(this);
                                 threadBlockedTimeAnalyzers[(int)givenArrayIndex].Add(blockedTimeAnalyzer);
                             }
 
@@ -282,6 +283,8 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             archive?.Dispose();
         }
 
+        public double StartTimeStampMSec { get; set; }
+
         public double TotalBlockedTime { get; set; }
 
         /// <summary>
@@ -293,8 +296,16 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             StackSourceCallStackIndex stackIndex = currentStackIndex;
 
             var sample = new StackSourceSample(this);
-            sample.TimeRelativeMSec = linuxEvent.TimeMSec;
-            sample.Metric = 1;
+            Debug.Assert(StartTimeStampMSec != 0);
+            sample.TimeRelativeMSec = linuxEvent.TimeMSec - StartTimeStampMSec;
+            if (linuxEvent.Kind == EventKind.Cpu)
+            {
+                sample.Metric = 1;
+            }
+            else if(linuxEvent.Kind == EventKind.Scheduler)
+            {
+                sample.Metric = (float)linuxEvent.Period;
+            }
 
             stackIndex = InternFrames(frames.GetEnumerator(), stackIndex, linuxEvent.ProcessID, linuxEvent.ThreadID, blockedTimeAnalyzer);
             sample.StackIndex = stackIndex;
@@ -328,12 +339,24 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
 
         protected virtual void DoInterning()
         {
-            BlockedTimeAnalyzer blockedTimeAnalyzer = doThreadTime ? new BlockedTimeAnalyzer() : null;
+            BlockedTimeAnalyzer blockedTimeAnalyzer = doThreadTime ? new BlockedTimeAnalyzer(this) : null;
 
             foreach (var linuxEvent in parser.ParseSkippingPreamble(masterSource))
             {
+                // Set the start timestamp of the trace using the first event.
+                if(StartTimeStampMSec == 0)
+                {
+                    StartTimeStampMSec = linuxEvent.TimeMSec;
+                }
+
                 blockedTimeAnalyzer?.UpdateThreadState(linuxEvent);
-                AddSample(CreateSampleFor(linuxEvent, blockedTimeAnalyzer));
+
+                // Always add a sample for CPU events.
+                // Blocked time samples must be added by the BlockedTimeAnalyzer.
+                if (linuxEvent.Kind == EventKind.Cpu)
+                {
+                    AddSample(CreateSampleFor(linuxEvent, blockedTimeAnalyzer));
+                }
             }
 
             blockedTimeAnalyzer?.FinishAnalyzing();
@@ -461,6 +484,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
         public Dictionary<LinuxEvent, StackSourceSample> LinuxEventSamples { get; }
         public Dictionary<int, int> EndingCpuUsage { get; }
         public List<ThreadPeriod> BlockedThreadPeriods { get; }
+        public LinuxPerfScriptStackSource StackSource { get; }
 
         public double TotalBlockedTime
         {
@@ -476,13 +500,14 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             }
         }
 
-        public BlockedTimeAnalyzer()
+        public BlockedTimeAnalyzer(LinuxPerfScriptStackSource stackSource)
         {
             BeginningStates = new Dictionary<int, KeyValuePair<LinuxThreadState, LinuxEvent>>();
             EndingStates = new Dictionary<int, KeyValuePair<LinuxThreadState, LinuxEvent>>();
             LinuxEventSamples = new Dictionary<LinuxEvent, StackSourceSample>();
             EndingCpuUsage = new Dictionary<int, int>();
             BlockedThreadPeriods = new List<ThreadPeriod>();
+            StackSource = stackSource;
         }
 
         public void UpdateThreadState(LinuxEvent linuxEvent)
@@ -531,7 +556,10 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             {
                 if (EndingStates[threadid].Key == LinuxThreadState.BLOCKED_TIME)
                 {
-                    AddThreadPeriod(threadid, EndingStates[threadid].Value.TimeMSec, TimeStamp);
+                    KeyValuePair<LinuxThreadState, LinuxEvent> sampleInfo = EndingStates[threadid];
+                    sampleInfo.Value.Period = TimeStamp - sampleInfo.Value.TimeMSec;
+                    AddThreadPeriod(threadid, sampleInfo.Value.TimeMSec, TimeStamp);
+                    StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Value, this));
                 }
             }
         }
@@ -539,11 +567,6 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
         private void DoMetrics(LinuxEvent linuxEvent)
         {
             KeyValuePair<LinuxThreadState, LinuxEvent> sampleInfo;
-
-            if (EndingStates.TryGetValue(linuxEvent.ThreadID, out sampleInfo))
-            {
-                linuxEvent.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
-            }
 
             // This is check for completed scheduler events, ones that start with prev_comm and have 
             //   corresponding next_comm.
@@ -553,24 +576,44 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                 if (EndingStates.ContainsKey(schedEvent.Switch.PreviousThreadID) &&
                     EndingStates[schedEvent.Switch.PreviousThreadID].Key == LinuxThreadState.CPU_TIME) // Blocking
                 {
-                    sampleInfo = EndingStates[schedEvent.Switch.PreviousThreadID];
-
+                    // PreviousThreadID is now blocking.  linuxEvent contains its blocking stack, so save it here.
+                    // When it unblocks (becomes NextThreadID below, we'll log a sample for it.)
                     EndingStates[schedEvent.Switch.PreviousThreadID] =
                         new KeyValuePair<LinuxThreadState, LinuxEvent>(LinuxThreadState.BLOCKED_TIME, linuxEvent);
-
-                    linuxEvent.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
                 }
 
                 if (EndingStates.TryGetValue(schedEvent.Switch.NextThreadID, out sampleInfo) &&
                     sampleInfo.Key == LinuxThreadState.BLOCKED_TIME) // Unblocking
                 {
+                    sampleInfo.Value.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
+                    AddThreadPeriod(sampleInfo.Value.ThreadID, sampleInfo.Value.TimeMSec, linuxEvent.TimeMSec);
+                    StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Value, this));
+
                     EndingStates[schedEvent.Switch.NextThreadID] =
                         new KeyValuePair<LinuxThreadState, LinuxEvent>(LinuxThreadState.CPU_TIME, linuxEvent);
-
-                    // sampleInfo.Value.Period = linuxEvent.Time - sampleInfo.Value.Time;
-                    AddThreadPeriod(linuxEvent.ThreadID, sampleInfo.Value.TimeMSec, linuxEvent.TimeMSec);
                 }
 
+            }
+            else if(linuxEvent.Kind == EventKind.ThreadExit)
+            {
+                ThreadExitEvent exitEvent = (ThreadExitEvent)linuxEvent;
+                if (EndingStates.TryGetValue(exitEvent.Exit.ThreadID, out sampleInfo))
+                {
+                    if (sampleInfo.Key == LinuxThreadState.BLOCKED_TIME) // Blocked on exit
+                    {
+                        sampleInfo.Value.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
+                        AddThreadPeriod(sampleInfo.Value.ThreadID, sampleInfo.Value.TimeMSec, linuxEvent.TimeMSec);
+                        StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Value, this));
+                    }
+                    else // Unblocked on exit
+                    {
+                        linuxEvent.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
+                        StackSource.AddSample(StackSource.CreateSampleFor(linuxEvent, this));
+                    }
+
+                    // Remove the thread so that any events that might come after the exit are ignored.
+                    EndingStates.Remove(exitEvent.Exit.ThreadID);
+                }
             }
             else if (linuxEvent.Kind == EventKind.Cpu)
             {
@@ -583,6 +626,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                             new KeyValuePair<LinuxThreadState, LinuxEvent>(LinuxThreadState.CPU_TIME, linuxEvent);
                         sampleInfo.Value.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
                         AddThreadPeriod(linuxEvent.ThreadID, sampleInfo.Value.TimeMSec, linuxEvent.TimeMSec);
+                        StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Value, this));
                     }
                 }
             }


### PR DESCRIPTION
 - Support for OffCPU tracing (shows up in PerfView as Thread Time stacks under the Experimental group).
 - Fix naming of Process frames to be distinguishable from other non-process frames: `Process name (PID)` instead of `name`.
 - Transform frames that were resolved via perf jitdump into the format `module!namespace::method` to allow them to be nicely grouped.