### PR TITLE
Fix /NetCapture When DataFile Does Not End With ".etl"

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -369,6 +369,10 @@ namespace PerfView
             {
                 parsedArgs.DataFile = parsedArgs.DataFile.Substring(0, parsedArgs.DataFile.Length - 4);
             }
+            else if(!parsedArgs.DataFile.EndsWith(".etl"))
+            {
+                parsedArgs.DataFile = parsedArgs.DataFile + ".etl";
+            }
 
             // Don't clobber the results file if we were told not to.  
             if (parsedArgs.CollectMultiple > 1)


### PR DESCRIPTION
Make sure that the `DataFile` argument gets updated to include an ".etl" file extension if one is not specified.  Without this, `/NetCapture` is broken because UI setup code will change the file name to `PerfViewData.etl.zip` because it doesn't have a valid file extension.

Fixes #1211.

cc: @yang-er, @suprak