### PR TITLE
Don't Divide By Zero When Profiling Allocations

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4395,7 +4395,7 @@ table {
                     newHeap.OnObjectCreate += delegate (Address objAddress, GCHeapSimulatorObject objInfo)
                     {
                         sample.Metric = objInfo.RepresentativeSize;
-                        sample.Count = objInfo.RepresentativeSize / objInfo.Size;                                               // We guess a count from the size.  
+                        sample.Count = objInfo.GuessCountBasedOnSize();                                                          // We guess a count from the size.
                         sample.TimeRelativeMSec = objInfo.AllocationTimeRelativeMSec;
                         sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);        // Add the type as a pseudo frame.  
                         stackSource.AddSample(sample);
@@ -4419,7 +4419,7 @@ table {
                     newHeap.OnObjectCreate += delegate (Address objAddress, GCHeapSimulatorObject objInfo)
                     {
                         sample.Metric = objInfo.RepresentativeSize;
-                        sample.Count = objInfo.RepresentativeSize / objInfo.Size;                                                // We guess a count from the size.  
+                        sample.Count = objInfo.GuessCountBasedOnSize();                                                          // We guess a count from the size.
                         sample.TimeRelativeMSec = objInfo.AllocationTimeRelativeMSec;
                         sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);        // Add the type as a pseudo frame.  
                         stackSource.AddSample(sample);
@@ -4428,7 +4428,7 @@ table {
                     newHeap.OnObjectDestroy += delegate (double time, int gen, Address objAddress, GCHeapSimulatorObject objInfo)
                     {
                         sample.Metric = -objInfo.RepresentativeSize;
-                        sample.Count = -(objInfo.RepresentativeSize / objInfo.Size);                                            // We guess a count from the size.  
+                        sample.Count = -(objInfo.GuessCountBasedOnSize());                                            // We guess a count from the size.
                         sample.TimeRelativeMSec = time;
                         sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);       // We remove the same stack we added at alloc.  
                         stackSource.AddSample(sample);
@@ -4465,7 +4465,7 @@ table {
                         if (2 <= gen)
                         {
                             sample.Metric = objInfo.RepresentativeSize;
-                            sample.Count = (objInfo.RepresentativeSize / objInfo.Size);                                         // We guess a count from the size.  
+                            sample.Count = objInfo.GuessCountBasedOnSize();                                         // We guess a count from the size.
                             sample.TimeRelativeMSec = objInfo.AllocationTimeRelativeMSec;
                             sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);
                             stackSource.AddSample(sample);
@@ -9010,7 +9010,7 @@ table {
                             newHeap.OnObjectCreate += delegate (Address objAddress, GCHeapSimulatorObject objInfo)
                             {
                                 sample.Metric = objInfo.RepresentativeSize;
-                                sample.Count = objInfo.RepresentativeSize / objInfo.Size;                                               // We guess a count from the size.  
+                                sample.Count = objInfo.GuessCountBasedOnSize();                                                          // We guess a count from the size.
                                 sample.TimeRelativeMSec = objInfo.AllocationTimeRelativeMSec;
                                 sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);        // Add the type as a pseudo frame.  
                                 stackSource.AddSample(sample);
@@ -9043,7 +9043,7 @@ table {
                                 newHeap.OnObjectCreate += delegate (Address objAddress, GCHeapSimulatorObject objInfo)
                                 {
                                     sample.Metric = objInfo.RepresentativeSize;
-                                    sample.Count = objInfo.RepresentativeSize / objInfo.Size;                                                // We guess a count from the size.  
+                                    sample.Count = objInfo.GuessCountBasedOnSize();                                                          // We guess a count from the size.
                                     sample.TimeRelativeMSec = objInfo.AllocationTimeRelativeMSec;
                                     sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);        // Add the type as a pseudo frame.  
                                     stackSource.AddSample(sample);
@@ -9052,7 +9052,7 @@ table {
                                 newHeap.OnObjectDestroy += delegate (double time, int gen, Address objAddress, GCHeapSimulatorObject objInfo)
                                 {
                                     sample.Metric = -objInfo.RepresentativeSize;
-                                    sample.Count = -(objInfo.RepresentativeSize / objInfo.Size);                                            // We guess a count from the size.  
+                                    sample.Count = -(objInfo.GuessCountBasedOnSize());                                                      // We guess a count from the size.
                                     sample.TimeRelativeMSec = time;
                                     sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);       // We remove the same stack we added at alloc.  
                                     stackSource.AddSample(sample);
@@ -9089,7 +9089,7 @@ table {
                                     if (2 <= gen)
                                     {
                                         sample.Metric = objInfo.RepresentativeSize;
-                                        sample.Count = (objInfo.RepresentativeSize / objInfo.Size);                                         // We guess a count from the size.  
+                                        sample.Count = objInfo.GuessCountBasedOnSize();                                         // We guess a count from the size.
                                         sample.TimeRelativeMSec = objInfo.AllocationTimeRelativeMSec;
                                         sample.StackIndex = stackSource.Interner.CallStackIntern(objInfo.ClassFrame, objInfo.AllocStack);
                                         stackSource.AddSample(sample);

--- a/src/PerfView/memory/GCHeapSimulator.cs
+++ b/src/PerfView/memory/GCHeapSimulator.cs
@@ -732,5 +732,10 @@ namespace PerfView
         public int Size;                                // This is the size of the object being allocated on this particular event.  
         public int RepresentativeSize;                  // If sampling is on, this sample may represent many allocations. This is the sum of the sizes of all those allocations.  
         // If sampling is off this is the same as Size.  
+
+        public int GuessCountBasedOnSize()
+        {
+            return Size > 0 ? (RepresentativeSize / Size) : 1;
+        }
     }
 }


### PR DESCRIPTION
Work around a reported object size of 0 when profiling allocations through the CLR profiler API.