### PR TITLE
Disable ClrStack/Walk Events During Rundown

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3472,9 +3472,12 @@ namespace PerfView
                     if (parsedArgs.ClrEvents != ClrTraceEventParser.Keywords.None)
                     {
                         // Always enable minimal rundown, which ensures that we get the runtime start event.
-                        // We use the keyword 0x40000000 which does not match any valid keyword in the rundown provider.
+                        // We use the keyword 0x800000000000 which does not match any valid keyword in the rundown provider.
                         // Choosing 0 results in enabling all keywords based on the logic that checks for keyword status in the runtime.
-                        var rundownKeywords = (ClrRundownTraceEventParser.Keywords)0x40000000;
+                        // NOTE: This used to be 0x40000000 which matched the ClrStack keyword in the main provider.  This resulted in
+                        // lots of ClrStack/Walk events that couldn't be matched with Clr events, because for V2 rundown, we enable
+                        // the Clr provider.
+                        var rundownKeywords = (ClrRundownTraceEventParser.Keywords)0x800000000000;
 
                         // Only consider forcing suppression of these keywords if full rundown is enabled.
                         if (!parsedArgs.NoRundown && !parsedArgs.NoClrRundown)


### PR DESCRIPTION
ClrStack/Walk events are unintentionally enabled during rundown if any of the rundown suppression arguments are used.  This can result in a large number of stacks that can't be matched to CLR events and overall slower conversion of an ETL file to ETLX.

An example configuration where this occurs is with `/GCCollectOnly` traces where the fully expanded commandline includes `/NoRundown`:
```
PerfView /RestartingToElevelate:collect /DataFile:PerfViewGCCollectOnly.etl /BufferSizeMB:256 /StackCompression /KernelEvents:Process,ImageLoad /ClrEventLevel:Informational /ClrEvents:GC /NoGui /SessionName:PerfViewGCSession /NoRundown /GCCollectOnly Collect
```

These events are not needed during rundown, but are enabled because rundown for V2.0 runtimes occurs via the public provider instead of the rundown provider.  The fix is to switch the non-existent starting rundown keywords to be a value that doesn't intersect with anything in the public provider or the rundown provider.

cc: @Maoni0 