### PR TITLE
Display JIT Allocated Heap Size

### DIFF
--- a/src/PerfView/JitStats.cs
+++ b/src/PerfView/JitStats.cs
@@ -154,7 +154,7 @@ namespace Stats
                 writer.WriteLine("<LI> Summary of jitting time by module:</P>");
                 writer.WriteLine("<Center>");
                 writer.WriteLine("<Table Border=\"1\">");
-                writer.WriteLine("<TR>" +
+                writer.Write("<TR>" +
                     "<TH Title=\"The name of the module\">Name</TH>" +
                     "<TH Title=\"The total CPU time spent jitting for all methods in this module\">JitTime<BR/>msec</TH>" +
                     "<TH Title=\"The number of times the JIT was invoked for methods in this module\">Num Compilations</TH>" +
@@ -166,9 +166,9 @@ namespace Stats
 
                 if (runtime.JIT.Stats().IsJitAllocSizePresent)
                 {
-                    writer.WriteLine("<TH Title=\"The total amount of heap memory requested for the code produced by the JIT for all methods in this module.  \">Allocation Size for Hotcode</TH>");
-                    writer.WriteLine("<TH Title=\"The total amount of heap memory requested for the read-only data of code produced by the JIT for all methods in this module.  \">Allocation Size for ROData</TH>");
-                    writer.WriteLine("<TH Title=\"The total amount of heap memory allocated for the code produced by the JIT for all methods in this module. \">Allocated size</TH>");
+                    writer.Write("<TH Title=\"The total amount of heap memory requested for the code produced by the JIT for all methods in this module.  \">Allocation Size for Hotcode</TH>");
+                    writer.Write("<TH Title=\"The total amount of heap memory requested for the read-only data of code produced by the JIT for all methods in this module.  \">Allocation Size for ROData</TH>");
+                    writer.Write("<TH Title=\"The total amount of heap memory allocated for the code produced by the JIT for all methods in this module. \">Allocated size</TH>");
                 }
 
                 writer.WriteLine("</TR>");
@@ -181,8 +181,7 @@ namespace Stats
                     "<TD Align=\"Center\">{4:n0}</TD>" +
                     "<TD Align=\"Center\">{5:n1}</TD>" +
                     "<TD Align=\"Center\">{6:n1}</TD>" +
-                    "<TD Align=\"Center\">{7:n1}</TD>" +
-                    "</TR>";
+                    "<TD Align=\"Center\">{7:n1}</TD>";
                 
                 writer.Write(moduleTableRow,
                     "TOTAL",
@@ -200,8 +199,7 @@ namespace Stats
                     allocSizeColumns +=
                        "<TD Align=\"Center\">{0:n0}</TD>" +
                        "<TD Align=\"Center\">{1:n0}</TD>" +
-                       "<TD Align=\"Center\">{2:n0}</TD>" +
-                       "<TD Align=\"Center\">N/A</TD>"; //TODO: See if this is needed.
+                       "<TD Align=\"Center\">{2:n0}</TD>";
 
                     writer.Write(allocSizeColumns,
                         runtime.JIT.Stats().TotalHotCodeAllocSize,
@@ -231,7 +229,7 @@ namespace Stats
                             info.TotalAllocSizeForJitCode);
                     }
 
-                    writer.WriteLine();
+                    writer.WriteLine("</TR>");
 
                 }
                 writer.WriteLine("</Table>");
@@ -305,10 +303,10 @@ namespace Stats
                 if (_event.IsJitAllocSizePresent)
                 {
                     writer.Write(
-                        "<TD Align=\"Center\">{0:n0}</TD>",
-                        "<TD Align=\"Center\">{1:n0}</TD>",
-                        "<TD Align=\"Center\">{2:n0}</TD>",
-                        "<TD Align=\"Center\">{3:n0}</TD>",
+                        "<TD Align=\"Center\">{0}</TD>" +
+                        "<TD Align=\"Center\">{1}</TD>" +
+                        "<TD Align=\"Center\">{2}</TD>" +
+                        "<TD Align=\"Center\">{3}</TD>",
                         _event.HotCodeAllocSize,
                         _event.RODataAllocSize,
                         _event.RequestedAllocSizeForJitCode,
@@ -440,7 +438,11 @@ namespace Stats
             bool showOptimizationTiers = ShouldShowOptimizationTiers(runtime);
             using (var writer = File.CreateText(filePath))
             {
-                writer.Write("Start MSec{0}JitTime MSec{0}ThreadID{0}IL Size{0}Native Size{0}LoaderHeap Allocation Size", listSeparator);
+                writer.Write("Start MSec{0}JitTime MSec{0}ThreadID{0}IL Size{0}Native Size", listSeparator);
+                if (runtime.JIT.Stats().IsJitAllocSizePresent)
+                {
+                    writer.Write("HotCode Size{0}RO data Size{0}Allocated Heap Size{0}JIT Allocation Flag", listSeparator);
+                }
                 if (showOptimizationTiers)
                 {
                     writer.Write("{0}OptimizationTier", listSeparator);

--- a/src/PerfView/JitStats.cs
+++ b/src/PerfView/JitStats.cs
@@ -160,7 +160,7 @@ namespace Stats
                     "<TH Title=\"The number of times the JIT was invoked for methods in this module\">Num Compilations</TH>" +
                     "<TH Title=\"The total amount of IL processed by the JIT for all methods in this module\">IL Size</TH>" +
                     "<TH Title=\"The total amount of native code produced by the JIT for all methods in this module\">Native Size</TH>" +
-                    "<TH Title=\"The total amount of heap memory allocated for the code produced by the JIT for all methods in this module\">Allocated Heap Size</TH>" +
+                    "<TH Title=\"The total amount of heap memory allocated for the code produced by the JIT for all methods in this module\">LoaderHeap Allocation Size</TH>" +
                     "<TH Title=\"Time spent jitting synchronously to produce code for methods that were just invoked. These compilations often consume time at startup.\">" + GetLongNameForThreadClassification(CompilationThreadKind.Foreground) + "<BR/>msec</TH>" +
                     "<TH Title=\"Time spent jitting asynchronously to produce code for methods the runtime speculates will be invoked in the future.\">" + GetLongNameForThreadClassification(CompilationThreadKind.MulticoreJitBackground) + "<BR/>msec</TH>" +
                     "<TH Title=\"Time spent jitting asynchronously to produce code for methods that is more optimized than their initial code.\">" + GetLongNameForThreadClassification(CompilationThreadKind.TieredCompilationBackground) + "<BR/>msec</TH>" +
@@ -183,7 +183,7 @@ namespace Stats
                     runtime.JIT.Stats().Count,
                     runtime.JIT.Stats().TotalILSize,
                     runtime.JIT.Stats().TotalNativeSize,
-                    runtime.JIT.Stats().TotalAllocatedHeapSize,
+                    runtime.JIT.Stats().TotalLoaderHeapAllocSize,
                     runtime.JIT.Stats().TotalForegroundCpuTimeMSec,
                     runtime.JIT.Stats().TotalBackgroundMultiCoreJitCpuTimeMSec,
                     runtime.JIT.Stats().TotalBackgroundTieredCompilationCpuTimeMSec);
@@ -196,7 +196,7 @@ namespace Stats
                         info.Count,
                         info.TotalILSize,
                         info.TotalNativeSize,
-                        info.TotalAllocatedHeapSize,
+                        info.TotalLoaderHeapAllocSize,
                         info.TotalForegroundCpuTimeMSec,
                         info.TotalBackgroundMultiCoreJitCpuTimeMSec,
                         info.TotalBackgroundTieredCompilationCpuTimeMSec);
@@ -259,7 +259,7 @@ namespace Stats
                     _event.CompileCpuTimeMSec,
                     _event.ILSize,
                     _event.NativeSize,
-                    _event.AllocatedHeapSize);
+                    _event.LoaderHeapAllocSize);
                 if (showOptimizationTiers)
                 {
                     writer.Write(
@@ -384,7 +384,7 @@ namespace Stats
             bool showOptimizationTiers = ShouldShowOptimizationTiers(runtime);
             using (var writer = File.CreateText(filePath))
             {
-                writer.Write("Start MSec{0}JitTime MSec{0}ThreadID{0}IL Size{0}Native Size{0}Allocated Heap Size", listSeparator);
+                writer.Write("Start MSec{0}JitTime MSec{0}ThreadID{0}IL Size{0}Native Size{0}LoaderHeap Allocation Size", listSeparator);
                 if (showOptimizationTiers)
                 {
                     writer.Write("{0}OptimizationTier", listSeparator);
@@ -404,7 +404,7 @@ namespace Stats
                         _event.ThreadID,
                         _event.ILSize,
                         _event.NativeSize,
-                        _event.AllocatedHeapSize);
+                        _event.LoaderHeapAllocSize);
                     if (showOptimizationTiers)
                     {
                         writer.Write(
@@ -487,7 +487,7 @@ namespace Stats
 
             // TODO pay attention to indent;
             writer.Write(" <JitProcess Process=\"{0}\" ProcessID=\"{1}\" JitTimeMSec=\"{2:n3}\" Count=\"{3}\" ILSize=\"{4}\" NativeSize=\"{5}\" AllocatedHeapSize=\"{6}\"",
-                stats.Name, stats.ProcessID, runtime.JIT.Stats().TotalCpuTimeMSec, runtime.JIT.Stats().Count, runtime.JIT.Stats().TotalILSize, runtime.JIT.Stats().TotalNativeSize, runtime.JIT.Stats().TotalAllocatedHeapSize);
+                stats.Name, stats.ProcessID, runtime.JIT.Stats().TotalCpuTimeMSec, runtime.JIT.Stats().Count, runtime.JIT.Stats().TotalILSize, runtime.JIT.Stats().TotalNativeSize, runtime.JIT.Stats().TotalLoaderHeapAllocSize);
             if (stats.CPUMSec != 0)
             {
                 writer.Write(" ProcessCpuTimeMsec=\"{0}\"", stats.CPUMSec);
@@ -509,7 +509,7 @@ namespace Stats
             writer.WriteLine("  </JitEvents>");
 
             writer.WriteLine(" <ModuleStats Count=\"{0}\" TotalCount=\"{1}\" TotalJitTimeMSec=\"{2:n3}\" TotalILSize=\"{3}\" TotalNativeSize=\"{4}\" TotalAllocatedHeapSize=\"{5}\">",
-                statsEx.TotalModuleStats.Count, runtime.JIT.Stats().Count, runtime.JIT.Stats().TotalCpuTimeMSec, runtime.JIT.Stats().TotalILSize, runtime.JIT.Stats().TotalNativeSize, runtime.JIT.Stats().TotalAllocatedHeapSize);
+                statsEx.TotalModuleStats.Count, runtime.JIT.Stats().Count, runtime.JIT.Stats().TotalCpuTimeMSec, runtime.JIT.Stats().TotalILSize, runtime.JIT.Stats().TotalNativeSize, runtime.JIT.Stats().TotalLoaderHeapAllocSize);
 
             // Sort the module list by Jit Time;
             List<string> moduleNames = new List<string>(statsEx.TotalModuleStats.Keys);
@@ -536,7 +536,7 @@ namespace Stats
                 writer.Write(" Count={0}", StringUtilities.QuotePadLeft(info.Count.ToString(), 7));
                 writer.Write(" ILSize={0}", StringUtilities.QuotePadLeft(info.TotalILSize.ToString(), 9));
                 writer.Write(" NativeSize={0}", StringUtilities.QuotePadLeft(info.TotalNativeSize.ToString(), 9));
-                writer.Write(" AllocatedHeapSize={0}", StringUtilities.QuotePadLeft(info.TotalAllocatedHeapSize.ToString(), 9));
+                writer.Write(" AllocatedHeapSize={0}", StringUtilities.QuotePadLeft(info.TotalLoaderHeapAllocSize.ToString(), 9));
                 writer.Write(" Name=\"{0}\"", moduleName);
                 writer.WriteLine("/>");
             }
@@ -552,7 +552,7 @@ namespace Stats
             writer.Write(" JitTimeMSec={0}", StringUtilities.QuotePadLeft(info.CompileCpuTimeMSec.ToString("n3"), 8));
             writer.Write(" ILSize={0}", StringUtilities.QuotePadLeft(info.ILSize.ToString(), 10));
             writer.Write(" NativeSize={0}", StringUtilities.QuotePadLeft(info.NativeSize.ToString(), 10));
-            writer.Write(" AllocatedHeapSize={0}", StringUtilities.QuotePadLeft(info.AllocatedHeapSize.ToString(), 10));
+            writer.Write(" AllocatedHeapSize={0}", StringUtilities.QuotePadLeft(info.LoaderHeapAllocSize.ToString(), 10));
             if (showOptimizationTiers)
             {
                 writer.Write(

--- a/src/PerfView/JitStats.cs
+++ b/src/PerfView/JitStats.cs
@@ -166,9 +166,9 @@ namespace Stats
 
                 if (runtime.JIT.Stats().IsJitAllocSizePresent)
                 {
-                    writer.Write("<TH Title=\"The total amount of heap memory requested for the code produced by the JIT for all methods in this module.  \">Allocation Size for Hotcode</TH>");
-                    writer.Write("<TH Title=\"The total amount of heap memory requested for the read-only data of code produced by the JIT for all methods in this module.  \">Allocation Size for ROData</TH>");
-                    writer.Write("<TH Title=\"The total amount of heap memory allocated for the code produced by the JIT for all methods in this module. \">Allocated size</TH>");
+                    writer.Write("<TH Title=\"The total amount of heap memory requested for the code produced by the JIT for all methods in this module.  \">JIT Hotcode request size</TH>");
+                    writer.Write("<TH Title=\"The total amount of heap memory requested for the read-only data of code produced by the JIT for all methods in this module.  \">JIT RO-data request size</TH>");
+                    writer.Write("<TH Title=\"The total amount of heap memory allocated for the code produced by the JIT for all methods in this module. \">Allocated size for JIT code</TH>");
                 }
 
                 writer.WriteLine("</TR>");
@@ -264,10 +264,10 @@ namespace Stats
             if (runtime.JIT.Stats().IsJitAllocSizePresent)
             {
                 writer.Write(
-                    "<TH>HotCode<BR/>Size</TH>" +
-                    "<TH>RO data<BR/>Size</TH>" +
-                    "<TH>Allocated<BR/>Heap Size</TH>" +
-                    "<TH>JIT Allocation<BR/>Flag</TH>"
+                    "<TH>JIT Hotcode<BR/>request size</TH>" +
+                    "<TH>JIT RO-data<BR/>request size</TH>" +
+                    "<TH>Allocated size<BR/>for JIT code</TH>" +
+                    "<TH>JIT Allocation<BR/>Flags</TH>"
                     );
             }
 
@@ -307,9 +307,9 @@ namespace Stats
                         "<TD Align=\"Center\">{1}</TD>" +
                         "<TD Align=\"Center\">{2}</TD>" +
                         "<TD Align=\"Center\">{3}</TD>",
-                        _event.HotCodeAllocSize,
-                        _event.RODataAllocSize,
-                        _event.RequestedAllocSizeForJitCode,
+                        _event.JitHotCodeRequestSize,
+                        _event.JitRODataRequestSize,
+                        _event.AllocatedSizeForJitCode,
                         _event.JitAllocFlag
                         );
                 }
@@ -441,7 +441,7 @@ namespace Stats
                 writer.Write("Start MSec{0}JitTime MSec{0}ThreadID{0}IL Size{0}Native Size", listSeparator);
                 if (runtime.JIT.Stats().IsJitAllocSizePresent)
                 {
-                    writer.Write("{0}HotCode Size{0}RO data Size{0}Allocated Heap Size{0}JIT Allocation Flag", listSeparator);
+                    writer.Write("{0}JIT HotCode request size{0}JIT RO-data request size{0}Allocated size for JIT code{0}JIT Allocation Flag", listSeparator);
                 }
                 if (showOptimizationTiers)
                 {
@@ -467,9 +467,9 @@ namespace Stats
                     {
                         writer.Write("{0}{1}{0}{2}{0}{3}{0}{4}",
                             listSeparator,
-                            _event.HotCodeAllocSize,
-                            _event.RODataAllocSize,
-                            _event.RequestedAllocSizeForJitCode,
+                            _event.JitHotCodeRequestSize,
+                            _event.JitRODataRequestSize,
+                            _event.AllocatedSizeForJitCode,
                             _event.JitAllocFlag);
                     }
 
@@ -632,9 +632,9 @@ namespace Stats
 
             if (info.IsJitAllocSizePresent)
             {
-                writer.Write(" HotCodeAllocSize={0}", StringUtilities.QuotePadLeft(info.HotCodeAllocSize.ToString(), 10));
-                writer.Write(" RODataAllocSize={0}", StringUtilities.QuotePadLeft(info.RODataAllocSize.ToString(), 10));
-                writer.Write(" RequestedAllocSizeForJitCode={0}", StringUtilities.QuotePadLeft(info.RequestedAllocSizeForJitCode.ToString(), 10));
+                writer.Write(" JITHotCodeRequestSize={0}", StringUtilities.QuotePadLeft(info.JitHotCodeRequestSize.ToString(), 10));
+                writer.Write(" JITRODataRequestSize={0}", StringUtilities.QuotePadLeft(info.JitRODataRequestSize.ToString(), 10));
+                writer.Write(" AllocSizeForJitCode={0}", StringUtilities.QuotePadLeft(info.AllocatedSizeForJitCode.ToString(), 10));
                 writer.Write(" JitAllocFlag={0}", StringUtilities.QuotePadLeft(info.JitAllocFlag.ToString(), 10));
             }
             if (showOptimizationTiers)

--- a/src/PerfView/JitStats.cs
+++ b/src/PerfView/JitStats.cs
@@ -441,7 +441,7 @@ namespace Stats
                 writer.Write("Start MSec{0}JitTime MSec{0}ThreadID{0}IL Size{0}Native Size", listSeparator);
                 if (runtime.JIT.Stats().IsJitAllocSizePresent)
                 {
-                    writer.Write("HotCode Size{0}RO data Size{0}Allocated Heap Size{0}JIT Allocation Flag", listSeparator);
+                    writer.Write("{0}HotCode Size{0}RO data Size{0}Allocated Heap Size{0}JIT Allocation Flag", listSeparator);
                 }
                 if (showOptimizationTiers)
                 {
@@ -465,7 +465,7 @@ namespace Stats
 
                     if (_event.IsJitAllocSizePresent)
                     {
-                        writer.Write("{1}{0}{2}{0}{3}{0}{4}",
+                        writer.Write("{0}{1}{0}{2}{0}{3}{0}{4}",
                             listSeparator,
                             _event.HotCodeAllocSize,
                             _event.RODataAllocSize,
@@ -554,8 +554,11 @@ namespace Stats
             JITStatsEx statsEx = JITStatsEx.Create(runtime);
 
             // TODO pay attention to indent;
-            writer.Write(" <JitProcess Process=\"{0}\" ProcessID=\"{1}\" JitTimeMSec=\"{2:n3}\" Count=\"{3}\" ILSize=\"{4}\" NativeSize=\"{5}\" HotCodeAllocSize=\"{6}\" RODataAllocSize=\"{7}\" AllocSizeForJitCode=\"{8}\"",
-                stats.Name, stats.ProcessID, runtime.JIT.Stats().TotalCpuTimeMSec, runtime.JIT.Stats().Count, runtime.JIT.Stats().TotalILSize, runtime.JIT.Stats().TotalNativeSize, runtime.JIT.Stats().TotalHotCodeAllocSize, runtime.JIT.Stats().TotalRODataAllocSize, runtime.JIT.Stats().TotalAllocSizeForJitCode);
+            writer.Write(" <JitProcess Process=\"{0}\" ProcessID=\"{1}\" JitTimeMSec=\"{2:n3}\" Count=\"{3}\" ILSize=\"{4}\" NativeSize=\"{5}\"", stats.Name, stats.ProcessID, runtime.JIT.Stats().TotalCpuTimeMSec, runtime.JIT.Stats().Count, runtime.JIT.Stats().TotalILSize, runtime.JIT.Stats().TotalNativeSize);
+            if (runtime.JIT.Stats().IsJitAllocSizePresent)
+            {
+                writer.Write("HotCodeAllocSize=\"{0}\" RODataAllocSize=\"{1}\" AllocSizeForJitCode=\"{2}\"", runtime.JIT.Stats().TotalHotCodeAllocSize, runtime.JIT.Stats().TotalRODataAllocSize, runtime.JIT.Stats().TotalAllocSizeForJitCode);
+            }
             if (stats.CPUMSec != 0)
             {
                 writer.Write(" ProcessCpuTimeMsec=\"{0}\"", stats.CPUMSec);

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -3849,6 +3849,8 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
         /// </summary>
         public HashSet<string> SymbolsMissing = new HashSet<string>();
 
+        public string TotalLoaderHeapAllocSizeIfAvailable => TotalLoaderHeapAllocSize > 0 ? TotalLoaderHeapAllocSize.ToString() : "N/A";
+
         /// <summary>
         /// Aggregate a method to be included in the statistics
         /// </summary>
@@ -3933,6 +3935,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
             TraceJittedMethod _method = stats.JIT.m_stats.FindIncompleteJitEventOnThread(stats, data.ThreadID);
             if (_method != null)
             {
+                _method.IsLoaderHeapAllocSizePresent = true;
                 _method.LoaderHeapAllocSize += data.RequestSize;
                 stats.JIT.m_stats.TotalLoaderHeapAllocSize += data.RequestSize;
             }
@@ -4230,6 +4233,14 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
         public int VersionID;
 
         public bool IsDefaultVersion { get { return VersionID == 0; } }
+
+        internal bool IsLoaderHeapAllocSizePresent
+        {
+            get;
+            set;
+        }
+
+        public string LoaderHeapAllocSizeIfAvailable => IsLoaderHeapAllocSizePresent ? LoaderHeapAllocSize.ToString() : "N/A";
 
 #region private
         internal void SetOptimizationTier(OptimizationTier optimizationTier, TraceLoadedDotNetRuntime stats)

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -3934,10 +3934,10 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
             TraceJittedMethod _method = stats.JIT.m_stats.FindIncompleteJitEventOnThread(stats, data.ThreadID);
             if (_method != null)
             {
-                _method.AllocatedHeapSize = data.RequestSize;
+                _method.AllocatedHeapSize += data.RequestSize;
+                stats.JIT.m_stats.TotalAllocatedHeapSize += data.RequestSize;
             }
 
-            stats.JIT.m_stats.TotalAllocatedHeapSize += data.RequestSize;
             return _method;
         }
 

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -3871,10 +3871,10 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
             TotalCpuTimeMSec += method.CompileCpuTimeMSec;
             TotalILSize += method.ILSize;
             TotalNativeSize += method.NativeSize;
-            TotalHotCodeAllocSize += method.HotCodeAllocSize;
-            TotalRODataAllocSize += method.RODataAllocSize;
+            TotalHotCodeAllocSize += method.JitHotCodeRequestSize;
+            TotalRODataAllocSize += method.JitRODataRequestSize;
             IsJitAllocSizePresent |= method.IsJitAllocSizePresent;
-            TotalAllocSizeForJitCode += method.RequestedAllocSizeForJitCode;
+            TotalAllocSizeForJitCode += method.AllocatedSizeForJitCode;
             if (method.CompilationThreadKind == CompilationThreadKind.MulticoreJitBackground)
             {
                 CountBackgroundMultiCoreJit++;
@@ -3949,13 +3949,13 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
             if (_method != null)
             {
                 // If we already counted alloc size for a method, don't count it again.
-                if (_method.HotCodeAllocSize == 0)
+                if (_method.JitHotCodeRequestSize == 0)
                 {
                     _method.IsJitAllocSizePresent = true;
-                    _method.HotCodeAllocSize = data.HotCodeSize;
-                    _method.RODataAllocSize = data.RODataSize;
-                    _method.RequestedAllocSizeForJitCode = data.TotalRequestSize;
-                    _method.JitAllocFlag = data.CorJitAllocMemFlag;
+                    _method.JitHotCodeRequestSize = data.JitHotCodeRequestSize;
+                    _method.JitRODataRequestSize = data.JitRODataRequestSize;
+                    _method.AllocatedSizeForJitCode = data.AllocatedSizeForJitCode;
+                    _method.JitAllocFlag = data.JitAllocFlag;
                 }
             }
         }
@@ -4166,15 +4166,15 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
         /// <summary>
         /// Hot code size allocated for JIT code of method
         /// </summary>
-        public long HotCodeAllocSize;
+        public long JitHotCodeRequestSize;
         /// <summary>
         /// Read-only data size allocated for JIT code of method
         /// </summary>
-        public long RODataAllocSize;
+        public long JitRODataRequestSize;
         /// <summary>
         /// Total size allocated for JIT code of method
         /// </summary>
-        public long RequestedAllocSizeForJitCode;
+        public long AllocatedSizeForJitCode;
         /// <summary>
         /// Jit allocation flag
         /// </summary>

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -3918,7 +3918,6 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
                 }
             }
             _method.NativeSize = data.MethodSize;
-            Console.WriteLine("MethodName= {0}, Size= {1}", methodName, data.MethodSize);
             _method.CompileCpuTimeMSec = data.TimeStampRelativeMSec - _method.StartTimeMSec;
             _method.SetOptimizationTier(data.OptimizationTier, stats);
             _method.VersionID = rejitID;

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -3873,6 +3873,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
             TotalNativeSize += method.NativeSize;
             TotalHotCodeAllocSize += method.HotCodeAllocSize;
             TotalRODataAllocSize += method.RODataAllocSize;
+            IsJitAllocSizePresent |= method.IsJitAllocSizePresent;
             TotalAllocSizeForJitCode += method.RequestedAllocSizeForJitCode;
             if (method.CompilationThreadKind == CompilationThreadKind.MulticoreJitBackground)
             {
@@ -3947,18 +3948,15 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.JIT
             TraceJittedMethod _method = stats.JIT.m_stats.FindIncompleteJitEventOnThread(stats, data.ThreadID);
             if (_method != null)
             {
-                Debug.Assert(_method.HotCodeAllocSize == 0);
-
-                _method.IsJitAllocSizePresent = true;
-                _method.HotCodeAllocSize = data.HotCodeSize;
-                _method.RODataAllocSize = data.RODataSize;
-                _method.RequestedAllocSizeForJitCode = data.TotalRequestSize;
-                _method.JitAllocFlag = data.CorJitAllocMemFlag;
-
-                stats.JIT.m_stats.IsJitAllocSizePresent = true;
-                stats.JIT.m_stats.TotalHotCodeAllocSize += data.HotCodeSize;
-                stats.JIT.m_stats.TotalRODataAllocSize += data.RODataSize;
-                stats.JIT.m_stats.TotalAllocSizeForJitCode += data.TotalRequestSize;
+                // If we already counted alloc size for a method, don't count it again.
+                if (_method.HotCodeAllocSize == 0)
+                {
+                    _method.IsJitAllocSizePresent = true;
+                    _method.HotCodeAllocSize = data.HotCodeSize;
+                    _method.RODataAllocSize = data.RODataSize;
+                    _method.RequestedAllocSizeForJitCode = data.TotalRequestSize;
+                    _method.JitAllocFlag = data.CorJitAllocMemFlag;
+                }
             }
         }
 

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -8808,14 +8808,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
 
     public sealed class MethodJitMemoryAllocatedForCodeTraceData : TraceEvent
     {
-        public string MethodBeingCompiledNamespace { get { return GetUnicodeStringAt(0); } }
-        public string MethodBeingCompiledName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
-        public string MethodBeingCompiledNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(0))); } }
-        public long JitHotCodeRequestSize { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))); } }
-        public long JitRODataRequestSize { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 8); } }
-        public long AllocatedSizeForJitCode { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 16); } }
-        public int JitAllocFlag { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 24); } }
-        public int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 28); } }
+        public long MethodID { get { return GetInt64At(0); } }
+        public long ModuleID { get { return GetInt64At(8); } }
+        public long JitHotCodeRequestSize { get { return GetInt64At(16); } }
+        public long JitRODataRequestSize { get { return GetInt64At(24); } }
+        public long AllocatedSizeForJitCode { get { return GetInt64At(32); } }
+        public int JitAllocFlag { get { return GetInt32At(40); } }
+        public int ClrInstanceID { get { return GetInt16At(44); } }
 
         #region Private
         internal MethodJitMemoryAllocatedForCodeTraceData(Action<MethodJitMemoryAllocatedForCodeTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -8829,8 +8828,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         }
         protected internal override void Validate()
         {
-            Debug.Assert(!(Version == 0 && EventDataLength != SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 30));
-            Debug.Assert(!(Version > 0 && EventDataLength < SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 30));
+            Debug.Assert(!(Version == 0 && EventDataLength != 46));
+            Debug.Assert(!(Version > 0 && EventDataLength < 46));
         }
         protected internal override Delegate Target
         {
@@ -8840,9 +8839,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
-            XmlAttrib(sb, "MethodBeingCompiledNamespace", MethodBeingCompiledNamespace);
-            XmlAttrib(sb, "MethodBeingCompiledName", MethodBeingCompiledName);
-            XmlAttrib(sb, "MethodBeingCompiledNameSignature", MethodBeingCompiledNameSignature);
+            XmlAttrib(sb, "MethodID", MethodID);
+            XmlAttrib(sb, "ModuleID", ModuleID);
             XmlAttrib(sb, "JitHotCodeRequestSize", JitHotCodeRequestSize);
             XmlAttrib(sb, "JitRODataRequestSize", JitRODataRequestSize);
             XmlAttrib(sb, "AllocatedSizeForJitCode", AllocatedSizeForJitCode);
@@ -8857,7 +8855,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "MethodBeingCompiledNamespace", "MethodBeingCompiledName", "MethodBeingCompiledNameSignature", "JitHotCodeRequestSize", "JitRODataRequestSize", "AllocatedSizeForJitCode", "JitAllocFlag", "ClrInstanceID" };
+                    payloadNames = new string[] { "MethodID", "ModuleID", "JitHotCodeRequestSize", "JitRODataRequestSize", "AllocatedSizeForJitCode", "JitAllocFlag", "ClrInstanceID" };
                 return payloadNames;
             }
         }
@@ -8867,20 +8865,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             switch (index)
             {
                 case 0:
-                    return MethodBeingCompiledNamespace;
+                    return MethodID;
                 case 1:
-                    return MethodBeingCompiledName;
+                    return ModuleID;
                 case 2:
-                    return MethodBeingCompiledNameSignature;
-                case 3:
                     return JitHotCodeRequestSize;
-                case 4:
+                case 3:
                     return JitRODataRequestSize;
-                case 5:
+                case 4:
                     return AllocatedSizeForJitCode;
-                case 6:
+                case 5:
                     return JitAllocFlag;
-                case 7:
+                case 6:
                     return ClrInstanceID;
                 default:
                     Debug.Assert(false, "Bad field index");

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -8811,10 +8811,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         public string MethodBeingCompiledNamespace { get { return GetUnicodeStringAt(0); } }
         public string MethodBeingCompiledName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
         public string MethodBeingCompiledNameSignature { get { return GetUnicodeStringAt(SkipUnicodeString(SkipUnicodeString(0))); } }
-        public long HotCodeSize { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))); } }
-        public long RODataSize { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 8); } }
-        public long TotalRequestSize { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 16); } }
-        public int CorJitAllocMemFlag { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 24); } }
+        public long JitHotCodeRequestSize { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0)))); } }
+        public long JitRODataRequestSize { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 8); } }
+        public long AllocatedSizeForJitCode { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 16); } }
+        public int JitAllocFlag { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 24); } }
         public int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(SkipUnicodeString(SkipUnicodeString(0))) + 28); } }
 
         #region Private
@@ -8843,10 +8843,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             XmlAttrib(sb, "MethodBeingCompiledNamespace", MethodBeingCompiledNamespace);
             XmlAttrib(sb, "MethodBeingCompiledName", MethodBeingCompiledName);
             XmlAttrib(sb, "MethodBeingCompiledNameSignature", MethodBeingCompiledNameSignature);
-            XmlAttrib(sb, "HotCodeSize", HotCodeSize);
-            XmlAttrib(sb, "RODataSize", RODataSize);
-            XmlAttrib(sb, "TotalRequestSize", TotalRequestSize);
-            XmlAttrib(sb, "CorJitAllocMemFlag", CorJitAllocMemFlag);
+            XmlAttrib(sb, "JitHotCodeRequestSize", JitHotCodeRequestSize);
+            XmlAttrib(sb, "JitRODataRequestSize", JitRODataRequestSize);
+            XmlAttrib(sb, "AllocatedSizeForJitCode", AllocatedSizeForJitCode);
+            XmlAttrib(sb, "JitAllocFlag", JitAllocFlag);
             XmlAttrib(sb, "ClrInstanceID", ClrInstanceID);
             sb.Append("/>");
             return sb;
@@ -8857,7 +8857,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "MethodBeingCompiledNamespace", "MethodBeingCompiledName", "MethodBeingCompiledNameSignature", "HotCodeSize", "RODataSize", "TotalRequestSize", "CorJitAllocMemFlag", "ClrInstanceID" };
+                    payloadNames = new string[] { "MethodBeingCompiledNamespace", "MethodBeingCompiledName", "MethodBeingCompiledNameSignature", "JitHotCodeRequestSize", "JitRODataRequestSize", "AllocatedSizeForJitCode", "JitAllocFlag", "ClrInstanceID" };
                 return payloadNames;
             }
         }
@@ -8873,13 +8873,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
                 case 2:
                     return MethodBeingCompiledNameSignature;
                 case 3:
-                    return HotCodeSize;
+                    return JitHotCodeRequestSize;
                 case 4:
-                    return RODataSize;
+                    return JitRODataRequestSize;
                 case 5:
-                    return TotalRequestSize;
+                    return AllocatedSizeForJitCode;
                 case 6:
-                    return CorJitAllocMemFlag;
+                    return JitAllocFlag;
                 case 7:
                     return ClrInstanceID;
                 default:

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -2015,7 +2015,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[134];
+                var templates = new TraceEvent[135];
                 templates[0] = new GCStartTraceData(null, 1, 1, "GC", GCTaskGuid, 1, "Start", ProviderGuid, ProviderName);
                 templates[1] = new GCEndTraceData(null, 2, 1, "GC", GCTaskGuid, 2, "Stop", ProviderGuid, ProviderName);
                 templates[2] = new GCNoUserDataTraceData(null, 3, 1, "GC", GCTaskGuid, 132, "RestartEEStop", ProviderGuid, ProviderName);
@@ -2157,6 +2157,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[131]  = R2RGetEntryPointStartTemplate(null);
                 templates[132]  = TypeLoadStartTemplate(null);
                 templates[133]  = TypeLoadStopTemplate(null);
+                templates[134]  = MethodMemoryAllocatedForJitCodeTemplate(null);
 
                 s_templates = templates;
             }


### PR DESCRIPTION
Added a new event `MethodJitMemoryAllocatedForCode`  in https://github.com/dotnet/runtime/pull/44030 to log the JIT 's memory request for code. This PR displays that information in PerfView.

Here is the screenshot:

![image](https://user-images.githubusercontent.com/12488060/97618047-c2b36100-19db-11eb-96a9-5da404b4ac4d.png)
