### PR TITLE
Use numbers for startValue and endValue

### DIFF
--- a/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
                 writer.Write("\"type\": \"evented\", ");
                 writer.Write($"\"name\": \"{perThread.Key}\", ");
                 writer.Write("\"unit\": \"milliseconds\", ");
-                writer.Write($"\"startValue\": \"{sortedProfileEvents.First().RelativeTime.ToString("R", CultureInfo.InvariantCulture)}\", ");
-                writer.Write($"\"endValue\": \"{sortedProfileEvents.Last().RelativeTime.ToString("R", CultureInfo.InvariantCulture)}\", ");
+                writer.Write($"\"startValue\": {sortedProfileEvents.First().RelativeTime.ToString("R", CultureInfo.InvariantCulture)}, ");
+                writer.Write($"\"endValue\": {sortedProfileEvents.Last().RelativeTime.ToString("R", CultureInfo.InvariantCulture)}, ");
                 writer.Write("\"events\": [ ");
                 for (int i = 0; i < sortedProfileEvents.Count; i++)
                 {


### PR DESCRIPTION
This commit updates SpeedScopeStackSourceWriter to emit startValue and endValue as numbers, in line with the [JSON schema](https://www.speedscope.app/file-format-schema.json).