### PR TITLE
TraceParserGen: Fix incorrect debug string format.

### DIFF
--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -329,7 +329,7 @@ namespace ETWManifest
                                 ReadMap(reader, false);
                                 break;
                             default:
-                                Debug.WriteLine("Skipping unknown element {0}", reader.Name);
+                                Debug.WriteLine("Skipping unknown element: {0}", (object)reader.Name);
                                 reader.Read();
                                 break;
                         }


### PR DESCRIPTION
{0} was printed instead of xml element name.
Wrong overload of Debug.WriteLine was called.