### PR TITLE
Fix RelatedActivityID storage and lookup in ETLX

### DIFF
--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -892,7 +892,7 @@ namespace Microsoft.Diagnostics.Tracing
                 }
                 else
                 {
-                    if (eventRecord->ExtendedDataCount > 0)
+                    if (eventRecord->ExtendedData != null)
                     {
                         return traceEventSource.GetRelatedActivityID(eventRecord);
                     }


### PR DESCRIPTION
Fixes #1345.

This is a regression from #1277, which adds storage for the ContainerID, and changes how storage of the RelatedActivityID is stored in the ETLX file.