### PR TITLE
TraceParserGen: Exception in UpdateStrings()

### DIFF
--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -919,7 +919,11 @@ namespace ETWManifest
             }
 
             m_stringsLookedUp = true;
-            foreach (var key in m_values.Keys)
+
+            int[] keys = new int[m_values.Keys.Count];
+            m_values.Keys.CopyTo(keys, 0);
+
+            foreach (var key in keys)
             {
                 var value = m_values[key];
                 if (Provider.Replace(ref value, stringMap))


### PR DESCRIPTION
Fixed InvalidOperationException: Collection was modified after the enumerator was instantiated.

fix #1394