### PR TITLE
Enable stacks for more FileIO events

### DIFF
--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -2047,6 +2047,34 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
                 stackTracingIds[curID].Type = 0x44;     // Write
                 curID++;
+
+                stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
+                stackTracingIds[curID].Type = 0x45;     // SetInfo
+                curID++;
+
+                stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
+                stackTracingIds[curID].Type = 0x46;     // Delete
+                curID++;
+
+                stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
+                stackTracingIds[curID].Type = 0x47;     // Rename
+                curID++;
+
+                stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
+                stackTracingIds[curID].Type = 0x4A;     // QueryInfo
+                curID++;
+
+                stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
+                stackTracingIds[curID].Type = 0x4B;     // FSControl
+                curID++;
+
+                stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
+                stackTracingIds[curID].Type = 0x48;     // DirEnum
+                curID++;
+
+                stackTracingIds[curID].EventGuid = KernelTraceEventParser.FileIOTaskGuid;
+                stackTracingIds[curID].Type = 0x4D;     // DirNotify
+                curID++;
             }
 
             if ((stackCapture & KernelTraceEventParser.Keywords.Registry) != 0)


### PR DESCRIPTION
The current File Queries and Directory Enumerations stack views don't show the full stack if the trace was collected with PerfView, because stacks are never enabled for these events.  This PR enables stack collection for these events.