### PR TITLE
Use GC.KeepAlive to prevent GC hole

### DIFF
--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -195,6 +195,7 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                 {
                     EventMarker eventMarker = oldestEventQueue.Dequeue();
                     OnEvent?.Invoke(ref eventMarker.Header);
+                    GC.KeepAlive(eventMarker);
                 }
             }
 


### PR DESCRIPTION
fixes #1474 
CC dotnet/runtime#67216 (note this will require a TraceEvent update to fix)
CC dotnet/runtime#54801
CC dotnet/runtime#59448

As described in #1474, the sequence of calls on a `ref` parameter result in it being passed as a pointer, so the underlying pinned buffer is no longer referenced. This patch adds a `GC.KeepAlive` which should keep the memory referenced through the whole function duration.