### PR TITLE
Add support for TRACEEVENT_ANALYZER_PATH envVar probe path

### DIFF
--- a/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
@@ -18,9 +18,17 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
                 {
                     // Assume plugins sit in a plugins directory next to the current assembly.
 #if AUTOANALYSIS_EXTENSIBILITY
-                    s_analyzersDirectory = Path.Combine(
-                        Path.GetDirectoryName(typeof(AnalyzerResolver).Assembly.Location),
-                        AnalyzersDirectoryName);
+                    string probePath = Environment.GetEnvironmentVariable("TRACEEVENT_ANALYZER_PATH");
+                    if (!string.IsNullOrEmpty(probePath))
+                    {
+                        s_analyzersDirectory = probePath;
+                    }
+                    else
+                    {
+                        s_analyzersDirectory = Path.Combine(
+                            Path.GetDirectoryName(typeof(AnalyzerResolver).Assembly.Location),
+                            AnalyzersDirectoryName);
+                    }
 #endif
                 }
                 return s_analyzersDirectory;


### PR DESCRIPTION
Current behavior was probing relative to the TraceEvent.dll. This change allows us to configure the path via Environment Variable `TRACEEVENT_ANALYZER_PATH` instead. 

Other considerations include:
* Supporting multiple probe paths
* MEF or Dependency Injection
* Custom resolvers