### PR TITLE
Allow override of SupportFilesDir

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -335,32 +335,60 @@ namespace PerfView
 #endif
         }
 
-        // ConfigData
-        public static string ConfigDataFileName
+        // UserConfigData
+        public static string UserConfigDataFileName
         {
             get
             {
-                if (s_ConfigDataName == null)
+                if (s_UserConfigDataName == null)
                 {
-                    s_ConfigDataName = Path.Combine(SupportFiles.SupportFileDirBase, "UserConfig.xml");
+                    s_UserConfigDataName = Path.Combine(SupportFiles.SupportFileDirBase, "UserConfig.xml");
                 }
 
-                return s_ConfigDataName;
+                return s_UserConfigDataName;
             }
         }
-        public static ConfigData ConfigData
+        public static ConfigData UserConfigData
         {
             get
             {
-                if (s_ConfigData == null)
+                if (s_UserConfigData == null)
                 {
-                    s_ConfigData = new ConfigData(ConfigDataFileName, autoWrite: true);
+                    s_UserConfigData = new ConfigData(UserConfigDataFileName, autoWrite: true);
                 }
 
-                return s_ConfigData;
+                return s_UserConfigData;
             }
         }
-        public static void WriteConfig() { ConfigData.Write(ConfigDataFileName); }
+        public static void WriteUserConfig() { UserConfigData.Write(UserConfigDataFileName); }
+
+        // UserConfigData
+        public static string AppConfigDataFileName
+        {
+            get
+            {
+                if (s_AppConfigDataName == null)
+                {
+                    string exePath = Path.GetDirectoryName(SupportFiles.ExePath);
+                    s_AppConfigDataName = Path.Combine(exePath, "AppConfig.xml");
+                }
+
+                return s_AppConfigDataName;
+            }
+        }
+        public static ConfigData AppConfigData
+        {
+            get
+            {
+                if (s_AppConfigData == null)
+                {
+                    s_AppConfigData = new ConfigData(AppConfigDataFileName);
+                }
+
+                return s_AppConfigData;
+            }
+        }
+
 
         // Logfile
         /// <summary>
@@ -599,7 +627,7 @@ namespace PerfView
         // Legal stuff (EULA)
         public static bool NeedsEulaConfirmation(CommandLineArgs commandLineArgs)
         {
-            var acceptedVersion = App.ConfigData["EULA_Accepted"];
+            var acceptedVersion = App.UserConfigData["EULA_Accepted"];
             if (acceptedVersion != null && acceptedVersion == EulaVersion)
             {
                 return false;
@@ -608,7 +636,7 @@ namespace PerfView
             // Did the accept the EULA by command line argument?
             if (App.CommandLineArgs.AcceptEULA)
             {
-                App.ConfigData["EULA_Accepted"] = EulaVersion;
+                App.UserConfigData["EULA_Accepted"] = EulaVersion;
                 return false;
             }
 
@@ -622,7 +650,7 @@ namespace PerfView
         }
         public static void AcceptEula()
         {
-            App.ConfigData["EULA_Accepted"] = EulaVersion;
+            App.UserConfigData["EULA_Accepted"] = EulaVersion;
             // It will auto-update the user state.  
         }
 
@@ -653,7 +681,7 @@ namespace PerfView
                     var symPath = new SymbolPath(Microsoft.Diagnostics.Symbols.SymbolPath.SymbolPathFromEnvironment);
 
                     // Add any path that we had on previous runs.  
-                    var savedPath = App.ConfigData["_NT_SYMBOL_PATH"];
+                    var savedPath = App.UserConfigData["_NT_SYMBOL_PATH"];
                     if (savedPath != null)
                     {
                         symPath.Add(savedPath);
@@ -699,9 +727,9 @@ namespace PerfView
             set
             {
                 m_SymbolPath = value;
-                if (App.ConfigData["_NT_SYMBOL_PATH"] != m_SymbolPath)
+                if (App.UserConfigData["_NT_SYMBOL_PATH"] != m_SymbolPath)
                 {
-                    App.ConfigData["_NT_SYMBOL_PATH"] = m_SymbolPath;
+                    App.UserConfigData["_NT_SYMBOL_PATH"] = m_SymbolPath;
                 }
             }
         }
@@ -712,7 +740,7 @@ namespace PerfView
                 if (m_SourcePath == null)
                 {
                     var symPath = new SymbolPath(Environment.GetEnvironmentVariable("_NT_SOURCE_PATH"));
-                    var savedPath = App.ConfigData["_NT_SOURCE_PATH"];
+                    var savedPath = App.UserConfigData["_NT_SOURCE_PATH"];
                     if (savedPath != null)
                     {
                         symPath.Add(savedPath);
@@ -726,7 +754,7 @@ namespace PerfView
             set
             {
                 m_SourcePath = value;
-                App.ConfigData["_NT_SOURCE_PATH"] = value;
+                App.UserConfigData["_NT_SOURCE_PATH"] = value;
             }
         }
 
@@ -962,8 +990,10 @@ namespace PerfView
         private static WeakReference s_splashScreen;
 #endif
         private const string EulaVersion = "1";
-        private static ConfigData s_ConfigData;
-        private static string s_ConfigDataName;
+        private static ConfigData s_UserConfigData;
+        private static string s_UserConfigDataName;
+        private static ConfigData s_AppConfigData;
+        private static string s_AppConfigDataName;
 
         private static bool s_IsElevated;
         private static bool s_IsElevatedInited;

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1476,12 +1476,12 @@ namespace PerfView
             LogFile.WriteLine("[Merging data files to " + Path.GetFileName(parsedArgs.DataFile) + ".  Can take 10s of seconds... (can skip if data analyzed on same machine with PerfView)]");
             Stopwatch sw = Stopwatch.StartNew();
 
-            if (!parsedArgs.NoGui && !App.ConfigData.ContainsKey("InformedAboutSkippingMerge"))
+            if (!parsedArgs.NoGui && !App.UserConfigData.ContainsKey("InformedAboutSkippingMerge"))
             {
                 if (IsGuiCollection(parsedArgs))
                 {
                     InformedAboutSkippingMerge();
-                    App.ConfigData["InformedAboutSkippingMerge"] = "true";
+                    App.UserConfigData["InformedAboutSkippingMerge"] = "true";
                 }
             }
 
@@ -2330,13 +2330,13 @@ namespace PerfView
                     parsedArgs.Merge = collectWindow.MergeCheckBox.IsChecked;
                     if (collectWindow.m_mergeOrZipCheckboxTouched && parsedArgs.Merge.HasValue)
                     {
-                        App.ConfigData["Merge"] = parsedArgs.Merge.Value.ToString();
+                        App.UserConfigData["Merge"] = parsedArgs.Merge.Value.ToString();
                     }
 
                     parsedArgs.Zip = collectWindow.ZipCheckBox.IsChecked;
                     if (collectWindow.m_mergeOrZipCheckboxTouched && parsedArgs.Zip.HasValue)
                     {
-                        App.ConfigData["Zip"] = parsedArgs.Zip.Value.ToString();
+                        App.UserConfigData["Zip"] = parsedArgs.Zip.Value.ToString();
                     }
 
                     parsedArgs.NoRundown = !(collectWindow.RundownCheckBox.IsChecked ?? false);
@@ -3255,14 +3255,14 @@ namespace PerfView
                 return;
             }
 
-            var warnedAboutAspNetTracing = App.ConfigData["WarnedAboutAspNetTracing"];
+            var warnedAboutAspNetTracing = App.UserConfigData["WarnedAboutAspNetTracing"];
             if (warnedAboutAspNetTracing == "true")
             {
                 return;
             }
 
             ShowAspNetWarningBox(message);
-            App.ConfigData["WarnedAboutAspNetTracing"] = "true";
+            App.UserConfigData["WarnedAboutAspNetTracing"] = "true";
         }
 
         // In its own routine so that we don't run WPF on ARM.  

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -69,7 +69,7 @@ namespace PerfView
             CurrentDirTextBox.Text = Environment.CurrentDirectory;
 
             // Initialize the CommandToRun history if available. 
-            var commandToRunHistory = App.ConfigData["CommandToRunHistory"];
+            var commandToRunHistory = App.UserConfigData["CommandToRunHistory"];
             if (commandToRunHistory != null)
             {
                 CommandToRunTextBox.SetHistory(commandToRunHistory.Split(';'));
@@ -108,7 +108,7 @@ namespace PerfView
                 if (!ZipCheckBox.IsChecked.HasValue)
                 {
                     string configZip;
-                    if (App.ConfigData.TryGetValue("Zip", out configZip))
+                    if (App.UserConfigData.TryGetValue("Zip", out configZip))
                     {
                         ZipCheckBox.IsChecked = string.Compare(configZip, "true", true) == 0;
                     }
@@ -116,7 +116,7 @@ namespace PerfView
                 if (!MergeCheckBox.IsChecked.HasValue)
                 {
                     string configMerge;
-                    if (App.ConfigData.TryGetValue("Merge", out configMerge))
+                    if (App.UserConfigData.TryGetValue("Merge", out configMerge))
                     {
                         MergeCheckBox.IsChecked = string.Compare(configMerge, "true", true) == 0;
                     }
@@ -258,7 +258,7 @@ namespace PerfView
             }
 
             // Initialize history of additional providers
-            var additionalProvidersHistory = App.ConfigData["AdditionalProvidersHistory"];
+            var additionalProvidersHistory = App.UserConfigData["AdditionalProvidersHistory"];
             if (additionalProvidersHistory != null)
             {
                 AdditionalProvidersTextBox.SetHistory(additionalProvidersHistory.Split(';'));
@@ -569,7 +569,7 @@ namespace PerfView
                             sb.Append(item);
                         }
                     }
-                    App.ConfigData["CommandToRunHistory"] = sb.ToString();
+                    App.UserConfigData["CommandToRunHistory"] = sb.ToString();
                 }
             }
             else
@@ -808,7 +808,7 @@ namespace PerfView
                             sb.Append(item);
                         }
                     }
-                    App.ConfigData["AdditionalProvidersHistory"] = sb.ToString();
+                    App.UserConfigData["AdditionalProvidersHistory"] = sb.ToString();
                 }
             }
 

--- a/src/PerfView/Dialogs/UserCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/UserCommandDialog.xaml.cs
@@ -18,7 +18,7 @@ namespace PerfView.Dialogs
             CommandTextBox.HistoryLength = 50;      // Keep a fair bit of history for user commands. 
 
             // Initialize from persistent store. 
-            var history = App.ConfigData["UserCommandHistory"];
+            var history = App.UserConfigData["UserCommandHistory"];
             if (history != null)
             {
                 CommandTextBox.SetHistory(history.Split(';'));
@@ -57,7 +57,7 @@ namespace PerfView.Dialogs
 
                 sb.Append(item);
             }
-            App.ConfigData["UserCommandHistory"] = sb.ToString();
+            App.UserConfigData["UserCommandHistory"] = sb.ToString();
         }
 
         private void DoHyperlinkHelp(object sender, ExecutedRoutedEventArgs e)

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -374,7 +374,7 @@ namespace PerfViewExtensibility
         /// ConfigData is a set of key-value dictionary that is persisted (as AppData\Roaming\PerfView\UserConfig.xml)
         /// so it is remembered across invocations of the program.  
         /// </summary>
-        public static ConfigData ConfigData { get { return App.ConfigData; } }
+        public static ConfigData ConfigData { get { return App.UserConfigData; } }
         /// <summary>
         /// This is a directory where you can place temporary files.   These files will be cleaned up
         /// eventually if the number grows too large.   (this is %TEMP%\PerfView)

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1055,7 +1055,7 @@ namespace PerfView
             DataContext = this;
 
             // Initialize the directory history if available. 
-            var directoryHistory = App.ConfigData["DirectoryHistory"];
+            var directoryHistory = App.UserConfigData["DirectoryHistory"];
             if (directoryHistory != null)
             {
                 Directory.SetHistory(directoryHistory.Split(';'));
@@ -1069,14 +1069,14 @@ namespace PerfView
             }
 
             // Make sure the location is sane so it can be displayed. 
-            var top = App.ConfigData.GetDouble("MainWindowTop", Top);
+            var top = App.UserConfigData.GetDouble("MainWindowTop", Top);
             Top = Math.Min(Math.Max(top, 0), System.Windows.SystemParameters.PrimaryScreenHeight - 200);
 
-            var left = App.ConfigData.GetDouble("MainWindowLeft", Left);
+            var left = App.UserConfigData.GetDouble("MainWindowLeft", Left);
             Left = Math.Min(Math.Max(left, 0), System.Windows.SystemParameters.PrimaryScreenWidth - 200);
 
-            Height = App.ConfigData.GetDouble("MainWindowHeight", Height);
-            Width = App.ConfigData.GetDouble("MainWindowWidth", Width);
+            Height = App.UserConfigData.GetDouble("MainWindowHeight", Height);
+            Width = App.UserConfigData.GetDouble("MainWindowWidth", Width);
 
             Loaded += delegate (object sender1, RoutedEventArgs e2)
             {
@@ -1101,10 +1101,10 @@ namespace PerfView
 
                 if (WindowState != System.Windows.WindowState.Maximized)
                 {
-                    App.ConfigData["MainWindowWidth"] = RenderSize.Width.ToString("f0", CultureInfo.InvariantCulture);
-                    App.ConfigData["MainWindowHeight"] = RenderSize.Height.ToString("f0", CultureInfo.InvariantCulture);
-                    App.ConfigData["MainWindowTop"] = Top.ToString("f0", CultureInfo.InvariantCulture);
-                    App.ConfigData["MainWindowLeft"] = Left.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["MainWindowWidth"] = RenderSize.Width.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["MainWindowHeight"] = RenderSize.Height.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["MainWindowTop"] = Top.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["MainWindowLeft"] = Left.ToString("f0", CultureInfo.InvariantCulture);
                 }
 
                 AppLog.LogUsage("Exiting");
@@ -1146,7 +1146,7 @@ namespace PerfView
 
                             sb.Append(item);
                         }
-                        App.ConfigData["DirectoryHistory"] = sb.ToString();
+                        App.UserConfigData["DirectoryHistory"] = sb.ToString();
                     }
 
                     FileFilterTextBox.Text = "";
@@ -1479,9 +1479,9 @@ namespace PerfView
         }
         private void DoClearUserConfig(object sender, RoutedEventArgs e)
         {
-            StatusBar.Log("Deleting user config file " + App.ConfigDataFileName + ".");
-            FileUtilities.ForceDelete(App.ConfigDataFileName);
-            App.ConfigData.Clear();
+            StatusBar.Log("Deleting user config file " + App.UserConfigDataFileName + ".");
+            FileUtilities.ForceDelete(App.UserConfigDataFileName);
+            App.UserConfigData.Clear();
         }
 
         private void DoCancel(object sender, ExecutedRoutedEventArgs e)
@@ -2200,7 +2200,7 @@ namespace PerfView
             {
                 if (!m_AllowNativateToWeb)
                 {
-                    var naviateToWeb = App.ConfigData["AllowNavigateToWeb"];
+                    var naviateToWeb = App.UserConfigData["AllowNavigateToWeb"];
                     m_AllowNativateToWeb = naviateToWeb == "true";
                     if (!m_AllowNativateToWeb)
                     {
@@ -2210,7 +2210,7 @@ namespace PerfView
                         if (result == MessageBoxResult.Yes)
                         {
                             m_AllowNativateToWeb = true;
-                            App.ConfigData["AllowNavigateToWeb"] = "true";
+                            App.UserConfigData["AllowNavigateToWeb"] = "true";
                         }
                     }
                 }

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -6922,7 +6922,7 @@ table {
             // Warn the user about the behavior of type name lookup, but only once per user.  
             if (stackSourceName == "Net OS Heap Alloc")
             {
-                if (App.ConfigData["WarnedAboutOsHeapAllocTypes"] == null)
+                if (App.UserConfigData["WarnedAboutOsHeapAllocTypes"] == null)
                 {
                     MessageBox.Show(stackWindow,
                         "Warning: Allocation type resolution only happens on window launch.\r\n" +
@@ -6932,7 +6932,7 @@ table {
                         "\r\n" +
                         "You must close and reopen this window to get the allocation types.\r\n"
                         , "May need to resolve PDBs and reopen.");
-                    App.ConfigData["WarnedAboutOsHeapAllocTypes"] = "true";
+                    App.UserConfigData["WarnedAboutOsHeapAllocTypes"] = "true";
                 }
             }
         }

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -92,7 +92,7 @@ namespace PerfView
         }
         public string GetDefaultFoldPercentage()
         {
-            string defaultFoldPercentage = App.ConfigData["DefaultFoldPercent"];
+            string defaultFoldPercentage = App.UserConfigData["DefaultFoldPercent"];
             if (defaultFoldPercentage == null)
             {
                 defaultFoldPercentage = "1";
@@ -102,7 +102,7 @@ namespace PerfView
         }
         public string GetDefaultFoldPat()
         {
-            string defaultFoldPat = App.ConfigData["DefaultFoldPat"];
+            string defaultFoldPat = App.UserConfigData["DefaultFoldPat"];
             if (defaultFoldPat == null)
             {
                 defaultFoldPat = "ntoskrnl!%ServiceCopyEnd";
@@ -112,7 +112,7 @@ namespace PerfView
         }
         public string GetDefaultGroupPat()
         {
-            string defaultGroupPat = App.ConfigData["DefaultGroupPat"];
+            string defaultGroupPat = App.UserConfigData["DefaultGroupPat"];
 
             // By default, it is Just My App.  
             if (defaultGroupPat == null)
@@ -864,8 +864,8 @@ namespace PerfView
         }
         private void DoSetStartupPreset(object sender, RoutedEventArgs e)
         {
-            App.ConfigData["DefaultFoldPercent"] = FoldPercentTextBox.Text;
-            App.ConfigData["DefaultFoldPat"] = FoldRegExTextBox.Text;
+            App.UserConfigData["DefaultFoldPercent"] = FoldPercentTextBox.Text;
+            App.UserConfigData["DefaultFoldPat"] = FoldRegExTextBox.Text;
 
             var defaultGroupPat = GroupRegExTextBox.Text;
             if (defaultGroupPat.StartsWith("[Just My App]"))
@@ -873,7 +873,7 @@ namespace PerfView
                 defaultGroupPat = defaultGroupPat.Substring(0, 13);
             }
 
-            App.ConfigData["DefaultGroupPat"] = defaultGroupPat;
+            App.UserConfigData["DefaultGroupPat"] = defaultGroupPat;
         }
         private void DoSaveAs(object sender, RoutedEventArgs e)
         {
@@ -2881,13 +2881,13 @@ namespace PerfView
 
                 if (value)
                 {
-                    App.ConfigData["NotesPaneHidden"] = "true";
+                    App.UserConfigData["NotesPaneHidden"] = "true";
                     m_NotesPaneHidden = true;
                     NodePaneRowDef.MaxHeight = 0;
                 }
                 else
                 {
-                    App.ConfigData["NotesPaneHidden"] = "false";
+                    App.UserConfigData["NotesPaneHidden"] = "false";
                     m_NotesPaneHidden = false;
                     NodePaneRowDef.MaxHeight = Double.PositiveInfinity;
                 }
@@ -3377,10 +3377,10 @@ namespace PerfView
 
                 if (StackWindows[0] == this && WindowState != System.Windows.WindowState.Maximized)
                 {
-                    App.ConfigData["StackWindowTop"] = Top.ToString("f0", CultureInfo.InvariantCulture);
-                    App.ConfigData["StackWindowLeft"] = Left.ToString("f0", CultureInfo.InvariantCulture);
-                    App.ConfigData["StackWindowWidth"] = RenderSize.Width.ToString("f0", CultureInfo.InvariantCulture);
-                    App.ConfigData["StackWindowHeight"] = RenderSize.Height.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["StackWindowTop"] = Top.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["StackWindowLeft"] = Left.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["StackWindowWidth"] = RenderSize.Width.ToString("f0", CultureInfo.InvariantCulture);
+                    App.UserConfigData["StackWindowHeight"] = RenderSize.Height.ToString("f0", CultureInfo.InvariantCulture);
                 }
 
                 StackWindows.Remove(this);
@@ -3423,19 +3423,19 @@ namespace PerfView
                 --GuiApp.MainWindow.NumWindowsNeedingSaving;
             }
 
-            NotesPaneHidden = (App.ConfigData["NotesPaneHidden"] == "true");
+            NotesPaneHidden = (App.UserConfigData["NotesPaneHidden"] == "true");
 
             if (StackWindows.Count == 1)
             {
                 // Make sure the location is sane so it can be displayed. 
-                var top = App.ConfigData.GetDouble("StackWindowTop", Top);
+                var top = App.UserConfigData.GetDouble("StackWindowTop", Top);
                 Top = Math.Min(Math.Max(top, 0), System.Windows.SystemParameters.PrimaryScreenHeight - 200);
 
-                var left = App.ConfigData.GetDouble("StackWindowLeft", Left);
+                var left = App.UserConfigData.GetDouble("StackWindowLeft", Left);
                 Left = Math.Min(Math.Max(left, 0), System.Windows.SystemParameters.PrimaryScreenWidth - 200);
 
-                Height = App.ConfigData.GetDouble("StackWindowHeight", Height);
-                Width = App.ConfigData.GetDouble("StackWindowWidth", Width);
+                Height = App.UserConfigData.GetDouble("StackWindowHeight", Height);
+                Width = App.UserConfigData.GetDouble("StackWindowWidth", Width);
             }
         }
 
@@ -3472,7 +3472,7 @@ namespace PerfView
 
                         // Checked value and visibliity of column is based off of ConfigData.
                         // If there is no ConfigData property for it, it is defaulted to display. 
-                        string configValue = App.ConfigData[XmlConvert.EncodeName(header + "ColumnView")];
+                        string configValue = App.UserConfigData[XmlConvert.EncodeName(header + "ColumnView")];
                         if (configValue == null || configValue == "1")
                         {
                             menuItem.IsChecked = true;
@@ -3540,7 +3540,7 @@ namespace PerfView
                         // XmlConvert.EncodeName is used to handle symbols like %
                         // E.g. CallTreeViewNameColumnView
                         string name = XmlConvert.EncodeName(header + "ColumnView");
-                        App.ConfigData[name] = mItem.IsChecked ? "1" : "0";
+                        App.UserConfigData[name] = mItem.IsChecked ? "1" : "0";
                     }
                 }
             };
@@ -3896,7 +3896,7 @@ namespace PerfView
 
         private void ConfigurePresetMenu()
         {
-            var presets = App.ConfigData["Presets"];
+            var presets = App.UserConfigData["Presets"];
             m_presets = Preset.ParseCollection(presets);
 
             foreach (var preset in m_presets)
@@ -3985,7 +3985,7 @@ namespace PerfView
                 m_presets.Insert(0, preset);
                 m_presets.Sort((x, y) => Comparer<string>.Default.Compare(x.Name, y.Name));
             }
-            App.ConfigData["Presets"] = Preset.Serialize(m_presets);
+            App.UserConfigData["Presets"] = Preset.Serialize(m_presets);
 
             DoUpdatePresetMenu();
         }
@@ -3996,7 +3996,7 @@ namespace PerfView
             managePresetsDialog.Owner = this;
             managePresetsDialog.ShowDialog();
             m_presets = managePresetsDialog.Presets;
-            App.ConfigData["Presets"] = Preset.Serialize(m_presets);
+            App.UserConfigData["Presets"] = Preset.Serialize(m_presets);
             DoUpdatePresetMenu();
         }
 

--- a/src/PerfView/Utilities/SupportFiles.cs
+++ b/src/PerfView/Utilities/SupportFiles.cs
@@ -128,15 +128,21 @@ namespace Utilities
         /// <summary>
         /// SupportFileDir is a directory that is reserved for CURRENT VERSION of the software (if a later version is installed)
         /// It gets its own directory).   This is the directory where files in the EXE get unpacked to.  
+        /// NOTE: It is possible to override this through the AppConfig.xml file for cases where we don't want to use the unpacked version.
         /// </summary>
         public static string SupportFileDir
         {
             get
             {
+                if (s_supportFileDir == null)
                 {
-                    var exeLastWriteTime = File.GetLastWriteTime(MainAssemblyPath);
-                    var version = exeLastWriteTime.ToString("VER.yyyy'-'MM'-'dd'.'HH'.'mm'.'ss.fff");
-                    s_supportFileDir = Path.Combine(SupportFileDirBase, version);
+                    s_supportFileDir = App.AppConfigData["SupportFilesDir"];
+                    if (s_supportFileDir == null)
+                    {
+                        var exeLastWriteTime = File.GetLastWriteTime(MainAssemblyPath);
+                        var version = exeLastWriteTime.ToString("VER.yyyy'-'MM'-'dd'.'HH'.'mm'.'ss.fff");
+                        s_supportFileDir = Path.Combine(SupportFileDirBase, version);
+                    }
                 }
                 return s_supportFileDir;
             }


### PR DESCRIPTION
Some environments where PerfView.exe is deployed require that its dependencies be pre-unpacked.  When this happens, we must be able to point at the pre-unpacked files.

This change adds the ability to create an AppConfig.xml file with the following contents:
```
<?xml version="1.0" encoding="utf-8"?>
<ConfigData>
  <SupportFilesDir>C:\PerfView</SupportFilesDir>
</ConfigData>
```

If this file and contents are present, then PerfView's SupportFiles load behavior will use the specified directory when looking for support files.