### PR TITLE
Require StreamLabel be 2-byte aligned for serialization

### DIFF
--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -65,8 +65,17 @@ namespace FastSerialization
                 }
             }
         }
-        public virtual StreamLabel GetLabel()
+        public virtual StreamLabel GetLabel(bool allowPadding)
         {
+            if ((Length & 0x1) != 0)
+            {
+                if (!allowPadding)
+                    throw new NotSupportedException("Labels must be aligned to a 2-byte boundary.");
+
+                Write((byte)Tags.Padding);
+                Debug.Assert((Length & 0x1) == 0);
+            }
+
             return (StreamLabel)Length;
         }
         public void WriteSuffixLabel(StreamLabel value)

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -327,7 +327,9 @@ namespace FastSerialization
         /// </summary>
         public void Write(StreamLabel value)
         {
-            Debug.Assert((long)value <= int.MaxValue);
+            if (((long)value & 0x1) != 0)
+                throw new NotSupportedException("Labels must be aligned to a 2-byte boundary.");
+
             Write((int)value);
         }
         /// <summary>
@@ -368,8 +370,17 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of IStreamWriter
         /// </summary>
-        public virtual StreamLabel GetLabel()
+        public virtual StreamLabel GetLabel(bool allowPadding)
         {
+            if ((Length & 0x1) != 0)
+            {
+                if (!allowPadding)
+                    throw new NotSupportedException("Labels must be aligned to a 2-byte boundary.");
+
+                Write((byte)Tags.Padding);
+                Debug.Assert((Length & 0x1) == 0);
+            }
+
             return (StreamLabel)Length;
         }
         /// <summary>
@@ -1068,12 +1079,21 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of the IStreamWriter interface 
         /// </summary>
-        public override StreamLabel GetLabel()
+        public override StreamLabel GetLabel(bool allowPadding)
         {
             long len = Length;
             if (len != (uint)len)
             {
                 throw new NotSupportedException("Streams larger than 4 GB.  You need to use /MaxEventCount to limit the size.");
+            }
+
+            if ((len & 0x1) != 0)
+            {
+                if (!allowPadding)
+                    throw new NotSupportedException("Labels must be aligned to a 2-byte boundary.");
+
+                Write((byte)Tags.Padding);
+                len++;
             }
 
             return (StreamLabel)len;

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -415,7 +415,7 @@ namespace Graphs
         internal void SetNodeTypeAndSize(NodeIndex nodeIndex, NodeTypeIndex typeIndex, int sizeInBytes)
         {
             Debug.Assert(m_nodes[(int)nodeIndex] == m_undefinedObjDef, "Calling SetNode twice for node index " + nodeIndex);
-            m_nodes[(int)nodeIndex] = m_writer.GetLabel();
+            m_nodes[(int)nodeIndex] = m_writer.GetLabel(allowPadding: true);
 
             Debug.Assert(sizeInBytes >= 0);
             // We are going to assume that if this is negative it is because it is a large positive number.  
@@ -473,7 +473,7 @@ namespace Graphs
 
             // Create an undefined node, kind of gross because SetNode expects to have an entry
             // in the m_nodes table, so we make a fake one and then remove it.  
-            m_undefinedObjDef = m_writer.GetLabel();
+            m_undefinedObjDef = m_writer.GetLabel(allowPadding: false);
             m_nodes.Add(m_undefinedObjDef);
             SetNode(0, CreateType("UNDEFINED"), 0, new GrowableArray<NodeIndex>());
             Debug.Assert(m_nodes[0] == m_undefinedObjDef);
@@ -513,6 +513,9 @@ namespace Graphs
             serializer.Write(m_nodes.Count);
             for (int i = 0; i < m_nodes.Count; i++)
             {
+                if (((long)m_nodes[i] & 0x1) != 0)
+                    throw new NotSupportedException("Labels must be aligned to a 2-byte boundary.");
+
                 serializer.Write((int)m_nodes[i]);
             }
 


### PR DESCRIPTION
Forcing `StreamLabel` to be 2-byte aligned for serialization allows it to be serialized without loss of precision with a right shift of 1. This in turn allows the 4GiB file size limit for .gcdump and .etlx to be raised to 8GiB. This pull request implements the first step of this process.

This is a breaking change to the serialization format of FastSerialization, but it's not clear whether or not that is a problem.