### PR TITLE
Remove superfluous flush from TraceEventSession.SetFileName

### DIFF
--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -956,12 +956,6 @@ namespace Microsoft.Diagnostics.Tracing.Session
 
             var origFileName = m_FileName;      // Remember the original name we had.  
 
-            // If we are in file mode, flush it before we close it and move on to the next file.  
-            if (origFileName != null)
-            {
-                Flush();
-            }
-
             // Set up the properties for the new file name 
             var propertiesBuff = stackalloc byte[PropertiesSize];
             m_FileName = newName;


### PR DESCRIPTION
Removes an extra ETW flush command that is not needed, since rotating the trace file by setting the file name will cause ETW to automatically flush.  In some situations, this extra flush can cause lost events.