### PR TITLE
Keep Default Filter Parameters in Stacks from Event Viewer

### DIFF
--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -481,9 +481,6 @@ namespace PerfView
                         dataSource.ConfigureStackWindow(stackWindow);
                         stackWindow.StartTextBox.Text = startTimeRelativeMSec.ToString();
                         stackWindow.EndTextBox.Text = endTimeRelativeMSec.ToString();
-                        stackWindow.GroupRegExTextBox.Text = "";
-                        stackWindow.FoldPercentTextBox.Text = "";
-                        stackWindow.CallTreeTab.IsSelected = true;
                         stackWindow.Show();
                         stackWindow.SetStackSource(stackSource);
                     });


### PR DESCRIPTION
When stack views are opened from the Event View, they currently clear out most of the filter parameters from their configured defaults.  This change reverts most of this change because the view has been properly configured based on the stack source requested.