### PR TITLE
Add configurable alignment to FastSerializer

### DIFF
--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -84,6 +84,20 @@ namespace FastSerialization
     };
 
     /// <summary>
+    /// Allows users of serialization and de-serialization mechanism to specify the alignment required by the
+    /// reader.
+    /// </summary>
+#if FASTSERIALIZATION_PUBLIC
+    public
+#endif
+    enum StreamReaderAlignment
+    {
+        OneByte     = 1,
+        FourBytes   = 4,
+        EightBytes  = 8
+    };
+
+    /// <summary>
     /// These settings apply to use of Serializer and Deserializer specifically.
     /// </summary>
 #if FASTSERIALIZATION_PUBLIC
@@ -92,6 +106,7 @@ namespace FastSerialization
     sealed class SerializationConfiguration
     {
         public StreamLabelWidth StreamLabelWidth { get; set; }
+        public StreamReaderAlignment StreamReaderAlignment { get; set; } = StreamReaderAlignment.EightBytes;
     }
 
     /// <summary>

--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -90,7 +90,7 @@ namespace FastSerialization
 #if FASTSERIALIZATION_PUBLIC
     public
 #endif
-    enum StreamReaderAlignment
+    enum StreamReaderAlignment : int
     {
         OneByte     = 1,
         FourBytes   = 4,
@@ -106,7 +106,6 @@ namespace FastSerialization
     sealed class SerializationConfiguration
     {
         public StreamLabelWidth StreamLabelWidth { get; set; }
-        public StreamReaderAlignment StreamReaderAlignment { get; set; } = StreamReaderAlignment.EightBytes;
     }
 
     /// <summary>

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -718,8 +718,12 @@ namespace FastSerialization
                     while (amountToThrowOut > 0)
                     {
                         int read = inputStream.Read(bytes, 0, (int)Math.Min(amountToThrowOut, (long)bytes.Length));
-                        amountToThrowOut -= read;
                         inputStreamBytesRead += read;
+                        if (read == 0)
+                        {
+                            throw new Exception("Read past end of stream.");
+                        }
+                        amountToThrowOut -= read;
                     }
                 }
 

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -646,10 +646,10 @@ namespace FastSerialization
         /// Create a new IOStreamStreamReader from the given System.IO.Stream.   Optionally you can specify the size of the read buffer
         /// The stream will be closed by the IOStreamStreamReader when it is closed.  
         /// </summary>
-        public IOStreamStreamReader(Stream inputStream, int bufferSize = defaultBufferSize, bool leaveOpen = false, SerializationConfiguration config = null)
-            : base(new byte[bufferSize + (((int?)config?.StreamReaderAlignment) ?? 8)], 0, 0, config)
+        public IOStreamStreamReader(Stream inputStream, int bufferSize = defaultBufferSize, bool leaveOpen = false, SerializationConfiguration config = null, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
+            : base(new byte[bufferSize + (int)alignment], 0, 0, config)
         {
-            align = (int?)config?.StreamReaderAlignment ?? 8;
+            align = (int)alignment;
             Debug.Assert(bufferSize % align == 0);
             this.inputStream = inputStream;
             this.leaveOpen = leaveOpen;
@@ -783,7 +783,6 @@ namespace FastSerialization
             base.Dispose(disposing);
         }
 
-        internal /*protected*/  readonly int align = 8;        // Needs to be a power of 2
         internal /*protected*/  const int defaultBufferSize = 0x4000;  // 16K 
 
         /// <summary>
@@ -877,6 +876,8 @@ namespace FastSerialization
                 throw new Exception("Read past end of stream.");
             }
         }
+
+        internal /*protected*/  readonly int align = 8;        // Needs to be a power of 2
         internal /*protected*/  Stream inputStream;
         internal /* protected*/ long inputStreamBytesRead; // only required for non-seekable streams
         private bool leaveOpen;
@@ -907,8 +908,8 @@ namespace FastSerialization
         /// Create a new PinnedStreamReader that gets its data from a given System.IO.Stream.  You can optionally set the size of the read buffer.  
         /// The stream will be closed by the PinnedStreamReader when it is closed.  
         /// </summary>
-        public PinnedStreamReader(Stream inputStream, int bufferSize = defaultBufferSize, SerializationConfiguration config = null)
-            : base(inputStream, bufferSize, config: config)
+        public PinnedStreamReader(Stream inputStream, int bufferSize = defaultBufferSize, SerializationConfiguration config = null, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
+            : base(inputStream, bufferSize, config: config, alignment: alignment)
         {
             // Pin the array
             pinningHandle = System.Runtime.InteropServices.GCHandle.Alloc(bytes, System.Runtime.InteropServices.GCHandleType.Pinned);

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tracing
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, config: new SerializationConfiguration { StreamReaderAlignment = StreamReaderAlignment.OneByte }), "stream")
+            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte), "stream")
         {
         }
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Diagnostics.Tracing
         {
         }
 
-        public EventPipeEventSource(Stream stream) : this(new PinnedStreamReader(stream), "stream")
+        public EventPipeEventSource(Stream stream)
+            : this(new PinnedStreamReader(stream, config: new SerializationConfiguration { StreamReaderAlignment = StreamReaderAlignment.OneByte }), "stream")
         {
         }
 

--- a/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿using FastSerialization;
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.EventPipe;
 using Microsoft.Diagnostics.Tracing.Parsers;
@@ -251,6 +252,21 @@ namespace TraceEventTests
                 {
                     Assert.NotEqual(0, counts[i]);
                 }
+            }
+        }
+
+        [Fact]
+        public void GotoWorksForPositionsGreaterThanAlignment()
+        {
+            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), config: new SerializationConfiguration { StreamReaderAlignment = StreamReaderAlignment.EightBytes }))
+            {
+                reader.Goto((StreamLabel)0x148);
+                var buf = new byte[100_000];
+                // Specifically doing a read larger than the default buffer size (16KB) to avoid caching path.
+                reader.Read(buf, 0, buf.Length);
+                // 0x14 is the 148th byte of the MockHugeStream (it is deterministic).
+                // If MockHugeStream changes, then this should be changed as well.
+                Assert.Equal(0x14, buf[0]);
             }
         }
 
@@ -897,6 +913,7 @@ namespace TraceEventTests
         const int payloadSize = 60000;
 
         MemoryStream _currentChunk = new MemoryStream();
+        FileStream _loggingStream = new FileStream($"testdata_{DateTime.Now:yyyyMMddhhmmss}.nettrace", FileMode.OpenOrCreate);
         long _minSize;
         long _bytesWritten;
         int _sequenceNumber = 1;
@@ -977,6 +994,7 @@ namespace TraceEventTests
                 _bytesWritten += _currentChunk.Length;
                 ret = _currentChunk.Read(buffer, offset, count);
             }
+            _loggingStream.Write(buffer, offset, ret);
             return ret;
         }
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
@@ -258,7 +258,7 @@ namespace TraceEventTests
         [Fact]
         public void GotoWorksForPositionsGreaterThanAlignment()
         {
-            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), config: new SerializationConfiguration { StreamReaderAlignment = StreamReaderAlignment.EightBytes }))
+            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), bufferSize: 0x4000 /* 16KB */, config: new SerializationConfiguration { StreamReaderAlignment = StreamReaderAlignment.EightBytes }))
             {
                 reader.Goto((StreamLabel)0x148);
                 var buf = new byte[100_000];
@@ -913,7 +913,6 @@ namespace TraceEventTests
         const int payloadSize = 60000;
 
         MemoryStream _currentChunk = new MemoryStream();
-        FileStream _loggingStream = new FileStream($"testdata_{DateTime.Now:yyyyMMddhhmmss}.nettrace", FileMode.OpenOrCreate);
         long _minSize;
         long _bytesWritten;
         int _sequenceNumber = 1;
@@ -994,7 +993,6 @@ namespace TraceEventTests
                 _bytesWritten += _currentChunk.Length;
                 ret = _currentChunk.Read(buffer, offset, count);
             }
-            _loggingStream.Write(buffer, offset, ret);
             return ret;
         }
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EventPipeParsing.cs
@@ -258,7 +258,7 @@ namespace TraceEventTests
         [Fact]
         public void GotoWorksForPositionsGreaterThanAlignment()
         {
-            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), bufferSize: 0x4000 /* 16KB */, config: new SerializationConfiguration { StreamReaderAlignment = StreamReaderAlignment.EightBytes }))
+            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), bufferSize: 0x4000 /* 16KB */, alignment: StreamReaderAlignment.EightBytes))
             {
                 reader.Goto((StreamLabel)0x148);
                 var buf = new byte[100_000];


### PR DESCRIPTION
IOStreamStreamReader had a hard coded 8 byte alignment. EventPipe streams do not have any alignment requirements (save for some 4 byte alignments inside blocks). This means that blocks can have sizes that are not aligned. EventPipeEventSource will not dispatch events read from the stream until reads complete. In live cases where these blocks are unaligned, but no new data is coming down the pipe, the reader can attempt to enforce the alignment and end up blocking until new data arrives. This results in latency for event dispatch. For infrequent events, this can be a long period of time causing users to think they haven't received events.

For example:

EventBlock 1, EventBlock 2, and EventBlock 3 all arrive with aligned lengths. EventBlock 4 arrives with an unaligned length. Until more data arrives on the stream, none of the events in EventBlock 4 will be dispatched to the user. 

This change adds a configuration switch for changing the alignment of the reader. The default is the old behavior (8 byte alignment) and the live reading for EventPipe was changed to 1 byte alignment.

Changing to an alignment of 1 uncovered a bug where calling `Goto(StreamLabel)` with a label greater than the alignment length would cause the subsequent read to return bytes from the wrong position in the stream. Up until now, this wasn't an issue for EventPipe because all `Goto` calls were for jumps < 4 due to the internal alignment, which is always less than 8.

This patch also fixes that bug.

TODO: tag all the issues this will close. I believe there are issues in dotnet/runtime, dotnet/diagnostics, dotnet/dotnet-monitor, and microsoft/perfview that are tracking this issue.

CC @tommcdon @jander-msft @wiktork 