### PR TITLE
TraceParserGen: Remove internal keyword when not requested.

### DIFF
--- a/src/TraceParserGen/TraceParserGen.cs
+++ b/src/TraceParserGen/TraceParserGen.cs
@@ -289,7 +289,7 @@ internal class TraceParserGen
 
         output.WriteLine();
         output.WriteLine("        static private volatile TraceEvent[] s_templates;");
-        output.WriteLine("        protected internal {0}override void EnumerateTemplates(Func<string, string, EventFilterResponse> eventsToObserve, Action<TraceEvent> callback)", internalOpt);
+        output.WriteLine("        protected {0}override void EnumerateTemplates(Func<string, string, EventFilterResponse> eventsToObserve, Action<TraceEvent> callback)", internalOpt);
         output.WriteLine("        {");
         output.WriteLine("            if (s_templates == null)");
         output.WriteLine("            {");
@@ -506,19 +506,19 @@ internal class TraceParserGen
             }
 
             // Write out the dispatch method
-            output.WriteLine("        protected internal {0}override void Dispatch()", internalOpt);
+            output.WriteLine("        protected {0}override void Dispatch()", internalOpt);
             output.WriteLine("        {");
             output.WriteLine("            Action(this);");
             output.WriteLine("        }");
 
             // And the debugging logic
-            output.WriteLine("        protected internal {0}override void Validate()", internalOpt);
+            output.WriteLine("        protected {0}override void Validate()", internalOpt);
             output.WriteLine("        {");
             output.Write(lengthAssert);
             output.WriteLine("        }");
 
             // And for setting and inspecting the callback delegate
-            output.WriteLine("        protected internal {0}override Delegate Target", internalOpt);
+            output.WriteLine("        protected {0}override Delegate Target", internalOpt);
             output.WriteLine("        {");
             output.WriteLine("            get { return Action; }");
             output.WriteLine("            set { Action = (Action<" + templateClassName + ">) value; }");


### PR DESCRIPTION
Partial revert of 46a2f3a73fd91fc2b0ae30440666589a9ca72212

I think that @billwert introduced issue here.
It looks like internalOpt should be used to insert "internal" keyword instead of hardcoding it in string.
If "Internal" would be set, the it would generate double "internal" in function header.