### PR TITLE
Fix /MinSecForTrigger for CLR counters of 64-bit processes

### DIFF
--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -47,6 +47,7 @@ internal class Program
             bool forceGC = false;
             bool processDump = false;
             string inputSpec = null;
+            int minSecForTrigger = -1;
             var dumper = new GCHeapDumper(Console.Out);
 
             for (int curArgIdx = 0; curArgIdx < args.Length; curArgIdx++)
@@ -120,7 +121,7 @@ internal class Program
                     {
                         string spec = arg.Substring(19);
                         bool done = false;
-                        using (var trigger = new PerformanceCounterTrigger(spec, decayToZeroHours, Console.Out, delegate (PerformanceCounterTrigger t) { done = true; }))
+                        using (var trigger = new PerformanceCounterTrigger(spec, decayToZeroHours, Console.Out, delegate (PerformanceCounterTrigger t) { done = true; }) { MinSecForTrigger = minSecForTrigger })
                         {
                             for (int i = 0; !done; i++)
                             {
@@ -134,6 +135,10 @@ internal class Program
                         }
                         Console.WriteLine("[PerfCounter Triggered: {0}]", spec);
                         return 0;
+                    }
+                    else if (arg.StartsWith("/MinSecForTrigger:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        minSecForTrigger = int.Parse(arg.Substring(18));
                     }
                     else if (arg.StartsWith("/PromotedBytesThreshold:", StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/PerfView/Triggers.cs
+++ b/src/PerfView/Triggers.cs
@@ -262,7 +262,7 @@ namespace Triggers
             {
                 m_log.WriteLine("To allow 64 bit processes to participate in the perf counters, we launch a 64 bit process to do the monitoring");
                 string heapDumpExe = Path.Combine(Utilities.SupportFiles.SupportFileDir, @"AMD64\HeapDump.exe");
-                string commandLine = heapDumpExe + " \"/StopOnPerfCounter:" + m_spec + "\"";
+                string commandLine = heapDumpExe + " /MinSecForTrigger:" + MinSecForTrigger + " \"/StopOnPerfCounter:" + m_spec + "\"";
                 m_log.WriteLine("Exec: {0}", commandLine);
                 var options = new Utilities.CommandOptions().AddNoThrow().AddTimeout(Utilities.CommandOptions.Infinite).AddOutputStream(m_log);
                 m_cmd = Utilities.Command.Run(commandLine, options);


### PR DESCRIPTION
CLR performance counters belonging to 64-bit processes are not visible from 32-bit processes, such as PerfView.exe.  As such, PerfView must shell out to a 64-bit process when creating triggers on performance counters belonging to these processes.  `/MinSecForTrigger` was not properly plumbed through this path, and so this change plumbs it through.

Thanks @maoni0 for reporting this.