### PR TITLE
Fixed typo in the Circular MB tooltip

### DIFF
--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -93,7 +93,7 @@
             </TextBlock>
             <CheckBox Grid.Column="1" Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" />
 
-            <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="After this size (in metabytes) old events are thown away to keep file size under control" >
+            <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="After this size (in megabytes) old events are thown away to keep file size under control" >
                         <Hyperlink Command="Help" CommandParameter="CircularTextBox">Circular<LineBreak/>MB:</Hyperlink>
             </TextBlock>
 


### PR DESCRIPTION
Fixed typo in the Circular MB tooltip from metabytes to megabytes. To fix: https://github.com/microsoft/perfview/issues/1315

![image](https://user-images.githubusercontent.com/4951960/138011680-dd788b4b-95bb-4f59-9a14-0f42e6ed6c8b.png)
