### PR TITLE
Allow TraceEventSession to set EVENT_TRACE_NO_PER_PROCESSOR_BUFFERING

### DIFF
--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Diagnostics.Tracing
         internal const uint EVENT_TRACE_FILE_MODE_NEWFILE = 0x00000008;
         internal const uint EVENT_TRACE_BUFFERING_MODE = 0x00000400;
         internal const uint EVENT_TRACE_INDEPENDENT_SESSION_MODE = 0x08000000;
+        internal const uint EVENT_TRACE_NO_PER_PROCESSOR_BUFFERING = 0x10000000;
 
         internal const uint EVENT_TRACE_CONTROL_QUERY = 0;
         internal const uint EVENT_TRACE_CONTROL_STOP = 1;


### PR DESCRIPTION
Expose `EVENT_TRACE_NO_PER_PROCESSOR_BUFFERING` via `TraceEventSessionOptions.NoPerProcessorBuffering`.