### PR TITLE
Don't Depend on NuGet.org Inheritance

### DIFF
--- a/Nuget.config
+++ b/Nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Local" value=".\src\NugetSupportFiles" />
   </packageSources>


### PR DESCRIPTION
Builds should only require official NuGet packages and consumption of locally build `SupportFiles` packages.