### PR TITLE
Fix JSON escaping

### DIFF
--- a/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
@@ -55,8 +55,10 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
             IReadOnlyDictionary<ThreadInfo, IReadOnlyList<ProfileEvent>> sortedProfileEventsPerThread,
             TextWriter writer, string name)
         {
+            Dictionary<string, string> escapedNames = new Dictionary<string, string>();
+
             writer.Write("{");
-            writer.Write($"\"otherData\": {{ \"name\": \"{name}\", \"exporter\": \"{GetExporterInfo()}\" }}, ");
+            writer.Write($"\"otherData\": {{ \"name\": \"{GetEscaped(name, escapedNames)}\", \"exporter\": \"{GetExporterInfo()}\" }}, ");
             writer.Write("\"traceEvents\": [");
             bool isFirst = true;
             foreach (var perThread in sortedProfileEventsPerThread.OrderBy(pair => pair.Value.First().RelativeTime))
@@ -69,7 +71,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
                         isFirst = false;
 
                     writer.Write("{");
-                    writer.Write($"\"name\": \"{frameIdToFrameTuple[profileEvent.FrameId].Name}\", ");
+                    writer.Write($"\"name\": \"{GetEscaped(frameIdToFrameTuple[profileEvent.FrameId].Name, escapedNames)}\", ");
                     writer.Write($"\"cat\": \"sampleEvent\", ");
                     writer.Write($"\"ph\": \"{(profileEvent.Type == ProfileEventType.Open ? "B" : "E")}\", ");
                     writer.Write($"\"ts\": {profileEvent.RelativeTime.ToString("R", CultureInfo.InvariantCulture)}, ");
@@ -93,7 +95,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
                 var frameId = frame.Key;
                 var frameInfo = frame.Value;
                 writer.Write($"\"{frameId}\": {{");
-                writer.Write($"\"name\": \"{frameInfo.Name}\", ");
+                writer.Write($"\"name\": \"{GetEscaped(frameInfo.Name, escapedNames)}\", ");
                 writer.Write($"\"category\": \"{frameInfo.Category}\"");
                 if (frameInfo.ParentId != -1)
                     writer.Write($", \"parent\": {frameInfo.ParentId}");

--- a/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs
@@ -52,16 +52,18 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
         private static void WriteToFile(IReadOnlyDictionary<string, IReadOnlyList<ProfileEvent>> sortedProfileEventsPerThread,
             IReadOnlyList<string> orderedFrameNames, TextWriter writer, string name)
         {
+            Dictionary<string, string> escapedNames = new Dictionary<string, string>();
+
             writer.Write("{");
             writer.Write($"\"exporter\": \"{GetExporterInfo()}\", ");
-            writer.Write($"\"name\": \"{name}\", ");
+            writer.Write($"\"name\": \"{GetEscaped(name, escapedNames)}\", ");
             writer.Write("\"activeProfileIndex\": 0, ");
             writer.Write("\"$schema\": \"https://www.speedscope.app/file-format-schema.json\", ");
 
             writer.Write("\"shared\": { \"frames\": [ ");
             for (int i = 0; i < orderedFrameNames.Count; i++)
             {
-                writer.Write($"{{ \"name\": \"{orderedFrameNames[i].Replace("\\", "\\\\").Replace("\"", "\\\"")}\" }}");
+                writer.Write($"{{ \"name\": \"{GetEscaped(orderedFrameNames[i], escapedNames)}\" }}");
 
                 if (i != orderedFrameNames.Count - 1)
                     writer.Write(", ");
@@ -82,7 +84,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
 
                 writer.Write("{ ");
                 writer.Write("\"type\": \"evented\", ");
-                writer.Write($"\"name\": \"{perThread.Key}\", ");
+                writer.Write($"\"name\": \"{GetEscaped(perThread.Key, escapedNames)}\", ");
                 writer.Write("\"unit\": \"milliseconds\", ");
                 writer.Write($"\"startValue\": {sortedProfileEvents.First().RelativeTime.ToString("R", CultureInfo.InvariantCulture)}, ");
                 writer.Write($"\"endValue\": {sortedProfileEvents.Last().RelativeTime.ToString("R", CultureInfo.InvariantCulture)}, ");

--- a/src/TraceEvent/TraceEvent.Tests/SpeedScopeExporterTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/SpeedScopeExporterTests.cs
@@ -402,6 +402,21 @@ namespace TraceEventTests
             }
         }
 
+        [Theory]
+        [InlineData("simple", "simple")]
+        [InlineData(@"Process64 Test (1) Args:  -r:C:\Test\", @"Process64 Test (1) Args:  -r:C:\\Test\\")]
+        [InlineData("CPU Wait > 10ms", "CPU Wait \\u003e 10ms")]
+        [InlineData("methodName(value class argument&,float32)", "methodName(value class argument\\u0026,float32)")]
+        [InlineData("IEqualityComparer`1<!0>", "IEqualityComparer`1\\u003c!0\\u003e")]
+        public void NamesGetEscaped(string name, string expected)
+        {
+            Dictionary<string, string> escapedNames = new Dictionary<string, string>();
+
+            Assert.Equal(expected, GetEscaped(name, escapedNames));
+            Assert.True(escapedNames.ContainsKey(name));
+            Assert.Equal(expected, escapedNames[name]);
+        }
+
         #region private
         internal class FakeStackSourceSample
         {

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -61,6 +61,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Today I've tried to convert a trace provided by the customer in https://github.com/dotnet/runtime/issues/63621#issuecomment-1010030287 to Chromium trace file format. I was able to save the file, but unable to load it in Chromium Developer Tools (F12).

It turned out that the Chromium/Speedscope exporters were not escaping some of the strings correctly.