### PR TITLE
Ignore errors instantiating symbol checksum algorithm.

### DIFF
--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -626,15 +626,15 @@ namespace Microsoft.Diagnostics.Symbols
                 // 3 checksum generated with the SHA256 hashing algorithm.
                 if (sourceFile.checksumType == 1)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.MD5.Create();
+                    try { _hashAlgorithm = System.Security.Cryptography.MD5.Create(); } catch (Exception) { }
                 }
                 else if (sourceFile.checksumType == 2)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create();
+                    try { _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); } catch (Exception) { }
                 }
                 else if (sourceFile.checksumType == 3)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.SHA256.Create();
+                    try { _hashAlgorithm = System.Security.Cryptography.SHA256.Create(); } catch (Exception) { }
                 }
 
                 if (_hashAlgorithm != null)

--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -95,11 +95,11 @@ namespace Microsoft.Diagnostics.Symbols
                 Guid hashAlgorithmGuid = _portablePdb._metaData.GetGuid(_sourceFileDocument.HashAlgorithm);
                 if (hashAlgorithmGuid == HashAlgorithmSha1)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create();
+                    try { _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); } catch (Exception) { }
                 }
                 else if (hashAlgorithmGuid == HashAlgorithmSha256)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.SHA256.Create();
+                    try { _hashAlgorithm = System.Security.Cryptography.SHA256.Create(); } catch (Exception) { }
                 }
 
                 if (_hashAlgorithm != null)


### PR DESCRIPTION
Ignore errors instantiating source checksum method during symbol source lookup.  For many use cases, source checksum is a "nice to have", but not a requirement.  Cryptography method instantiation may fail in certain cases.  For example, if FipsAlgorithmPolicy is in place on your host machine, you are not allowed to instantiate MD5.  Failing to checksum should not prevent source lookup workflow in my opinion (seems to work fine without it being performed for well behaving source server).