### PR TITLE
Warn User That Linux Process Dumps Aren't Supported

### DIFF
--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Diagnostics.Runtime;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -41,6 +42,7 @@ internal class Program
     private static int MainWorker(string[] args)
     {
         string outputFile = null;
+        int exceptionExitCode = 1;
         try
         {
             float decayToZeroHours = 0;
@@ -251,6 +253,13 @@ internal class Program
         }
         catch (Exception e)
         {
+            ClrDiagnosticsException diagException = e as ClrDiagnosticsException;
+            if ((diagException != null) && ((uint)diagException.HResult == 0x80070057))
+            {
+                exceptionExitCode = 3;
+                Console.WriteLine("HeapDump Error: Unable to open process dump.  HeapDump only supports converting Windows process dumps.");
+            }
+
             if (e is ApplicationException)
             {
                 Console.WriteLine("HeapDump Error: {0}", e.Message);
@@ -266,7 +275,7 @@ internal class Program
                 catch (Exception) { }
             }
         }
-        return 1;
+        return exceptionExitCode;
     }
 
     #region private

--- a/src/PerfView/memory/HeapSnapshot.cs
+++ b/src/PerfView/memory/HeapSnapshot.cs
@@ -171,7 +171,11 @@ namespace PerfView
             log.WriteLine("Exec: {0}", commandLine);
             PerfViewLogger.Log.TriggerHeapSnapshot(outputFile, inputArg, qualifiers);
             var cmd = Command.Run(commandLine, options);
-            if (cmd.ExitCode != 0)
+            if (cmd.ExitCode == 3)
+            {
+                throw new ApplicationException("Unable to open the process dump.  PerfView only supports converting Windows process dumps.  Please confirm that this is a Windows process dump.");
+            }
+            else if (cmd.ExitCode != 0)
             {
                 throw new ApplicationException("HeapDump failed with exit code " + cmd.ExitCode);
             }


### PR DESCRIPTION
Warn the user if they attempt to convert a Linux process dump that this is not supported.  Currently, the user gets a failure that doesn't make this clear.

Fixes #1562.