### PR TITLE
Add a thread adjustment reason

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -12602,6 +12602,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         Stabilizing = 0x5,
         Starvation = 0x6,
         ThreadTimedOut = 0x7,
+        CooperativeBlocking = 0x8,
     }
 
     [Flags]


### PR DESCRIPTION
- Depends on https://github.com/dotnet/runtime/pull/53471
- The change above added a new reason for thread adjustment (`CooperativeBlocking`), added here too