### PR TITLE
New Instrumentation Support for .NET 6

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -1864,6 +1864,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 source.UnregisterEventTemplate(value, 84, MethodTaskGuid);
             }
         }
+        public event Action<GCSettingsTraceData> GCSettingsRundown
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                RegisterTemplate(new GCSettingsTraceData(value, 10, 40, "Runtime", RuntimeTaskGuid, 1, "GCSettingsRundown", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 10, ProviderGuid);
+                source.UnregisterEventTemplate(value, 40, RuntimeTaskGuid);
+            }
+        }
         public event Action<RuntimeInformationTraceData> RuntimeStart
         {
             add
@@ -2141,7 +2154,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[141];
+                var templates = new TraceEvent[144];
                 templates[0] = new GCStartTraceData(null, 1, 1, "GC", GCTaskGuid, 1, "Start", ProviderGuid, ProviderName);
                 templates[1] = new GCEndTraceData(null, 2, 1, "GC", GCTaskGuid, 2, "Stop", ProviderGuid, ProviderName);
                 templates[2] = new GCNoUserDataTraceData(null, 3, 1, "GC", GCTaskGuid, 132, "RestartEEStop", ProviderGuid, ProviderName);
@@ -2291,6 +2304,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
                 templates[139] = ExecutionCheckpointTemplate(null);
                 templates[140] = YieldProcessorMeasurementTemplate(null);
+
+                templates[141] = new GCLOHCompactTraceData(null, 208, 1, "GC", GCTaskGuid, 208, "LOHCompact", ProviderGuid, ProviderName);
+                templates[142] = new GCFitBucketInfoTraceData(null, 209, 1, "GC", GCTaskGuid, 209, "FitBucketInfo", ProviderGuid, ProviderName);
+                templates[143] = new GCSettingsTraceData(null, 10, 40, "GC", GCTaskGuid, 40, "GCSettings", ProviderGuid, ProviderName);
 
                 s_templates = templates;
             }

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -12270,7 +12270,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         }
         protected internal override void Validate()
         {
-            Debug.Assert(!(Version == 0 && EventDataLength != 50);
+            Debug.Assert(!(Version == 0 && EventDataLength != 50));
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {


### PR DESCRIPTION
Completes work item described in issue #1467.

For .NET 6.0, several new GC events were introduced. PerfView requires to know about them as well, so traces can be interpreted properly. This PR adds the support.