### PR TITLE
Smaller gcdump storage

### DIFF
--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace FastSerialization
 {
-    public class SegmentedMemoryStreamReader
+    public class SegmentedMemoryStreamReader : IStreamReader
     {
          const int BlockCopyCapacity = 10 * 1024 * 1024;
 
@@ -126,6 +126,10 @@ namespace FastSerialization
                 --len;
             }
             return sb.ToString();
+        }
+        void IStreamReader.Read(byte[] data, int offset, int length)
+        {
+            throw new NotImplementedException();
         }
         /// <summary>
         /// Implementation of IStreamReader

--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace FastSerialization
 {
-    public class SegmentedMemoryStreamWriter
+    public class SegmentedMemoryStreamWriter : IStreamWriter
     {
         public SegmentedMemoryStreamWriter() : this(64) { }
         public SegmentedMemoryStreamWriter(int initialSize)


### PR DESCRIPTION
* Use shared storage for module names
* Apply differential compression to m_nodes
* Apply differential compression to m_nodeAddresses