### PR TITLE
Upgrading to .NET framework 4.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ PerfView is developed in Visual Studio 2019 using features through C# 6.
 
 You will want to deploy the 'Release' rather than the 'Debug' version of PerfView.  Thus, first set your build configuration
 to 'Release' (Text window in the top toolbar, or right click on the .SLN file -> Configuration Manager -> Active Solution Configuration).
-Next build (Build -> Build Solution (Ctrl-Shift-B)).   The result will be that in the src\perfView\bin\net45\Release directory there will be
+Next build (Build -> Build Solution (Ctrl-Shift-B)).   The result will be that in the src\perfView\bin\net462\Release directory there will be
 among other things a PerfView.exe.   This one file is all you need to deploy.   Simply copy it to where you wish to deploy the app.  
 
 ### Information for build troubleshooting.  

--- a/src/CSVReader/CSVReader.csproj
+++ b/src/CSVReader/CSVReader.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
 
     <Description>CSVReader</Description>
     <Company>Microsoft</Company>

--- a/src/EtwClrProfilerSigning/EtwClrProfilerSigning.csproj
+++ b/src/EtwClrProfilerSigning/EtwClrProfilerSigning.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/EtwHeapDump/EtwHeapDump.csproj
+++ b/src/EtwHeapDump/EtwHeapDump.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.EtwHeapDump</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.EtwHeapDump</AssemblyName>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard1.3</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.FastSerialization</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.FastSerialization</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/HeapDumpDLL/HeapDumpDLL.csproj
+++ b/src/HeapDumpDLL/HeapDumpDLL.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.HeapDump</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.HeapDump</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
+++ b/src/LinuxEvent.Tests/LinuxTracing.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Description>Unit tests.</Description>
     <Copyright>Copyright © Microsoft 2016</Copyright>

--- a/src/MemoryGraph/MemoryGraph.csproj
+++ b/src/MemoryGraph/MemoryGraph.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.MemoryGraph</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.MemoryGraph</AssemblyName>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
+++ b/src/PerfView.TestUtilities/PerfView.TestUtilities.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <Description>Unit test utility library.</Description>
     <Copyright>Copyright © Microsoft 2017</Copyright>
 

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <RootNamespace>PerfViewTests</RootNamespace>
     <AssemblyName>PerfViewTests</AssemblyName>
     <Description>Unit tests for PerfView.</Description>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Prefer32Bit>True</Prefer32Bit>
@@ -241,14 +241,14 @@
       <Link>amd64\vcruntime140_1.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net45\HeapDump.exe">
+    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net462\HeapDump.exe">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\amd64\HeapDump.exe</LogicalName>
       <Link>amd64\HeapDump.exe</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net45\HeapDump.exe.config">
+    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net462\HeapDump.exe.config">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\amd64\HeapDump.exe.config</LogicalName>
@@ -263,14 +263,14 @@
       <Visible>False</Visible>
     </EmbeddedResource>
     <!-- For Forcing GC and per-object allocation stats -->
-    <EmbeddedResource Include="..\EtwClrProfilerSigning\bin\$(Configuration)\net45\x86\EtwClrProfiler.dll">
+    <EmbeddedResource Include="..\EtwClrProfilerSigning\bin\$(Configuration)\net462\x86\EtwClrProfiler.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\x86\EtwClrProfiler.dll</LogicalName>
       <Link>x86\EtwClrProfiler.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\EtwClrProfilerSigning\bin\$(Configuration)\net45\amd64\EtwClrProfiler.dll">
+    <EmbeddedResource Include="..\EtwClrProfilerSigning\bin\$(Configuration)\net462\amd64\EtwClrProfiler.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\amd64\EtwClrProfiler.dll</LogicalName>

--- a/src/PerfView64/PerfView64.csproj
+++ b/src/PerfView64/PerfView64.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <Prefer32Bit>False</Prefer32Bit>
 
     <OutputPath>..\PerfView\bin\$(Configuration)\</OutputPath>

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -76,14 +76,14 @@
 <!-- TODO: These are needed for Heap dump and fine grained .NET allocation and call profiling but 
      I have pruned these out for now so we can at least get ETW working.   Bring them back eventually.
 
-    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net45\HeapDump.exe">
+    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net462\HeapDump.exe">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\amd64\HeapDump.exe</LogicalName>
       <Link>amd64\HeapDump.exe</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net45\HeapDump.exe.config">
+    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net462\HeapDump.exe.config">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\amd64\HeapDump.exe.config</LogicalName>

--- a/src/PerfViewExtensions/GlobalSrc/Global.csproj
+++ b/src/PerfViewExtensions/GlobalSrc/Global.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TraceEvent/BPerf/BPerfEventSource.cs
+++ b/src/TraceEvent/BPerf/BPerfEventSource.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 long length = fs.Length;
 
-#if NET45
+#if NET462
                 using (var mmapedFile = MemoryMappedFile.CreateFromFile(fs, null, length, MemoryMappedFileAccess.Read, null, HandleInheritability.None, true))
 #else
                 using (var mmapedFile = MemoryMappedFile.CreateFromFile(fs, null, length, MemoryMappedFileAccess.Read, HandleInheritability.None, true))

--- a/src/TraceEvent/Compatibility.cs
+++ b/src/TraceEvent/Compatibility.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Tracing.Compatibility
 #endif
         }
 
-#if NET45
+#if NET462
         public static StringDictionary GetEnvironment(this ProcessStartInfo startInfo) => startInfo.EnvironmentVariables;
 #else
         public static IDictionary<string, string> GetEnvironment(this ProcessStartInfo startInfo) => startInfo.Environment;

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/CtfTracing.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <RootNamespace>Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
     <Description>Unit tests.</Description>

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -100,18 +100,18 @@
     <!-- NET 4.5 Framework -->
 
     <!-- Built libraries -->
-    <file src="$OutDir$net45\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\net45" />
-    <file src="$OutDir$net45\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\net45" />
-    <file src="$OutDir$net45\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\net45" />
+    <file src="$OutDir$net462\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\net462" />
+    <file src="$OutDir$net462\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\net462" />
+    <file src="$OutDir$net462\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\net462" />
 
-    <file src="$OutDir$net45\Microsoft.Diagnostics.FastSerialization.dll" target="lib\net45" />
-    <file src="$OutDir$net45\Microsoft.Diagnostics.FastSerialization.xml" target="lib\net45" />
-    <file src="$OutDir$net45\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\net45" />
+    <file src="$OutDir$net462\Microsoft.Diagnostics.FastSerialization.dll" target="lib\net462" />
+    <file src="$OutDir$net462\Microsoft.Diagnostics.FastSerialization.xml" target="lib\net462" />
+    <file src="$OutDir$net462\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\net462" />
 
     <!-- Support Dlls -->
-    <file src="$OutDir$net45\Dia2Lib.dll" target="lib\net45" />
-    <file src="$OutDir$net45\TraceReloggerLib.dll" target="lib\net45" />
-    <file src="$OutDir$net45\OSExtensions.dll" target="lib\net45" />
+    <file src="$OutDir$net462\Dia2Lib.dll" target="lib\net462" />
+    <file src="$OutDir$net462\TraceReloggerLib.dll" target="lib\net462" />
+    <file src="$OutDir$net462\OSExtensions.dll" target="lib\net462" />
 
     <!-- Source code (All Frameworks *) -->
     <file exclude="obj\**\*.cs;bin\**\*.cs;TraceEvent.Tests\**\*.cs;Ctf\CtfTracing.Tests\**\*.cs" src="**\*.cs" target="src" />

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -99,7 +99,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\net45\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\net45\OSExtensions.dll">
+    <None Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\net462\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\net462\OSExtensions.dll">
       <Link>OSExtensions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/src/TraceEvent/Samples/TraceEventSamples.csproj
+++ b/src/TraceEvent/Samples/TraceEventSamples.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
 
     <Company>Microsoft</Company>
     <Product>TraceEvent Samples</Product>

--- a/src/TraceEvent/Samples/packages.config
+++ b/src/TraceEvent/Samples/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.1.30214.0" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net45" />
-  <package id="Rx-Main" version="2.1.30214.0" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.1.30214.0" targetFramework="net45" />
-  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />
-  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net45" requireReinstallation="true" />
+  <package id="Rx-Core" version="2.1.30214.0" targetFramework="net462" />
+  <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net462" />
+  <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net462" />
+  <package id="Rx-Main" version="2.1.30214.0" targetFramework="net462" />
+  <package id="Rx-PlatformServices" version="2.1.30214.0" targetFramework="net462" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net462" requireReinstallation="true" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net462" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net462" requireReinstallation="true" />
 </packages>

--- a/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
+++ b/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                     .GetType("System.Web.HttpUtility, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
                     .GetMethod("JavaScriptStringEncode", new Type[1] { typeof(string) })
                     .Invoke(null, new object[] { name });
-#elif NETSTANDARD2_0 || NET45
+#elif NETSTANDARD2_0 || NET462
                 escaped = escapedNames[name] = System.Web.HttpUtility.JavaScriptStringEncode(name);
 #endif
             }

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <RootNamespace>TraceEventTests</RootNamespace>
     <AssemblyName>TraceEventTests</AssemblyName>
     <Description>Unit tests for TraceEvent.</Description>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk"> 
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard1.6;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -40,8 +40,8 @@
   </PropertyGroup>
 
   <!--
-    Unconditional use of PackageReference would work if we targeted net46, but the reference APIs do not include
-    support for net45 targets. Work around the issue by using conditional references.
+    Unconditional use of PackageReference would work if we targeted net462, but the reference APIs do not include
+    support for net462 targets. Work around the issue by using conditional references.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
@@ -58,7 +58,7 @@
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
@@ -196,7 +196,7 @@
     <!-- *********************************************************** -->
     <!-- Copying three managed binaries explicitly should not be needed because the 
          dependency logic should just do it for us, but for some reason ths only
-         works for the net45 target framework and not the netstandard1.6.  and netstanard2.0 
+         works for the net462 target framework and not the netstandard1.6.  and netstanard2.0 
          We work around it here by copying the files explicitly. 
 	 We don't have version for 2.0 so we use the 1.6 versions.  -->
 

--- a/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
+++ b/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
    
   <ItemGroup>

--- a/src/TraceParserGen/TraceParserGen.csproj
+++ b/src/TraceParserGen/TraceParserGen.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>TraceParserGen</AssemblyName>
   </PropertyGroup>

--- a/src/Utilities/Utilities.csproj
+++ b/src/Utilities/Utilities.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.Utilities</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.Utilities</AssemblyName>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
As [this](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/) blog post indicates, .NET 4.5 has gone unsupported for a while, and even .NET 4.6.1 will reach the end of support by this April. 

This change retargets PerfView to run on top of .NET 4.6.2 instead. This will also make it possible to build with Visual Studio 2022. (Without this change, it is impossible to build with Visual Studio 2022, and there is no way you can install .NET 4.5 support for it)