### PR TITLE
Add vcruntime140_1.dll for amd64

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,7 +29,7 @@
   <!-- versions of dependencies that more than one project use -->
   <PropertyGroup>
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.21</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.22</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisRulesVersion>0.1.0</MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisRulesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>1.1.37504</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.3.0</XunitVersion>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -227,6 +227,13 @@
       <Link>amd64\vcruntime140.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140_1.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\amd64\vcruntime140_1.dll</LogicalName>
+      <Link>amd64\vcruntime140_1.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net45\HeapDump.exe">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -48,6 +48,7 @@
     <file src="$OutDir$netstandard2.0\amd64\msdia140.dll" target="lib\native\amd64\msdia140.dll" />
     <file src="$OutDir$netstandard2.0\amd64\msvcp140.dll" target="lib\native\amd64\msvcp140.dll" />
     <file src="$OutDir$netstandard2.0\amd64\vcruntime140.dll" target="lib\native\amd64\vcruntime140.dll" />
+    <file src="$OutDir$netstandard2.0\amd64\vcruntime140_1.dll" target="lib\native\amd64\vcruntime140_1.dll" />
 
     <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.dll" target="lib\native\x86\KernelTraceControl.dll" />
     <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.Win61.dll" target="lib\native\x86\KernelTraceControl.Win61.dll" />

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -46,6 +46,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\native\amd64\vcruntime140_1.dll')" Include="$(MSBuildThisFileDirectory)..\lib\native\amd64\vcruntime140_1.dll">
+      <Link>amd64\vcruntime140_1.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
 
     <!-- There are no static references to these so I need to copy them explicitly.  
          The first two COM interop assemblies so they are the same for all targets, I pick netstandard1.6 pretty arbitraily 

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -132,6 +132,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
+    <None Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140_1.dll">
+      <Link>amd64\vcruntime140_1.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
     <None Include="$(TraceEventSupportFilesBase)native\x86\KernelTraceControl.dll">
       <Link>x86\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
vcruntime140.dll on amd64 has an extra dependency on vcruntime140_1.dll.  This change includes vcruntime140_1.dll in supportfiles and consumes it from TraceEvent and PerfView.

Fixes #1268.