### PR TITLE
Rename Read methods to indicate the type

### DIFF
--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -1149,7 +1149,7 @@ namespace FastSerialization
         /// <summary>
         /// Read a bool from the stream
         /// </summary>
-        public void Read(out bool ret)
+        public void ReadBoolean(out bool ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1162,7 +1162,7 @@ namespace FastSerialization
         /// <summary>
         /// Read a byte from the stream
         /// </summary>
-        public void Read(out byte ret)
+        public void ReadByte(out byte ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1175,7 +1175,7 @@ namespace FastSerialization
         /// <summary>
         /// Read a short from the stream
         /// </summary>
-        public void Read(out short ret)
+        public void ReadInt16(out short ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1188,7 +1188,7 @@ namespace FastSerialization
         /// <summary>
         /// Read an int from the stream
         /// </summary>
-        public void Read(out int ret)
+        public void ReadInt32(out int ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1201,7 +1201,7 @@ namespace FastSerialization
         /// <summary>
         /// Read a long from the stream
         /// </summary>
-        public void Read(out long ret)
+        public void ReadInt64(out long ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1214,7 +1214,7 @@ namespace FastSerialization
         /// <summary>
         /// Read a Guid from the stream
         /// </summary>
-        public unsafe void Read(out Guid ret)
+        public unsafe void ReadGuid(out Guid ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1233,21 +1233,21 @@ namespace FastSerialization
         /// <summary>
         /// Read a float from the stream
         /// </summary>
-        public void Read(out float ret)
+        public void ReadSingle(out float ret)
         {
-            ret = ReadFloat();
+            ret = ReadSingle();
         }
         /// <summary>
         /// Read a double from the stream
         /// </summary>
-        public void Read(out double ret)
+        public void ReadDouble(out double ret)
         {
             ret = ReadDouble();
         }
         /// <summary>
         /// Read a string from the stream.  Can represent null
         /// </summary>
-        public void Read(out string ret)
+        public void ReadString(out string ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1263,7 +1263,7 @@ namespace FastSerialization
         /// <summary>
         /// d) from the stream
         /// </summary>
-        public void Read(out StreamLabel ret)
+        public void ReadLabel(out StreamLabel ret)
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1277,7 +1277,7 @@ namespace FastSerialization
         /// <summary>
         /// Read a IFastSerializable object from the stream and place it in ret
         /// </summary>
-        public void Read<T>(out T ret) where T : IFastSerializable
+        public void ReadObject<T>(out T ret) where T : IFastSerializable
         {
             ret = (T)ReadObject();
         }
@@ -1398,7 +1398,7 @@ namespace FastSerialization
         /// <summary>
         /// Read an int from the stream and return it
         /// </summary>
-        public int ReadInt()
+        public int ReadInt32()
         {
 #if DEBUG
             StreamLabel label = reader.Current;
@@ -1426,7 +1426,7 @@ namespace FastSerialization
         /// <summary>
         /// Read a float from the stream and return it
         /// </summary>
-        public unsafe float ReadFloat()
+        public unsafe float ReadSingle()
         {
             float ret;
             int* intPtr = (int*)&ret;
@@ -1622,13 +1622,13 @@ namespace FastSerialization
         /// <summary>
         /// Try to read tagged value from the stream.  If it is a tagged bool, return int in ret and return true, otherwise leave the cursor unchanged and return false
         /// </summary>
-        public bool TryReadTagged(ref bool ret)
+        public bool TryReadTaggedBoolean(ref bool ret)
         {
             Tags tag = ReadTag();
             if (tag == Tags.Byte)
             {
                 byte data = 0;
-                Read(out data);
+                ReadByte(out data);
                 ret = (data != 0);
                 return true;
             }
@@ -1638,12 +1638,12 @@ namespace FastSerialization
         /// <summary>
         /// Try to read tagged value from the stream.  If it is a tagged byte, return int in ret and return true, otherwise leave the cursor unchanged and return false
         /// </summary>
-        public bool TryReadTagged(ref byte ret)
+        public bool TryReadTaggedByte(ref byte ret)
         {
             Tags tag = ReadTag();
             if (tag == Tags.Byte)
             {
-                Read(out ret);
+                ReadByte(out ret);
                 return true;
             }
             reader.Goto(Current - 1);
@@ -1652,12 +1652,12 @@ namespace FastSerialization
         /// <summary>
         /// Try to read tagged value from the stream.  If it is a tagged short, return int in ret and return true, otherwise leave the cursor unchanged and return false
         /// </summary>
-        public bool TryReadTagged(ref short ret)
+        public bool TryReadTaggedInt16(ref short ret)
         {
             Tags tag = ReadTag();
             if (tag == Tags.Int16)
             {
-                Read(out ret);
+                ReadInt16(out ret);
                 return true;
             }
             reader.Goto(Current - 1);
@@ -1666,12 +1666,12 @@ namespace FastSerialization
         /// <summary>
         /// Try to read tagged value from the stream.  If it is a tagged int, return int in ret and return true, otherwise leave the cursor unchanged and return false
         /// </summary>
-        public bool TryReadTagged(ref int ret)
+        public bool TryReadTaggedInt32(ref int ret)
         {
             Tags tag = ReadTag();
             if (tag == Tags.Int32)
             {
-                Read(out ret);
+                ReadInt32(out ret);
                 return true;
             }
             reader.Goto(Current - 1);
@@ -1680,12 +1680,12 @@ namespace FastSerialization
         /// <summary>
         /// Try to read tagged value from the stream.  If it is a tagged long, return int in ret and return true, otherwise leave the cursor unchanged and return false
         /// </summary>
-        public bool TryReadTagged(ref long ret)
+        public bool TryReadTaggedInt64(ref long ret)
         {
             Tags tag = ReadTag();
             if (tag == Tags.Int64)
             {
-                Read(out ret);
+                ReadInt64(out ret);
                 return true;
             }
             reader.Goto(Current - 1);
@@ -1694,12 +1694,12 @@ namespace FastSerialization
         /// <summary>
         /// Try to read tagged value from the stream.  If it is a tagged string, return int in ret and return true, otherwise leave the cursor unchanged and return false
         /// </summary>
-        public bool TryReadTagged(ref string ret)
+        public bool TryReadTaggedString(ref string ret)
         {
             Tags tag = ReadTag();
             if (tag == Tags.String)
             {
-                Read(out ret);
+                ReadString(out ret);
                 return true;
             }
             reader.Goto(Current - 1);
@@ -1725,7 +1725,7 @@ namespace FastSerialization
         /// <summary>
         /// Try to read tagged value from the stream.  If it is a tagged FastSerializable, return int in ret and return true, otherwise leave the cursor unchanged and return false
         /// </summary>
-        public bool TryReadTagged<T>(ref T ret) where T : IFastSerializable
+        public bool TryReadTaggedObject<T>(ref T ret) where T : IFastSerializable
         {
             // Tagged objects always start with a SkipRegion so we don't need to know its size.  
             Tags tag = ReadTag();
@@ -2428,9 +2428,9 @@ namespace FastSerialization
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out version);
-            deserializer.Read(out minimumReaderVersion);
-            deserializer.Read(out fullName);
+            deserializer.ReadInt32(out version);
+            deserializer.ReadInt32(out minimumReaderVersion);
+            deserializer.ReadString(out fullName);
             factory = deserializer.GetFactory(fullName);
             // This is only here for efficiency (you don't have to cast every instance)
             // since most objects won't be versioned.  However it means that you have to

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -308,11 +308,11 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
             throw new SerializationException("Unsupported version GCDump version: 8");
         }
 
-        deserializer.Read(out m_graph);
+        deserializer.ReadObject(out m_graph);
         deserializer.ReadBool();                    // Used to be Is64Bit but that is now on m_graph and we want to keep compatibility. 
 
-        AverageCountMultiplier = deserializer.ReadFloat();
-        AverageSizeMultiplier = deserializer.ReadFloat();
+        AverageCountMultiplier = deserializer.ReadSingle();
+        AverageSizeMultiplier = deserializer.ReadSingle();
 
         JSHeapInfo = (JSHeapInfo)deserializer.ReadObject();
         DotNetHeapInfo = (DotNetHeapInfo)deserializer.ReadObject();
@@ -321,18 +321,18 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
         TimeCollected = new DateTime(deserializer.ReadInt64());
         MachineName = deserializer.ReadString();
         ProcessName = deserializer.ReadString();
-        ProcessID = deserializer.ReadInt();
+        ProcessID = deserializer.ReadInt32();
         TotalProcessCommit = deserializer.ReadInt64();
         TotalProcessWorkingSet = deserializer.ReadInt64();
 
         int count;
-        deserializer.Read(out count);
+        deserializer.ReadInt32(out count);
         if (count != 0)
         {
             var a = new float[count];
             for (int i = 0; i < a.Length; i++)
             {
-                a[i] = deserializer.ReadFloat();
+                a[i] = deserializer.ReadSingle();
             }
 
             CountMultipliersByType = a;
@@ -340,9 +340,9 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 
         // Things after version 8 go here. Always add the the end, and it should always work
         // and use the tagged variation.  
-        deserializer.TryReadTagged<InteropInfo>(ref m_interop);
+        deserializer.TryReadTaggedObject<InteropInfo>(ref m_interop);
         string creationTool = null;
-        deserializer.TryReadTagged(ref creationTool);
+        deserializer.TryReadTaggedString(ref creationTool);
         CreationTool = creationTool;
     }
 
@@ -353,7 +353,7 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
     {
         DotNetHeapInfo = new DotNetHeapInfo();
 
-        deserializer.Read(out m_graph);
+        deserializer.ReadObject(out m_graph);
         DotNetHeapInfo.SizeOfAllSegments = deserializer.ReadInt64();
         deserializer.ReadInt64(); // Size of dumped objects 
         deserializer.ReadInt64(); // Number of dumped objects 
@@ -365,14 +365,14 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
             TimeCollected = new DateTime(deserializer.ReadInt64());
             MachineName = deserializer.ReadString();
             ProcessName = deserializer.ReadString();
-            ProcessID = deserializer.ReadInt();
+            ProcessID = deserializer.ReadInt32();
             TotalProcessCommit = deserializer.ReadInt64();
             TotalProcessWorkingSet = deserializer.ReadInt64();
 
             if (deserializer.VersionBeingRead >= 6)
             {
                 // Skip the segments
-                var count = deserializer.ReadInt();
+                var count = deserializer.ReadInt32();
                 for (int i = 0; i < count; i++)
                 {
                     deserializer.ReadObject();
@@ -619,16 +619,16 @@ public class InteropInfo : IFastSerializable
 
     void IFastSerializable.FromStream(Deserializer deserializer)
     {
-        int countRCWCCW = deserializer.ReadInt();
+        int countRCWCCW = deserializer.ReadInt32();
         if (countRCWCCW == 0)
         {
             return;
         }
 
-        m_countRCWs = deserializer.ReadInt();
-        m_countCCWs = deserializer.ReadInt();
-        m_countInterfaces = deserializer.ReadInt();
-        m_countModules = deserializer.ReadInt();
+        m_countRCWs = deserializer.ReadInt32();
+        m_countCCWs = deserializer.ReadInt32();
+        m_countInterfaces = deserializer.ReadInt32();
+        m_countModules = deserializer.ReadInt32();
 
         m_listRCWInfo = new List<RCWInfo>(m_countRCWs);
         m_listCCWInfo = new List<CCWInfo>(m_countCCWs);
@@ -640,13 +640,13 @@ public class InteropInfo : IFastSerializable
         for (int i = 0; i < m_countRCWs; i++)
         {
             RCWInfo infoRCW = new RCWInfo();
-            infoRCW.node = (NodeIndex)deserializer.ReadInt();
-            infoRCW.refCount = deserializer.ReadInt();
+            infoRCW.node = (NodeIndex)deserializer.ReadInt32();
+            infoRCW.refCount = deserializer.ReadInt32();
             infoRCW.addrIUnknown = (Address)deserializer.ReadInt64();
             infoRCW.addrJupiter = (Address)deserializer.ReadInt64();
             infoRCW.addrVTable = (Address)deserializer.ReadInt64();
-            infoRCW.firstComInf = deserializer.ReadInt();
-            infoRCW.countComInf = deserializer.ReadInt();
+            infoRCW.firstComInf = deserializer.ReadInt32();
+            infoRCW.countComInf = deserializer.ReadInt32();
             m_listRCWInfo.Add(infoRCW);
             m_countRCWInterfaces += infoRCW.countComInf;
         }
@@ -654,12 +654,12 @@ public class InteropInfo : IFastSerializable
         for (int i = 0; i < m_countCCWs; i++)
         {
             CCWInfo infoCCW = new CCWInfo();
-            infoCCW.node = (NodeIndex)deserializer.ReadInt();
-            infoCCW.refCount = deserializer.ReadInt();
+            infoCCW.node = (NodeIndex)deserializer.ReadInt32();
+            infoCCW.refCount = deserializer.ReadInt32();
             infoCCW.addrIUnknown = (Address)deserializer.ReadInt64();
             infoCCW.addrHandle = (Address)deserializer.ReadInt64();
-            infoCCW.firstComInf = deserializer.ReadInt();
-            infoCCW.countComInf = deserializer.ReadInt();
+            infoCCW.firstComInf = deserializer.ReadInt32();
+            infoCCW.countComInf = deserializer.ReadInt32();
             m_listCCWInfo.Add(infoCCW);
         }
 
@@ -667,8 +667,8 @@ public class InteropInfo : IFastSerializable
         {
             ComInterfaceInfo infoInterface = new ComInterfaceInfo();
             infoInterface.fRCW = ((deserializer.ReadByte() == 1) ? true : false);
-            infoInterface.owner = deserializer.ReadInt();
-            infoInterface.typeID = (NodeTypeIndex)deserializer.ReadInt();
+            infoInterface.owner = deserializer.ReadInt32();
+            infoInterface.typeID = (NodeTypeIndex)deserializer.ReadInt32();
             infoInterface.addrInterface = (Address)deserializer.ReadInt64();
             infoInterface.addrFirstVTable = (Address)deserializer.ReadInt64();
             infoInterface.addrFirstFunc = (Address)deserializer.ReadInt64();
@@ -679,9 +679,9 @@ public class InteropInfo : IFastSerializable
         {
             InteropModuleInfo infoModule = new InteropModuleInfo();
             infoModule.baseAddress = (Address)deserializer.ReadInt64();
-            infoModule.fileSize = (uint)deserializer.ReadInt();
-            infoModule.timeStamp = (uint)deserializer.ReadInt();
-            deserializer.Read(out infoModule.fileName);
+            infoModule.fileSize = (uint)deserializer.ReadInt32();
+            infoModule.timeStamp = (uint)deserializer.ReadInt32();
+            deserializer.ReadString(out infoModule.fileName);
             infoModule.loadOrder = i;
             m_listModules.Add(infoModule);
         }

--- a/src/HeapDumpCommon/DotNetHeapInfo.cs
+++ b/src/HeapDumpCommon/DotNetHeapInfo.cs
@@ -95,7 +95,7 @@ public class DotNetHeapInfo : IFastSerializable
     void IFastSerializable.FromStream(Deserializer deserializer)
     {
         SizeOfAllSegments = deserializer.ReadInt64();
-        var count = deserializer.ReadInt();
+        var count = deserializer.ReadInt32();
         Segments = new List<GCHeapDumpSegment>(count);
         for (int i = 0; i < count; i++)
         {

--- a/src/MemoryGraph/MemoryGraph.cs
+++ b/src/MemoryGraph/MemoryGraph.cs
@@ -132,7 +132,7 @@ namespace Graphs
         {
             base.FromStream(deserializer);
             // Read in the Memory addresses of each object 
-            int addressCount = deserializer.ReadInt();
+            int addressCount = deserializer.ReadInt32();
             m_nodeAddresses = new SegmentedList<Address>(SegmentSize, addressCount);
 
             for (int i = 0; i < addressCount; i++)
@@ -141,7 +141,7 @@ namespace Graphs
             }
 
             bool is64bit = false;
-            deserializer.TryReadTagged(ref is64bit);
+            deserializer.TryReadTaggedBoolean(ref is64bit);
             Is64Bit = is64bit;
         }
 

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -555,33 +555,33 @@ namespace Graphs
 
         public void FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out m_totalSize);
-            RootIndex = (NodeIndex)deserializer.ReadInt();
+            deserializer.ReadInt64(out m_totalSize);
+            RootIndex = (NodeIndex)deserializer.ReadInt32();
 
             // Read in the Types 
             TypeInfo info = new TypeInfo();
-            int typeCount = deserializer.ReadInt();
+            int typeCount = deserializer.ReadInt32();
             m_types = new GrowableArray<TypeInfo>(typeCount);
             for (int i = 0; i < typeCount; i++)
             {
-                deserializer.Read(out info.Name);
-                deserializer.Read(out info.Size);
-                deserializer.Read(out info.ModuleName);
+                deserializer.ReadString(out info.Name);
+                deserializer.ReadInt32(out info.Size);
+                deserializer.ReadString(out info.ModuleName);
                 m_types.Add(info);
             }
 
             // Read in the Nodes 
-            int nodeCount = deserializer.ReadInt();
+            int nodeCount = deserializer.ReadInt32();
             m_nodes = new SegmentedList<StreamLabel>(SegmentSize, nodeCount);
 
             for (int i = 0; i < nodeCount; i++)
             {
-                m_nodes.Add((StreamLabel)(uint)deserializer.ReadInt());
+                m_nodes.Add((StreamLabel)(uint)deserializer.ReadInt32());
             }
 
             // Read in the Blob stream.  
             // TODO be lazy about reading in the blobs.  
-            int blobCount = deserializer.ReadInt();
+            int blobCount = deserializer.ReadInt32();
             SegmentedMemoryStreamWriter writer = new SegmentedMemoryStreamWriter(blobCount);
             while (8 <= blobCount)
             {
@@ -607,12 +607,12 @@ namespace Graphs
                 expansion.Read(deserializer, delegate ()
                 {
                     // I don't need to use Tagged types for my 'first' version of this new region 
-                    int count = deserializer.ReadInt();
+                    int count = deserializer.ReadInt32();
                     for (int i = 0; i < count; i++)
                     {
                         m_deferedTypes.Add(new DeferedTypeInfo()
                         {
-                            TypeID = deserializer.ReadInt(),
+                            TypeID = deserializer.ReadInt32(),
                             Module = (Module)deserializer.ReadObject(),
                             TypeNameSuffix = deserializer.ReadString()
                         });
@@ -1090,13 +1090,13 @@ namespace Graphs
         /// </summary>
         public void FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out Path);
+            deserializer.ReadString(out Path);
             ImageBase = (Address)deserializer.ReadInt64();
-            deserializer.Read(out Size);
+            deserializer.ReadInt32(out Size);
             BuildTime = new DateTime(deserializer.ReadInt64());
-            deserializer.Read(out PdbName);
-            deserializer.Read(out PdbGuid);
-            deserializer.Read(out PdbAge);
+            deserializer.ReadString(out PdbName);
+            deserializer.ReadGuid(out PdbGuid);
+            deserializer.ReadInt32(out PdbAge);
         }
         #endregion
     }

--- a/src/PerfView/memory/ClrProfilerMemoryGraph.cs
+++ b/src/PerfView/memory/ClrProfilerMemoryGraph.cs
@@ -322,7 +322,7 @@ namespace Graphs
             base.FromStream(deserializer);
             // Read in the Memory addresses of each object 
             m_nodeAddresses.Clear();
-            int addressCount = deserializer.ReadInt();
+            int addressCount = deserializer.ReadInt32();
             for (int i = 0; i < addressCount; i++)
             {
                 m_nodeAddresses.Add((Address)deserializer.ReadInt64());

--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -1648,7 +1648,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 if (fetchType == 1 || fetchType == 2)
                 {
                     IDictionary<long, string> map = null;
-                    int mapCount = deserializer.ReadInt();
+                    int mapCount = deserializer.ReadInt32();
                     if (fetchType == 1)
                     {
                         map = new SortedDictionary<long, string>();
@@ -1670,14 +1670,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 {
                     PayloadFetchClassInfo classInfo = new PayloadFetchClassInfo();
 
-                    var fieldNamesCount = deserializer.ReadInt();
+                    var fieldNamesCount = deserializer.ReadInt32();
                     classInfo.FieldNames = new string[fieldNamesCount];
                     for (int i = 0; i < fieldNamesCount; i++)
                     {
                         classInfo.FieldNames[i] = deserializer.ReadString();
                     }
 
-                    var fieldFetchCount = deserializer.ReadInt();
+                    var fieldFetchCount = deserializer.ReadInt32();
                     classInfo.FieldFetches = new DynamicTraceEventData.PayloadFetch[fieldFetchCount];
                     for (int i = 0; i < fieldFetchCount; i++)
                     {
@@ -1689,7 +1689,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 else if (fetchType == 4)  // Array
                 {
                     PayloadFetchArrayInfo arrayInfo = new PayloadFetchArrayInfo();
-                    deserializer.Read(out arrayInfo.FixedCount);
+                    deserializer.ReadInt32(out arrayInfo.FixedCount);
                     arrayInfo.Element.FromStream(deserializer);
                     info = arrayInfo;
                 }
@@ -1751,27 +1751,27 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         }
         public void FromStream(Deserializer deserializer)
         {
-            eventID = (TraceEventID)deserializer.ReadInt();
-            task = (TraceEventTask)deserializer.ReadInt();
-            deserializer.Read(out taskName);
-            deserializer.Read(out taskGuid);
-            opcode = (TraceEventOpcode)deserializer.ReadInt();
-            deserializer.Read(out opcodeName);
-            deserializer.Read(out providerGuid);
-            deserializer.Read(out providerName);
-            deserializer.Read(out MessageFormat);
-            deserializer.Read(out lookupAsClassic);
-            deserializer.Read(out lookupAsWPP);
-            deserializer.Read(out containsSelfDescribingMetadata);
+            eventID = (TraceEventID)deserializer.ReadInt32();
+            task = (TraceEventTask)deserializer.ReadInt32();
+            deserializer.ReadString(out taskName);
+            deserializer.ReadGuid(out taskGuid);
+            opcode = (TraceEventOpcode)deserializer.ReadInt32();
+            deserializer.ReadString(out opcodeName);
+            deserializer.ReadGuid(out providerGuid);
+            deserializer.ReadString(out providerName);
+            deserializer.ReadString(out MessageFormat);
+            deserializer.ReadBoolean(out lookupAsClassic);
+            deserializer.ReadBoolean(out lookupAsWPP);
+            deserializer.ReadBoolean(out containsSelfDescribingMetadata);
             int count;
-            deserializer.Read(out count);
+            deserializer.ReadInt32(out count);
             payloadNames = new string[count];
             for (int i = 0; i < count; i++)
             {
-                deserializer.Read(out payloadNames[i]);
+                deserializer.ReadString(out payloadNames[i]);
             }
 
-            deserializer.Read(out count);
+            deserializer.ReadInt32(out count);
             payloadFetches = new PayloadFetch[count];
             for (int i = 0; i < count; i++)
             {
@@ -1887,11 +1887,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
             int count;
-            deserializer.Read(out count);
+            deserializer.ReadInt32(out count);
             for (int i = 0; i < count; i++)
             {
                 ProviderManifest provider;
-                deserializer.Read(out provider);
+                deserializer.ReadObject(out provider);
                 providers.Add(provider.Guid, provider);
             }
         }
@@ -2555,11 +2555,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out majorVersion);
-            deserializer.Read(out minorVersion);
-            format = (ManifestEnvelope.ManifestFormats)deserializer.ReadInt();
-            deserializer.Read(out id);
-            int count = deserializer.ReadInt();
+            deserializer.ReadByte(out majorVersion);
+            deserializer.ReadByte(out minorVersion);
+            format = (ManifestEnvelope.ManifestFormats)deserializer.ReadInt32();
+            deserializer.ReadString(out id);
+            int count = deserializer.ReadInt32();
             serializedManifest = new byte[count];
             for (int i = 0; i < count; i++)
             {

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -372,17 +372,17 @@ namespace Microsoft.Diagnostics.Tracing
             short second = deserializer.ReadInt16();
             short milliseconds = deserializer.ReadInt16();
             _syncTimeUTC = new DateTime(year, month, day, hour, minute, second, milliseconds, DateTimeKind.Utc);
-            deserializer.Read(out _syncTimeQPC);
-            deserializer.Read(out _QPCFreq);
+            deserializer.ReadInt64(out _syncTimeQPC);
+            deserializer.ReadInt64(out _QPCFreq);
 
             sessionStartTimeQPC = _syncTimeQPC;
 
             if (3 <= deserializer.VersionBeingRead)
             {
-                deserializer.Read(out pointerSize);
-                deserializer.Read(out _processId);
-                deserializer.Read(out numberOfProcessors);
-                deserializer.Read(out _expectedCPUSamplingRate);
+                deserializer.ReadInt32(out pointerSize);
+                deserializer.ReadInt32(out _processId);
+                deserializer.ReadInt32(out numberOfProcessors);
+                deserializer.ReadInt32(out _expectedCPUSamplingRate);
             }
 #if SUPPORT_V1_V2
             else
@@ -854,7 +854,7 @@ namespace Microsoft.Diagnostics.Tracing
         public unsafe void FromStream(Deserializer deserializer)
         {
             // blockSizeInBytes does not include padding bytes to ensure alignment.
-            var blockSizeInBytes = deserializer.ReadInt();
+            var blockSizeInBytes = deserializer.ReadInt32();
 
             // after the block size comes eventual padding, we just need to skip it by jumping to the nearest aligned address
             if ((long)deserializer.Current % 4 != 0)

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -13022,7 +13022,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             lazyTypeIDToName.Read(deserializer, delegate
             {
                 int count;
-                deserializer.Read(out count);
+                deserializer.ReadInt32(out count);
                 Debug.Assert(count >= 0);
                 deserializer.Log("<Marker name=\"typeIDToName\"/ count=\"" + count + "\">");
                 if (count > 0)
@@ -13035,8 +13035,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
                     for (int i = 0; i < count; i++)
                     {
                         Address key; deserializer.ReadAddress(out key);
-                        long startTimeQPC; deserializer.Read(out startTimeQPC);
-                        string value; deserializer.Read(out value);
+                        long startTimeQPC; deserializer.ReadInt64(out startTimeQPC);
+                        string value; deserializer.ReadString(out value);
                         _typeIDToName.Add(key, startTimeQPC, value);
                     }
                 }

--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -3301,20 +3301,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out driveMapping);
+            deserializer.ReadObject(out driveMapping);
 
-            int count; deserializer.Read(out count);
+            int count; deserializer.ReadInt32(out count);
             Debug.Assert(count >= 0);
             deserializer.Log("<Marker name=\"ProcessIDForThread\"/ count=\"" + count + "\">");
             for (int i = 0; i < count; i++)
             {
-                int key; deserializer.Read(out key);
-                long startTimeQPC; deserializer.Read(out startTimeQPC);
-                int value; deserializer.Read(out value);
+                int key; deserializer.ReadInt32(out key);
+                long startTimeQPC; deserializer.ReadInt64(out startTimeQPC);
+                int value; deserializer.ReadInt32(out value);
                 threadIDtoProcessID.Add(key, startTimeQPC, value);
             }
 
-            deserializer.Read(out count);
+            deserializer.ReadInt32(out count);
             Debug.Assert(count >= 0);
             deserializer.Log("<Marker name=\"ProcessIDForThreadRundown\"/ count=\"" + count + "\">");
             if (count > 0)
@@ -3322,39 +3322,39 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 threadIDtoProcessIDRundown = new HistoryDictionary<int, int>(count);
                 for (int i = 0; i < count; i++)
                 {
-                    int key; deserializer.Read(out key);
-                    long startTimeQPC; deserializer.Read(out startTimeQPC);
-                    int value; deserializer.Read(out value);
+                    int key; deserializer.ReadInt32(out key);
+                    long startTimeQPC; deserializer.ReadInt64(out startTimeQPC);
+                    int value; deserializer.ReadInt32(out value);
                     threadIDtoProcessIDRundown.Add(key, startTimeQPC, value);
                 }
             }
 
             lazyFileIDToName.Read(deserializer, delegate
             {
-                deserializer.Read(out count);
+                deserializer.ReadInt32(out count);
                 Debug.Assert(count >= 0);
                 deserializer.Log("<Marker name=\"fileIDToName\"/ count=\"" + count + "\">");
                 for (int i = 0; i < count; i++)
                 {
                     Address key; deserializer.ReadAddress(out key);
-                    long startTimeQPC; deserializer.Read(out startTimeQPC);
-                    string value; deserializer.Read(out value);
+                    long startTimeQPC; deserializer.ReadInt64(out startTimeQPC);
+                    string value; deserializer.ReadString(out value);
                     fileIDToName.Add(key, startTimeQPC, value);
                 }
             });
 
             lazyDiskEventTimeStamp.Read(deserializer, delegate
             {
-                deserializer.Read(out count);
+                deserializer.ReadInt32(out count);
                 Debug.Assert(count >= 0);
                 deserializer.Log("<Marker name=\"diskEventTimeStamp\"/ count=\"" + count + "\">");
                 for (int i = 0; i < count; i++)
                 {
-                    diskEventTimeStamp.Add(new DiskIOTime(deserializer.ReadInt(), deserializer.ReadDouble()));
+                    diskEventTimeStamp.Add(new DiskIOTime(deserializer.ReadInt32(), deserializer.ReadDouble()));
                 }
             });
 
-            deserializer.Read(out count);
+            deserializer.ReadInt32(out count);
             Debug.Assert(count >= 0);
             if (count > 0)
             {
@@ -3362,7 +3362,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 _objectTypeToName = new Dictionary<int, string>(count);
                 for (int i = 0; i < count; i++)
                 {
-                    _objectTypeToName.Add(deserializer.ReadInt(), deserializer.ReadString());
+                    _objectTypeToName.Add(deserializer.ReadInt32(), deserializer.ReadString());
                 }
             }
         }
@@ -3579,15 +3579,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            int numDrives; deserializer.Read(out numDrives);
+            int numDrives; deserializer.ReadInt32(out numDrives);
             for (int i = 0; i < numDrives; i++)
             {
                 string key, value;
-                deserializer.Read(out key);
-                deserializer.Read(out value);
+                deserializer.ReadString(out key);
+                deserializer.ReadString(out value);
                 kernelToDriveMap.Add(new KeyValuePair<string, string>(key, value));
             }
-            deserializer.Read(out systemDrive);
+            deserializer.ReadString(out systemDrive);
         }
         #endregion
     }

--- a/src/TraceEvent/RegisteredTraceEventParser.cs
+++ b/src/TraceEvent/RegisteredTraceEventParser.cs
@@ -1418,12 +1418,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         public virtual void FromStream(Deserializer deserializer)
         {
             int count;
-            deserializer.Read(out count);
+            deserializer.ReadInt32(out count);
             m_templates = new Dictionary<TraceEvent, DynamicTraceEventData>(count, new TraceEventComparer());
             for (int i = 0; i < count; i++)
             {
                 DynamicTraceEventData template;
-                deserializer.Read(out template);
+                deserializer.ReadObject(out template);
                 m_templates.Add(template, template);
             }
         }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3671,11 +3671,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             deserializer.Log("<Marker Name=\"RawEvents\"/>");
             byte align;
-            deserializer.Read(out align);
+            deserializer.ReadByte(out align);
             while (align > 0)
             {
                 byte zero;
-                deserializer.Read(out zero);
+                deserializer.ReadByte(out zero);
                 --align;
             }
 
@@ -3684,57 +3684,57 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             deserializer.Log("<Marker Name=\"sessionStartTime\"/>");
             _syncTimeUTC = DateTime.FromFileTimeUtc(deserializer.ReadInt64());
-            deserializer.Read(out pointerSize);
-            deserializer.Read(out numberOfProcessors);
-            deserializer.Read(out cpuSpeedMHz);
+            deserializer.ReadInt32(out pointerSize);
+            deserializer.ReadInt32(out numberOfProcessors);
+            deserializer.ReadInt32(out cpuSpeedMHz);
             osVersion = new Version(deserializer.ReadByte(), deserializer.ReadByte(), deserializer.ReadByte(), deserializer.ReadByte());
-            deserializer.Read(out _QPCFreq);
-            deserializer.Read(out sessionStartTimeQPC);
+            deserializer.ReadInt64(out _QPCFreq);
+            deserializer.ReadInt64(out sessionStartTimeQPC);
             _syncTimeQPC = sessionStartTimeQPC;
-            deserializer.Read(out sessionEndTimeQPC);
-            deserializer.Read(out eventsLost);
-            deserializer.Read(out machineName);
-            deserializer.Read(out memorySizeMeg);
+            deserializer.ReadInt64(out sessionEndTimeQPC);
+            deserializer.ReadInt32(out eventsLost);
+            deserializer.ReadString(out machineName);
+            deserializer.ReadInt32(out memorySizeMeg);
 
-            deserializer.Read(out processes);
-            deserializer.Read(out threads);
-            deserializer.Read(out codeAddresses);
-            deserializer.Read(out stats);
-            deserializer.Read(out callStacks);
-            deserializer.Read(out moduleFiles);
+            deserializer.ReadObject(out processes);
+            deserializer.ReadObject(out threads);
+            deserializer.ReadObject(out codeAddresses);
+            deserializer.ReadObject(out stats);
+            deserializer.ReadObject(out callStacks);
+            deserializer.ReadObject(out moduleFiles);
 
             deserializer.Log("<Marker Name=\"eventPages\"/>");
-            int count = deserializer.ReadInt();
+            int count = deserializer.ReadInt32();
             eventPages = new GrowableArray<EventPageEntry>(count + 1);
             EventPageEntry entry = new EventPageEntry();
             for (int i = 0; i < count; i++)
             {
-                deserializer.Read(out entry.TimeQPC);
-                deserializer.Read(out entry.Position);
+                deserializer.ReadInt64(out entry.TimeQPC);
+                deserializer.ReadLabel(out entry.Position);
                 eventPages.Add(entry);
             }
-            int checkCount = deserializer.ReadInt();
+            int checkCount = deserializer.ReadInt32();
             if (count != checkCount)
             {
                 throw new SerializationException("Redundant count check fail.");
             }
 
-            deserializer.Read(out eventCount);
+            deserializer.ReadInt32(out eventCount);
 
             lazyEventsToStacks.Read(deserializer, delegate
             {
-                int stackCount = deserializer.ReadInt();
+                int stackCount = deserializer.ReadInt32();
                 deserializer.Log("<Marker name=\"eventToStackIndex\" count=\"" + stackCount + "\"/>");
                 eventsToStacks = new GrowableArray<EventsToStackIndex>(stackCount + 1);
                 EventsToStackIndex eventToStackIndex = new EventsToStackIndex();
                 for (int i = 0; i < stackCount; i++)
                 {
-                    eventToStackIndex.EventIndex = (EventIndex)deserializer.ReadInt();
+                    eventToStackIndex.EventIndex = (EventIndex)deserializer.ReadInt32();
                     Debug.Assert((int)eventToStackIndex.EventIndex < eventCount);
-                    eventToStackIndex.CallStackIndex = (CallStackIndex)deserializer.ReadInt();
+                    eventToStackIndex.CallStackIndex = (CallStackIndex)deserializer.ReadInt32();
                     eventsToStacks.Add(eventToStackIndex);
                 }
-                int stackCheckCount = deserializer.ReadInt();
+                int stackCheckCount = deserializer.ReadInt32();
                 if (stackCount != stackCheckCount)
                 {
                     throw new SerializationException("Redundant count check fail.");
@@ -3744,18 +3744,18 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             lazyCswitchBlockingEventsToStacks.Read(deserializer, delegate
             {
-                int stackCount = deserializer.ReadInt();
+                int stackCount = deserializer.ReadInt32();
                 deserializer.Log("<Marker Name=\"lazyCswitchBlockingEventsToStacks\" count=\"" + stackCount + "\"/>");
                 cswitchBlockingEventsToStacks = new GrowableArray<EventsToStackIndex>(stackCount + 1);
                 EventsToStackIndex eventToStackIndex = new EventsToStackIndex();
                 for (int i = 0; i < stackCount; i++)
                 {
-                    eventToStackIndex.EventIndex = (EventIndex)deserializer.ReadInt();
+                    eventToStackIndex.EventIndex = (EventIndex)deserializer.ReadInt32();
                     Debug.Assert((int)eventToStackIndex.EventIndex < eventCount);
-                    eventToStackIndex.CallStackIndex = (CallStackIndex)deserializer.ReadInt();
+                    eventToStackIndex.CallStackIndex = (CallStackIndex)deserializer.ReadInt32();
                     cswitchBlockingEventsToStacks.Add(eventToStackIndex);
                 }
-                int stackCheckCount = deserializer.ReadInt();
+                int stackCheckCount = deserializer.ReadInt32();
                 if (stackCount != stackCheckCount)
                 {
                     throw new SerializationException("Redundant count check fail.");
@@ -3765,18 +3765,18 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             lazyEventsToCodeAddresses.Read(deserializer, delegate
             {
-                int codeAddressCount = deserializer.ReadInt();
+                int codeAddressCount = deserializer.ReadInt32();
                 deserializer.Log("<Marker Name=\"eventToCodeAddressIndex\" count=\"" + codeAddressCount + "\"/>");
                 eventsToCodeAddresses = new GrowableArray<EventsToCodeAddressIndex>(codeAddressCount + 1);
                 EventsToCodeAddressIndex eventToCodeAddressIndex = new EventsToCodeAddressIndex();
                 for (int i = 0; i < codeAddressCount; i++)
                 {
-                    eventToCodeAddressIndex.EventIndex = (EventIndex)deserializer.ReadInt();
+                    eventToCodeAddressIndex.EventIndex = (EventIndex)deserializer.ReadInt32();
                     deserializer.ReadAddress(out eventToCodeAddressIndex.Address);
-                    eventToCodeAddressIndex.CodeAddressIndex = (CodeAddressIndex)deserializer.ReadInt();
+                    eventToCodeAddressIndex.CodeAddressIndex = (CodeAddressIndex)deserializer.ReadInt32();
                     eventsToCodeAddresses.Add(eventToCodeAddressIndex);
                 }
-                int codeAddressCheckCount = deserializer.ReadInt();
+                int codeAddressCheckCount = deserializer.ReadInt32();
                 if (codeAddressCount != codeAddressCheckCount)
                 {
                     throw new SerializationException("Redundant count check fail.");
@@ -3784,52 +3784,52 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             });
             lazyEventsToCodeAddresses.FinishRead();        // TODO REMOVE
 
-            count = deserializer.ReadInt();
+            count = deserializer.ReadInt32();
             deserializer.Log("<Marker Name=\"userData\" count=\"" + count + "\"/>");
             for (int i = 0; i < count; i++)
             {
                 string key;
-                deserializer.Read(out key);
+                deserializer.ReadString(out key);
                 IFastSerializable value = deserializer.ReadObject();
                 userData[key] = value;
             }
-            checkCount = deserializer.ReadInt();
+            checkCount = deserializer.ReadInt32();
             if (count != checkCount)
             {
                 throw new SerializationException("Redundant count check fail.");
             }
 
-            deserializer.Read(out sampleProfileInterval100ns);
-            deserializer.Read(out osName);
-            deserializer.Read(out osBuild);
-            deserializer.Read(out bootTime100ns);
+            deserializer.ReadInt32(out sampleProfileInterval100ns);
+            deserializer.ReadString(out osName);
+            deserializer.ReadString(out osBuild);
+            deserializer.ReadInt64(out bootTime100ns);
             int encodedUtcOffsetMinutes;
-            deserializer.Read(out encodedUtcOffsetMinutes);
+            deserializer.ReadInt32(out encodedUtcOffsetMinutes);
             if (encodedUtcOffsetMinutes != int.MinValue)
             {
                 utcOffsetMinutes = encodedUtcOffsetMinutes;
             }
 
-            deserializer.Read(out hasPdbInfo);
+            deserializer.ReadBoolean(out hasPdbInfo);
 
-            count = deserializer.ReadInt();
+            count = deserializer.ReadInt32();
             Guid guid;
             relatedActivityIDs.Clear();
             for (int i = 0; i < count; i++)
             {
-                deserializer.Read(out guid);
+                deserializer.ReadGuid(out guid);
                 relatedActivityIDs.Add(guid);
             }
             containerIDs.Clear();
-            count = deserializer.ReadInt();
+            count = deserializer.ReadInt32();
             string containerID;
             for(int i=0; i<count; i++)
             {
-                deserializer.Read(out containerID);
+                deserializer.ReadString(out containerID);
                 containerIDs.Add(containerID);
             }
-            deserializer.Read(out truncated);
-            firstTimeInversion = (EventIndex) (uint) deserializer.ReadInt();
+            deserializer.ReadBoolean(out truncated);
+            firstTimeInversion = (EventIndex) (uint) deserializer.ReadInt32();
         }
         int IFastSerializableVersion.Version
         {
@@ -4536,12 +4536,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out m_log);
+            deserializer.ReadObject(out m_log);
             m_counts.Clear();
-            int count = deserializer.ReadInt();
+            int count = deserializer.ReadInt32();
             for (int i = 0; i < count; i++)
             {
-                TraceEventCounts elem; deserializer.Read(out elem);
+                TraceEventCounts elem; deserializer.ReadObject(out elem);
                 m_counts.Add(elem.m_key, elem);
             }
         }
@@ -4589,9 +4589,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         internal TraceEventCountsKey(Deserializer deserializer)
         {
-            deserializer.Read(out m_providerGuid);
-            m_eventId = (TraceEventID)deserializer.ReadInt();
-            deserializer.Read(out m_classicProvider);
+            deserializer.ReadGuid(out m_providerGuid);
+            m_eventId = (TraceEventID)deserializer.ReadInt32();
+            deserializer.ReadBoolean(out m_classicProvider);
         }
 
         public bool Equals(TraceEventCountsKey other)
@@ -4864,11 +4864,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out m_stats);
+            deserializer.ReadObject(out m_stats);
             m_key = new TraceEventCountsKey(deserializer);
-            deserializer.Read(out m_count);
-            deserializer.Read(out m_stackCount);
-            deserializer.Read(out m_eventDataLenTotal);
+            deserializer.ReadInt32(out m_count);
+            deserializer.ReadInt32(out m_stackCount);
+            deserializer.ReadInt64(out m_eventDataLenTotal);
         }
 
         private TraceEventStats m_stats;             // provides the context to get the template (more info about event like its name)
@@ -5462,22 +5462,22 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out log);
+            deserializer.ReadObject(out log);
 
             Debug.Assert(processes.Count == 0);
-            int count = deserializer.ReadInt();
+            int count = deserializer.ReadInt32();
             processes = new GrowableArray<TraceProcess>(count + 1);
             for (int i = 0; i < count; i++)
             {
-                TraceProcess elem; deserializer.Read(out elem);
+                TraceProcess elem; deserializer.ReadObject(out elem);
                 processes.Add(elem);
             }
 
-            count = deserializer.ReadInt();
+            count = deserializer.ReadInt32();
             processesByPID = new GrowableArray<TraceProcess>(count + 1);
             for (int i = 0; i < count; i++)
             {
-                TraceProcess elem; deserializer.Read(out elem);
+                TraceProcess elem; deserializer.ReadObject(out elem);
                 processesByPID.Add(elem);
             }
         }
@@ -5829,29 +5829,29 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out processID);
-            int processIndex; deserializer.Read(out processIndex); this.processIndex = (ProcessIndex)processIndex;
-            deserializer.Read(out log);
-            deserializer.Read(out commandLine);
-            deserializer.Read(out imageFileName);
-            deserializer.Read(out firstEventSeenQPC);
-            deserializer.Read(out startTimeQPC);
-            deserializer.Read(out endTimeQPC);
+            deserializer.ReadInt32(out processID);
+            int processIndex; deserializer.ReadInt32(out processIndex); this.processIndex = (ProcessIndex)processIndex;
+            deserializer.ReadObject(out log);
+            deserializer.ReadString(out commandLine);
+            deserializer.ReadString(out imageFileName);
+            deserializer.ReadInt64(out firstEventSeenQPC);
+            deserializer.ReadInt64(out startTimeQPC);
+            deserializer.ReadInt64(out endTimeQPC);
             if (deserializer.ReadBool())                // read an int? for exitStatus
             {
-                exitStatus = deserializer.ReadInt();
+                exitStatus = deserializer.ReadInt32();
             }
             else
             {
                 exitStatus = null;
             }
 
-            deserializer.Read(out parentID);
-            deserializer.Read(out parent);
-            deserializer.Read(out loadedModules);
-            deserializer.Read(out cpuSamples);
-            deserializer.Read(out loadedAModuleHigh);
-            deserializer.Read(out anyModuleLoaded);
+            deserializer.ReadInt32(out parentID);
+            deserializer.ReadObject(out parent);
+            deserializer.ReadObject(out loadedModules);
+            deserializer.ReadInt32(out cpuSamples);
+            deserializer.ReadBoolean(out loadedAModuleHigh);
+            deserializer.ReadBoolean(out anyModuleLoaded);
         }
 
         private int processID;
@@ -6277,14 +6277,14 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out log);
+            deserializer.ReadObject(out log);
             Debug.Assert(threads.Count == 0);
-            int count = deserializer.ReadInt();
+            int count = deserializer.ReadInt32();
             threads = new GrowableArray<TraceThread>(count + 1);
 
             for (int i = 0; i < count; i++)
             {
-                TraceThread elem; deserializer.Read(out elem);
+                TraceThread elem; deserializer.ReadObject(out elem);
                 threads.Add(elem);
             }
         }
@@ -6481,20 +6481,20 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out threadID);
-            int threadIndex; deserializer.Read(out threadIndex); this.threadIndex = (ThreadIndex)threadIndex;
-            deserializer.Read(out process);
-            deserializer.Read(out startTimeQPC);
-            deserializer.Read(out endTimeQPC);
-            deserializer.Read(out cpuSamples);
-            deserializer.Read(out threadInfo);
+            deserializer.ReadInt32(out threadID);
+            int threadIndex; deserializer.ReadInt32(out threadIndex); this.threadIndex = (ThreadIndex)threadIndex;
+            deserializer.ReadObject(out process);
+            deserializer.ReadInt64(out startTimeQPC);
+            deserializer.ReadInt64(out endTimeQPC);
+            deserializer.ReadInt32(out cpuSamples);
+            deserializer.ReadString(out threadInfo);
             userStackBase = (Address)deserializer.ReadInt64();
 
-            int count; deserializer.Read(out count);
+            int count; deserializer.ReadInt32(out count);
             activityIds = new GrowableArray<ActivityIndex>(count);
             for (int i = 0; i < count; ++i)
             {
-                activityIds.Add((ActivityIndex)deserializer.ReadInt());
+                activityIds.Add((ActivityIndex)deserializer.ReadInt32());
             }
         }
 
@@ -7008,12 +7008,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out process);
+            deserializer.ReadObject(out process);
             Debug.Assert(modules.Count == 0);
-            int count; deserializer.Read(out count);
+            int count; deserializer.ReadInt32(out count);
             for (int i = 0; i < count; i++)
             {
-                TraceLoadedModule elem; deserializer.Read(out elem);
+                TraceLoadedModule elem; deserializer.ReadObject(out elem);
                 modules.Add(elem);
             }
         }
@@ -7186,13 +7186,13 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             long address;
 
-            deserializer.Read(out loadTimeQPC);
-            deserializer.Read(out unloadTimeQPC);
-            deserializer.Read(out managedModule);
-            deserializer.Read(out process);
-            deserializer.Read(out moduleFile);
-            deserializer.Read(out address); key = (ulong)address;
-            deserializer.Read(out overlaps);
+            deserializer.ReadInt64(out loadTimeQPC);
+            deserializer.ReadInt64(out unloadTimeQPC);
+            deserializer.ReadObject(out managedModule);
+            deserializer.ReadObject(out process);
+            deserializer.ReadObject(out moduleFile);
+            deserializer.ReadInt64(out address); key = (ulong)address;
+            deserializer.ReadBoolean(out overlaps);
         }
 
         internal ulong key;                          // Either the base address (for unmanaged) or moduleID (managed) 
@@ -7275,9 +7275,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             int flags;
             base.FromStream(deserializer);
-            deserializer.Read(out assemblyID);
-            deserializer.Read(out nativeModule);
-            deserializer.Read(out flags); this.flags = (ModuleFlags)flags;
+            deserializer.ReadInt64(out assemblyID);
+            deserializer.ReadObject(out nativeModule);
+            deserializer.ReadInt32(out flags); this.flags = (ModuleFlags)flags;
             InitializeNativeModuleIsReadyToRun();
         }
         #endregion
@@ -7562,19 +7562,19 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out log);
-            deserializer.Read(out codeAddresses);
+            deserializer.ReadObject(out log);
+            deserializer.ReadObject(out codeAddresses);
 
             lazyCallStacks.Read(deserializer, delegate
             {
                 deserializer.Log("<Marker Name=\"callStacks\"/>");
-                int count = deserializer.ReadInt();
+                int count = deserializer.ReadInt32();
                 callStacks = new GrowableArray<CallStackInfo>(count + 1);
                 CallStackInfo callStackInfo = new CallStackInfo();
                 for (int i = 0; i < count; i++)
                 {
-                    callStackInfo.codeAddressIndex = (CodeAddressIndex)deserializer.ReadInt();
-                    callStackInfo.callerIndex = (CallStackIndex)deserializer.ReadInt();
+                    callStackInfo.codeAddressIndex = (CodeAddressIndex)deserializer.ReadInt32();
+                    callStackInfo.callerIndex = (CallStackIndex)deserializer.ReadInt32();
                     callStacks.Add(callStackInfo);
                 }
             });
@@ -8751,22 +8751,22 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             lazyCodeAddresses.Read(deserializer, delegate
             {
-                deserializer.Read(out log);
-                deserializer.Read(out moduleFiles);
-                deserializer.Read(out methods);
+                deserializer.ReadObject(out log);
+                deserializer.ReadObject(out moduleFiles);
+                deserializer.ReadObject(out methods);
 
                 int storedCodeAddressInfoSerializationVersion = 0;
-                deserializer.TryReadTagged(ref storedCodeAddressInfoSerializationVersion);
-                int count = deserializer.ReadInt();
+                deserializer.TryReadTaggedInt32(ref storedCodeAddressInfoSerializationVersion);
+                int count = deserializer.ReadInt32();
                 deserializer.Log("<Marker name=\"codeAddresses\" count=\"" + count + "\"/>");
                 CodeAddressInfo codeAddressInfo = new CodeAddressInfo();
                 codeAddresses = new GrowableArray<CodeAddressInfo>(count + 1);
                 for (int i = 0; i < count; i++)
                 {
                     deserializer.ReadAddress(out codeAddressInfo.Address);
-                    codeAddressInfo.moduleFileIndex = (ModuleFileIndex)deserializer.ReadInt();
-                    codeAddressInfo.methodOrProcessOrIlMapIndex = deserializer.ReadInt();
-                    deserializer.Read(out codeAddressInfo.InclusiveCount);
+                    codeAddressInfo.moduleFileIndex = (ModuleFileIndex)deserializer.ReadInt32();
+                    codeAddressInfo.methodOrProcessOrIlMapIndex = deserializer.ReadInt32();
+                    deserializer.ReadInt32(out codeAddressInfo.InclusiveCount);
 
                     if (storedCodeAddressInfoSerializationVersion >= 1)
                     {
@@ -8775,12 +8775,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
                     codeAddresses.Add(codeAddressInfo);
                 }
-                deserializer.Read(out totalCodeAddresses);
+                deserializer.ReadInt32(out totalCodeAddresses);
 
-                ILToNativeMaps.Count = deserializer.ReadInt();
+                ILToNativeMaps.Count = deserializer.ReadInt32();
                 for (int i = 0; i < ILToNativeMaps.Count; i++)
                 {
-                    deserializer.Read(out ILToNativeMaps.UnderlyingArray[i]);
+                    deserializer.ReadObject(out ILToNativeMaps.UnderlyingArray[i]);
                 }
             });
             lazyCodeAddresses.FinishRead();        // TODO REMOVE 
@@ -9111,8 +9111,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             internal void Deserialize(Deserializer deserializer)
             {
-                deserializer.Read(out ILOffset);
-                deserializer.Read(out NativeOffset);
+                deserializer.ReadInt32(out ILOffset);
+                deserializer.ReadInt32(out NativeOffset);
             }
             internal void Serialize(Serializer serializer)
             {
@@ -9191,11 +9191,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             }
             void IFastSerializable.FromStream(Deserializer deserializer)
             {
-                MethodIndex = (MethodIndex)deserializer.ReadInt();
+                MethodIndex = (MethodIndex)deserializer.ReadInt32();
                 deserializer.ReadAddress(out MethodStart);
-                deserializer.Read(out MethodLength);
+                deserializer.ReadInt32(out MethodLength);
 
-                Map.Count = deserializer.ReadInt();
+                Map.Count = deserializer.ReadInt32();
                 for (int i = 0; i < Map.Count; i++)
                 {
                     Map.UnderlyingArray[i].Deserialize(deserializer);
@@ -9588,17 +9588,17 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             lazyMethods.Read(deserializer, delegate
             {
-                deserializer.Read(out codeAddresses);
-                int count = deserializer.ReadInt();
+                deserializer.ReadObject(out codeAddresses);
+                int count = deserializer.ReadInt32();
                 deserializer.Log("<Marker name=\"methods\" count=\"" + count + "\"/>");
                 MethodInfo methodInfo = new MethodInfo();
                 methods = new GrowableArray<MethodInfo>(count + 1);
 
                 for (int i = 0; i < count; i++)
                 {
-                    deserializer.Read(out methodInfo.fullMethodName);
-                    deserializer.Read(out methodInfo.methodDefOrRva);
-                    methodInfo.moduleIndex = (ModuleFileIndex)deserializer.ReadInt();
+                    deserializer.ReadString(out methodInfo.fullMethodName);
+                    deserializer.ReadInt32(out methodInfo.methodDefOrRva);
+                    methodInfo.moduleIndex = (ModuleFileIndex)deserializer.ReadInt32();
                     methods.Add(methodInfo);
                 }
             });
@@ -9898,13 +9898,13 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out log);
-            int count = deserializer.ReadInt();
+            deserializer.ReadObject(out log);
+            int count = deserializer.ReadInt32();
             moduleFiles = new GrowableArray<TraceModuleFile>(count + 1);
             for (int i = 0; i < count; i++)
             {
                 TraceModuleFile elem;
-                deserializer.Read(out elem);
+                deserializer.ReadObject(out elem);
                 moduleFiles.Add(elem);
             }
             moduleFilesByName = null;
@@ -10158,20 +10158,20 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            deserializer.Read(out fileName);
-            deserializer.Read(out imageSize);
+            deserializer.ReadString(out fileName);
+            deserializer.ReadInt32(out imageSize);
             deserializer.ReadAddress(out imageBase);
 
-            deserializer.Read(out pdbName);
-            deserializer.Read(out pdbSignature);
-            deserializer.Read(out pdbAge);
-            deserializer.Read(out fileVersion);
-            deserializer.Read(out productVersion);
-            deserializer.Read(out timeDateStamp);
-            deserializer.Read(out imageChecksum);
-            moduleFileIndex = (ModuleFileIndex)deserializer.ReadInt();
-            deserializer.Read(out codeAddressesInModule);
-            deserializer.Read(out managedModule);
+            deserializer.ReadString(out pdbName);
+            deserializer.ReadGuid(out pdbSignature);
+            deserializer.ReadInt32(out pdbAge);
+            deserializer.ReadString(out fileVersion);
+            deserializer.ReadString(out productVersion);
+            deserializer.ReadInt32(out timeDateStamp);
+            deserializer.ReadInt32(out imageChecksum);
+            moduleFileIndex = (ModuleFileIndex)deserializer.ReadInt32();
+            deserializer.ReadInt32(out codeAddressesInModule);
+            deserializer.ReadObject(out managedModule);
         }
         #endregion
     }
@@ -10472,17 +10472,17 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         void IFastSerializable.FromStream(Deserializer deserializer)
         {
-            activityIndex = (ActivityIndex)deserializer.ReadInt();
-            deserializer.Read(out creator);
-            creationCallStackIndex = (CallStackIndex)deserializer.ReadInt();
-            deserializer.Read(out thread);
-            creationEventIndex = (EventIndex)deserializer.ReadInt();
-            deserializer.Read(out creationTimeQPC);
-            deserializer.Read(out startTimeQPC);
-            deserializer.Read(out endTimeQPC);
-            deserializer.Read(out multiTrigger);
-            deserializer.Read(out gcBound);
-            short kind; deserializer.Read(out kind); this.kind = (TraceActivity.ActivityKind)kind;
+            activityIndex = (ActivityIndex)deserializer.ReadInt32();
+            deserializer.ReadObject(out creator);
+            creationCallStackIndex = (CallStackIndex)deserializer.ReadInt32();
+            deserializer.ReadObject(out thread);
+            creationEventIndex = (EventIndex)deserializer.ReadInt32();
+            deserializer.ReadInt64(out creationTimeQPC);
+            deserializer.ReadInt64(out startTimeQPC);
+            deserializer.ReadInt64(out endTimeQPC);
+            deserializer.ReadBoolean(out multiTrigger);
+            deserializer.ReadBoolean(out gcBound);
+            short kind; deserializer.ReadInt16(out kind); this.kind = (TraceActivity.ActivityKind)kind;
         }
 
         private ActivityIndex activityIndex;
@@ -10885,7 +10885,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         public static void ReadAddress(this Deserializer deserializer, out Address address)
         {
             long longAddress;
-            deserializer.Read(out longAddress);
+            deserializer.ReadInt64(out longAddress);
             address = (Address)longAddress;
         }
     }


### PR DESCRIPTION
This change helps ensure refactorings do not unintentionally change the deserialized result.

Related to #1321 