### PR TITLE
Decoding traces produced by generational aware analysis.

### DIFF
--- a/src/HeapDumpCommon/DotNetHeapInfo.cs
+++ b/src/HeapDumpCommon/DotNetHeapInfo.cs
@@ -115,6 +115,7 @@ public class GCHeapDumpSegment : IFastSerializable
     public Address Gen1End { get; internal set; }
     public Address Gen2End { get; internal set; }
     public Address Gen3End { get; internal set; }
+    public Address Gen4End { get; internal set; }
 
     #region private
     void IFastSerializable.ToStream(Serializer serializer)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3770,6 +3770,11 @@ table {
                     // For .NET, we are looking for a Gen 2 GC Start that is induced that has GCBulkNodes after it.   
                     var lastGCStartsRelMSec = new Dictionary<int, double>();
 
+                    source.Clr.GCGenAwareStart += delegate (Microsoft.Diagnostics.Tracing.Parsers.Clr.GenAwareBeginTraceData data)
+                    {
+                        lastGCStartsRelMSec[data.ProcessID] = data.TimeStampRelativeMSec;
+                    };
+
                     source.Clr.GCStart += delegate (Microsoft.Diagnostics.Tracing.Parsers.Clr.GCStartTraceData data)
                     {
                         // Look for induced GCs.  and remember their when it happened.    


### PR DESCRIPTION
Here are the changes required to decode the traces produced by generational aware analysis I introduced in https://github.com/dotnet/runtime/pull/40332

Notice the latest change requires https://github.com/dotnet/runtime/pull/41052