### PR TITLE
Fix TraceParserGen to generate meaningful parser for WPF

### DIFF
--- a/src/TraceParserGen/ETWManifest.cs
+++ b/src/TraceParserGen/ETWManifest.cs
@@ -277,6 +277,7 @@ namespace ETWManifest
                                     {
                                         m_taskNames = new Dictionary<int, string>();
                                         m_taskValues = new Dictionary<string, int>();
+                                        m_taskGuids = new Dictionary<string, Guid>();
                                     }
                                     string name = reader.GetAttribute("name");
                                     int value = (int)ParseNumber(reader.GetAttribute("value"));
@@ -290,7 +291,12 @@ namespace ETWManifest
                                     m_taskNames.Add(value, message);
                                     m_taskValues.Add(name, value);
 
-                                    // Remember enuough to resolve opcodes nested inside this task.
+                                    if (Guid.TryParse(reader.GetAttribute("eventGUID"), out var guid))
+                                    {
+                                        m_taskGuids.Add(name, guid);
+                                    }
+
+                                    // Remember enough to resolve opcodes nested inside this task.
                                     curTask = value;
                                     curTaskDepth = reader.Depth;
                                     reader.Read();
@@ -556,6 +562,7 @@ namespace ETWManifest
         private List<Event> m_events = new List<Event>();
         internal string[] m_keywordNames;
         internal Dictionary<int, string> m_taskNames;
+        internal Dictionary<string, Guid> m_taskGuids;
         // Note that the key is task << 8 + opcode to allow for private opcode names
         internal Dictionary<int, string> m_opcodeNames;
 


### PR DESCRIPTION
This attempts to resolve https://github.com/microsoft/perfview/issues/1351 and supports creating a parser for the Microsoft-Windows-WPF provider from the manifest at C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF\wpf-etw.man.

See also https://github.com/microsoft/perfview/issues/554.

Addresses various issues with the generated provider:

- Enum should not be normalized it if's already PascalCase, so the normalizing logic is skipped if no "_" is present in a field name.
- `RegisterTemplate()` seems not to exist; `source.RegisterEventTemplate` is apparently what was intended.
- Task GUID constants were previously referenced but not generated.
- Template class names were incorrectly referenced.