### PR TITLE
Make RegisterEventHandlers Public

### DIFF
--- a/src/PerfView/StateMachineFramework/ComputingResourceStateMachine.cs
+++ b/src/PerfView/StateMachineFramework/ComputingResourceStateMachine.cs
@@ -325,7 +325,7 @@ namespace PerfView
         /// <summary>
         /// Register event handlers before data is processed.
         /// </summary>
-        internal abstract void RegisterEventHandlers(
+        public abstract void RegisterEventHandlers(
             TraceEventDispatcher eventDispatcher);
     }
 

--- a/src/PerfView/StateMachineFramework/ServerRequestComputer.cs
+++ b/src/PerfView/StateMachineFramework/ServerRequestComputer.cs
@@ -65,7 +65,7 @@ namespace PerfView
         /// <summary>
         /// Execute the server request computer.
         /// </summary>
-        internal override void RegisterEventHandlers(TraceEventDispatcher eventDispatcher)
+        public override void RegisterEventHandlers(TraceEventDispatcher eventDispatcher)
         {
             var aspNetParser = new AspNetTraceEventParser(eventDispatcher);
             var WCFParser = new ApplicationServerTraceEventParser(eventDispatcher);


### PR DESCRIPTION
`RegisterEventHandlers` is currently marked as internal, which means that consumers of the `StateMachineFramework` in PerfView extensions are unable to register their own event handlers.