### PR TITLE
Non-blocking EventPipeEventSource Ctor

### DIFF
--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Tracing
         {
         }
 
-        private EventPipeEventSource(PinnedStreamReader streamReader, string name, bool isLive)
+        private EventPipeEventSource(PinnedStreamReader streamReader, string name, bool isStreaming)
         {
             _deserializerIntializer = () =>
             {
@@ -83,7 +83,7 @@ namespace Microsoft.Diagnostics.Tracing
             osVersion = new Version("0.0.0.0");
             cpuSpeedMHz = 10;
 
-            if (!isLive)
+            if (!isStreaming)
                 _deserializer = _deserializerIntializer();
 
             EventCache = new EventCache();

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -848,8 +848,6 @@ namespace Microsoft.Diagnostics.Tracing
         private StreamLabel _endOfEventStream;
 #endif
         private Dictionary<int, EventPipeEventMetaDataHeader> _eventMetadataDictionary = new Dictionary<int, EventPipeEventMetaDataHeader>();
-        private PinnedStreamReader _streamReader;
-        private string _name;
         private Deserializer _deserializer;
         private Dictionary<TraceEvent, DynamicTraceEventData> _metadataTemplates =
             new Dictionary<TraceEvent, DynamicTraceEventData>(new ExternalTraceEventParserState.TraceEventComparer());

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -28,55 +28,63 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher, IFastSerializable, IFastSerializableVersion
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, 0x20000), fileName)
+        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, 0x20000), fileName, false)
         {
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte), "stream")
+            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte), "stream", true)
         {
         }
 
-        private EventPipeEventSource(PinnedStreamReader streamReader, string name)
+        private EventPipeEventSource(PinnedStreamReader streamReader, string name, bool isLive)
         {
-            StreamLabel start = streamReader.Current;
-            byte[] netTraceMagic = new byte[8];
-            streamReader.Read(netTraceMagic, 0, netTraceMagic.Length);
-            byte[] expectedMagic = Encoding.UTF8.GetBytes("Nettrace");
-            bool isNetTrace = true;
-            if (!netTraceMagic.SequenceEqual(expectedMagic))
+            _deserializerIntializer = () =>
             {
-                // The older netperf format didn't have this 'Nettrace' magic on it.
-                streamReader.Goto(start);
-                isNetTrace = false;
-            }
+                StreamLabel start = streamReader.Current;
+                byte[] netTraceMagic = new byte[8];
+                streamReader.Read(netTraceMagic, 0, netTraceMagic.Length);
+                byte[] expectedMagic = Encoding.UTF8.GetBytes("Nettrace");
+                bool isNetTrace = true;
+                if (!netTraceMagic.SequenceEqual(expectedMagic))
+                {
+                    // The older netperf format didn't have this 'Nettrace' magic on it.
+                    streamReader.Goto(start);
+                    isNetTrace = false;
+                }
+
+                var deserializer = new Deserializer(streamReader, name);
+
+#if SUPPORT_V1_V2
+                // This is only here for V2 and V1.  V3+ should use the name EventTrace, it can be removed when we drop support.
+                deserializer.RegisterFactory("Microsoft.DotNet.Runtime.EventPipeFile", delegate { return this; });
+#endif
+                deserializer.RegisterFactory("Trace", delegate { return this; });
+                deserializer.RegisterFactory("EventBlock", delegate { return new EventPipeEventBlock(this); });
+                deserializer.RegisterFactory("MetadataBlock", delegate { return new EventPipeMetadataBlock(this); });
+                deserializer.RegisterFactory("SPBlock", delegate { return new EventPipeSequencePointBlock(this); });
+                deserializer.RegisterFactory("StackBlock", delegate { return new EventPipeStackBlock(this); });
+
+                var entryObj = deserializer.GetEntryObject(); // this call invokes FromStream and reads header data
+
+                if ((FileFormatVersionNumber >= 4) != isNetTrace)
+                {
+                    //NetTrace header should be present iff the version is >= 4
+                    throw new SerializationException("Invalid NetTrace file format version");
+                }
+
+                // Because we told the deserialize to use 'this' when creating a EventPipeFile, we
+                // expect the entry object to be 'this'.
+                Debug.Assert(entryObj == this);
+
+                return deserializer;
+            };
 
             osVersion = new Version("0.0.0.0");
             cpuSpeedMHz = 10;
 
-            _deserializer = new Deserializer(streamReader, name);
-
-#if SUPPORT_V1_V2
-            // This is only here for V2 and V1.  V3+ should use the name EventTrace, it can be removed when we drop support.
-            _deserializer.RegisterFactory("Microsoft.DotNet.Runtime.EventPipeFile", delegate { return this; });
-#endif
-            _deserializer.RegisterFactory("Trace", delegate { return this; });
-            _deserializer.RegisterFactory("EventBlock", delegate { return new EventPipeEventBlock(this); });
-            _deserializer.RegisterFactory("MetadataBlock", delegate { return new EventPipeMetadataBlock(this); });
-            _deserializer.RegisterFactory("SPBlock", delegate { return new EventPipeSequencePointBlock(this); });
-            _deserializer.RegisterFactory("StackBlock", delegate { return new EventPipeStackBlock(this); });
-
-            var entryObj = _deserializer.GetEntryObject(); // this call invokes FromStream and reads header data
-
-            if((FileFormatVersionNumber >= 4) != isNetTrace)
-            {
-                //NetTrace header should be present iff the version is >= 4
-                throw new SerializationException("Invalid NetTrace file format version");
-            }
-
-            // Because we told the deserialize to use 'this' when creating a EventPipeFile, we
-            // expect the entry object to be 'this'.
-            Debug.Assert(entryObj == this);
+            if (!isLive)
+                _deserializer = _deserializerIntializer();
 
             EventCache = new EventCache();
             EventCache.OnEvent += EventCache_OnEvent;
@@ -126,6 +134,10 @@ namespace Microsoft.Diagnostics.Tracing
 
         public override bool Process()
         {
+            if (_deserializer is null)
+                _deserializer = _deserializerIntializer?.Invoke() ?? throw new Exception("TODO: Come up with better errror path later");
+
+
             if (FileFormatVersionNumber >= 3)
             {
                 // loop through the stream until we hit a null object.  Deserialization of
@@ -832,6 +844,8 @@ namespace Microsoft.Diagnostics.Tracing
         private StreamLabel _endOfEventStream;
 #endif
         private Dictionary<int, EventPipeEventMetaDataHeader> _eventMetadataDictionary = new Dictionary<int, EventPipeEventMetaDataHeader>();
+        private PinnedStreamReader _streamReader;
+        private string _name;
         private Deserializer _deserializer;
         private Dictionary<TraceEvent, DynamicTraceEventData> _metadataTemplates =
             new Dictionary<TraceEvent, DynamicTraceEventData>(new ExternalTraceEventParserState.TraceEventComparer());
@@ -840,6 +854,7 @@ namespace Microsoft.Diagnostics.Tracing
         private Guid _relatedActivityId;
         internal int _processId;
         internal int _expectedCPUSamplingRate;
+        private Func<Deserializer> _deserializerIntializer;
         #endregion
     }
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -135,7 +135,11 @@ namespace Microsoft.Diagnostics.Tracing
         public override bool Process()
         {
             if (_deserializer is null)
-                _deserializer = _deserializerIntializer?.Invoke() ?? throw new Exception("TODO: Come up with better errror path later");
+            {
+                Debug.Assert(_deserializerIntializer != null);
+                _deserializer = _deserializerIntializer?.Invoke();
+                Debug.Assert(_deserializer != null);
+            }
 
 
             if (FileFormatVersionNumber >= 3)


### PR DESCRIPTION
This PR makes the constructor for `EventPipeEventSource` non-blocking. Previously, the constructor would block until data was sent on the stream. This brings `EventPipeEventSource` closer in behavior to other similar APIs in the TraceEvent library.

~One issue that isn't solved by this PR (yet) is that we need to handle the case where users try to get metadata about the source before data arrives. Before this PR, users were guaranteed to have that information when the ctor returned. Now, this is only true for opening a completed file, hence the special casing for files. Currently, this PR makes no attempt to stop users from reading metadata properties. _I am hoping for some feedback on whether this should throw an exception or now. Until this is decided, I'll leave this in draft mode._~ I'm going to leave this alone for now, and address it if users are hitting this behavior. The only use case for these Properties seems to be covered fine by differentiating streaming vs non-streaming.

fixes #1172 