### PR TITLE
Condition IDebugClient.cs on CROSS_GENERATION_LIVENESS

### DIFF
--- a/src/HeapDump/CrossGenerationLiveness/IDebugClient.cs
+++ b/src/HeapDump/CrossGenerationLiveness/IDebugClient.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Diagnostics.Runtime.Interop;
+﻿#if CROSS_GENERATION_LIVENESS
+using Microsoft.Diagnostics.Runtime.Interop;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -232,3 +233,4 @@ namespace Microsoft.Diagnostics.CrossGenerationLiveness
         int FlushCallbacks();
     }
 }
+#endif


### PR DESCRIPTION
This change simplifies the transition to ClrMD 2.0 for builds where `CROSS_GENERATION_LIVENESS` is not defined.