### PR TITLE
Documentation reference to incorrect commands location

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -726,7 +726,7 @@
     </p>
     <ol>
         <li>
-            The <strong>File-&gt;Run</strong> (Alt-R) menu item, which prompts for a data file
+            The <strong>Collect-&gt;Run</strong> (Alt-R) menu item, which prompts for a data file
             name to create and a command to run.&nbsp;&nbsp; The command turns on profiling,
             runs the command, and then turns profiling off.&nbsp; The resulting file is then
             display in the stack viewer.&nbsp;&nbsp; This is the preferred mechanism when it
@@ -735,7 +735,7 @@
             right corner of the main view).&nbsp;
         </li>
         <li>
-            The <strong>File-&gt;Collect </strong>(Alt-C) menu item which only prompt for a
+            The <strong>Collect-&gt;Collect </strong>(Alt-C) menu item which only prompt for a
             data file name to create. After clicking the 'Start Collection' button you are then
             free to interact with machine in any way necessary to capture the activity of interest.&nbsp;&nbsp;
             Since profiling is machine wide you are guaranteed to capture it.&nbsp;&nbsp; Once
@@ -5901,7 +5901,7 @@
     </p>
     <ul>
         <li>Right clicking on the file in the main tree view an selecting &#39;Merge&#39;</li>
-        <li>Using the File-&gt;Merge menu item. </li>
+        <li>Using the Collect-&gt;Merge menu item. </li>
         <li>Clicking the &#39;Merge&#39; checkbox when the data is collected</li>
         <li>
             Collect the data from the command line (using &#39;run&#39; or &#39;collect&#39;)


### PR DESCRIPTION
I assume that File menu was split as part of improvement, but docs remain stale.