### PR TITLE
Restore and opt into multi-proc on build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,7 +3,7 @@
 @echo.This script simply calls msbuild to build PerfView.exe
 @echo.*************************************************************
 @echo.
-msbuild /restore /p:Configuration=Release %*
+msbuild /restore /m /p:Configuration=Release %*
 @if '%ERRORLEVEL%' == '0' (
     echo.
     echo.

--- a/build.cmd
+++ b/build.cmd
@@ -3,7 +3,7 @@
 @echo.This script simply calls msbuild to build PerfView.exe
 @echo.*************************************************************
 @echo.
-msbuild /p:Configuration=Release %*
+msbuild /restore /p:Configuration=Release %*
 @if '%ERRORLEVEL%' == '0' (
     echo.
     echo.


### PR DESCRIPTION
- Restore projects on build
  - This changes MSBuild to restore packages on build, to avoid immediately getting
building about missing assets files the first time you clone the repository. This
added 1.8 seconds to build time on my i7-9700k if restore is up-to-date.

- Use multi-proc build 
  - This opts into multi-proc build which reduced up-to-date build from ~8 seconds
down to 6 seconds on my i7-9700k.