### PR TITLE
Add additional info to SourceLocation for better source viewing

### DIFF
--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Symbols
                 return null;
             }
 
-            return new SourceLocation(GetSourceFile(lastSequencePoint.Document), lastSequencePoint.StartLine);
+            return new SourceLocation(GetSourceFile(lastSequencePoint.Document), lastSequencePoint.StartLine, lastSequencePoint.EndLine, lastSequencePoint.StartColumn, lastSequencePoint.EndColumn);
         }
 
         #region private 

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -1760,12 +1760,33 @@ namespace Microsoft.Diagnostics.Symbols
         /// </summary>
         public SourceFile SourceFile { get; private set; }
         /// <summary>
-        /// The line number for the code.
+        /// The starting line number for the code.
         /// </summary>
         public int LineNumber { get; private set; }
+        /// <summary>
+        /// The ending line number for the code.
+        /// </summary>
+        public int LineNumberEnd { get; private set; }
+        /// <summary>
+        /// The starting column number for the code. This column corresponds to the starting line number.
+        /// </summary>
+        public int ColumnNumber { get; private set; }
+        /// <summary>
+        /// The ending column number for the code. This column corresponds to the ending line number.
+        /// </summary>
+        public int ColumnNumberEnd { get; private set; }
 
         #region private
-        internal SourceLocation(SourceFile sourceFile, int lineNumber)
+        internal SourceLocation(SourceFile sourceFile, int lineNumberBegin, int lineNumberEnd, int columnNumberBegin, int columnNumberEnd)
+        {
+            SourceFile = sourceFile;
+            LineNumber = SanitizeLineNumber(lineNumberBegin);
+            LineNumberEnd = SanitizeLineNumber(lineNumberEnd);
+            ColumnNumber = SanitizeLineNumber(columnNumberBegin);
+            ColumnNumberEnd = SanitizeLineNumber(columnNumberEnd);
+        }
+
+        private int SanitizeLineNumber(int lineNumber)
         {
             // The library seems to see FEEFEE for the 'unknown' line number.  0 seems more intuitive
             if (0xFEEFEE <= lineNumber)
@@ -1773,8 +1794,7 @@ namespace Microsoft.Diagnostics.Symbols
                 lineNumber = 0;
             }
 
-            SourceFile = sourceFile;
-            LineNumber = lineNumber;
+            return lineNumber;
         }
         #endregion
     }


### PR DESCRIPTION
Add additional info to SourceLocation so that we can get the exact section of code a "line" refers to. This additional info includes an end line number and column begin/end numbers. 

This is useful for showing better visualizations when highlighting source.  For example, in Visual Studio, we show source line highlighting to show which lines of the source are "hot". With this extra info, we can better highlight the sections of code that are hot instead of needing to highlight the entire row. e.g. a line of code may contain multiple statements which should each have their own highlighting. This extra info helps distinguishes those statements from each other.