### PR TITLE
Update to TraceEvent SupportFiles 1.0.19

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,7 +29,7 @@
   <!-- versions of dependencies that more than one project use -->
   <PropertyGroup>
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.18</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.19</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisRulesVersion>0.1.0</MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisRulesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>1.1.37504</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.3.0</XunitVersion>


### PR DESCRIPTION
Updates KernelTraceControl.dll to a newer version that addresses a bug that made merge fail.