### PR TITLE
Rename Write methods to indicate the type

### DIFF
--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -106,27 +106,27 @@ namespace FastSerialization
         /// <summary>
         /// Write a byte to a stream
         /// </summary>
-        void Write(byte value);
+        void WriteByte(byte value);
         /// <summary>
         /// Write a short to a stream
         /// </summary>
-        void Write(short value);
+        void WriteInt16(short value);
         /// <summary>
         /// Write an int to a stream
         /// </summary>
-        void Write(int value);
+        void WriteInt32(int value);
         /// <summary>
         /// Write a long to a stream
         /// </summary>
-        void Write(long value);
+        void WriteInt64(long value);
         /// <summary>
         /// Write a StreamLabel (a pointer to another part of the stream) to a stream
         /// </summary>
-        void Write(StreamLabel value);
+        void WriteLabel(StreamLabel value);
         /// <summary>
         /// Write a string to a stream (supports null values).  
         /// </summary>
-        void Write(string value);
+        void WriteString(string value);
         /// <summary>
         /// Get the stream label for the current position (points at whatever is written next
         /// </summary>
@@ -226,12 +226,12 @@ namespace FastSerialization
         /// <summary>
         /// Writes a Guid to stream 'writer' as sequence of 8 bytes
         /// </summary>
-        public static void Write(this IStreamWriter writer, Guid guid)
+        public static void WriteGuid(this IStreamWriter writer, Guid guid)
         {
             byte[] bytes = guid.ToByteArray();
             for (int i = 0; i < bytes.Length; i++)
             {
-                writer.Write(bytes[i]);
+                writer.WriteByte(bytes[i]);
             }
         }
         /// <summary>
@@ -508,10 +508,10 @@ namespace FastSerialization
 
                 Log("<Serializer>");
                 // Write the header. 
-                Write("!FastSerialization.1");
+                WriteString("!FastSerialization.1");
 
                 // Write the main object.  This is recursive and does most of the work. 
-                Write(entryObject);
+                WriteObject(entryObject);
 
                 // Write any forward references. 
                 WriteDeferedObjects();
@@ -524,17 +524,17 @@ namespace FastSerialization
                 Log("<ForwardRefTable StreamLabel=\"0x" + forwardRefsLabel.ToString("x") + "\">");
                 if (forwardReferenceDefinitions != null)
                 {
-                    Write(forwardReferenceDefinitions.Count);
+                    WriteInt32(forwardReferenceDefinitions.Count);
                     for (int i = 0; i < forwardReferenceDefinitions.Count; i++)
                     {
                         Debug.Assert(forwardReferenceDefinitions[i] != StreamLabel.Invalid);
                         Log("<ForwardDefEntry index=\"" + i + "\" StreamLabelRef=\"0x" + forwardReferenceDefinitions[i].ToString("x") + "\"/>");
-                        writer.Write(forwardReferenceDefinitions[i]);
+                        writer.WriteLabel(forwardReferenceDefinitions[i]);
                     }
                 }
                 else
                 {
-                    Write(0);
+                    WriteInt32(0);
                 }
 
                 Log("</ForwardRefTable>");
@@ -543,7 +543,7 @@ namespace FastSerialization
                 // items.  
                 StreamLabel trailerLabel = writer.GetLabel();
                 Log("<Trailer StreamLabel=\"0x" + trailerLabel.ToString("x") + "\">");
-                Write(forwardRefsLabel);
+                WriteLabel(forwardRefsLabel);
                 // More stuff goes here in future versions. 
                 Log("</Trailer>");
 
@@ -565,58 +565,58 @@ namespace FastSerialization
         /// <summary>
         /// Write a bool to a stream
         /// </summary>
-        public void Write(bool value)
+        public void WriteBoolean(bool value)
         {
-            Write((byte)(value ? 1 : 0));
+            WriteByte((byte)(value ? 1 : 0));
         }
         /// <summary>
         /// Write a byte to a stream
         /// </summary>
-        public void Write(byte value)
+        public void WriteByte(byte value)
         {
             Log("<Write Type=\"byte\" Value=\"" + value + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
-            writer.Write(value);
+            writer.WriteByte(value);
         }
         /// <summary>
         /// Write a short to a stream
         /// </summary>
-        public void Write(short value)
+        public void WriteInt16(short value)
         {
             Log("<Write Type=\"short\" Value=\"" + value + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
-            writer.Write(value);
+            writer.WriteInt16(value);
         }
         /// <summary>
         /// Write an int to a stream
         /// </summary>
-        public void Write(int value)
+        public void WriteInt32(int value)
         {
             Log("<Write Type=\"int\" Value=\"" + value + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
-            writer.Write(value);
+            writer.WriteInt32(value);
         }
         /// <summary>
         /// Write a long to a stream
         /// </summary>
-        public void Write(long value)
+        public void WriteInt64(long value)
         {
             Log("<Write Type=\"long\" Value=\"" + value + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
-            writer.Write(value);
+            writer.WriteInt64(value);
         }
         /// <summary>
         /// Write a Guid to a stream
         /// </summary>
-        public void Write(Guid value)
+        public void WriteGuid(Guid value)
         {
             Log("<Write Type=\"Guid\" Value=\"" + value + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
             byte[] bytes = value.ToByteArray();
             for (int i = 0; i < bytes.Length; i++)
             {
-                writer.Write(bytes[i]);
+                writer.WriteByte(bytes[i]);
             }
         }
         /// <summary>
         /// Write a string to a stream
         /// </summary>
-        public void Write(string value)
+        public void WriteString(string value)
         {
 #if DEBUG
             if (value == null)
@@ -624,44 +624,44 @@ namespace FastSerialization
             else
                 Log("<Write Type=\"string\" Value=" + value + " StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
 #endif
-            writer.Write(value);
+            writer.WriteString(value);
         }
         /// <summary>
         /// Write a float to a stream
         /// </summary>
-        public unsafe void Write(float value)
+        public unsafe void WriteSingle(float value)
         {
             int* intPtr = (int*)&value;
-            writer.Write(*intPtr);
+            writer.WriteInt32(*intPtr);
         }
         /// <summary>
         /// Write a double to a stream
         /// </summary>
-        public unsafe void Write(double value)
+        public unsafe void WriteDouble(double value)
         {
             long* longPtr = (long*)&value;
-            writer.Write(*longPtr);
+            writer.WriteInt64(*longPtr);
         }
         /// <summary>
         /// Write a StreamLabel (pointer to some other part of the stream whose location is current known) to the stream
         /// </summary>
-        public void Write(StreamLabel value)
+        public void WriteLabel(StreamLabel value)
         {
             Log("<Write Type=\"StreamLabel\" StreamLabelRef=\"0x" + value.ToString("x") + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
-            writer.Write(value);
+            writer.WriteLabel(value);
         }
         /// <summary>
         /// Write a ForwardReference (pointer to some other part of the stream that whose location is not currently known) to the stream
         /// </summary>
-        public void Write(ForwardReference value)
+        public void WriteForwardReference(ForwardReference value)
         {
             Log("<Write Type=\"ForwardReference\" indexRef=\"" + value + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
-            writer.Write((int)value);
+            writer.WriteInt32((int)value);
         }
         /// <summary>
         /// If the object is potentially aliased (multiple references to it), you should write it with this method.
         /// </summary>
-        public void Write(IFastSerializable obj) { WriteObjectRef(obj, false); }
+        public void WriteObject(IFastSerializable obj) { WriteObjectRef(obj, false); }
         /// <summary>
         /// To tune working set (or disk seeks), or to make the dump of the format more readable, it is
         /// valuable to have control over which of several references to an object will actually cause it to
@@ -672,7 +672,7 @@ namespace FastSerialization
         /// WriteObject() occurs, then the object is serialized automatically before the stream is closed
         /// (thus dangling references are impossible).        
         /// </summary>
-        public void WriteDefered(IFastSerializable obj) { WriteObjectRef(obj, true); }
+        public void WriteDeferredObject(IFastSerializable obj) { WriteObjectRef(obj, true); }
         /// <summary>
         /// This is an optimized version of WriteObjectReference that can be used in some cases.
         /// 
@@ -688,7 +688,7 @@ namespace FastSerialization
         /// 
         /// TODO Need a DEBUG mode where we detect if others besides the owner reference the object.
         /// </summary>
-        public void WritePrivate(IFastSerializable obj)
+        public void WritePrivateObject(IFastSerializable obj)
         {
             Log("<WritePrivateObject obj=\"0x" + obj.GetHashCode().ToString("x") +
                 "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\">");
@@ -726,36 +726,36 @@ namespace FastSerialization
         /// <summary>
         /// Write a byte preceded by a tag that indicates its a byte.  These should be read with the corresponding TryReadTagged operation
         /// </summary>
-        public void WriteTagged(bool value) { WriteTag(Tags.Byte); Write(value ? (byte)1 : (byte)0); }
+        public void WriteTaggedBoolean(bool value) { WriteTag(Tags.Byte); WriteByte(value ? (byte)1 : (byte)0); }
         /// <summary>
         /// Write a byte preceded by a tag that indicates its a byte.  These should be read with the corresponding TryReadTagged operation
         /// </summary>
-        public void WriteTagged(byte value) { WriteTag(Tags.Byte); Write(value); }
+        public void WriteTaggedByte(byte value) { WriteTag(Tags.Byte); WriteByte(value); }
         /// <summary>
         /// Write a byte preceded by a tag that indicates its a short.  These should be read with the corresponding TryReadTagged operation
         /// </summary>
-        public void WriteTagged(short value) { WriteTag(Tags.Int16); Write(value); }
+        public void WriteTaggedInt16(short value) { WriteTag(Tags.Int16); WriteInt16(value); }
         /// <summary>
         /// Write a byte preceded by a tag that indicates its a int.  These should be read with the corresponding TryReadTagged operation
         /// </summary>
-        public void WriteTagged(int value) { WriteTag(Tags.Int32); Write(value); }
+        public void WriteTaggedInt32(int value) { WriteTag(Tags.Int32); WriteInt32(value); }
         /// <summary>
         /// Write a byte preceded by a tag that indicates its a long.  These should be read with the corresponding TryReadTagged operation
         /// </summary>
-        public void WriteTagged(long value) { WriteTag(Tags.Int64); Write(value); }
+        public void WriteTaggedInt64(long value) { WriteTag(Tags.Int64); WriteInt64(value); }
         /// <summary>
         /// Write a byte preceded by a tag that indicates its a string.  These should be read with the corresponding TryReadTagged operation
         /// </summary>
-        public void WriteTagged(string value) { WriteTag(Tags.String); Write(value); }
+        public void WriteTaggedString(string value) { WriteTag(Tags.String); WriteString(value); }
         /// <summary>
         /// Write a byte preceded by a tag that indicates its a object.  These should be read with the corresponding TryReadTagged operation
         /// </summary>
-        public void WriteTagged(IFastSerializable value)
+        public void WriteTaggedObject(IFastSerializable value)
         {
             WriteTag(Tags.SkipRegion);
             ForwardReference endRegion = GetForwardReference();
-            Write(endRegion);        // Allow the reader to skip this. 
-            Write(value);            // Write the data we can skip
+            WriteForwardReference(endRegion);        // Allow the reader to skip this. 
+            WriteObject(value);            // Write the data we can skip
             DefineForwardReference(endRegion);  // This is where the forward reference refers to 
         }
 
@@ -769,7 +769,7 @@ namespace FastSerialization
         public void WriteTaggedBlobHeader(int size)
         {
             WriteTag(Tags.Blob);
-            Write(size);
+            WriteInt32(size);
         }
 
         /// <summary>
@@ -811,7 +811,7 @@ namespace FastSerialization
         private void WriteTag(Tags tag)
         {
             Log("<WriteTag Type=\"" + tag + "\" Value=\"" + ((int)tag).ToString() + "\" StreamLabel=\"0x" + writer.GetLabel().ToString("x") + "\"/>");
-            writer.Write((byte)tag);
+            writer.WriteByte((byte)tag);
         }
         private void WriteObjectRef(IFastSerializable obj, bool defered)
         {
@@ -830,7 +830,7 @@ namespace FastSerialization
                 Log("<WriteReference streamLabelRef=\"0x" + reference.ToString("x") +
                     "\" objRef=\"0x" + obj.GetHashCode().ToString("x") + "\">");
                 WriteTag(Tags.ObjectReference);
-                Write(reference);
+                WriteLabel(reference);
                 Log("</WriteReference>");
                 return;
             }
@@ -855,7 +855,7 @@ namespace FastSerialization
                 WriteTag(Tags.ForwardReference);
 
                 // Write the forward forwardReference index
-                Write((int)forwardReference);
+                WriteInt32((int)forwardReference);
                 // And its type. 
                 WriteTypeForObject(obj);
                 Log("</WriteForwardReference>");
@@ -875,7 +875,7 @@ namespace FastSerialization
                 Log("<WriteForwardReferenceDefinition index=\"0x" + ((int)forwardReference).ToString("x") + "\">");
                 // OK, tag the definition with the forward forwardReference index
                 WriteTag(Tags.ForwardDefinition);
-                Write((int)forwardReference);
+                WriteInt32((int)forwardReference);
 
                 // And also put it in the ForwardReferenceTable.  
                 forwardReferenceDefinitions[(int)forwardReference] = objLabel;
@@ -928,7 +928,7 @@ namespace FastSerialization
                 objs.AddRange(ObjectsWithForwardReferences.Keys);
                 foreach (IFastSerializable obj in objs)
                 {
-                    Write(obj);
+                    WriteObject(obj);
                     Debug.Assert(!ObjectsWithForwardReferences.ContainsKey(obj));
                 }
                 objs.Clear();
@@ -2145,7 +2145,7 @@ namespace FastSerialization
             serializer.Log("<DeferedRegion>\r\n");
             // We actually don't use the this pointer!  We did this for symmetry with Read
             ForwardReference endRegion = serializer.GetForwardReference();
-            serializer.Write(endRegion);        // Allow the reader to skip this. 
+            serializer.WriteForwardReference(endRegion);        // Allow the reader to skip this. 
             toStream();                         // Write the deferred data. 
             serializer.DefineForwardReference(endRegion);
             serializer.Log("</DeferedRegion>\r\n");
@@ -2422,9 +2422,9 @@ namespace FastSerialization
         }
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(version);
-            serializer.Write(minimumReaderVersion);
-            serializer.Write(fullName);
+            serializer.WriteInt32(version);
+            serializer.WriteInt32(minimumReaderVersion);
+            serializer.WriteString(fullName);
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -262,7 +262,7 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of IStreamWriter
         /// </summary>
-        public void Write(byte value)
+        public void WriteByte(byte value)
         {
             if (endPosition >= bytes.Length)
             {
@@ -274,7 +274,7 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of IStreamWriter
         /// </summary>
-        public unsafe void Write(short value)
+        public unsafe void WriteInt16(short value)
         {
             if (endPosition + sizeof(short) > bytes.Length)
             {
@@ -291,7 +291,7 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of IStreamWriter
         /// </summary>
-        public unsafe void Write(int value)
+        public unsafe void WriteInt32(int value)
         {
             if (endPosition + sizeof(int) > bytes.Length)
             {
@@ -308,7 +308,7 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of IStreamWriter
         /// </summary>
-        public unsafe void Write(long value)
+        public unsafe void WriteInt64(long value)
         {
             if (endPosition + sizeof(long) > bytes.Length)
             {
@@ -325,42 +325,42 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of IStreamWriter
         /// </summary>
-        public void Write(StreamLabel value)
+        public void WriteLabel(StreamLabel value)
         {
             Debug.Assert((long)value <= int.MaxValue);
-            Write((int)value);
+            WriteInt32((int)value);
         }
         /// <summary>
         /// Implementation of IStreamWriter
         /// </summary>
-        public void Write(string value)
+        public void WriteString(string value)
         {
             if (value == null)
             {
-                Write(-1);          // negative charCount means null. 
+                WriteInt32(-1);          // negative charCount means null. 
             }
             else
             {
-                Write(value.Length);
+                WriteInt32(value.Length);
                 for (int i = 0; i < value.Length; i++)
                 {
                     char c = value[i];
                     if (c <= 0x7F)
                     {
-                        Write((byte)value[i]);                 // Only need one byte for UTF8
+                        WriteByte((byte)value[i]);                 // Only need one byte for UTF8
                     }
                     else if (c <= 0x7FF)
                     {
                         // TODO confirm that this is correct!
-                        Write((byte)(0xC0 | (c >> 6)));                // Encode 2 byte UTF8
-                        Write((byte)(0x80 | (c & 0x3F)));
+                        WriteByte((byte)(0xC0 | (c >> 6)));                // Encode 2 byte UTF8
+                        WriteByte((byte)(0x80 | (c & 0x3F)));
                     }
                     else
                     {
                         // TODO confirm that this is correct!
-                        Write((byte)(0xE0 | ((c >> 12) & 0xF)));        // Encode 3 byte UTF8
-                        Write((byte)(0x80 | ((c >> 6) & 0x3F)));
-                        Write((byte)(0x80 | (c & 0x3F)));
+                        WriteByte((byte)(0xE0 | ((c >> 12) & 0xF)));        // Encode 3 byte UTF8
+                        WriteByte((byte)(0x80 | ((c >> 6) & 0x3F)));
+                        WriteByte((byte)(0x80 | (c & 0x3F)));
                     }
                 }
             }
@@ -379,7 +379,7 @@ namespace FastSerialization
         {
             // This is guaranteed to be uncompressed, but since we are not compressing anything, we can
             // simply write the value.  
-            Write(value);
+            WriteLabel(value);
         }
 
         /// <summary>

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -258,41 +258,41 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 
     void IFastSerializable.ToStream(Serializer serializer)
     {
-        serializer.Write(m_graph);
-        serializer.Write(m_graph.Is64Bit);  // This is redundant but graph did not used to hold this value 
+        serializer.WriteObject(m_graph);
+        serializer.WriteBoolean(m_graph.Is64Bit);  // This is redundant but graph did not used to hold this value 
         // we write the bit here to preserve compatibility. 
-        serializer.Write(AverageCountMultiplier);
-        serializer.Write(AverageSizeMultiplier);
+        serializer.WriteSingle(AverageCountMultiplier);
+        serializer.WriteSingle(AverageSizeMultiplier);
 
-        serializer.Write(JSHeapInfo);
-        serializer.Write(DotNetHeapInfo);
+        serializer.WriteObject(JSHeapInfo);
+        serializer.WriteObject(DotNetHeapInfo);
 
-        serializer.Write(CollectionLog);
-        serializer.Write(TimeCollected.Ticks);
-        serializer.Write(MachineName);
-        serializer.Write(ProcessName);
-        serializer.Write(ProcessID);
-        serializer.Write(TotalProcessCommit);
-        serializer.Write(TotalProcessWorkingSet);
+        serializer.WriteString(CollectionLog);
+        serializer.WriteInt64(TimeCollected.Ticks);
+        serializer.WriteString(MachineName);
+        serializer.WriteString(ProcessName);
+        serializer.WriteInt32(ProcessID);
+        serializer.WriteInt64(TotalProcessCommit);
+        serializer.WriteInt64(TotalProcessWorkingSet);
 
         if (CountMultipliersByType == null)
         {
-            serializer.Write(0);
+            serializer.WriteInt32(0);
         }
         else
         {
-            serializer.Write(CountMultipliersByType.Length);
+            serializer.WriteInt32(CountMultipliersByType.Length);
             for (int i = 0; i < CountMultipliersByType.Length; i++)
             {
-                serializer.Write(CountMultipliersByType[i]);
+                serializer.WriteSingle(CountMultipliersByType[i]);
             }
         }
 
         // All fields after version 8 should go here and should be in
         // the version order (thus always add at the end).  Also use the 
         // WriteTagged variation to write. 
-        serializer.WriteTagged(m_interop);
-        serializer.WriteTagged(CreationTool);
+        serializer.WriteTaggedObject(m_interop);
+        serializer.WriteTaggedString(CreationTool);
     }
 
     void IFastSerializable.FromStream(Deserializer deserializer)
@@ -566,54 +566,54 @@ public class InteropInfo : IFastSerializable
     {
         int countRCWCCW = m_listRCWInfo.Count + m_listCCWInfo.Count;
 
-        serializer.Write(countRCWCCW);
+        serializer.WriteInt32(countRCWCCW);
         if (countRCWCCW == 0)
         {
             return;
         }
 
-        serializer.Write(m_listRCWInfo.Count);
-        serializer.Write(m_listCCWInfo.Count);
-        serializer.Write(m_listComInterfaceInfo.Count);
-        serializer.Write(m_listModules.Count);
+        serializer.WriteInt32(m_listRCWInfo.Count);
+        serializer.WriteInt32(m_listCCWInfo.Count);
+        serializer.WriteInt32(m_listComInterfaceInfo.Count);
+        serializer.WriteInt32(m_listModules.Count);
 
         for (int i = 0; i < m_listRCWInfo.Count; i++)
         {
-            serializer.Write((int)m_listRCWInfo[i].node);
-            serializer.Write(m_listRCWInfo[i].refCount);
-            serializer.Write((long)m_listRCWInfo[i].addrIUnknown);
-            serializer.Write((long)m_listRCWInfo[i].addrJupiter);
-            serializer.Write((long)m_listRCWInfo[i].addrVTable);
-            serializer.Write(m_listRCWInfo[i].firstComInf);
-            serializer.Write(m_listRCWInfo[i].countComInf);
+            serializer.WriteInt32((int)m_listRCWInfo[i].node);
+            serializer.WriteInt32(m_listRCWInfo[i].refCount);
+            serializer.WriteInt64((long)m_listRCWInfo[i].addrIUnknown);
+            serializer.WriteInt64((long)m_listRCWInfo[i].addrJupiter);
+            serializer.WriteInt64((long)m_listRCWInfo[i].addrVTable);
+            serializer.WriteInt32(m_listRCWInfo[i].firstComInf);
+            serializer.WriteInt32(m_listRCWInfo[i].countComInf);
         }
 
         for (int i = 0; i < m_listCCWInfo.Count; i++)
         {
-            serializer.Write((int)m_listCCWInfo[i].node);
-            serializer.Write(m_listCCWInfo[i].refCount);
-            serializer.Write((long)m_listCCWInfo[i].addrIUnknown);
-            serializer.Write((long)m_listCCWInfo[i].addrHandle);
-            serializer.Write(m_listCCWInfo[i].firstComInf);
-            serializer.Write(m_listCCWInfo[i].countComInf);
+            serializer.WriteInt32((int)m_listCCWInfo[i].node);
+            serializer.WriteInt32(m_listCCWInfo[i].refCount);
+            serializer.WriteInt64((long)m_listCCWInfo[i].addrIUnknown);
+            serializer.WriteInt64((long)m_listCCWInfo[i].addrHandle);
+            serializer.WriteInt32(m_listCCWInfo[i].firstComInf);
+            serializer.WriteInt32(m_listCCWInfo[i].countComInf);
         }
 
         for (int i = 0; i < m_listComInterfaceInfo.Count; i++)
         {
-            serializer.Write(m_listComInterfaceInfo[i].fRCW ? (byte)1 : (byte)0);
-            serializer.Write(m_listComInterfaceInfo[i].owner);
-            serializer.Write((int)m_listComInterfaceInfo[i].typeID);
-            serializer.Write((long)m_listComInterfaceInfo[i].addrInterface);
-            serializer.Write((long)m_listComInterfaceInfo[i].addrFirstVTable);
-            serializer.Write((long)m_listComInterfaceInfo[i].addrFirstFunc);
+            serializer.WriteByte(m_listComInterfaceInfo[i].fRCW ? (byte)1 : (byte)0);
+            serializer.WriteInt32(m_listComInterfaceInfo[i].owner);
+            serializer.WriteInt32((int)m_listComInterfaceInfo[i].typeID);
+            serializer.WriteInt64((long)m_listComInterfaceInfo[i].addrInterface);
+            serializer.WriteInt64((long)m_listComInterfaceInfo[i].addrFirstVTable);
+            serializer.WriteInt64((long)m_listComInterfaceInfo[i].addrFirstFunc);
         }
 
         for (int i = 0; i < m_listModules.Count; i++)
         {
-            serializer.Write((long)m_listModules[i].baseAddress);
-            serializer.Write((int)m_listModules[i].fileSize);
-            serializer.Write((int)m_listModules[i].timeStamp);
-            serializer.Write(m_listModules[i].fileName);
+            serializer.WriteInt64((long)m_listModules[i].baseAddress);
+            serializer.WriteInt32((int)m_listModules[i].fileSize);
+            serializer.WriteInt32((int)m_listModules[i].timeStamp);
+            serializer.WriteString(m_listModules[i].fileName);
         }
     }
 

--- a/src/HeapDumpCommon/DotNetHeapInfo.cs
+++ b/src/HeapDumpCommon/DotNetHeapInfo.cs
@@ -78,18 +78,18 @@ public class DotNetHeapInfo : IFastSerializable
     #region private
     void IFastSerializable.ToStream(Serializer serializer)
     {
-        serializer.Write(SizeOfAllSegments);
+        serializer.WriteInt64(SizeOfAllSegments);
         if (Segments != null)
         {
-            serializer.Write(Segments.Count);
+            serializer.WriteInt32(Segments.Count);
             foreach (var segment in Segments)
             {
-                serializer.Write(segment);
+                serializer.WriteObject(segment);
             }
         }
         else
         {
-            serializer.Write(0);
+            serializer.WriteInt32(0);
         }
     }
     void IFastSerializable.FromStream(Deserializer deserializer)
@@ -119,12 +119,12 @@ public class GCHeapDumpSegment : IFastSerializable
     #region private
     void IFastSerializable.ToStream(Serializer serializer)
     {
-        serializer.Write((long)Start);
-        serializer.Write((long)End);
-        serializer.Write((long)Gen0End);
-        serializer.Write((long)Gen1End);
-        serializer.Write((long)Gen2End);
-        serializer.Write((long)Gen3End);
+        serializer.WriteInt64((long)Start);
+        serializer.WriteInt64((long)End);
+        serializer.WriteInt64((long)Gen0End);
+        serializer.WriteInt64((long)Gen1End);
+        serializer.WriteInt64((long)Gen2End);
+        serializer.WriteInt64((long)Gen3End);
     }
 
     void IFastSerializable.FromStream(Deserializer deserializer)

--- a/src/MemoryGraph/MemoryGraph.cs
+++ b/src/MemoryGraph/MemoryGraph.cs
@@ -119,13 +119,13 @@ namespace Graphs
         {
             base.ToStream(serializer);
             // Write out the Memory addresses of each object 
-            serializer.Write(m_nodeAddresses.Count);
+            serializer.WriteInt32(m_nodeAddresses.Count);
             for (int i = 0; i < m_nodeAddresses.Count; i++)
             {
-                serializer.Write((long)m_nodeAddresses[i]);
+                serializer.WriteInt64((long)m_nodeAddresses[i]);
             }
 
-            serializer.WriteTagged(Is64Bit);
+            serializer.WriteTaggedBoolean(Is64Bit);
         }
 
         void IFastSerializable.FromStream(Deserializer deserializer)

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -498,32 +498,32 @@ namespace Graphs
 
         public virtual void ToStream(Serializer serializer)
         {
-            serializer.Write(m_totalSize);
-            serializer.Write((int)RootIndex);
+            serializer.WriteInt64(m_totalSize);
+            serializer.WriteInt32((int)RootIndex);
             // Write out the Types 
-            serializer.Write(m_types.Count);
+            serializer.WriteInt32(m_types.Count);
             for (int i = 0; i < m_types.Count; i++)
             {
-                serializer.Write(m_types[i].Name);
-                serializer.Write(m_types[i].Size);
-                serializer.Write(m_types[i].ModuleName);
+                serializer.WriteString(m_types[i].Name);
+                serializer.WriteInt32(m_types[i].Size);
+                serializer.WriteString(m_types[i].ModuleName);
             }
 
             // Write out the Nodes 
-            serializer.Write(m_nodes.Count);
+            serializer.WriteInt32(m_nodes.Count);
             for (int i = 0; i < m_nodes.Count; i++)
             {
-                serializer.Write((int)m_nodes[i]);
+                serializer.WriteInt32((int)m_nodes[i]);
             }
 
             // Write out the Blob stream.  
             // TODO this is inefficient.  Also think about very large files.  
             int readerLen = (int)m_reader.Length;
-            serializer.Write(readerLen);
+            serializer.WriteInt32(readerLen);
             m_reader.Goto((StreamLabel)0);
             for (uint i = 0; i < readerLen; i++)
             {
-                serializer.Write(m_reader.ReadByte());
+                serializer.WriteByte(m_reader.ReadByte());
             }
 
             // Are we writing a format for 1 or greater?   If so we can use the new (breaking) format, otherwise
@@ -538,12 +538,12 @@ namespace Graphs
                 expansion.Write(serializer, delegate ()
                 {
                     // I don't need to use Tagged types for my 'first' version of this new region 
-                    serializer.Write(m_deferedTypes.Count);
+                    serializer.WriteInt32(m_deferedTypes.Count);
                     for (int i = 0; i < m_deferedTypes.Count; i++)
                     {
-                        serializer.Write(m_deferedTypes[i].TypeID);
-                        serializer.Write(m_deferedTypes[i].Module);
-                        serializer.Write(m_deferedTypes[i].TypeNameSuffix);
+                        serializer.WriteInt32(m_deferedTypes[i].TypeID);
+                        serializer.WriteObject(m_deferedTypes[i].Module);
+                        serializer.WriteString(m_deferedTypes[i].TypeNameSuffix);
                     }
 
                     // You can place tagged values in here always adding right before the WriteTaggedEnd
@@ -1077,13 +1077,13 @@ namespace Graphs
         /// </summary>
         public void ToStream(Serializer serializer)
         {
-            serializer.Write(Path);
-            serializer.Write((long)ImageBase);
-            serializer.Write(Size);
-            serializer.Write(BuildTime.Ticks);
-            serializer.Write(PdbName);
-            serializer.Write(PdbGuid);
-            serializer.Write(PdbAge);
+            serializer.WriteString(Path);
+            serializer.WriteInt64((long)ImageBase);
+            serializer.WriteInt32(Size);
+            serializer.WriteInt64(BuildTime.Ticks);
+            serializer.WriteString(PdbName);
+            serializer.WriteGuid(PdbGuid);
+            serializer.WriteInt32(PdbAge);
         }
         /// <summary>
         /// Implementing IFastSerializable interface.  

--- a/src/PerfView/memory/ClrProfilerMemoryGraph.cs
+++ b/src/PerfView/memory/ClrProfilerMemoryGraph.cs
@@ -311,10 +311,10 @@ namespace Graphs
         {
             base.ToStream(serializer);
             // Write out the Memory addresses of each object 
-            serializer.Write(m_nodeAddresses.Count);
+            serializer.WriteInt32(m_nodeAddresses.Count);
             for (int i = 0; i < m_nodeAddresses.Count; i++)
             {
-                serializer.Write((long)m_nodeAddresses[i]);
+                serializer.WriteInt64((long)m_nodeAddresses[i]);
             }
         }
         void IFastSerializable.FromStream(Deserializer deserializer)

--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -1574,15 +1574,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             }
             public void ToStream(Serializer serializer)
             {
-                serializer.Write((short)Offset);
-                serializer.Write((short)Size);
+                serializer.WriteInt16((short)Offset);
+                serializer.WriteInt16((short)Size);
                 if (Type == null)
                 {
-                    serializer.Write((string)null);
+                    serializer.WriteString((string)null);
                 }
                 else
                 {
-                    serializer.Write(Type.FullName);
+                    serializer.WriteString(Type.FullName);
                 }
 
                 var map = Map;
@@ -1591,32 +1591,32 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                     var asSortedList = map as SortedDictionary<long, string>;
                     if (asSortedList != null)
                     {
-                        serializer.Write((byte)1);
+                        serializer.WriteByte((byte)1);
                     }
                     else
                     {
-                        serializer.Write((byte)2);
+                        serializer.WriteByte((byte)2);
                     }
 
-                    serializer.Write(map.Count);
+                    serializer.WriteInt32(map.Count);
                     foreach (var keyValue in map)
                     {
-                        serializer.Write(keyValue.Key);
-                        serializer.Write(keyValue.Value);
+                        serializer.WriteInt64(keyValue.Key);
+                        serializer.WriteString(keyValue.Value);
                     }
                 }
                 else if (Class != null)
                 {
                     PayloadFetchClassInfo classInfo = Class;
-                    serializer.Write((byte)3);
+                    serializer.WriteByte((byte)3);
 
-                    serializer.Write(classInfo.FieldNames.Length);
+                    serializer.WriteInt32(classInfo.FieldNames.Length);
                     foreach (var name in classInfo.FieldNames)
                     {
-                        serializer.Write(name);
+                        serializer.WriteString(name);
                     }
 
-                    serializer.Write(classInfo.FieldFetches.Length);
+                    serializer.WriteInt32(classInfo.FieldFetches.Length);
                     for (int i = 0; i < classInfo.FieldFetches.Length; i++)
                     {
                         classInfo.FieldFetches[i].ToStream(serializer);
@@ -1625,13 +1625,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 else if (Array != null)
                 {
                     PayloadFetchArrayInfo arrayInfo = Array;
-                    serializer.Write((byte)4);
-                    serializer.Write(arrayInfo.FixedCount);
+                    serializer.WriteByte((byte)4);
+                    serializer.WriteInt32(arrayInfo.FixedCount);
                     arrayInfo.Element.ToStream(serializer);
                 }
                 else
                 {
-                    serializer.Write((byte)0);
+                    serializer.WriteByte((byte)0);
                 }
             }
             public void FromStream(Deserializer deserializer)
@@ -1724,26 +1724,26 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         public void ToStream(Serializer serializer)
         {
-            serializer.Write((int)eventID);
-            serializer.Write((int)task);
-            serializer.Write(taskName);
-            serializer.Write(taskGuid);
-            serializer.Write((int)opcode);
-            serializer.Write(opcodeName);
-            serializer.Write(providerGuid);
-            serializer.Write(providerName);
-            serializer.Write(MessageFormat);
-            serializer.Write(lookupAsClassic);
-            serializer.Write(lookupAsWPP);
-            serializer.Write(containsSelfDescribingMetadata);
+            serializer.WriteInt32((int)eventID);
+            serializer.WriteInt32((int)task);
+            serializer.WriteString(taskName);
+            serializer.WriteGuid(taskGuid);
+            serializer.WriteInt32((int)opcode);
+            serializer.WriteString(opcodeName);
+            serializer.WriteGuid(providerGuid);
+            serializer.WriteString(providerName);
+            serializer.WriteString(MessageFormat);
+            serializer.WriteBoolean(lookupAsClassic);
+            serializer.WriteBoolean(lookupAsWPP);
+            serializer.WriteBoolean(containsSelfDescribingMetadata);
 
-            serializer.Write(payloadNames.Length);
+            serializer.WriteInt32(payloadNames.Length);
             foreach (var payloadName in payloadNames)
             {
-                serializer.Write(payloadName);
+                serializer.WriteString(payloadName);
             }
 
-            serializer.Write(payloadFetches.Length);
+            serializer.WriteInt32(payloadFetches.Length);
             foreach (var payloadFetch in payloadFetches)
             {
                 payloadFetch.ToStream(serializer);
@@ -1877,10 +1877,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(providers.Count);
+            serializer.WriteInt32(providers.Count);
             foreach (ProviderManifest provider in providers.Values)
             {
-                serializer.Write(provider);
+                serializer.WriteObject(provider);
             }
         }
 
@@ -2536,20 +2536,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(majorVersion);
-            serializer.Write(minorVersion);
-            serializer.Write((int)format);
-            serializer.Write(id);
+            serializer.WriteByte(majorVersion);
+            serializer.WriteByte(minorVersion);
+            serializer.WriteInt32((int)format);
+            serializer.WriteString(id);
             int count = 0;
             if (serializedManifest != null)
             {
                 count = serializedManifest.Length;
             }
 
-            serializer.Write(count);
+            serializer.WriteInt32(count);
             for (int i = 0; i < count; i++)
             {
-                serializer.Write(serializedManifest[i]);
+                serializer.WriteByte(serializedManifest[i]);
             }
         }
 

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -13002,16 +13002,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             {
                 if (_typeIDToName == null)
                 {
-                    serializer.Write(0);
+                    serializer.WriteInt32(0);
                     return;
                 }
                 serializer.Log("<WriteCollection name=\"typeIDToName\" count=\"" + _typeIDToName.Count + "\">\r\n");
-                serializer.Write(_typeIDToName.Count);
+                serializer.WriteInt32(_typeIDToName.Count);
                 foreach (HistoryDictionary<Address, string>.HistoryValue entry in _typeIDToName.Entries)
                 {
                     serializer.WriteAddress(entry.Key);
-                    serializer.Write(entry.StartTime);
-                    serializer.Write(entry.Value);
+                    serializer.WriteInt64(entry.StartTime);
+                    serializer.WriteString(entry.Value);
                 }
                 serializer.Log("</WriteCollection>\r\n");
             });

--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -3229,30 +3229,30 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         #region private
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(driveMapping);
+            serializer.WriteObject(driveMapping);
 
-            serializer.Write(threadIDtoProcessID.Count);
+            serializer.WriteInt32(threadIDtoProcessID.Count);
             serializer.Log("<WriteCollection name=\"ProcessIDForThread\" count=\"" + threadIDtoProcessID.Count + "\">\r\n");
             foreach (HistoryDictionary<int, int>.HistoryValue entry in threadIDtoProcessID.Entries)
             {
-                serializer.Write(entry.Key);
-                serializer.Write(entry.StartTime);
-                serializer.Write(entry.Value);
+                serializer.WriteInt32(entry.Key);
+                serializer.WriteInt64(entry.StartTime);
+                serializer.WriteInt32(entry.Value);
             }
 
             if (threadIDtoProcessIDRundown == null)
             {
-                serializer.Write(0);
+                serializer.WriteInt32(0);
             }
             else
             {
-                serializer.Write(threadIDtoProcessIDRundown.Count);
+                serializer.WriteInt32(threadIDtoProcessIDRundown.Count);
                 serializer.Log("<WriteCollection name=\"ProcessIDForThreadRundown\" count=\"" + threadIDtoProcessIDRundown.Count + "\">\r\n");
                 foreach (HistoryDictionary<int, int>.HistoryValue entry in threadIDtoProcessIDRundown.Entries)
                 {
-                    serializer.Write(entry.Key);
-                    serializer.Write(entry.StartTime);
-                    serializer.Write(entry.Value);
+                    serializer.WriteInt32(entry.Key);
+                    serializer.WriteInt64(entry.StartTime);
+                    serializer.WriteInt32(entry.Value);
                 }
                 serializer.Log("</WriteCollection>\r\n");
             }
@@ -3260,12 +3260,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             lazyFileIDToName.Write(serializer, delegate
             {
                 serializer.Log("<WriteCollection name=\"fileIDToName\" count=\"" + fileIDToName.Count + "\">\r\n");
-                serializer.Write(fileIDToName.Count);
+                serializer.WriteInt32(fileIDToName.Count);
                 foreach (HistoryDictionary<Address, string>.HistoryValue entry in fileIDToName.Entries)
                 {
                     serializer.WriteAddress(entry.Key);
-                    serializer.Write(entry.StartTime);
-                    serializer.Write(entry.Value);
+                    serializer.WriteInt64(entry.StartTime);
+                    serializer.WriteString(entry.Value);
                 }
                 serializer.Log("</WriteCollection>\r\n");
             });
@@ -3273,12 +3273,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             lazyDiskEventTimeStamp.Write(serializer, delegate
             {
                 serializer.Log("<WriteCollection name=\"diskEventTimeStamp\" count=\"" + diskEventTimeStamp.Count + "\">\r\n");
-                serializer.Write(diskEventTimeStamp.Count);
+                serializer.WriteInt32(diskEventTimeStamp.Count);
                 for (int i = 0; i < diskEventTimeStamp.Count; i++)
                 {
                     Debug.Assert(i == 0 || diskEventTimeStamp[i - 1].TimeStampRelativeMSec <= diskEventTimeStamp[i].TimeStampRelativeMSec);
-                    serializer.Write(diskEventTimeStamp[i].DiskNum);
-                    serializer.Write(diskEventTimeStamp[i].TimeStampRelativeMSec);
+                    serializer.WriteInt32(diskEventTimeStamp[i].DiskNum);
+                    serializer.WriteDouble(diskEventTimeStamp[i].TimeStampRelativeMSec);
                 }
                 serializer.Log("</WriteCollection>");
             });
@@ -3286,17 +3286,17 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             if (_objectTypeToName != null)
             {
                 serializer.Log("<WriteCollection name=\"objectTypeToName\" count=\"" + _objectTypeToName.Count + "\">\r\n");
-                serializer.Write(_objectTypeToName.Count);
+                serializer.WriteInt32(_objectTypeToName.Count);
                 foreach (KeyValuePair<int, string> keyValue in _objectTypeToName)
                 {
-                    serializer.Write(keyValue.Key);
-                    serializer.Write(keyValue.Value);
+                    serializer.WriteInt32(keyValue.Key);
+                    serializer.WriteString(keyValue.Value);
                 }
                 serializer.Log("</WriteCollection>\r\n");
             }
             else
             {
-                serializer.Write(0);
+                serializer.WriteInt32(0);
             }
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
@@ -3566,15 +3566,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(kernelToDriveMap.Count);
+            serializer.WriteInt32(kernelToDriveMap.Count);
             serializer.Log("<WriteCollection name=\"driveNames\" count=\"" + kernelToDriveMap.Count + "\">\r\n");
             foreach (var keyValue in kernelToDriveMap)
             {
-                serializer.Write(keyValue.Key);
-                serializer.Write(keyValue.Value);
+                serializer.WriteString(keyValue.Key);
+                serializer.WriteString(keyValue.Value);
             }
             serializer.Log("</WriteCollection>\r\n");
-            serializer.Write(systemDrive);
+            serializer.WriteString(systemDrive);
         }
 
         void IFastSerializable.FromStream(Deserializer deserializer)

--- a/src/TraceEvent/RegisteredTraceEventParser.cs
+++ b/src/TraceEvent/RegisteredTraceEventParser.cs
@@ -1398,7 +1398,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 }
             }
 
-            serializer.Write(count);
+            serializer.WriteInt32(count);
             foreach (var template in m_templates.Values)
             {
                 if (template != null)
@@ -1406,7 +1406,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 #if DEBUG
                     --count;
 #endif
-                    serializer.Write(template);
+                    serializer.WriteObject(template);
                 }
             }
             Debug.Assert(count == 0);

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3144,7 +3144,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             int intCount = byteCount >> 2;
             while (intCount > 0)
             {
-                writer.Write(*sourcePtr++);
+                writer.WriteInt32(*sourcePtr++);
                 --intCount;
             }
         }
@@ -3511,10 +3511,10 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 align = 8 - align;
             }
 
-            serializer.Write((byte)align);
+            serializer.WriteByte((byte)align);
             for (int i = 0; i < align; i++)
             {
-                serializer.Write((byte)0);
+                serializer.WriteByte((byte)0);
             }
 
             Debug.Assert((int)serializer.Writer.GetLabel() % 8 == 0);
@@ -3535,11 +3535,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 {
                     if (i == 2)
                     {
-                        serializer.Write(long.MaxValue);
+                        serializer.WriteInt64(long.MaxValue);
                     }
                     else
                     {
-                        serializer.Write((long)0);          // The important field here is the EventDataSize field 
+                        serializer.WriteInt64((long)0);          // The important field here is the EventDataSize field 
                     }
                 }
 
@@ -3550,52 +3550,52 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             });
 
             serializer.Log("<Marker name=\"sessionStartTime\"/>");
-            serializer.Write(_syncTimeUTC.ToFileTimeUtc());
-            serializer.Write(pointerSize);
-            serializer.Write(numberOfProcessors);
-            serializer.Write(cpuSpeedMHz);
-            serializer.Write((byte)osVersion.Major);
-            serializer.Write((byte)osVersion.Minor);
-            serializer.Write((byte)osVersion.MajorRevision);
-            serializer.Write((byte)osVersion.MinorRevision);
-            serializer.Write(QPCFreq);
-            serializer.Write(sessionStartTimeQPC);
-            serializer.Write(sessionEndTimeQPC);
-            serializer.Write(eventsLost);
-            serializer.Write(machineName);
-            serializer.Write(memorySizeMeg);
+            serializer.WriteInt64(_syncTimeUTC.ToFileTimeUtc());
+            serializer.WriteInt32(pointerSize);
+            serializer.WriteInt32(numberOfProcessors);
+            serializer.WriteInt32(cpuSpeedMHz);
+            serializer.WriteByte((byte)osVersion.Major);
+            serializer.WriteByte((byte)osVersion.Minor);
+            serializer.WriteByte((byte)osVersion.MajorRevision);
+            serializer.WriteByte((byte)osVersion.MinorRevision);
+            serializer.WriteInt64(QPCFreq);
+            serializer.WriteInt64(sessionStartTimeQPC);
+            serializer.WriteInt64(sessionEndTimeQPC);
+            serializer.WriteInt32(eventsLost);
+            serializer.WriteString(machineName);
+            serializer.WriteInt32(memorySizeMeg);
 
-            serializer.Write(processes);
-            serializer.Write(threads);
-            serializer.Write(codeAddresses);
-            serializer.Write(stats);
-            serializer.Write(callStacks);
-            serializer.Write(moduleFiles);
+            serializer.WriteObject(processes);
+            serializer.WriteObject(threads);
+            serializer.WriteObject(codeAddresses);
+            serializer.WriteObject(stats);
+            serializer.WriteObject(callStacks);
+            serializer.WriteObject(moduleFiles);
 
             serializer.Log("<WriteCollection name=\"eventPages\" count=\"" + eventPages.Count + "\">\r\n");
-            serializer.Write(eventPages.Count);
+            serializer.WriteInt32(eventPages.Count);
             for (int i = 0; i < eventPages.Count; i++)
             {
-                serializer.Write(eventPages[i].TimeQPC);
-                serializer.Write(eventPages[i].Position);
+                serializer.WriteInt64(eventPages[i].TimeQPC);
+                serializer.WriteLabel(eventPages[i].Position);
             }
-            serializer.Write(eventPages.Count);                 // redundant as a checksum
+            serializer.WriteInt32(eventPages.Count);                 // redundant as a checksum
             serializer.Log("</WriteCollection>\r\n");
-            serializer.Write(eventCount);
+            serializer.WriteInt32(eventCount);
 
             serializer.Log("<Marker Name=\"eventsToStacks\"/>");
             lazyEventsToStacks.Write(serializer, delegate
             {
                 serializer.Log("<WriteCollection name=\"eventsToStacks\" count=\"" + eventsToStacks.Count + "\">\r\n");
-                serializer.Write(eventsToStacks.Count);
+                serializer.WriteInt32(eventsToStacks.Count);
                 for (int i = 0; i < eventsToStacks.Count; i++)
                 {
                     EventsToStackIndex eventToStack = eventsToStacks[i];
                     Debug.Assert(i == 0 || eventsToStacks[i - 1].EventIndex <= eventsToStacks[i].EventIndex, "event list not sorted");
-                    serializer.Write((int)eventToStack.EventIndex);
-                    serializer.Write((int)eventToStack.CallStackIndex);
+                    serializer.WriteInt32((int)eventToStack.EventIndex);
+                    serializer.WriteInt32((int)eventToStack.CallStackIndex);
                 }
-                serializer.Write(eventsToStacks.Count);             // Redundant as a checksum
+                serializer.WriteInt32(eventsToStacks.Count);             // Redundant as a checksum
                 serializer.Log("</WriteCollection>\r\n");
             });
 
@@ -3603,15 +3603,15 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             lazyEventsToStacks.Write(serializer, delegate
             {
                 serializer.Log("<WriteCollection name=\"cswitchBlockingEventsToStacks\" count=\"" + cswitchBlockingEventsToStacks.Count + "\">\r\n");
-                serializer.Write(cswitchBlockingEventsToStacks.Count);
+                serializer.WriteInt32(cswitchBlockingEventsToStacks.Count);
                 for (int i = 0; i < cswitchBlockingEventsToStacks.Count; i++)
                 {
                     EventsToStackIndex eventToStack = cswitchBlockingEventsToStacks[i];
                     Debug.Assert(i == 0 || cswitchBlockingEventsToStacks[i - 1].EventIndex <= cswitchBlockingEventsToStacks[i].EventIndex, "event list not sorted");
-                    serializer.Write((int)eventToStack.EventIndex);
-                    serializer.Write((int)eventToStack.CallStackIndex);
+                    serializer.WriteInt32((int)eventToStack.EventIndex);
+                    serializer.WriteInt32((int)eventToStack.CallStackIndex);
                 }
-                serializer.Write(cswitchBlockingEventsToStacks.Count);             // Redundant as a checksum
+                serializer.WriteInt32(cswitchBlockingEventsToStacks.Count);             // Redundant as a checksum
                 serializer.Log("</WriteCollection>\r\n");
             });
 
@@ -3619,53 +3619,53 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             lazyEventsToCodeAddresses.Write(serializer, delegate
             {
                 serializer.Log("<WriteCollection name=\"eventsToCodeAddresses\" count=\"" + eventsToCodeAddresses.Count + "\">\r\n");
-                serializer.Write(eventsToCodeAddresses.Count);
+                serializer.WriteInt32(eventsToCodeAddresses.Count);
                 foreach (EventsToCodeAddressIndex eventsToCodeAddress in eventsToCodeAddresses)
                 {
-                    serializer.Write((int)eventsToCodeAddress.EventIndex);
-                    serializer.Write((long)eventsToCodeAddress.Address);
-                    serializer.Write((int)eventsToCodeAddress.CodeAddressIndex);
+                    serializer.WriteInt32((int)eventsToCodeAddress.EventIndex);
+                    serializer.WriteInt64((long)eventsToCodeAddress.Address);
+                    serializer.WriteInt32((int)eventsToCodeAddress.CodeAddressIndex);
                 }
-                serializer.Write(eventsToCodeAddresses.Count);       // Redundant as a checksum
+                serializer.WriteInt32(eventsToCodeAddresses.Count);       // Redundant as a checksum
                 serializer.Log("</WriteCollection>\r\n");
             });
 
             serializer.Log("<WriteCollection name=\"userData\" count=\"" + userData.Count + "\">\r\n");
-            serializer.Write(userData.Count);
+            serializer.WriteInt32(userData.Count);
             foreach (KeyValuePair<string, object> pair in UserData)
             {
-                serializer.Write(pair.Key);
+                serializer.WriteString(pair.Key);
                 IFastSerializable asFastSerializable = (IFastSerializable)pair.Value;
-                serializer.Write(asFastSerializable);
+                serializer.WriteObject(asFastSerializable);
             }
-            serializer.Write(userData.Count);                   // Redundant as a checksum
+            serializer.WriteInt32(userData.Count);                   // Redundant as a checksum
             serializer.Log("</WriteCollection>\r\n");
 
-            serializer.Write(sampleProfileInterval100ns);
-            serializer.Write(osName);
-            serializer.Write(osBuild);
-            serializer.Write(bootTime100ns);
-            serializer.Write(utcOffsetMinutes ?? int.MinValue);
-            serializer.Write(hasPdbInfo);
+            serializer.WriteInt32(sampleProfileInterval100ns);
+            serializer.WriteString(osName);
+            serializer.WriteString(osBuild);
+            serializer.WriteInt64(bootTime100ns);
+            serializer.WriteInt32(utcOffsetMinutes ?? int.MinValue);
+            serializer.WriteBoolean(hasPdbInfo);
 
             serializer.Log("<WriteCollection name=\"m_relatedActivityIds\" count=\"" + relatedActivityIDs.Count + "\">\r\n");
-            serializer.Write(relatedActivityIDs.Count);
+            serializer.WriteInt32(relatedActivityIDs.Count);
             for (int i = 0; i < relatedActivityIDs.Count; i++)
             {
-                serializer.Write(relatedActivityIDs[i]);
+                serializer.WriteGuid(relatedActivityIDs[i]);
             }
 
             serializer.Log("<WriteCollection name=\"containerIDs\" count=\"" + containerIDs.Count + "\">\r\n");
-            serializer.Write(containerIDs.Count);
+            serializer.WriteInt32(containerIDs.Count);
             for(int i=0; i<containerIDs.Count; i++)
             {
-                serializer.Write(containerIDs[i]);
+                serializer.WriteString(containerIDs[i]);
             }
 
             serializer.Log("</WriteCollection>\r\n");
 
-            serializer.Write(truncated);
-            serializer.Write((int) firstTimeInversion);
+            serializer.WriteBoolean(truncated);
+            serializer.WriteInt32((int) firstTimeInversion);
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
@@ -4527,11 +4527,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(m_log);
-            serializer.Write(m_counts.Count);
+            serializer.WriteObject(m_log);
+            serializer.WriteInt32(m_counts.Count);
             foreach (var counts in m_counts.Values)
             {
-                serializer.Write(counts);
+                serializer.WriteObject(counts);
             }
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
@@ -4613,9 +4613,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         public void Serialize(Serializer serializer)
         {
-            serializer.Write(m_providerGuid);
-            serializer.Write((int)m_eventId);
-            serializer.Write(m_classicProvider);
+            serializer.WriteGuid(m_providerGuid);
+            serializer.WriteInt32((int)m_eventId);
+            serializer.WriteBoolean(m_classicProvider);
         }
     }
 
@@ -4856,11 +4856,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(m_stats);
+            serializer.WriteObject(m_stats);
             m_key.Serialize(serializer);
-            serializer.Write(m_count);
-            serializer.Write(m_stackCount);
-            serializer.Write(m_eventDataLenTotal);
+            serializer.WriteInt32(m_count);
+            serializer.WriteInt32(m_stackCount);
+            serializer.WriteInt64(m_eventDataLenTotal);
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
@@ -5441,21 +5441,21 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(log);
+            serializer.WriteObject(log);
             serializer.Log("<WriteCollection name=\"Processes\" count=\"" + processes.Count + "\">\r\n");
-            serializer.Write(processes.Count);
+            serializer.WriteInt32(processes.Count);
             for (int i = 0; i < processes.Count; i++)
             {
-                serializer.Write(processes[i]);
+                serializer.WriteObject(processes[i]);
             }
 
             serializer.Log("</WriteCollection>\r\n");
 
             serializer.Log("<WriteCollection name=\"ProcessesByPID\" count=\"" + processesByPID.Count + "\">\r\n");
-            serializer.Write(processesByPID.Count);
+            serializer.WriteInt32(processesByPID.Count);
             for (int i = 0; i < processesByPID.Count; i++)
             {
-                serializer.Write(processesByPID[i]);
+                serializer.WriteObject(processesByPID[i]);
             }
 
             serializer.Log("</WriteCollection>\r\n");
@@ -5805,26 +5805,26 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(processID);
-            serializer.Write((int)processIndex);
-            serializer.Write(log);
-            serializer.Write(commandLine);
-            serializer.Write(imageFileName);
-            serializer.Write(firstEventSeenQPC);
-            serializer.Write(startTimeQPC);
-            serializer.Write(endTimeQPC);
-            serializer.Write(exitStatus.HasValue);
+            serializer.WriteInt32(processID);
+            serializer.WriteInt32((int)processIndex);
+            serializer.WriteObject(log);
+            serializer.WriteString(commandLine);
+            serializer.WriteString(imageFileName);
+            serializer.WriteInt64(firstEventSeenQPC);
+            serializer.WriteInt64(startTimeQPC);
+            serializer.WriteInt64(endTimeQPC);
+            serializer.WriteBoolean(exitStatus.HasValue);
             if (exitStatus.HasValue)
             {
-                serializer.Write(exitStatus.Value);
+                serializer.WriteInt32(exitStatus.Value);
             }
 
-            serializer.Write(parentID);
-            serializer.Write(parent);
-            serializer.Write(loadedModules);
-            serializer.Write(cpuSamples);
-            serializer.Write(loadedAModuleHigh);
-            serializer.Write(anyModuleLoaded);
+            serializer.WriteInt32(parentID);
+            serializer.WriteObject(parent);
+            serializer.WriteObject(loadedModules);
+            serializer.WriteInt32(cpuSamples);
+            serializer.WriteBoolean(loadedAModuleHigh);
+            serializer.WriteBoolean(anyModuleLoaded);
         }
 
         void IFastSerializable.FromStream(Deserializer deserializer)
@@ -6263,13 +6263,13 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(log);
+            serializer.WriteObject(log);
 
             serializer.Log("<WriteCollection name=\"threads\" count=\"" + threads.Count + "\">\r\n");
-            serializer.Write(threads.Count);
+            serializer.WriteInt32(threads.Count);
             for (int i = 0; i < threads.Count; i++)
             {
-                serializer.Write(threads[i]);
+                serializer.WriteObject(threads[i]);
             }
 
             serializer.Log("</WriteCollection>\r\n");
@@ -6460,20 +6460,20 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(threadID);
-            serializer.Write((int)threadIndex);
-            serializer.Write(process);
-            serializer.Write(startTimeQPC);
-            serializer.Write(endTimeQPC);
-            serializer.Write(cpuSamples);
-            serializer.Write(threadInfo);
-            serializer.Write((long)userStackBase);
+            serializer.WriteInt32(threadID);
+            serializer.WriteInt32((int)threadIndex);
+            serializer.WriteObject(process);
+            serializer.WriteInt64(startTimeQPC);
+            serializer.WriteInt64(endTimeQPC);
+            serializer.WriteInt32(cpuSamples);
+            serializer.WriteString(threadInfo);
+            serializer.WriteInt64((long)userStackBase);
 
-            serializer.Write(activityIds.Count);
+            serializer.WriteInt32(activityIds.Count);
             serializer.Log("<WriteCollection name=\"ActivityIDForThread\" count=\"" + activityIds.Count + "\">\r\n");
             foreach (ActivityIndex entry in activityIds)
             {
-                serializer.Write((int)entry);
+                serializer.WriteInt32((int)entry);
             }
 
             serializer.Log("</WriteCollection>\r\n");
@@ -6996,12 +6996,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(process);
+            serializer.WriteObject(process);
             serializer.Log("<WriteCollection count=\"" + modules.Count + "\">\r\n");
-            serializer.Write(modules.Count);
+            serializer.WriteInt32(modules.Count);
             for (int i = 0; i < modules.Count; i++)
             {
-                serializer.Write(modules[i]);
+                serializer.WriteObject(modules[i]);
             }
 
             serializer.Log("</WriteCollection>\r\n");
@@ -7170,13 +7170,13 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         void IFastSerializable.ToStream(Serializer serializer) { ToStream(serializer); }
         internal void ToStream(Serializer serializer)
         {
-            serializer.Write(loadTimeQPC);
-            serializer.Write(unloadTimeQPC);
-            serializer.Write(managedModule);
-            serializer.Write(process);
-            serializer.Write(moduleFile);
-            serializer.Write((long)key);
-            serializer.Write(overlaps);
+            serializer.WriteInt64(loadTimeQPC);
+            serializer.WriteInt64(unloadTimeQPC);
+            serializer.WriteObject(managedModule);
+            serializer.WriteObject(process);
+            serializer.WriteObject(moduleFile);
+            serializer.WriteInt64((long)key);
+            serializer.WriteBoolean(overlaps);
         }
         /// <summary>
         /// See IFastSerializable.FromStream.
@@ -7267,9 +7267,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         void IFastSerializable.ToStream(Serializer serializer)
         {
             base.ToStream(serializer);
-            serializer.Write(assemblyID);
-            serializer.Write(nativeModule);
-            serializer.Write((int)flags);
+            serializer.WriteInt64(assemblyID);
+            serializer.WriteObject(nativeModule);
+            serializer.WriteInt32((int)flags);
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
@@ -7545,16 +7545,16 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(log);
-            serializer.Write(codeAddresses);
+            serializer.WriteObject(log);
+            serializer.WriteObject(codeAddresses);
             lazyCallStacks.Write(serializer, delegate
             {
                 serializer.Log("<WriteCollection name=\"callStacks\" count=\"" + callStacks.Count + "\">\r\n");
-                serializer.Write(callStacks.Count);
+                serializer.WriteInt32(callStacks.Count);
                 for (int i = 0; i < callStacks.Count; i++)
                 {
-                    serializer.Write((int)callStacks[i].codeAddressIndex);
-                    serializer.Write((int)callStacks[i].callerIndex);
+                    serializer.WriteInt32((int)callStacks[i].codeAddressIndex);
+                    serializer.WriteInt32((int)callStacks[i].callerIndex);
                 }
                 serializer.Log("</WriteCollection>\r\n");
             });
@@ -8719,30 +8719,30 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             lazyCodeAddresses.Write(serializer, delegate
             {
-                serializer.Write(log);
-                serializer.Write(moduleFiles);
-                serializer.Write(methods);
+                serializer.WriteObject(log);
+                serializer.WriteObject(moduleFiles);
+                serializer.WriteObject(methods);
 
-                serializer.WriteTagged(CodeAddressInfoSerializationVersion);
-                serializer.Write(codeAddresses.Count);
+                serializer.WriteTaggedInt32(CodeAddressInfoSerializationVersion);
+                serializer.WriteInt32(codeAddresses.Count);
                 serializer.Log("<WriteCollection name=\"codeAddresses\" count=\"" + codeAddresses.Count + "\">\r\n");
                 for (int i = 0; i < codeAddresses.Count; i++)
                 {
                     serializer.WriteAddress(codeAddresses[i].Address);
-                    serializer.Write((int)codeAddresses[i].moduleFileIndex);
-                    serializer.Write((int)codeAddresses[i].methodOrProcessOrIlMapIndex);
-                    serializer.Write(codeAddresses[i].InclusiveCount);
+                    serializer.WriteInt32((int)codeAddresses[i].moduleFileIndex);
+                    serializer.WriteInt32((int)codeAddresses[i].methodOrProcessOrIlMapIndex);
+                    serializer.WriteInt32(codeAddresses[i].InclusiveCount);
 
                     // 'CodeAddressInfoSerializationVersion' >= 1
-                    serializer.Write((byte)codeAddresses[i].optimizationTier);
+                    serializer.WriteByte((byte)codeAddresses[i].optimizationTier);
                 }
-                serializer.Write(totalCodeAddresses);
+                serializer.WriteInt32(totalCodeAddresses);
                 serializer.Log("</WriteCollection>\r\n");
 
-                serializer.Write(ILToNativeMaps.Count);
+                serializer.WriteInt32(ILToNativeMaps.Count);
                 for (int i = 0; i < ILToNativeMaps.Count; i++)
                 {
-                    serializer.Write(ILToNativeMaps[i]);
+                    serializer.WriteObject(ILToNativeMaps[i]);
                 }
             });
         }
@@ -9116,8 +9116,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             }
             internal void Serialize(Serializer serializer)
             {
-                serializer.Write(ILOffset);
-                serializer.Write(NativeOffset);
+                serializer.WriteInt32(ILOffset);
+                serializer.WriteInt32(NativeOffset);
             }
         }
 
@@ -9179,11 +9179,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             void IFastSerializable.ToStream(Serializer serializer)
             {
-                serializer.Write((int)MethodIndex);
-                serializer.Write((long)MethodStart);
-                serializer.Write(MethodLength);
+                serializer.WriteInt32((int)MethodIndex);
+                serializer.WriteInt64((long)MethodStart);
+                serializer.WriteInt32(MethodLength);
 
-                serializer.Write(Map.Count);
+                serializer.WriteInt32(Map.Count);
                 for (int i = 0; i < Map.Count; i++)
                 {
                     Map[i].Serialize(serializer);
@@ -9571,14 +9571,14 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             lazyMethods.Write(serializer, delegate
             {
-                serializer.Write(codeAddresses);
-                serializer.Write(methods.Count);
+                serializer.WriteObject(codeAddresses);
+                serializer.WriteInt32(methods.Count);
                 serializer.Log("<WriteCollection name=\"methods\" count=\"" + methods.Count + "\">\r\n");
                 for (int i = 0; i < methods.Count; i++)
                 {
-                    serializer.Write(methods[i].fullMethodName);
-                    serializer.Write(methods[i].methodDefOrRva);
-                    serializer.Write((int)methods[i].moduleIndex);
+                    serializer.WriteString(methods[i].fullMethodName);
+                    serializer.WriteInt32(methods[i].methodDefOrRva);
+                    serializer.WriteInt32((int)methods[i].moduleIndex);
                 }
                 serializer.Log("</WriteCollection>\r\n");
             });
@@ -9889,11 +9889,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(log);
-            serializer.Write(moduleFiles.Count);
+            serializer.WriteObject(log);
+            serializer.WriteInt32(moduleFiles.Count);
             for (int i = 0; i < moduleFiles.Count; i++)
             {
-                serializer.Write(moduleFiles[i]);
+                serializer.WriteObject(moduleFiles[i]);
             }
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
@@ -10141,20 +10141,20 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write(fileName);
-            serializer.Write(imageSize);
+            serializer.WriteString(fileName);
+            serializer.WriteInt32(imageSize);
             serializer.WriteAddress(imageBase);
 
-            serializer.Write(pdbName);
-            serializer.Write(pdbSignature);
-            serializer.Write(pdbAge);
-            serializer.Write(fileVersion);
-            serializer.Write(productVersion);
-            serializer.Write(timeDateStamp);
-            serializer.Write(imageChecksum);
-            serializer.Write((int)moduleFileIndex);
-            serializer.Write(codeAddressesInModule);
-            serializer.Write(managedModule);
+            serializer.WriteString(pdbName);
+            serializer.WriteGuid(pdbSignature);
+            serializer.WriteInt32(pdbAge);
+            serializer.WriteString(fileVersion);
+            serializer.WriteString(productVersion);
+            serializer.WriteInt32(timeDateStamp);
+            serializer.WriteInt32(imageChecksum);
+            serializer.WriteInt32((int)moduleFileIndex);
+            serializer.WriteInt32(codeAddressesInModule);
+            serializer.WriteObject(managedModule);
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
@@ -10457,17 +10457,17 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.ToStream(Serializer serializer)
         {
-            serializer.Write((int)activityIndex);
-            serializer.Write(creator);
-            serializer.Write((int)creationCallStackIndex);
-            serializer.Write(thread);
-            serializer.Write((int)creationEventIndex);
-            serializer.Write(creationTimeQPC);
-            serializer.Write(startTimeQPC);
-            serializer.Write(endTimeQPC);
-            serializer.Write(multiTrigger);
-            serializer.Write(gcBound);
-            serializer.Write((short)kind);
+            serializer.WriteInt32((int)activityIndex);
+            serializer.WriteObject(creator);
+            serializer.WriteInt32((int)creationCallStackIndex);
+            serializer.WriteObject(thread);
+            serializer.WriteInt32((int)creationEventIndex);
+            serializer.WriteInt64(creationTimeQPC);
+            serializer.WriteInt64(startTimeQPC);
+            serializer.WriteInt64(endTimeQPC);
+            serializer.WriteBoolean(multiTrigger);
+            serializer.WriteBoolean(gcBound);
+            serializer.WriteInt16((short)kind);
         }
 
         void IFastSerializable.FromStream(Deserializer deserializer)
@@ -10880,7 +10880,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
     {
         public static void WriteAddress(this Serializer serializer, Address address)
         {
-            serializer.Write((long)address);
+            serializer.WriteInt64((long)address);
         }
         public static void ReadAddress(this Deserializer deserializer, out Address address)
         {


### PR DESCRIPTION
This change helps ensure refactorings do not unintentionally change the serialized result.