### PR TITLE
Fix download link for perfview.exe

### DIFF
--- a/documentation/Downloading.md
+++ b/documentation/Downloading.md
@@ -16,7 +16,7 @@ care about specific bug fixes or features go there.
 In the common case, you only need one file, PerfView.exe, to use the tool.  The most recent copy of
 this file can be downloaded here:
 
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/microsoft/perfview)](https://github.com/microsoft/perfview/releases/download/latest/PerfView.exe)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/microsoft/perfview)](https://github.com/microsoft/perfview/releases)
 
 Once you click the above link in your browser it will start downloading, the details of which vary from browser to browser.
 In some cases it will prompt for more information (IE) and in others (Chrome) it may not be obvious that

--- a/documentation/Downloading.md
+++ b/documentation/Downloading.md
@@ -16,7 +16,7 @@ care about specific bug fixes or features go there.
 In the common case, you only need one file, PerfView.exe, to use the tool.  The most recent copy of
 this file can be downloaded here:
 
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/microsoft/perfview)](https://github.com/microsoft/perfview/releases/latest)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/microsoft/perfview)](https://github.com/microsoft/perfview/releases/download/latest/PerfView.exe)
 
 Once you click the above link in your browser it will start downloading, the details of which vary from browser to browser.
 In some cases it will prompt for more information (IE) and in others (Chrome) it may not be obvious that


### PR DESCRIPTION
The old link confusingly only lists the TraceEvent release, which is tagged as latest. The updated link shows the list of releases, so you can easily find the perfview release underneath TraceEvent.
fixes #1543 