### PR TITLE
Update to TraceEvent SupportFiles1.0.20 to Fix Missing Dependencies

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,7 +29,7 @@
   <!-- versions of dependencies that more than one project use -->
   <PropertyGroup>
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.19</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.20</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisRulesVersion>0.1.0</MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisRulesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>1.1.37504</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.3.0</XunitVersion>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -148,6 +148,20 @@
       <Link>x86\msdia140.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\x86\msvcp140.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\x86\msvcp140.dll</LogicalName>
+      <Link>x86\msvcp140.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\x86\vcruntime140.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\x86\vcruntime140.dll</LogicalName>
+      <Link>x86\vcruntime140.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(PerfViewSupportFilesBase)native\x86\sd.exe">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
@@ -197,6 +211,20 @@
       <WithCulture>false</WithCulture>
       <LogicalName>.\amd64\msdia140.dll</LogicalName>
       <Link>amd64\msdia140.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\msvcp140.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\amd64\msvcp140.dll</LogicalName>
+      <Link>amd64\msvcp140.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\amd64\vcruntime140.dll</LogicalName>
+      <Link>amd64\vcruntime140.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
     <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net45\HeapDump.exe">

--- a/src/TraceEvent/NativeDlls.cs
+++ b/src/TraceEvent/NativeDlls.cs
@@ -34,6 +34,7 @@ internal class NativeDlls
         var thisDllDir = Path.GetDirectoryName(assemblyLocation);
 
         // Try next to the current DLL
+        SetDllDirectory(thisDllDir);
         var dllName = Path.Combine(thisDllDir, simpleName);
         var ret = LoadLibrary(dllName);
         if (ret != IntPtr.Zero)
@@ -42,6 +43,7 @@ internal class NativeDlls
         }
 
         // Try in <arch> directory
+        SetDllDirectory(Path.Combine(thisDllDir, ProcessArchitectureDirectory));
         dllName = Path.Combine(thisDllDir, ProcessArchitectureDirectory, simpleName);
         ret = LoadLibrary(dllName);
         if (ret != IntPtr.Zero)
@@ -50,6 +52,7 @@ internal class NativeDlls
         }
 
         // Try in ../native/<arch>.  This is where it will be in a nuget package. 
+        SetDllDirectory(Path.Combine(Path.GetDirectoryName(thisDllDir), "native", ProcessArchitectureDirectory));
         dllName = Path.Combine(Path.GetDirectoryName(thisDllDir), "native", ProcessArchitectureDirectory, simpleName);
         ret = LoadLibrary(dllName);
         if (ret != IntPtr.Zero)
@@ -93,4 +96,10 @@ internal class NativeDlls
 
     [System.Runtime.InteropServices.DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern IntPtr LoadLibrary(string lpFileName);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetDllDirectory(string lpPathName);
+
+
 }


### PR DESCRIPTION
The latest version of msdia140.dll depends upon msvcp.dll which in turn depends upon vcruntime140.dll.  This change includes them in the support files package for TraceEvent and also modifies how we load native binaries to ensure that they can be found when msdia140.dll is loaded.