### PR TITLE
Disable NGEN Rundown By Default

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -142,7 +142,7 @@ namespace PerfView
         public string FocusProcess;       // The target process for CLR Rundown.  
         public bool NoRundown;
         public bool NoNGenPdbs;
-        public bool NoNGenRundown;
+        public bool NoNGenRundown = true;
         public bool NoClrRundown;
         public bool NoV2Rundown;
         public bool LowPriority;


### PR DESCRIPTION
Disable rundown for pre-v4.0 runtimes by default.  This can be re-enabled from the command line via `/NoNGENRundown:false`.  Given that most processes are running v4.0+ runtimes, this should not have much impact, but should reduce the trace size since there is some overlap in events that are emitted for v4.0+ runtimes with these settings enabled.