### PR TITLE
Cherry-Pick Missing 64-bit Fixes and Improve Conversion Reporting

### DIFF
--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -105,7 +105,7 @@ namespace FastSerialization
 #endif
     sealed class SerializationConfiguration
     {
-        public StreamLabelWidth StreamLabelWidth { get; set; }
+        public StreamLabelWidth StreamLabelWidth { get; set; } = StreamLabelWidth.EightBytes;
     }
 
     /// <summary>

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -17,11 +17,11 @@ using Address = System.UInt64;
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName))
+        this(new Deserializer(inputFileName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName))
+        this(new Deserializer(inputStream, streamName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
     { }
 
     /// <summary>

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher, IFastSerializable, IFastSerializableVersion
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, 0x20000), fileName)
+        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, 0x20000, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), fileName)
         {
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte), "stream")
+            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "stream")
         {
         }
 

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1902,11 +1902,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         {
                             var curDurationSec = (DateTime.Now - startTime).TotalSeconds;
 
-                            var ratioOutputToInput = (double)eventCount / (double)rawEventCount;
-                            var estimatedFinalSizeMB = Math.Max(rawInputSizeMB * ratioOutputToInput * 1.15, curOutputSizeMB * 1.02);
-                            var ratioSizeComplete = curOutputSizeMB / estimatedFinalSizeMB;
-                            var estTimeLeftSec = (int)(curDurationSec / ratioSizeComplete - curDurationSec);
-
                             var message = "";
                             if (0 < startMSec && data.TimeStampRelativeMSec < startMSec)
                             {
@@ -1918,14 +1913,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                             }
 
                             options.ConversionLog.WriteLine(
-                                "[Sec {0,4:f0} Read {1,10:n0} events. At {2,7:n0}ms.  Wrote {3,4:f0}MB ({4,3:f0}%).  EstDone {5,2:f0} min {6,2:f0} sec.{7}]",
+                                "[ELAPSED {0,2:f0} seconds.     READ {1,10:n0} events.     TIMESTAMP {2,7:n0}ms.     WRITTEN {3,5:n0}MB.     {4}]",
                                 curDurationSec,
                                 rawEventCount,
                                 data.TimeStampRelativeMSec,
                                 curOutputSizeMB,
-                                ratioSizeComplete * 100.0,
-                                estTimeLeftSec / 60,
-                                estTimeLeftSec % 60,
                                 message);
                         }
                     }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1889,12 +1889,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 // Show status every 128K events
                 if ((rawEventCount & 0x1FFFF) == 0)
                 {
-                    var curOutputSizeMB = ((double)(uint)writer.GetLabel()) / 1000000.0;
-                    // Currently ETLX has a size restriction of 4Gig.  Thus if we are getting big, start truncating.
-                    if (curOutputSizeMB > 3500)
-                    {
-                        processingDisabled = true;
-                    }
+                    var curOutputSizeMB = ((double)(ulong)writer.GetLabel()) / 1000000.0;
 
                     if (options != null && options.ConversionLog != null)
                     {
@@ -1920,10 +1915,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                             else if (maxEventCount != -1 && eventCount >= maxEventCount)
                             {
                                 message = "  Hit MaxEventCount, truncating.";
-                            }
-                            else if (curOutputSizeMB > 3500)
-                            {
-                                message = "  Hit File size limit (3.5Gig) truncating.";
                             }
 
                             options.ConversionLog.WriteLine(

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3406,6 +3406,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             // If this Assert files, fix the declaration of headerSize to match
             Debug.Assert(sizeof(TraceEventNativeMethods.EVENT_HEADER) == 0x50 && sizeof(TraceEventNativeMethods.ETW_BUFFER_CONTEXT) == 4);
 
+            // As of TraceLog version 74, all StreamLabels are 64-bit.  See IFastSerializableVersion for details.
             Deserializer deserializer = new Deserializer(new PinnedStreamReader(etlxFilePath, 0x10000), etlxFilePath);
             deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
 
@@ -3850,7 +3851,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         int IFastSerializableVersion.Version
         {
-            get { return 73; }
+            get { return 74; }
         }
         int IFastSerializableVersion.MinimumVersionCanRead
         {


### PR DESCRIPTION
It looks like an earlier merge caused a couple of 64-bit fixes to be reverted in the PerfView 3.0 branch.  Bringing them back with this PR.