### PR TITLE
Fix PerfView ThreadTime View When Capturing cpu-clock and sched Events

### DIFF
--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -196,7 +196,7 @@ namespace LinuxTracing.Tests
         }
 
         [Fact]
-        public void SchedHeader()
+        public void SchedHeaderFormat1()
         {
             string path = Constants.GetTestingPerfDumpPath("one_complete_switch");
             HeaderTest(path, blockedTime: true,
@@ -208,6 +208,27 @@ namespace LinuxTracing.Tests
                 timeProperties: new int[] { 1, 1 },
                 events: new string[] { "sched", "sched" },
                 eventProperties: new string[] { "sched_switch: prev_comm=comm1 prev_pid=0 prev_prio=0 prev_state=S ==> next_comm=comm2 next_pid=1 next_prio=1", "sched_switch: prev_comm=comm2 prev_pid=1 prev_prio=0 prev_state=S ==> next_comm=comm1 next_pid=0 next_prio=1" },
+                eventKinds: new EventKind[] { EventKind.Scheduler, EventKind.Scheduler },
+                switches: new ScheduleSwitch[]
+                {
+                    new ScheduleSwitch("comm1", 0, 0, 'S', "comm2", 1, 1),
+                    new ScheduleSwitch("comm2", 1, 0, 'S', "comm1", 0, 1)
+                });
+        }
+
+        [Fact]
+        public void SchedHeaderFormat2()
+        {
+            string path = Constants.GetTestingPerfDumpPath("one_complete_switch_format2");
+            HeaderTest(path, blockedTime: true,
+                commands: new string[] { "comm1", "comm2" },
+                pids: new int[] { 0, 1 },
+                tids: new int[] { 0, 1 },
+                cpus: new int[] { 0, 1 },
+                times: new double[] { 0.0, 1000.0 },
+                timeProperties: new int[] { 1, 1 },
+                events: new string[] { "sched", "sched" },
+                eventProperties: new string[] { "sched_switch: comm1:0 [0] S ==> comm2:1 [1]", "sched_switch: comm2:1 [0] S ==> comm1:0 [1]" },
                 eventKinds: new EventKind[] { EventKind.Scheduler, EventKind.Scheduler },
                 switches: new ScheduleSwitch[]
                 {

--- a/src/LinuxEvent.Tests/Sources/one_complete_switch_format2.perf.data.dump
+++ b/src/LinuxEvent.Tests/Sources/one_complete_switch_format2.perf.data.dump
@@ -1,0 +1,5 @@
+﻿comm1	0/0		[000] 0.0:			1 sched:sched_switch: comm1:0 [0] S ==> comm2:1 [1]
+	address symbol (module)
+
+comm2	1/1		[001] 1.0:			1 sched:sched_switch: comm2:1 [0] S ==> comm1:0 [1]
+	address symbol (module)

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
@@ -731,8 +731,11 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             var pos = source.MarkPosition();
 
             // Look for 'prev_comm' (Example1)
-            if (source.ReadByte() == 'p' && source.ReadByte() == 'r' && source.ReadByte() == 'e' && source.ReadByte() == 'v' && source.ReadByte() == '_' &&
-                source.ReadByte() == 'c' && source.ReadByte() == 'o' && source.ReadByte() == 'm' && source.ReadByte() == 'm')
+            source.ReadFixedString(9, sb);
+            string nextField = sb.ToString();
+            sb.Clear();
+
+            if (nextField.Equals("prev_comm"))
             {
                 // This is of the format in Example1.
 


### PR DESCRIPTION
With this PR, and an accompanying change to `perfcollect` it is now possible to analyze threadtime (CPU and blocked time) of a Linux application.

 - Don't depend upon `sched` events being emitted every 1ms.  Instead, keep track of how often they are emitted per CPU and use that to calculate the metric applied to the sample.
 - Add support for another format of the `sched:sched_switch` event encountered on Debian.