### PR TITLE
Fix for SymbolReader's Age field rendering not following SSQP Key Conventions

### DIFF
--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Diagnostics.Symbols
                         if (pdbIndexPath == null)
                         {
                             // symbolsource.org and nuget.smbsrc.net only support upper case of pdbIndexGuid
-                            pdbIndexPath = pdbSimpleName + @"\" + pdbIndexGuid.ToString("N").ToUpper() + pdbIndexAge.ToString() + @"\" + pdbSimpleName;
+                            pdbIndexPath = pdbSimpleName + @"\" + pdbIndexGuid.ToString("N").ToUpper() + pdbIndexAge.ToString("x") + @"\" + pdbSimpleName;
                         }
 
                         string cache = element.Cache;


### PR DESCRIPTION
Fix for issue I reported earlier: https://github.com/microsoft/perfview/issues/1222

This fixes lookup for PDBs with age greater than 9.

Ran the tests, all groups passed. Not sure if there's anything else to include for this bugfix since the details are in the issue thread.

Thanks for your consideration.