### PR TITLE
Make ASP.NET Core Events Opt-In

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -125,6 +125,7 @@ namespace PerfView
         public bool DotNetCallsSampled;     // Sampling of .NET calls.  
         public bool DisableInlining;        // Force inlining to be disabled. (useful for DotNetCalls).  
         public bool JITInlining;            // Turn on logging of successful and failed JIT inlining
+        public bool? AspNetCoreStartStop;   // Turn on AspNetCore request start/stop events
         public int OSHeapProcess;           // Turn on OS Heap tracing for the process with the given process ID.
         public string OSHeapExe;            // Turn on OS heap tracing for any process with the given EXE
 
@@ -510,6 +511,7 @@ namespace PerfView
             parser.DefineOptionalQualifier("DotNetCallsSampled", ref DotNetCallsSampled, "Turns on per-call .NET profiling, sampling types in a smart way to keep overhead low.");
             parser.DefineOptionalQualifier("DisableInlining", ref DisableInlining, "Turns off inlining (but only affects processes that start after trace start.");
             parser.DefineOptionalQualifier("JITInlining", ref JITInlining, "Turns on logging of successful and failed JIT inlining attempts.");
+            parser.DefineOptionalQualifier("AspNetCoreStartStop", ref AspNetCoreStartStop, "Turns on logging of ASP.NET Core request start/stop events.");
             parser.DefineOptionalQualifier("CCWRefCount", ref CCWRefCount, "Turns on logging of information about .NET Native CCW reference counting.");
             parser.DefineOptionalQualifier("RuntimeLoading", ref RuntimeLoading, "Turn on logging of runtime loading operations.");
             parser.DefineOptionalQualifier("OSHeapProcess", ref OSHeapProcess, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given process ID.");


### PR DESCRIPTION
 - Remove collection of `Microsoft-AspNetCore-Hosting` and `Microsoft-ApplicationInsights-Core`.
 - Make ASP.NET Core DiagnosticSource events opt-in via `/AspNetCoreStartStop`.
 - Automatically enable ASP.NET Core DiagnosticSource events when `/ThreadTime` is specified unless `/AspNetCoreStartStop:false` is specified to explicitly opt-out.

cc: @stephentoub, @davidfowl 