### PR TITLE
2 fixes

### DIFF
--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -280,7 +280,7 @@ namespace Stats
                         continue;
                     }
 
-                    var allocGen0MB = _event.GenSizeBeforeMB[(int)Gens.Gen0];
+                    var allocGen0MB = _event.UserAllocated[(int)Gens.Gen0];
                     writer.WriteLine("{0}{26}{1:f3}{26}{2}{26}{3}{26}{4:f3}{26}{5:f1}{26}{6:f3}{26}{7:f2}{26}{8:f3}{26}{9:f3}{26}{10:2}{26}{11:f3}{26}{12:f3}{26}{13:f0}{26}{14:f2}{26}{15:f3}{26}{16:f0}{26}{17:f2}{26}{18:f3}{26}{19:f0}{26}{20:f2}{26}{21:f3}{26}{22:f0}{26}{23:f2}{26}{24:f2}{26}{25:f0}{26}{27:f1}{26}{28:f3}",
                                    _event.Number,
                                    _event.PauseStartRelativeMSec,

--- a/src/PerfView/UserCommands.cs
+++ b/src/PerfView/UserCommands.cs
@@ -1182,7 +1182,7 @@ namespace PerfViewExtensibility
             CommandProcessor.UnZipIfNecessary(ref etlFile, LogFile);
 
             List<Microsoft.Diagnostics.Tracing.Analysis.TraceProcess> processes = new List<Microsoft.Diagnostics.Tracing.Analysis.TraceProcess>();
-            using (var source = new ETWTraceEventSource(etlFile))
+            using (var source = TraceEventDispatcher.GetDispatcherFromFileName(etlFile))
             {
                 Microsoft.Diagnostics.Tracing.Analysis.TraceLoadedDotNetRuntimeExtensions.NeedLoadedDotNetRuntimes(source);
                 source.Process();


### PR DESCRIPTION
+ make the GCStats user command be able to read .nettrace files

+ fixed the incorrect gen0 alloc in the csv export of GCStats