### PR TITLE
Remove Default Event Limit

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1845,7 +1845,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 }
             };
 
-            const int defaultMaxEventCount = 20000000;                   // 20M events produces about 3GB of data.  which is close to the limit of ETLX.
+            const int defaultMaxEventCount = -1;
             int maxEventCount = defaultMaxEventCount;
             double startMSec = 0;
             if (options != null)
@@ -1865,7 +1865,10 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     options.ConversionLog.WriteLine("MaxEventCount {0} < 1000, assumed in error, ignoring", options.MaxEventCount);
                 }
             }
-            options.ConversionLog.WriteLine("Collecting a maximum of {0:n0} events.", maxEventCount);
+            if (maxEventCount != -1)
+            {
+                options.ConversionLog.WriteLine("Collecting a maximum of {0:n0} events.", maxEventCount);
+            }
 
             uint rawEventCount = 0;
             double rawInputSizeMB = rawEvents.Size / 1000000.0;
@@ -1914,7 +1917,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                             {
                                 message = "  Before StartMSec truncating";
                             }
-                            else if (eventCount >= maxEventCount)
+                            else if (maxEventCount != -1 && eventCount >= maxEventCount)
                             {
                                 message = "  Hit MaxEventCount, truncating.";
                             }
@@ -1956,7 +1959,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 }
                 else
                 {
-                    if (maxEventCount <= eventCount)
+                    if (maxEventCount != -1 && maxEventCount <= eventCount)
                     {
                         processingDisabled = true;
                     }
@@ -2107,7 +2110,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 eventsLost = rawEvents.EventsLost;
             }
 
-            if (eventCount >= maxEventCount)
+            if (maxEventCount != -1 && eventCount >= maxEventCount)
             {
                 if (options != null && options.ConversionLog != null)
                 {
@@ -2116,9 +2119,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         options.OnLostEvents(true, EventsLost, eventCount);
                     }
 
-                    options.ConversionLog.WriteLine("Truncated events to {0:n} events.  Use /MaxEventCount to change.", maxEventCount);
-                    options.ConversionLog.WriteLine("However  is a hard limit of 4GB of of processed (ETLX) data, increasing it over 15M will probably hit that.");
-                    options.ConversionLog.WriteLine("Instead you can use /SkipMSec:X to skip the beginning events and thus see the next window of /MaxEventCount the file.");
+                    options.ConversionLog.WriteLine("Truncated events to {0:n} events.  Change the value of /MaxEventCount or remove it entirely.", maxEventCount);
+                    options.ConversionLog.WriteLine("If you must use /MaxEventCount, consider using /SkipMSec:X to skip the beginning events and see the next window of /MaxEventCount the file.");
                 }
             }
 


### PR DESCRIPTION
Remove the 20M event limit now that ETLX files can support file sizes larger than 4GB.