### PR TITLE
Kernel based event can not be disabled on UI

### DIFF
--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -658,6 +658,10 @@ namespace PerfView
             {
                 m_args.KernelEvents = (KernelTraceEventParser.Keywords)(KernelTraceEventParser.Keywords.Default - KernelTraceEventParser.Keywords.Profile);
             }
+            else
+            {
+                m_args.KernelEvents = KernelTraceEventParser.Keywords.None;
+            }
 
             if (CpuSamplesCheckBox.IsChecked ?? false)
             {


### PR DESCRIPTION
When KernelBasedCheckBox is false, the default value is `KernelTraceEventParser.Keywords.Default`, which still has kernel events enabled.