### PR TITLE
Fix Registry Tracking using Rundown Events

### DIFF
--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -262,9 +262,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 // logic to initialize state
                 AddCallbackForEvents(delegate (RegistryTraceData data)
                 {
-                    var isRundown = (data.Opcode == (TraceEventOpcode)22);        // RegistryRundown
-                    if (RegistryTraceData.NameIsKeyName(data.Opcode))
-                        state.fileIDToName.Add(data.KeyHandle, data.TimeStampQPC, data.KeyName, isRundown);
+                    var isRundown = (data.Opcode == (TraceEventOpcode)22 || data.Opcode == (TraceEventOpcode)24 || data.Opcode == (TraceEventOpcode)25);        // RegistryRundown
+                        if (RegistryTraceData.NameIsKeyName(data.Opcode) && !string.IsNullOrEmpty(data.KeyName))
+                            state.fileIDToName.Add(data.KeyHandle, data.TimeStampQPC, data.KeyName, isRundown);
+
                 });
             }
             if ((tracking & ParserTrackingOptions.FileNameToObject) != 0 && (state.callBacksSet & ParserTrackingOptions.FileNameToObject) == 0)


### PR DESCRIPTION
Not all registry events contain the key name, so we do extra work to share the key name across events by using the KeyHandle as the common identifier.  The existing code does not include a couple of the rundown events, and also was saving many instances of string.Empty for the KeyName.

This change identifies a couple more rundown events, and also only saves the key name if it is non-null and non-empty.