### PR TITLE
Ignore the Microsoft-Windows-DotNETRuntime Dynamic Manifest

### DIFF
--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -198,6 +198,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 return false;
             }
 
+            // Starting with .NET 6, the manifest is written into the event stream, which results in
+            // duplicate event dispatch.  To avoid this, filter out the Microsoft-Windows-DotNETRuntime provider
+            // if it is present in the event stream.
+            if (data.ProviderGuid == ClrTraceEventParser.ProviderGuid)
+            {
+                return false;
+            }
+
             // Look up our information. 
             List<PartialManifestInfo> partialManifestsForGuid;
             if (!partialManifests.TryGetValue(data.ProviderGuid, out partialManifestsForGuid))


### PR DESCRIPTION
Starting with .NET 6, the runtime will emit the Microsoft-Windows-DotNETRuntime manifest into the event stream.  This results in two instances of the manifest:

 - The pre-compiled copy of the manifest: `ClrTraceEventParser`
 - The dynamic copy of the manifest which enables `DynamicTraceEventParser` to parse the CLR events

Normally, this would not be a problem, except that there is lots of code out there that knows that Microsoft-Windows-DotNETRuntime is not a dynamic provider, and so now that this provider manifest is written into the event stream, that code breaks.

This fix will cause `DynamicTraceEventParser` to ignore manifest events for the `Microsoft-Windows-DotNETRuntime` provider so that the previous behavior is restored.

Fixes #1591.

cc: @noahfalk, @josalem 