### PR TITLE
New Module Version Report

### DIFF
--- a/src/PerfView/ClrStats.cs
+++ b/src/PerfView/ClrStats.cs
@@ -10,9 +10,9 @@ namespace Stats
 {
     internal static class ClrStats
     {
-        public enum ReportType { JIT, GC, RuntimeLoader };
+        public enum ReportType { JIT, GC, RuntimeLoader, FileVersion };
 
-        public static void ToHtml(TextWriter writer, List<TraceProcess> perProc, string fileName, string title, ReportType type, bool justBody = false, bool doServerGCReport = false, RuntimeLoaderStatsData runtimeOpsStats = null)
+        public static void ToHtml(TextWriter writer, List<TraceProcess> perProc, string fileName, string title, ReportType type, bool justBody = false, bool doServerGCReport = false, RuntimeLoaderStatsData runtimeOpsStats = null, Microsoft.Diagnostics.Tracing.Etlx.TraceLog traceLog = null)
         {
             if (!justBody)
             {
@@ -37,6 +37,10 @@ namespace Stats
             else if (type == ReportType.RuntimeLoader)
             {
                 sortedProcs.Sort((TraceProcess p1, TraceProcess p2) => { return -RuntimeLoaderStats.TotalCPUMSec(p1, runtimeOpsStats).CompareTo(RuntimeLoaderStats.TotalCPUMSec(p2, runtimeOpsStats)); });
+            }
+            else if(type == ReportType.FileVersion)
+            {
+                sortedProcs.Sort((TraceProcess p1, TraceProcess p2) => { return string.Compare(p1.Name, p2.Name); });
             }
 
             int count = sortedProcs.Count;
@@ -95,6 +99,11 @@ namespace Stats
                 if (type == ReportType.RuntimeLoader && RuntimeLoaderStats.IsInteresting(stats, runtimeOpsStats))
                 {
                     Stats.RuntimeLoaderStats.ToHtml(writer, stats, fileName, runtimeOpsStats);
+                }
+
+                if(type == ReportType.FileVersion)
+                {
+                    Stats.FileVersionInformation.ToHtml(writer, stats, traceLog);
                 }
             }
 

--- a/src/PerfView/FileVersionInformation.cs
+++ b/src/PerfView/FileVersionInformation.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved
+
+using Microsoft.Diagnostics.Tracing.Analysis;
+using Etlx = Microsoft.Diagnostics.Tracing.Etlx;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace Stats
+{
+    internal static class FileVersionInformation
+    {
+        public static void ToHtml(TextWriter writer, TraceProcess stats, Etlx.TraceLog traceLog)
+        {
+            Etlx.TraceProcess traceProcess = traceLog.Processes.GetProcess(stats.ProcessID, stats.StartTimeRelativeMsec + 1);
+            if (traceProcess == null)
+            {
+                return;
+            }
+
+            writer.WriteLine("<H3><A Name=\"Stats_{0}\"><font color=\"blue\">File Version Information for for Process {1,5}: {2}</font><A></H3>", stats.ProcessID, stats.ProcessID, stats.Name);
+            writer.WriteLine("<UL>");
+            {
+                writer.WriteLine("<LI>CommandLine: {0}</LI>", traceProcess.CommandLine);
+            }
+            writer.WriteLine("</UL>");
+
+            writer.WriteLine("<H4><A Name=\"Events_{0}\">Individual Loaded Modules for Process {1,5}: {2}<A></H4>", stats.ProcessID, stats.ProcessID, stats.Name);
+
+            writer.WriteLine("<Center>");
+            writer.WriteLine("<Table Border=\"1\">");
+            writer.Write(
+                "<TR>" +
+                "<TH>File Path</TH>" +
+                "<TH>Version</TH>" +
+                "</TR>");
+            List<Etlx.TraceLoadedModule> modules = traceProcess.LoadedModules.ToList();
+            modules.Sort((Etlx.TraceLoadedModule t1, Etlx.TraceLoadedModule t2) => { return string.Compare(t1.Name, t2.Name); });
+            foreach (Etlx.TraceLoadedModule module in modules)
+            {
+                Etlx.TraceModuleFile moduleFile = module.ModuleFile;
+                writer.Write(
+                    "<TR>" +
+                    "<TD Align=\"Left\">{0}</TD>" +
+                    "<TD Align=\"Center\">{1}</TD>" +
+                    "</TR>",
+                    moduleFile.FilePath,
+                    moduleFile.FileVersion);
+            }
+            writer.WriteLine("</Table>");
+            writer.WriteLine("</Center>");
+
+            writer.WriteLine("<HR/><HR/><BR/><BR/>");
+        }
+    }
+}

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\PerfView\GcStats.cs" />
     <Compile Include="..\PerfView\JitStats.cs" />
     <Compile Include="..\PerfView\RuntimeLoaderStats.cs" />
+    <Compile Include="..\PerfView\FileVersionInformation.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Uses the `KernelTraceControl/ImageID` events to produce an HTML report with version information for loaded modules in each process.