### PR TITLE
Move Hide to be close to Exit

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -60,13 +60,14 @@
             </Grid.ColumnDefinitions>
             <Menu Grid.Column="0" Background="#FFD1D1D1">
                 <MenuItem Header="_File">
-                    <Separator/>
-                    <MenuItem Header="_Hide" Command="{x:Static src:MainWindow.HideCommand}" ToolTip="Hides the current window (can reopen using windows explorer)"/>
                     <MenuItem Header="_Clear Temp Files" Click="DoClearTempFiles" ToolTip="Some operations create temporary files.  This command clears all of these."/>
                     <MenuItem Header="Clear User Config" Click="DoClearUserConfig" ToolTip="Reset all user preferences back to their defaults when PerfView was first installed."/>
                     <MenuItem Header="Set Symbol _Path" Click="DoSetSymbolPath" ToolTip="Sets the locations to look for symbolic information (PDB files)."/>
                     <MenuItem Header="_User Command" Command="{x:Static src:MainWindow.UserCommand}" ToolTip="Run a User Defined Command."/>
                     <MenuItem Header="Go to Directory" Command="{x:Static src:MainWindow.FocusDirectoryCommand}" ToolTip="Focus and select the directory textbox."/>
+                    <Separator/>
+                    <MenuItem Header="_Hide" Command="{x:Static src:MainWindow.HideCommand}" ToolTip="Hides the current window (can reopen using windows explorer)"/>
+                    <Separator/>
                     <MenuItem Header="_Exit" Click="DoExit"/>
                 </MenuItem>
                 <MenuItem Header="_Collect">


### PR DESCRIPTION
This also removes leading separator on the File menu.

Before:
![image](https://user-images.githubusercontent.com/1103906/141295807-162f3ed6-93c0-4c7b-ae4a-2f32f4206c08.png)


After:
![image](https://user-images.githubusercontent.com/1103906/141295757-13ef3c05-ad43-43d0-8d6f-44eb659fcc3b.png)