### PR TITLE
Fix the condemned reason table construction logic

### DIFF
--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -856,18 +856,15 @@ namespace Stats
 
             bool hasAnyContent = false;
             bool[] columnHasContent = new bool[CondemnedReasonsHtmlHeader.Length];
-            foreach (byte[] condemnedReasonRow in condemnedReasonRows)
+            for (int j = 0; j < CondemnedReasonsHtmlHeader.Length; j++)
             {
-                for (int j = 0; j < CondemnedReasonsHtmlHeader.Length; j++)
+                foreach (byte[] condemnedReasonRow in condemnedReasonRows)
                 {
-                    if (columnHasContent[j])
-                    {
-                        break;
-                    }
                     if (condemnedReasonRow[j] != 0)
                     {
                         hasAnyContent = true;
                         columnHasContent[j] = true;
+                        break;
                     }
                 }
             }
@@ -1063,7 +1060,7 @@ namespace Stats
         {
             for (CondemnedReasonGroup i = 0; i < CondemnedReasonGroup.Max; i++)
             {
-                result[(int)i] = reasons.CondemnedReasonGroups[(int)i];
+                result[(int)i] |= reasons.CondemnedReasonGroups[(int)i];
             }
         }
 


### PR DESCRIPTION
There are two bugs in the condemned reason table construction logic:

- To determine if we should render a column. We wanted to fill `columnHasContent` array. When my original code scans a row, it stops whenever it reaches a column with data in it. We should not stop there, the remaining column could also have data. The break was intended to stop trying other rows, not other columns, in order to do that, I need to swap the loop order.

- `FillCondemnedReason` is called twice, once for `PerHeapHistory` and again for `GlobalHeapHistory`. The intent was to capture both, but my implementation overwrote the data instead of accumulating them.