### PR TITLE
Make Collection of TPL Events Opt-In

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -115,7 +115,7 @@ namespace PerfView
         public string[] CpuCounters;        // Specifies any profile sources (CPU counters) to turn on (Win 8 only)
         public ClrTraceEventParser.Keywords ClrEvents = ClrTraceEventParser.Keywords.Default;
         public TraceEventLevel ClrEventLevel = Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose;    // The verbosity of CLR events
-        public TplEtwProviderTraceEventParser.Keywords TplEvents = TplEtwProviderTraceEventParser.Keywords.Default;
+        public TplEtwProviderTraceEventParser.Keywords TplEvents = TplEtwProviderTraceEventParser.Keywords.None;
         public bool ThreadTime;             // Shortcut for /KernelEvents=ThreadTime
         public bool GCOnly;                 // collect only enough for GC analysis
         public bool GCCollectOnly;          // Turn off even the allocation Tick

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2916,6 +2916,11 @@ namespace PerfView
                 cmdLineArgs += " /ClrEvents:" + parsedArgs.ClrEvents.ToString().Replace(" ", "");
             }
 
+            if(parsedArgs.TplEvents != TplEtwProviderTraceEventParser.Keywords.None)
+            {
+                cmdLineArgs += " /TplEvents:" + parsedArgs.TplEvents.ToString().Replace(" ", "");
+            }
+
             if (parsedArgs.Providers != null)
             {
                 cmdLineArgs += " /Providers:" + Command.Quote(string.Join(",", parsedArgs.Providers));


### PR DESCRIPTION
With the proliferation of async/await, the TPL events have become more and more verbose, to the point where enabling them preturbs the CPU profiling data fairly heavily in some workloads.  This change makes them opt-in.

cc: @davidfowl, @stephentoub 