### PR TITLE
Update docs to mention .NET 4.6.2

### DIFF
--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -57,15 +57,15 @@
         way, right clicking allows you to discover what PerfView's can do for you.
     </p>
     <p>
-        PerfView is a V4.5 .NET application.&nbsp;&nbsp; Thus you need to have installed
-        a V4.5 .NET Runtime on the machine which you actually run PerfView.&nbsp;&nbsp;
-        On Windows 8, Windows 8.1, Windows 10 and Windows Server 2012 and up has .NET V4.5. 
-        On Windows 7 and Windows Server 2008 you can install .NET 4.5 from standalone installer. PerfView is not supported
-        on Win2K3 or WinXP.&nbsp;&nbsp;&nbsp; While PerfView itself needs a V4.5 runtime,
+        PerfView is a V4.6.2 .NET application.&nbsp;&nbsp; Thus you need to have installed
+        a V4.6.2 .NET Runtime on the machine which you actually run PerfView.&nbsp;&nbsp;
+        On Windows 10 and Windows Server 2016 has .NET V4.6.2.
+        On other supported OS you can install .NET 4.6.2 from standalone installer. PerfView is not supported
+        on Win2K3 or WinXP.&nbsp;&nbsp;&nbsp; While PerfView itself needs a V4.6.2 runtime,
         it can collect data on processes that use V2.0 and v4.0 runtimes. On machines that don't
-        have V4.5 or later of the .NET runtime installed, it is also possible to collect ETL data
+        have V4.6.2 or later of the .NET runtime installed, it is also possible to collect ETL data
         with another tool (e.g. XPERF or PerfMonitor) and then copy data file to a machine
-        with V4.5 and view it with PerfView.
+        with V4.6.2 and view it with PerfView.
     </p>
     <p>
         <a id="WhatPerfViewCanDoForYou"><strong>What can PerfView do for you?</strong></a>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -59,10 +59,11 @@
     <p>
         PerfView is a V4.5 .NET application.&nbsp;&nbsp; Thus you need to have installed
         a V4.5 .NET Runtime on the machine which you actually run PerfView.&nbsp;&nbsp;
-        On Windows 8, Windows 8.1, Windows 10 and Windows Server 2012 and up has .NET V4.5. PerfView is not supported
-        on Win2K3 or WinXP or Windows 7.&nbsp;&nbsp;&nbsp; While PerfView itself needs a V4.5 runtime,
+        On Windows 8, Windows 8.1, Windows 10 and Windows Server 2012 and up has .NET V4.5. 
+        On Windows 7 and Windows Server 2008 you can install .NET 4.5 from standalone installer. PerfView is not supported
+        on Win2K3 or WinXP.&nbsp;&nbsp;&nbsp; While PerfView itself needs a V4.5 runtime,
         it can collect data on processes that use V2.0 and v4.0 runtimes. On machines that don't
-        have V4.5 or later of the .NET runtime installed, it is also to collect ETL data
+        have V4.5 or later of the .NET runtime installed, it is also possible to collect ETL data
         with another tool (e.g. XPERF or PerfMonitor) and then copy data file to a machine
         with V4.5 and view it with PerfView.
     </p>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -57,15 +57,14 @@
         way, right clicking allows you to discover what PerfView's can do for you.
     </p>
     <p>
-        PerfView is a V4.0 .NET application.&nbsp;&nbsp; Thus you need to have installed
-        a V4.0 .NET Runtime on the machine which you actually run PerfView.&nbsp;&nbsp;
-        On Windows Vista, Windows 7 and Win2k8 windows update will install.NET V4.0, so
-        if windows update is turned on then PerfView will just work. PerfView is not supported
-        on Win2K3 or WinXP.&nbsp;&nbsp;&nbsp; While PerfView itself needs a V4.0 runtime,
-        it can collect data on processes that use V2.0 runtimes. On machines that don't
-        have V4.0 or later of the .NET runtime installed, it is also to collect ETL data
+        PerfView is a V4.5 .NET application.&nbsp;&nbsp; Thus you need to have installed
+        a V4.5 .NET Runtime on the machine which you actually run PerfView.&nbsp;&nbsp;
+        On Windows 8, Windows 8.1, Windows 10 and Windows Server 2012 and up has .NET V4.5. PerfView is not supported
+        on Win2K3 or WinXP or Windows 7.&nbsp;&nbsp;&nbsp; While PerfView itself needs a V4.5 runtime,
+        it can collect data on processes that use V2.0 and v4.0 runtimes. On machines that don't
+        have V4.5 or later of the .NET runtime installed, it is also to collect ETL data
         with another tool (e.g. XPERF or PerfMonitor) and then copy data file to a machine
-        with V4.0 and view it with PerfView.
+        with V4.5 and view it with PerfView.
     </p>
     <p>
         <a id="WhatPerfViewCanDoForYou"><strong>What can PerfView do for you?</strong></a>


### PR DESCRIPTION
This is reflects fact that minimum requirements for PervView is .NET 4.6.2
And as such minimum OS supported is OS which able to install .NET 4.6.2
When made changes I made some assumptions on supported OS,
which maybe too strict, and actual support wider.