### PR TITLE
Add Open Folder/Open Containing Folder commands

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -14,6 +14,10 @@
         <BitmapImage x:Key="FolderOpenBitmapImage"  UriSource="images/VSFolder_open.png"/>
         <BitmapImage x:Key="HtmlReportBitmapImage"  UriSource="images/VSProject_html.png"/>
         <BitmapImage x:Key="ChartBitmapImage"  UriSource="images/Chart.png"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <Style TargetType="MenuItem">
+            <Setter Property="Visibility" Value="{Binding RelativeSource={RelativeSource Self}, Path=IsEnabled, Converter={StaticResource BooleanToVisibilityConverter }}" />
+        </Style>
     </Window.Resources>
     <Window.CommandBindings>
         <CommandBinding Command="{x:Static src:MainWindow.ItemHelpCommand}" Executed="DoItemHelp" CanExecute="CanDoItemHelp"/>
@@ -30,6 +34,8 @@
         <CommandBinding Command="{x:Static src:MainWindow.OpenCommand}" Executed="DoOpen"/>
         <CommandBinding Command="{x:Static src:MainWindow.DeleteCommand}" Executed="DoDelete"/>
         <CommandBinding Command="{x:Static src:MainWindow.RenameCommand}" Executed="DoRename"/>
+        <CommandBinding Command="{x:Static src:MainWindow.OpenFolderCommand}" Executed="DoOpenFolder" CanExecute="CanOpenFolder"/>
+        <CommandBinding Command="{x:Static src:MainWindow.OpenContainingFolderCommand}" Executed="DoOpenContainingFolder" CanExecute="CanOpenContainingFolder"/>
         <CommandBinding Command="{x:Static src:MainWindow.MakeLocalSymbolDirCommand}" Executed="DoMakeLocalSymbolDir"/>
         <CommandBinding Command="{x:Static src:MainWindow.CloseCommand}" Executed="DoClose"/>
         <CommandBinding Command="{x:Static src:MainWindow.CancelCommand}" Executed="DoCancel"/>
@@ -182,6 +188,8 @@
                                         <MenuItem Command="{x:Static src:MainWindow.CloseCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.DeleteCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.RenameCommand}"/>
+                                        <MenuItem Command="{x:Static src:MainWindow.OpenFolderCommand}"/>
+                                        <MenuItem Command="{x:Static src:MainWindow.OpenContainingFolderCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.MergeCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.MakeLocalSymbolDirCommand}"/>
                                         <MenuItem Command="{x:Static src:MainWindow.ZipCommand}"/>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using PerfViewExtensibility;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -1819,6 +1820,7 @@ namespace PerfView
             // refresh the directory. 
             RefreshCurrentDirectory();
         }
+
         private void DoRename(object sender, ExecutedRoutedEventArgs e)
         {
             var selectedFile = TreeView.SelectedItem as PerfViewFile;
@@ -1862,6 +1864,42 @@ namespace PerfView
             // refresh the directory. 
             RefreshCurrentDirectory();
         }
+
+        private void CanOpenFolder(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = TreeView.SelectedItem is PerfViewDirectory;
+        }
+
+        private void DoOpenFolder(object sender, ExecutedRoutedEventArgs e)
+        {
+            var directory = (PerfViewDirectory)TreeView.SelectedItem;
+
+            ShellExecute("explorer.exe", directory.FilePath);
+        }
+
+        private void CanOpenContainingFolder(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = TreeView.SelectedItem is PerfViewFile;
+        }
+
+        private void DoOpenContainingFolder(object sender, ExecutedRoutedEventArgs e)
+        {
+            var file =  (PerfViewFile)TreeView.SelectedItem;
+
+            ShellExecute("explorer.exe", $"/select,\"{file.FilePath}\"");
+        }
+
+        private void ShellExecute(string fileName, string arguments)
+        {
+            try
+            {
+                Process.Start(fileName, arguments);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
         private void DoMakeLocalSymbolDir(object sender, ExecutedRoutedEventArgs e)
         {
             var selectedFile = TreeView.SelectedItem as PerfViewFile;
@@ -2000,6 +2038,8 @@ namespace PerfView
         public static RoutedUICommand DeleteCommand = new RoutedUICommand("Delete", "Delete", typeof(MainWindow),
             new InputGestureCollection() { new KeyGesture(Key.Delete) });   // TODO is this shortcut a good idea?
         public static RoutedUICommand RenameCommand = new RoutedUICommand("Rename", "Rename", typeof(MainWindow));
+        public static RoutedUICommand OpenFolderCommand = new RoutedUICommand("Open _Folder", "OpenFolder", typeof(MainWindow));
+        public static RoutedUICommand OpenContainingFolderCommand = new RoutedUICommand("Open Containing _Folder", "OpenContainingFolder", typeof(MainWindow));
         public static RoutedUICommand MakeLocalSymbolDirCommand = new RoutedUICommand(
             "Make Local Symbol Dir", "MakeLocalSymbolDir", typeof(MainWindow));
         public static RoutedUICommand CloseCommand = new RoutedUICommand("Close", "Close", typeof(MainWindow));


### PR DESCRIPTION
This adds two new commands mimicing Visual Studio's behavior.

**Open Folder:** Opens a folder in Windows Explorer
![image](https://user-images.githubusercontent.com/1103906/141666680-e88bb532-6c59-472f-9464-bf7f6a6e515a.png)

**Open Containing Folder:** Opens a file, selecting it, in Windows Explorer
![image](https://user-images.githubusercontent.com/1103906/141666644-af7845f7-9925-49f3-8b02-b5e9dc66fc8c.png)

This also has a behavior change for Menu Items, which is to hide them when they are not enabled.