### PR TITLE
Allows getting ActivityPathString by providing process id

### DIFF
--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -680,17 +680,18 @@ namespace Microsoft.Diagnostics.Tracing
 
         /// <summary>
         /// returns a string representation for the activity path.  If the GUID is not an activity path then it returns
-        /// the normal string representation for a GUID.  
+        /// the normal string representation for a GUID.
         /// </summary>
-        public static unsafe string ActivityPathString(Guid guid)
+        /// <remarks>
+        /// 0001111d-0000-0000-0000-00007bc7be59 will pass IsActivityPath check only when process Id 2125233 is provided.
+        /// </remarks>
+        public static unsafe string ActivityPathString(Guid guid, int processId = 0)
         {
-            return IsActivityPath(guid, 0) ? CreateActivityPathString(guid) : guid.ToString();
+            return IsActivityPath(guid, processId) ? CreateActivityPathString(guid) : guid.ToString();
         }
 
         internal static unsafe string CreateActivityPathString(Guid guid)
         {
-            Debug.Assert(IsActivityPath(guid, 0));
-
             var processID = ActivityPathProcessID(guid);
             StringBuilder sb = Utilities.StringBuilderCache.Acquire();
             if (processID != 0)


### PR DESCRIPTION
For example, activityid: 0001111d-0000-0000-0000-00007bc7be59

Before:
`ActivityPathString("0001111d-0000-0000-0000-00007bc7be59")` returns `0001111d-0000-0000-0000-00007bc7be59`;
After:
`ActivityPathString("0001111d-0000-0000-0000-00007bc7be59", 2125233)` returns `#/2125233/xxx/`

Reason:

```csharp
// Validation will pass with proper pid:
bool isIt1 = StartStopActivityComputer.IsActivityPath(Guid.Parse("0001111d-0000-0000-0000-00007bc7be59"), 2125233);
// What we had assumed 0 as the pid and would fail the validation:
bool isIt2 = StartStopActivityComputer.IsActivityPath(Guid.Parse("0001111d-0000-0000-0000-00007bc7be59"), 0);
// The process id and other info is actually valid. For example, get the pid from the guid, this returns 2125233
int pid = StartStopActivityComputer.ActivityPathProcessID(Guid.Parse("0001111d-0000-0000-0000-00007bc7be59"));
```

Before the change, 0 had been used as the process id and it won't pass the validation; since it was treated as not valid activity path, no process id could be fetched from the guid in turn. And thus, chicken & egg problem for pid.

Introducing an optional parameter of process id to break the cycle.