### PR TITLE
Fix amd64 Native DLL Loading

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,8 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <PerfViewVersion>2.0.75</PerfViewVersion>
-    <TraceEventVersion>2.0.75</TraceEventVersion>
+    <PerfViewVersion>2.0.76</PerfViewVersion>
+    <TraceEventVersion>2.0.76</TraceEventVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/TraceEvent/NativeDlls.cs
+++ b/src/TraceEvent/NativeDlls.cs
@@ -78,7 +78,8 @@ internal class NativeDlls
         {
             if (s_ProcessArchDirectory == null)
             {
-                s_ProcessArchDirectory = ProcessArch.ToString().ToLowerInvariant();
+                // Special case amd64 because the Architecture uses X64, but the previous behavior was to use amd64.
+                s_ProcessArchDirectory = ProcessArch == Architecture.X64 ? "amd64" : ProcessArch.ToString().ToLowerInvariant();
             }
 
             return s_ProcessArchDirectory;


### PR DESCRIPTION
With the addition of arm64 support, the value of `ProcessArch` is no longer `amd64`, but is now `x64`.  Special case this value when loading DLLs since the directory we unpack is called `amd64`.