### PR TITLE
Fix opening NativeAOT images

### DIFF
--- a/src/PerfView/memory/PdbScopeMemoryGraph.cs
+++ b/src/PerfView/memory/PdbScopeMemoryGraph.cs
@@ -495,7 +495,7 @@ public class PdbScopeMemoryGraph : MemoryGraph
         }
 
         string src = reader.GetAttribute("src");
-        if (src != null)
+        if (src != null && src != "<stdin>")
         {
             fullName += "@" + Path.GetFileName(src);
         }


### PR DESCRIPTION
After running ImageSize command on the NativeAOT generated image
It fails beause `SampleWindowsForms__Module___StartupCodeMain` symbol has `src="<stdin>"` after importing image. I simply workaround this issue, assuming that no other cases like that exists.