### PR TITLE
Emit the full stack when an exception is thrown during dispatch.

### DIFF
--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -3497,7 +3497,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 Debug.WriteLine("Error: exception thrown during callback.  Will be swallowed!");
                 Debug.WriteLine("Exception: " + e.Message);
-                Debug.Assert(false, "Thrown exception " + e.GetType().Name + " '" + e.Message + "'");
+                Debug.Assert(false, "Thrown exception:" + e.ToString());
             }
 #endif
         }


### PR DESCRIPTION
Hopefully this will help clarify where these exceptions are being thrown in the CI.