### PR TITLE
Added Attribute UseCulture("en-US") to prevent another time format from being taken

### DIFF
--- a/src/PerfView.Tests/GraphSerialization/GraphSerializationTests.cs
+++ b/src/PerfView.Tests/GraphSerialization/GraphSerializationTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Xunit;
 using System.Linq;
+using PerfView.TestUtilities;
 
 namespace PerfViewTests.GraphSerialization
 {
@@ -14,6 +15,7 @@ namespace PerfViewTests.GraphSerialization
         }
 
         [Theory]
+        [UseCulture("en-US")]
         [MemberData(nameof(TestGCDumpFiles))]
         public void GenerateBaselineXmlFiles(string gcDumpFileName)
         {


### PR DESCRIPTION
To prevent the test GenerateBaselineXmlFiles from using two different time formats, the attribute UseCulture("en-US") is added.
fixes #1581