### PR TITLE
Remove useless code

### DIFF
--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1391,13 +1391,6 @@ namespace PerfView
 
         private void DoMergeAndZipAll(object sender, RoutedEventArgs e)
         {
-            var unmergedFiles = new List<PerfViewFile>();
-            foreach (var file in TreeView.Items.OfType<PerfViewFile>())
-            {
-                if (file.FilePath.EndsWith(".etl"))
-                    unmergedFiles.Add(file);
-            }
-
             List<Action> actions = new List<Action>();
             foreach (var file in TreeView.Items.OfType<PerfViewFile>().Reverse())
             {


### PR DESCRIPTION
Seems like "unmergedFiles" collection is not used anywhere. So no need to fill it.