### PR TITLE
Add Back perfcollect -threadtime

### DIFF
--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -1462,8 +1462,9 @@ ProcessCollectedData()
     then
         # Get any perf-$pid.map files that were used by the
         # trace and store them alongside the trace.
+        local writeCrossgenWarning=1
         LogAppend "Saving perf.map files."
-            RunSilent "$perfcmd buildid-list --with-hits"
+        RunSilent "$perfcmd buildid-list --with-hits"
         local mapFiles=`$perfcmd buildid-list --with-hits | grep /tmp/perf- | cut -d ' ' -f 2`
         for mapFile in $mapFiles
         do
@@ -1490,6 +1491,19 @@ ProcessCollectedData()
                 fi
             else
                 LogAppend "Skipping $mapFile.  Some managed symbols may not be resolvable, but trace is still valid."
+            fi
+
+            # Also check for jit-<pid>.dump files.
+            # Convert to jit dump file name.
+            local pid=`echo $mapFile | awk -F"-" '{print $NF}' | awk -F"." '{print $1}'`
+            local path=`echo $mapFile | awk -F"/" '{OFS="/";NF--;print $0;}'`
+            local jitDumpFile="$path/jit-$pid.dump"
+
+            if [ -f $jitDumpFile ]
+            then
+                LogAppend "Saving $jitDumpFile"
+                RunSilent "cp $jitDumpFile ."
+                writeCrossgenWarning=0
             fi
         done
 
@@ -1555,14 +1569,12 @@ ProcessCollectedData()
             WriteStatus "...FINISHED"
 
         else
-        if [ "$buildidList" != "" ]
+        if [ "$buildidList" != "" ] && [ $writeCrossgenWarning -eq 1 ]
         then
             LogAppend "crossgen not found, skipping native image map generation."
             WriteStatus "...SKIPPED"
             WriteWarning "Crossgen not found.  Framework symbols will be unavailable."
             WriteWarning "See https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md#resolving-framework-symbols for details."
-        else
-            WriteWarning "libcoreclr.so not found in perf data. Please verify that your .NET Core process is running and consuming CPU."
         fi
         fi
 
@@ -1743,6 +1755,7 @@ PrintUsage()
     echo "collect options:"
     echo "By default, collection includes CPU samples collected every ms."
     echo "    -pid          : Only collect data from the specified process id."
+    echo "    -threadtime   : Collect events for thread time analysis (on and off cpu)."
     echo "    -offcpu       : Collect events for off-cpu analysis."
     echo "    -hwevents     : Collect (some) hardware counters."
     echo ""
@@ -1773,7 +1786,7 @@ PrintUsage()
 BuildPerfRecordArgs()
 {
     # Start with default collection arguments that record at realtime priority, all CPUs (-a), and collect call stacks (-g)
-    collectionArgs="record -r 50 -k 1 -a -g"
+    collectionArgs="record -k 1 -g"
 
     # Filter to a single process if desired
     if [ "$collectionPid" != "" ]
@@ -1786,8 +1799,15 @@ BuildPerfRecordArgs()
     # Enable CPU Collection
     if [ $collect_cpu -eq 1 ]
     then
-        collectionArgs="$collectionArgs -F 999"
+        collectionArgs="$collectionArgs"
         eventsToCollect=( "${eventsToCollect[@]}" "cpu-clock" )
+
+        # If only collecting CPU events, set the sampling rate to 1000.
+        # Otherwise, use the default sampling rate to avoid sampling sched events.
+        if [ $collect_threadTime -eq 0 ] && [ $collect_offcpu -eq 0 ]
+        then
+            collectionArgs="$collectionArgs -F 1000"
+        fi
     fi
 
     # Enable HW counters event collection


### PR DESCRIPTION
 - Add back the `-threadtime` parameter, which now properly collects `cpu-clock` and `sched` events.  This is accomplished by not specifying the `-F` parameter to `perf record`, and using the default sampling rate.  PerfView must adjust its handling of `cpu-clock` events to not assume that they come 1ms apart, but instead keep track of how often they come and dynamically adjust the sample metric.  This is done in #1213.
 - Capture `jit-<pid>.dump` files in case they are needed for debugging.
 - Don't log a warning when crossgen isn't present if `jit-<pid>.dump` files are present.