### PR TITLE
Handle More Corner Case Process Names in Linux Traces

### DIFF
--- a/src/LinuxEvent.Tests/EventParseTests.cs
+++ b/src/LinuxEvent.Tests/EventParseTests.cs
@@ -240,5 +240,22 @@ namespace LinuxTracing.Tests
                     new ScheduleSwitch("comm2", 1, 0, 'S', "comm1", 0, 1)
                 });
         }
+
+        [Fact]
+        public void CornerCaseProcessNames()
+        {
+            string path = Constants.GetTestingPerfDumpPath("corner_case_process_names");
+            HeaderTest(path, blockedTime: false,
+                commands: new string[] { "6", "77", "", "k/2", "k/[2]", "k:2"},
+                pids: new int[] { 0, 1, 2, 3, 4, 5 },
+                tids: new int[] { 0, 1, 2, 3, 4, 5 },
+                cpus: new int[] { 0, 0, 0, 0, 0, 0 },
+                times: new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                timeProperties: new int[] { 1, 1, 1, 1, 1, 1 },
+                events: new string[] { "event_name", "event_name", "event_name", "event_name", "event_name", "event_name" },
+                eventProperties: new string[] { "event_properties", "event_properties", "event_properties", "event_properties", "event_properties", "event_properties" },
+                eventKinds: null,
+                switches: null);
+        }
     }
 }

--- a/src/LinuxEvent.Tests/Sources/corner_case_process_names.perf.data.dump
+++ b/src/LinuxEvent.Tests/Sources/corner_case_process_names.perf.data.dump
@@ -1,0 +1,29 @@
+﻿6	0/0		[000] 0.0:			1 event_name: event_properties
+	address symbol (module)
+	address symbol2 (module2)
+	address main (main)
+
+77	1/1		[000] 0.0:			1 event_name: event_properties
+	address symbol3 (module3)
+	address symbol4 (module4)
+	address main (main)
+
+    2/2		[000] 0.0:			1 event_name: event_properties
+	address symbol5 (module5)
+	address symbol6 (module6)
+	address main (main)
+
+k/2    3/3		[000] 0.0:			1 event_name: event_properties
+	address symbol7 (module7)
+	address symbol8 (module8)
+	address main (main)
+
+k/[2]  4/4		[000] 0.0:			1 event_name: event_properties
+	address symbol9  (module9)
+	address symbol10 (module10)
+	address main (main)
+
+k:2    5/5		[000] 0.0:			1 event_name: event_properties
+	address symbol11 (module11)
+	address symbol12 (module12)
+	address main (main)

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
@@ -550,11 +550,18 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                     }
                     else if (!char.IsDigit((char)val))
                     {
-                        if(source.Peek(idx+1) == '[')
+                        if (source.Peek(idx + 1) == '[')
                         {
                             return firstSpaceIdx;
                         }
-                        goto startOver;
+                        else if (char.IsWhiteSpace((char)val))
+                        {
+                            firstSpaceIdx = (int)idx;
+                        }
+                        else
+                        {
+                            goto startOver;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
 - Handle process names that are just numbers.
 - Add a regression test for corner case process names.

cc: @mjrousos