### PR TITLE
Make FastSerialization.Deserializer.Dispose Callable Multiple Times

### DIFF
--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -1782,8 +1782,11 @@ namespace FastSerialization
         /// </summary>
         public void Dispose()
         {
-            reader.Dispose();
-            reader = null;
+            if (reader != null)
+            {
+                reader.Dispose();
+                reader = null;
+            }
             ObjectsInGraph = null;
             forwardReferenceDefinitions = null;
             unInitializedForwardReferences = null;


### PR DESCRIPTION
Fixes #1207.

Make sure that `reader` is non-null before calling `Dispose` on it.