### PR TITLE
Fix msdia140 Dependencies in TraceEvent NuGet Package

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.59</PerfViewVersion>
-    <TraceEventVersion>2.0.59</TraceEventVersion>
+    <PerfViewVersion>2.0.60</PerfViewVersion>
+    <TraceEventVersion>2.0.60</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -46,10 +46,14 @@
     <!-- Native binaries -->
     <file src="$OutDir$netstandard2.0\amd64\KernelTraceControl.dll" target="lib\native\amd64\KernelTraceControl.dll" />
     <file src="$OutDir$netstandard2.0\amd64\msdia140.dll" target="lib\native\amd64\msdia140.dll" />
+    <file src="$OutDir$netstandard2.0\amd64\msvcp140.dll" target="lib\native\amd64\msvcp140.dll" />
+    <file src="$OutDir$netstandard2.0\amd64\vcruntime140.dll" target="lib\native\amd64\vcruntime140.dll" />
 
     <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.dll" target="lib\native\x86\KernelTraceControl.dll" />
     <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.Win61.dll" target="lib\native\x86\KernelTraceControl.Win61.dll" />
     <file src="$OutDir$netstandard2.0\x86\msdia140.dll" target="lib\native\x86\msdia140.dll" />
+    <file src="$OutDir$netstandard2.0\x86\msvcp140.dll" target="lib\native\x86\msvcp140.dll" />
+    <file src="$OutDir$netstandard2.0\x86\vcruntime140.dll" target="lib\native\x86\vcruntime140.dll" />
 
     <!-- NetStandard 2.0 Framework -->
 	

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -122,6 +122,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
+    <None Include="$(TraceEventSupportFilesBase)native\amd64\msvcp140.dll">
+      <Link>amd64\msvcp140.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140.dll">
+      <Link>amd64\vcruntime140.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
     <None Include="$(TraceEventSupportFilesBase)native\x86\KernelTraceControl.dll">
       <Link>x86\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -134,6 +144,16 @@
     </None>
     <None Include="$(TraceEventSupportFilesBase)native\x86\msdia140.dll">
       <Link>x86\msdia140.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(TraceEventSupportFilesBase)native\x86\msvcp140.dll">
+      <Link>x86\msvcp140.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(TraceEventSupportFilesBase)native\x86\vcruntime140.dll">
+      <Link>x86\vcruntime140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
Include msvcp140.dll and vcruntime140.dll in TraceEvent NuGet package.