### PR TITLE
Removed duplicated text from UsersGuide.htm

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -6015,9 +6015,8 @@
     </ul>
     <p>
         Will turn on logging and run the given command.&nbsp; It will also <a href="#merging">merge</a>
-        the file, under the assumption that the file, under the assumption
-        that the file is likely to be moved off the current system.&nbsp; It will however
-        still bring up the GUI and it will not exit automatically when it is done (so that
+        the file, under the assumption that the file is likely to be moved off the current system.&nbsp; 
+        It will however still bring up the GUI and it will not exit automatically when it is done (so that
         the user can react to any failures or messages and is required for the &#39;collect&#39;
         command so that the user can indicate when collection should stop).&nbsp;
     </p>


### PR DESCRIPTION
Removed the text "under the assumption that the file" for the help of `/noView run` because it was duplicated in the sentence.