### PR TITLE
Revert PerfView/TraceEvent 3.0 Changes from Main

### DIFF
--- a/PerfView.sln
+++ b/PerfView.sln
@@ -57,6 +57,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CtfTracing.Tests", "src\Tra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TraceEvent.Tests", "src\TraceEvent\TraceEvent.Tests\TraceEvent.Tests.csproj", "{19281902-FBC4-48C0-962B-9FDADAF5C783}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfView64", "src\PerfView64\PerfView64.csproj", "{F7419073-A62B-42E0-9B8C-4C2C4CE243A3}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfView.Tests", "src\PerfView.Tests\PerfView.Tests.csproj", "{A0248EF2-8C39-478A-951E-324DDF4FF3EC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfView.TestUtilities", "src\PerfView.TestUtilities\PerfView.TestUtilities.csproj", "{FE5CC86D-E87E-4560-8004-8852F3DE6794}"

--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -91,7 +91,7 @@ namespace FastSerialization
 #endif
     sealed class SerializationConfiguration
     {
-        public StreamLabelWidth StreamLabelWidth { get; set; } = StreamLabelWidth.EightBytes;
+        public StreamLabelWidth StreamLabelWidth { get; set; }
     }
 
     /// <summary>

--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -499,14 +499,14 @@ namespace FastSerialization
         /// <summary>
         /// Create a serializer writes 'entryObject' to a file.  
         /// </summary>
-        public Serializer(string filePath, IFastSerializable entryObject, SerializationConfiguration config = null) : this(new IOStreamStreamWriter(filePath, config), entryObject) { }
+        public Serializer(string filePath, IFastSerializable entryObject) : this(new IOStreamStreamWriter(filePath), entryObject) { }
 
         /// <summary>
         /// Create a serializer that writes <paramref name="entryObject"/> to a <see cref="Stream"/>. The serializer
         /// will close the stream when it closes.
         /// </summary>
-        public Serializer(Stream outputStream, IFastSerializable entryObject, SerializationConfiguration config = null)
-            : this(outputStream, entryObject, false, config)
+        public Serializer(Stream outputStream, IFastSerializable entryObject)
+            : this(outputStream, entryObject, false)
         {
         }
 
@@ -515,8 +515,8 @@ namespace FastSerialization
         /// <paramref name="leaveOpen"/> parameter determines whether the serializer will close the stream when it
         /// closes.
         /// </summary>
-        public Serializer(Stream outputStream, IFastSerializable entryObject, bool leaveOpen, SerializationConfiguration config = null)
-            : this(new IOStreamStreamWriter(outputStream, leaveOpen: leaveOpen, config: config), entryObject)
+        public Serializer(Stream outputStream, IFastSerializable entryObject, bool leaveOpen)
+            : this(new IOStreamStreamWriter(outputStream, leaveOpen: leaveOpen), entryObject)
         {
         }
 

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -17,11 +17,11 @@ using Address = System.UInt64;
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputFileName))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputStream, streamName))
     { }
 
     /// <summary>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net45</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <Prefer32Bit>True</Prefer32Bit>
     <StartupObject>PerfView.App</StartupObject>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>

--- a/src/PerfView/app.config
+++ b/src/PerfView/app.config
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
 <configuration>
-  <runtime>
-    <gcAllowVeryLargeObjects enabled="true" />
-  </runtime>
   <system.diagnostics>
     <!-- Set the value to false to avoid poping up dialogs when assert fails. -->
     <assert assertuienabled="true"/>

--- a/src/PerfView64/App.config
+++ b/src/PerfView64/App.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <gcAllowVeryLargeObjects enabled="true"/>
+  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+  </startup>
+</configuration>

--- a/src/PerfView64/App.cs
+++ b/src/PerfView64/App.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+
+namespace PerfView64
+{
+    /// <summary>
+    /// This application simply loads and calls the main PerfView executable, passing along the command line arguments
+    /// as they were received. It works as a 64-bit application by leveraging the ability of AnyCPU binaries to run as
+    /// either 32- or 64-bit applications, and while the main PerfView executable has the "prefer 32-bit" option set,
+    /// the 64-bit wrapper does not (and thus is launched by the OS as a 64-bit image where available).
+    /// </summary>
+    public class App
+    {
+        [STAThread]
+        [DebuggerNonUserCode]
+        public static int Main(string[] args)
+        {
+            try
+            {
+                return Run(args);
+            }
+            catch (FileNotFoundException ex) when (ex.Message.StartsWith("Could not load file or assembly 'PerfView"))
+            {
+                MessageBox.Show("Failed to run application. Is PerfView.exe present?", "PerfView.exe not found", MessageBoxButton.OK, MessageBoxImage.Error);
+                return 1;
+            }
+        }
+
+        private static int Run(string[] args) => PerfView.App.Main(args);
+    }
+}

--- a/src/PerfView64/PerfView64.csproj
+++ b/src/PerfView64/PerfView64.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <Prefer32Bit>False</Prefer32Bit>
+
+    <OutputPath>..\PerfView\bin\$(Configuration)\</OutputPath>
+
+    <Company>Microsoft</Company>
+    <Product>PerfView</Product>
+    <Description>A 64-bit launcher for PerfView.</Description>
+    <Copyright>Copyright © Microsoft 2010</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ApplicationIcon>..\PerfView\performance.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PerfView\PerfView.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+  <!--
+    Since we're copying this to the PerfView output directory, we don't want to copy anything already copied by the
+    PerfView build.
+  -->
+  <Target Name="RemoveTransitiveProjectReferences" AfterTargets="IncludeTransitiveProjectReferences">
+    <ItemGroup>
+      <ProjectReference Remove="@(_TransitiveProjectReferences)" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Resource Include="..\PerfView\performance.ico">
+      <Link>performance.ico</Link>
+    </Resource>
+  </ItemGroup>
+
+  <!-- ******************* Signing Support *********************** -->
+  <ItemGroup>
+    <FilesToSign Include="$(TargetPath)">
+        <Authenticode>Microsoft400</Authenticode>
+    </FilesToSign>
+    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+
+</Project>

--- a/src/PerfView64/Properties/AssemblyInfo.cs
+++ b/src/PerfView64/Properties/AssemblyInfo.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.InteropServices;
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+//In order to begin building localizable applications, set
+//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
+//inside a <PropertyGroup>.  For example, if you are using US english
+//in your source files, set the <UICulture> to en-US.  Then uncomment
+//the NeutralResourceLanguage attribute below.  Update the "en-US" in
+//the line below to match the UICulture setting in the project file.
+
+//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+
+//[assembly: ThemeInfo(
+//    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+//                                     //(used if a resource is not found in the page,
+//                                     // or application resource dictionaries)
+//    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+//                                              //(used if a resource is not found in the page,
+//                                              // app, or any theme specific resource dictionaries)
+//)]

--- a/src/PerfView64/app.manifest
+++ b/src/PerfView64/app.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher, IFastSerializable, IFastSerializableVersion
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, 0x20000, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), fileName)
+        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, 0x20000), fileName)
         {
         }
 
-        public EventPipeEventSource(Stream stream) : this(new PinnedStreamReader(stream, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "stream")
+        public EventPipeEventSource(Stream stream) : this(new PinnedStreamReader(stream), "stream")
         {
         }
 

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3404,7 +3404,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             // If this Assert files, fix the declaration of headerSize to match
             Debug.Assert(sizeof(TraceEventNativeMethods.EVENT_HEADER) == 0x50 && sizeof(TraceEventNativeMethods.ETW_BUFFER_CONTEXT) == 4);
 
-            // As of TraceLog version 74, all StreamLabels are 64-bit.  See IFastSerializableVersion for details.
             Deserializer deserializer = new Deserializer(new PinnedStreamReader(etlxFilePath, 0x10000), etlxFilePath);
             deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
 
@@ -3849,7 +3848,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         int IFastSerializableVersion.Version
         {
-            get { return 74; }
+            get { return 73; }
         }
         int IFastSerializableVersion.MinimumVersionCanRead
         {

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1845,7 +1845,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 }
             };
 
-            const int defaultMaxEventCount = -1;
+            const int defaultMaxEventCount = 20000000;                   // 20M events produces about 3GB of data.  which is close to the limit of ETLX.
             int maxEventCount = defaultMaxEventCount;
             double startMSec = 0;
             if (options != null)
@@ -1865,10 +1865,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     options.ConversionLog.WriteLine("MaxEventCount {0} < 1000, assumed in error, ignoring", options.MaxEventCount);
                 }
             }
-            if (maxEventCount != -1)
-            {
-                options.ConversionLog.WriteLine("Collecting a maximum of {0:n0} events.", maxEventCount);
-            }
+            options.ConversionLog.WriteLine("Collecting a maximum of {0:n0} events.", maxEventCount);
 
             uint rawEventCount = 0;
             double rawInputSizeMB = rawEvents.Size / 1000000.0;
@@ -1917,7 +1914,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                             {
                                 message = "  Before StartMSec truncating";
                             }
-                            else if (maxEventCount != -1 && eventCount >= maxEventCount)
+                            else if (eventCount >= maxEventCount)
                             {
                                 message = "  Hit MaxEventCount, truncating.";
                             }
@@ -1959,7 +1956,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 }
                 else
                 {
-                    if (maxEventCount != -1 && maxEventCount <= eventCount)
+                    if (maxEventCount <= eventCount)
                     {
                         processingDisabled = true;
                     }
@@ -2110,7 +2107,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 eventsLost = rawEvents.EventsLost;
             }
 
-            if (maxEventCount != -1 && eventCount >= maxEventCount)
+            if (eventCount >= maxEventCount)
             {
                 if (options != null && options.ConversionLog != null)
                 {
@@ -2119,8 +2116,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         options.OnLostEvents(true, EventsLost, eventCount);
                     }
 
-                    options.ConversionLog.WriteLine("Truncated events to {0:n} events.  Change the value of /MaxEventCount or remove it entirely.", maxEventCount);
-                    options.ConversionLog.WriteLine("If you must use /MaxEventCount, consider using /SkipMSec:X to skip the beginning events and see the next window of /MaxEventCount the file.");
+                    options.ConversionLog.WriteLine("Truncated events to {0:n} events.  Use /MaxEventCount to change.", maxEventCount);
+                    options.ConversionLog.WriteLine("However  is a hard limit of 4GB of of processed (ETLX) data, increasing it over 15M will probably hit that.");
+                    options.ConversionLog.WriteLine("Instead you can use /SkipMSec:X to skip the beginning events and thus see the next window of /MaxEventCount the file.");
                 }
             }
 


### PR DESCRIPTION
I am starting to work on a PerfView/TraceEvent 3.0, and inadvertently checked these into main.  I am reverting them here, and will keep them in the feature/perfview-3.0 branch.