### PR TITLE
Switch to Azure Artifacts Feeds for Build Dependencies

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -27,7 +27,9 @@ jobs:
       displayName: 'NuGet Restore PerfView.sln'
       inputs:
         restoreSolution: PerfView.sln
+        feedsToUse: config
         includeNuGetOrg: false
+        nugetConfigPath: '.\NuGet.config'
 
     - task: MSBuild@1
       displayName: 'Build PerfView.sln'
@@ -80,7 +82,9 @@ jobs:
       displayName: 'NuGet Restore PerfView.sln'
       inputs:
         restoreSolution: PerfView.sln
+        feedsToUse: config
         includeNuGetOrg: false
+        nugetConfigPath: '.\NuGet.config'
 
     - task: MSBuild@1
       displayName: 'Build PerfView.sln'

--- a/.ado.yml
+++ b/.ado.yml
@@ -27,6 +27,7 @@ jobs:
       displayName: 'NuGet Restore PerfView.sln'
       inputs:
         restoreSolution: PerfView.sln
+        includeNuGetOrg: false
 
     - task: MSBuild@1
       displayName: 'Build PerfView.sln'
@@ -79,6 +80,7 @@ jobs:
       displayName: 'NuGet Restore PerfView.sln'
       inputs:
         restoreSolution: PerfView.sln
+        includeNuGetOrg: false
 
     - task: MSBuild@1
       displayName: 'Build PerfView.sln'

--- a/Nuget.config
+++ b/Nuget.config
@@ -2,7 +2,8 @@
 <configuration>
   <packageSources>
     <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="perfview-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/perfview-build/nuget/v3/index.json" />
     <add key="Local" value=".\src\NugetSupportFiles" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This switches the source of dependencies to a Microsoft-owned feed.  This should have no impact on functionality.