### PR TITLE
Use new SegmentedList and SegmentedDictionary to process large heap dumps

### DIFF
--- a/src/FastSerialization/SegmentedDictionary/SegmentedDictionary.cs
+++ b/src/FastSerialization/SegmentedDictionary/SegmentedDictionary.cs
@@ -781,7 +781,8 @@ namespace System.Collections.Generic
                 throw new ArgumentOutOfRangeException(nameof(capacity));
             }
 
-            var currentCapacity = _entries.Capacity;
+            // Normal usage of a dictionary should never ask for a capacity that exceeds int32.MaxValue.
+            var currentCapacity = (int)_entries.Capacity;
             if (currentCapacity >= capacity)
             {
                 return currentCapacity;

--- a/src/FastSerialization/SegmentedList.cs
+++ b/src/FastSerialization/SegmentedList.cs
@@ -100,7 +100,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public int Capacity => this.capacity;
+        public long Capacity => this.capacity;
 
         /// <summary>
         /// Copy to Array

--- a/src/FastSerialization/SegmentedList.cs
+++ b/src/FastSerialization/SegmentedList.cs
@@ -100,7 +100,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public long Capacity => this.capacity;
+        internal long Capacity => this.capacity;
 
         /// <summary>
         /// Copy to Array
@@ -177,7 +177,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public ref T GetElementByReference(int index) =>
+        internal ref T GetElementByReference(int index) =>
             ref this.items[index >> this.segmentShift][index & this.offsetMask];
 
         /// <summary>
@@ -188,6 +188,18 @@ namespace System.Collections.Generic
         public bool IsValidIndex(long index)
         {
             return this.items[index >> this.segmentShift] != null;
+        }
+
+        /// <summary>
+        /// Get slot of an element
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="slot"></param>
+        /// <returns></returns>
+        public T[] GetSlot(int index, out int slot)
+        {
+            slot = index & this.offsetMask;
+            return this.items[index >> this.segmentShift];
         }
 
         /// <summary>
@@ -443,12 +455,12 @@ namespace System.Collections.Generic
                     "Destination array is not long enough to copy all the items in the collection. Check array index and length.");
             }
 
-            int remain = (int)this.count;
+            long remain = this.count;
 
-            for (int i = 0; (remain > 0) && (i < this.items.Length); i++)
+            for (long i = 0; (remain > 0) && (i < this.items.Length); i++)
             {
                 // We can safely cast to int, since that is the max value that items[i].Length can have.
-                int len = Math.Min(remain, this.items[i].Length);
+                int len = (int)Math.Min(remain, this.items[i].Length);
 
                 Array.Copy(this.items[i], 0, array, arrayIndex, len);
 

--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Text;
 
 namespace FastSerialization
@@ -13,12 +12,31 @@ namespace FastSerialization
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given byte buffer
         /// </summary>
-        public SegmentedMemoryStreamReader(SegmentedList<byte> data) : this(data, 0, (int)data.Count) { }
+        public SegmentedMemoryStreamReader(SegmentedList<byte> data, SerializationConfiguration config = null) : this(data, 0, data.Count, config) { }
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given subregion of a byte buffer 
         /// </summary>
-        public SegmentedMemoryStreamReader(SegmentedList<byte> data, int start, int length)
+        public SegmentedMemoryStreamReader(SegmentedList<byte> data, long start, long length, SerializationConfiguration config = null)
         {
+            SerializationConfiguration = config ?? new SerializationConfiguration();
+
+            if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            {
+                readLabel = () =>
+                {
+                    return (StreamLabel)(uint)ReadInt32();
+                };
+                sizeOfSerializedStreamLabel = 4;
+            }
+            else
+            {
+                readLabel = () =>
+                {
+                    return (StreamLabel)(ulong)ReadInt64();
+                };
+                sizeOfSerializedStreamLabel = 8;
+            }
+
             bytes = new SegmentedList<byte>(65_536, length);
             bytes.AppendFrom(data, start, length);
             position = start;
@@ -130,18 +148,24 @@ namespace FastSerialization
         /// <summary>
         /// Implementation of IStreamReader
         /// </summary>
-        public StreamLabel ReadLabel()
-        {
-            return (StreamLabel)(uint)ReadInt32();
-        }
+        public StreamLabel ReadLabel() => readLabel();
+
         /// <summary>
         /// Implementation of IStreamReader
         /// </summary>
         public virtual void Goto(StreamLabel label)
         {
             Debug.Assert(label != StreamLabel.Invalid);
-            Debug.Assert((long)label <= int.MaxValue);
-            position = (int)label;
+
+            if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            {
+                Debug.Assert((long)label <= int.MaxValue);
+                position = (uint)label;
+            }
+            else
+            {
+                position = (long)label;
+            }
         }
         /// <summary>
         /// Implementation of IStreamReader
@@ -150,7 +174,14 @@ namespace FastSerialization
         {
             get
             {
-                return (StreamLabel)(uint)position;
+                if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+                {
+                    return (StreamLabel)(uint)position;
+                }
+                else
+                {
+                    return (StreamLabel)position;
+                }
             }
         }
         /// <summary>
@@ -158,8 +189,7 @@ namespace FastSerialization
         /// </summary>
         public virtual void GotoSuffixLabel()
         {
-            const int serializedStreamLabelSize = 4;
-            Goto((StreamLabel)(Length - serializedStreamLabelSize));
+            Goto((StreamLabel)(Length - sizeOfSerializedStreamLabel));
             Goto(ReadLabel());
         }
         /// <summary>
@@ -174,6 +204,11 @@ namespace FastSerialization
         /// Dispose pattern
         /// </summary>
         protected virtual void Dispose(bool disposing) { }
+
+        /// <summary>
+        /// Returns the SerializationConfiguration for this stream reader.
+        /// </summary>
+        public SerializationConfiguration SerializationConfiguration { get; private set; }
         #endregion
 
         #region private 
@@ -182,9 +217,11 @@ namespace FastSerialization
             throw new Exception("Streamreader read past end of buffer");
         }
         internal /*protected*/  SegmentedList<byte> bytes;
-        internal /*protected*/  int position;
-        internal /*protected*/  int endPosition;
+        internal /*protected*/  long position;
+        internal /*protected*/  long endPosition;
         private StringBuilder sb;
+        private Func<StreamLabel> readLabel;
+        private readonly int sizeOfSerializedStreamLabel;
         #endregion
     }
 }

--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -208,7 +208,7 @@ namespace FastSerialization
         /// <summary>
         /// Returns the SerializationConfiguration for this stream reader.
         /// </summary>
-        public SerializationConfiguration SerializationConfiguration { get; private set; }
+        internal SerializationConfiguration SerializationConfiguration { get; private set; }
         #endregion
 
         #region private 

--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace FastSerialization
@@ -15,6 +16,7 @@ namespace FastSerialization
             {
                 writeLabel = (value) =>
                 {
+                    Debug.Assert((int)value >= 0, "The StreamLabel overflowed, why do we think it is 32 bits!?");
                     Write((int)value);
                 };
             }
@@ -105,7 +107,7 @@ namespace FastSerialization
         /// <summary>
         /// Returns the SerializationConfiguration for this stream writer.
         /// </summary>
-        public SerializationConfiguration SerializationConfiguration { get; private set; }
+        internal SerializationConfiguration SerializationConfiguration { get; private set; }
 
         #region private
         protected virtual void MakeSpace()

--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -16,7 +16,7 @@ namespace FastSerialization
             {
                 writeLabel = (value) =>
                 {
-                    Debug.Assert((int)value >= 0, "The StreamLabel overflowed, why do we think it is 32 bits!?");
+                    Debug.Assert((long)value <= int.MaxValue, "The StreamLabel overflowed, it should not be treated as a 32bit value.");
                     Write((int)value);
                 };
             }

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -709,7 +709,7 @@ public class InteropInfo : IFastSerializable
 /// </graph>
 /// 
 /// </summary>
-public class XmlGcHeapDump
+internal class XmlGcHeapDump
 {
     public static GCHeapDump ReadGCHeapDumpFromXml(string fileName)
     {
@@ -840,7 +840,7 @@ public class XmlGcHeapDump
         return graph;
     }
 
-    public static void WriteGCDumpToXml(GCHeapDump gcDump, StreamWriter writer)
+    internal static void WriteGCDumpToXml(GCHeapDump gcDump, StreamWriter writer)
     {
         writer.WriteLine("<GCHeapDump>");
 

--- a/src/MemoryGraph/MemoryGraph.cs
+++ b/src/MemoryGraph/MemoryGraph.cs
@@ -12,7 +12,7 @@ namespace Graphs
         {
             // If we have too many addresses we will reach the Dictionary's internal array's size limit and throw.
             // Therefore use a new implementation of it that is similar in performance but that can handle the extra load.
-            if (expectedSize > 200_000)
+            if (isVeryLargeGraph)
             {
                 m_addressToNodeIndex = new SegmentedDictionary<Address, NodeIndex>(expectedSize);
             }

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Text.RegularExpressions;
 using Address = System.UInt64;
 


### PR DESCRIPTION
These changes are a continuation of the following PRs:

* [1486](https://github.com/microsoft/perfview/pull/1486) Let SegmentedList Handle more than 2^31-1 elements
* [1488](https://github.com/microsoft/perfview/pull/1488) SegmentedDictionary Initial Implementation and Tests
* [1491](https://github.com/microsoft/perfview/pull/1491) Opt-In 64-bit StreamLabel Support

In summary we are hooking everything together, and able to process large memory heap dumps. The actual changes are:

1. SegmentedDictionary.cs and SegmentedList.cs have minor improvements and make sure we don't delete public methods and that new methods that were added for this scenario remain internal.
2. SegmentedStreamReader.cs takes a `SerializationConfiguration` instance specifying if it should treat `StreamLabel` instances as 32 or 64bit objects; as well as making the necessary adjustments to take advantage of this fact when processing a memory graph.
3. SegmentedMemoryStreamWriter.cs is the same as SegmentedStreamReader.cs
4. GCHeapDump.cs did not require making the `XmlGcHeapDump` class public for it to be used in the PerfView.Tests project.
5. MemoryGraph.cs should not use the expected size to determine when to use a `SegmentedDictionary` instance since it is not that accurate and the range is subject to change if the internal implementation of a `Dictionary` changes.
6. Graph.cs makes sure that the `SegmentedMemoryStreamWriter` instance it creates is passed the correct `StreamLabel` size information.