### PR TITLE
Bump System.Runtime.CompilerServices.Unsafe to 4.5.3 in TraceEvent

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -30,13 +30,13 @@
 
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
       </group>
       <group targetFramework=".NETStandard1.6">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
       </group>
     </dependencies>
   </metadata>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -71,7 +71,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
 
   <!-- *** SourceLink Support *** -->
   <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
When consuming TraceEvent and other libraries from a dotnet core project, there is often times a conflict with the version of `System.Runtime.CompilerServices.Unsafe`.

For example,

`System.Memory` relies on `System.Runtime.CompilerServices.Unsafe >=4.5.3`

Hoping to bring TraceEvent up to the same common version.