### PR TITLE
Fix textbox autocomplete to work like modern browsers

### DIFF
--- a/src/PerfView/GuiUtilities/HistoryComboBox/HistoryCombBox.cs
+++ b/src/PerfView/GuiUtilities/HistoryComboBox/HistoryCombBox.cs
@@ -146,15 +146,7 @@ namespace Controls
         /// </summary>
         private void FireEnter(object sender, RoutedEventArgs e)
         {
-            // Remove selected text (completion guess), so we only get what the user typed
-            var selectionLength = GetTextBox().SelectionLength;
             var text = GetTextBox().Text;
-
-            // the selection is the whole textbox, go ahead and leave it.  
-            if (selectionLength != 0 && selectionLength != GetTextBox().Text.Length)
-            {
-                GetTextBox().Text = text.Substring(0, GetTextBox().SelectionStart);
-            }
 
             if (text.Length > 0)
             {


### PR DESCRIPTION
This changes the textbox autocomplete to work like a modern browser so that when it autocompletes, pressing enter navigates to the autocompleted location. Previously this would attempt to navigate to _just_ to the text that you had just typed. This bit me constantly.

In this scenario, I enter `C:\Temp\` and expect that when I press enter, the full autocompleted location is navigated to instead of just `C:\Temp`.

Before:
![PerfViewBefore](https://user-images.githubusercontent.com/1103906/141282319-07b917ea-3c2a-4637-836a-2229014a4ba3.gif)

After:
![PerfViewAfter](https://user-images.githubusercontent.com/1103906/141282337-5d6d25be-c317-40ec-9ade-101a652f427e.gif)

**Note:** PerfView has odd behavior where it navigates based on the textbox losing focus. This behavior also affects that scenario, there's not an app that I know that works like this with or without this behavior. Thoughts on this? 