### PR TITLE
Added the ability to filter events based on boolean expression(s) in the Events Window.

### DIFF
--- a/src/CSVReader/EventSource.cs
+++ b/src/CSVReader/EventSource.cs
@@ -114,7 +114,8 @@ namespace EventSources
 
             if (matched.Success)
             {
-                filterQueryExpressionTree = new FilterQueryExpressionTree(matched.Value.Replace("[", "").Replace("]", ""));
+                var cleanedExpressionString = matched.Value.Replace("[", string.Empty).Replace("]", string.Empty);
+                filterQueryExpressionTree = new FilterQueryExpressionTree(cleanedExpressionString);
             }
 
             var regex = new Regex(@"\s*(\S+)\s*");

--- a/src/CSVReader/EventSource.cs
+++ b/src/CSVReader/EventSource.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
@@ -66,6 +67,10 @@ namespace EventSources
         /// Optionally you can provide a list of columns available.  
         /// </summary>
         public virtual ICollection<string> AllColumnNames(List<string> eventNames) { return null; }
+        /// <summary>
+        /// An optional filter query expression tree that'll be used to filter different events. 
+        /// </summary>
+        public FilterQueryExpressionTree FilterQueryExpressionTree { get; set; } = null;
 
         /// <summary>
         /// The number of fields that are NOT put in the 'rest' column.  Defaults to 4
@@ -92,14 +97,26 @@ namespace EventSources
         /// Utility function that takes a specification for columns (which can include *) and the raw list of
         /// all possible columns and returns the list that match the specification. 
         /// </summary>
-        public static List<string> ParseColumns(string columnSpec, ICollection<string> columnNames)
+        public static List<string> ParseColumns(string columnSpec, ICollection<string> columnNames, out FilterQueryExpressionTree filterQueryExpressionTree)
         {
+            filterQueryExpressionTree = null;
+
             if (string.IsNullOrWhiteSpace(columnSpec))
             {
                 return null;
             }
 
             var ret = new List<string>();
+
+            var escapedMatch = new Regex(@"\[[^\]]*\]");
+            var matched = escapedMatch.Match(columnSpec);
+            columnSpec = escapedMatch.Replace(columnSpec, string.Empty);
+
+            if (matched.Success)
+            {
+                filterQueryExpressionTree = new FilterQueryExpressionTree(matched.Value.Replace("[", "").Replace("]", ""));
+            }
+
             var regex = new Regex(@"\s*(\S+)\s*");
             var index = 0;
             for (; ; )

--- a/src/CSVReader/EventSource.cs
+++ b/src/CSVReader/EventSource.cs
@@ -95,7 +95,7 @@ namespace EventSources
 
         /// <summary>
         /// Utility function that takes a specification for columns (which can include *) and the raw list of
-        /// all possible columns and returns the list that match the specification. 
+        /// all possible columns and returns the list that match the specification. This function also extracts the event filter query and creates a FilterQueryExpressionTree.
         /// </summary>
         public static List<string> ParseColumns(string columnSpec, ICollection<string> columnNames, out FilterQueryExpressionTree filterQueryExpressionTree)
         {

--- a/src/PerfView/EtwEventSource.cs
+++ b/src/PerfView/EtwEventSource.cs
@@ -327,6 +327,15 @@ namespace PerfView
                         }
                     }
 
+                    if (FilterQueryExpressionTree != null)
+                    {
+                        var match = FilterQueryExpressionTree.Match(data);
+                        if (!match)
+                        {
+                            return;
+                        }
+                    }
+
                     cnt++;
                     if (MaxRet < cnt)
                     {

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using EventSources;
 using Microsoft.Diagnostics.Symbols;
 using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression;
 using Microsoft.Diagnostics.Utilities;
 using System;
 using System.Collections.Generic;
@@ -1205,8 +1206,23 @@ namespace PerfView
             }
 
             m_source.SetEventFilter(eventFilter);
-            m_source.ColumnsToDisplay = EventSource.ParseColumns(ColumnsToDisplayTextBox.Text, m_source.AllColumnNames(eventFilter), out var filterQueryExpresionTree);
-            m_source.FilterQueryExpressionTree = filterQueryExpresionTree;
+            try
+            {
+                m_source.ColumnsToDisplay = EventSource.ParseColumns(ColumnsToDisplayTextBox.Text, m_source.AllColumnNames(eventFilter), out var filterQueryExpresionTree);
+                m_source.FilterQueryExpressionTree = filterQueryExpresionTree;
+            }
+
+            // Appropriately log any filter query expression parsing issue to give as much info to the user.
+            catch (FilterQueryExpressionTreeParsingException fqpEx)
+            {
+                StatusBar.Log(fqpEx.Message);
+                m_source.FilterQueryExpressionTree = null; 
+            }
+            catch (FilterQueryExpressionParsingException fqepEx)
+            {
+                StatusBar.Log(fqepEx.Message);
+                m_source.FilterQueryExpressionTree = null; 
+            }
 
             for (int i = 0; i < m_userDefinedColumns.Count; i++)
             {

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -1205,7 +1205,9 @@ namespace PerfView
             }
 
             m_source.SetEventFilter(eventFilter);
-            m_source.ColumnsToDisplay = EventSource.ParseColumns(ColumnsToDisplayTextBox.Text, m_source.AllColumnNames(eventFilter));
+            m_source.ColumnsToDisplay = EventSource.ParseColumns(ColumnsToDisplayTextBox.Text, m_source.AllColumnNames(eventFilter), out var filterQueryExpresionTree);
+            m_source.FilterQueryExpressionTree = filterQueryExpresionTree;
+
             for (int i = 0; i < m_userDefinedColumns.Count; i++)
             {
                 if (m_source.ColumnsToDisplay != null && i < m_source.ColumnsToDisplay.Count)

--- a/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTestTraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTestTraceEvent.cs
@@ -1,22 +1,34 @@
 ﻿using Microsoft.Diagnostics.Tracing;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TraceEventTests.FilterQueryExpressions
 {
     public sealed class FilterQueryExpressionTestTraceEvent : TraceEvent
     {
-        public string Value { get; set; }
+        private readonly List<Tuple<string, string>> _propertyNamesToValues;
+
+        public FilterQueryExpressionTestTraceEvent(List<Tuple<string, string>> propertyNamesToValues, string eventName = "")
+            : base(0, 0xFFFF, eventName, Guid.Empty, 0, "Fake", Guid.Empty, "Fake")
+        {
+            _propertyNamesToValues = propertyNamesToValues;
+            PayloadNames = propertyNamesToValues.Select(p => p.Item1).ToArray();
+            taskName = eventName;
+        }
 
         public FilterQueryExpressionTestTraceEvent(string propertyName, string value, string eventName = "")
             : base(0, 0xFFFF, eventName, Guid.Empty, 0, "Fake", Guid.Empty, "Fake")
         {
-            PayloadNames = new[] { propertyName };
-            Value = value;
+            _propertyNamesToValues = new List<Tuple<string, string>>
+            {
+                {  Tuple.Create(propertyName, value) }
+            };
+            PayloadNames = _propertyNamesToValues.Select(p => p.Item1).ToArray();
             taskName = eventName;
         }
 
-        public FilterQueryExpressionTestTraceEvent(int eventID, int task, string taskName, System.Guid taskGuid, int opcode, string opcodeName, System.Guid providerGuid, string providerName) 
+        public FilterQueryExpressionTestTraceEvent(int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName) 
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName) {}
 
         public override string[] PayloadNames { get; } 
@@ -26,14 +38,14 @@ namespace TraceEventTests.FilterQueryExpressions
 
         public override object PayloadValue(int index)
         {
-            if (index == 0)
+            if (index <= -1 || index >= _propertyNamesToValues.Count)
             {
-                return Value;
+                throw new ArgumentException($"Invalid index: {index}");
             }
 
             else
             {
-                throw new System.ArgumentException(nameof(index));
+                return _propertyNamesToValues[index].Item2;
             }
         }
     }

--- a/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTestTraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTestTraceEvent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using System;
+using System.Collections.Generic;
+
+namespace TraceEventTests.FilterQueryExpressions
+{
+    public sealed class FilterQueryExpressionTestTraceEvent : TraceEvent
+    {
+        public string Value { get; set; }
+
+        public FilterQueryExpressionTestTraceEvent(string propertyName, string value, string eventName = "")
+            : base(0, 0xFFFF, eventName, Guid.Empty, 0, "Fake", Guid.Empty, "Fake")
+        {
+            PayloadNames = new[] { propertyName };
+            Value = value;
+            taskName = eventName;
+        }
+
+        public FilterQueryExpressionTestTraceEvent(int eventID, int task, string taskName, System.Guid taskGuid, int opcode, string opcodeName, System.Guid providerGuid, string providerName) 
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName) {}
+
+        public override string[] PayloadNames { get; } 
+
+        // Not used.
+        protected internal override System.Delegate Target { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+        public override object PayloadValue(int index)
+        {
+            if (index == 0)
+            {
+                return Value;
+            }
+
+            else
+            {
+                throw new System.ArgumentException(nameof(index));
+            }
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression;
+using TraceEventTests.FilterQueryExpressions;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public sealed class FilterQueryExpressionTests
+    {
+        [Theory]
+        [InlineData("ThreadID = 1,001")]
+        [InlineData("ThreadID >= 1,001")]
+        [InlineData("ThreadID > 1,001")]
+        [InlineData("ThreadID < 1,001")]
+        [InlineData("ThreadID <= 1,001")]
+        [InlineData("ThreadID != 1,001")]
+        [InlineData("ThreadID Contains 1")]
+        [InlineData("GC/Start::ThreadID Contains 1")]
+        public void IsValidExpression_Valid_True(string expression)
+        {
+            var isValid = FilterQueryExpression.IsValidExpression(expression);
+            Assert.True(isValid);
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("Depth 1000")]
+        [InlineData("Depth<1000")]
+        [InlineData("Depth <1000")]
+        [InlineData("Depth> 1000")]
+        [InlineData("> 1000")]
+        [InlineData("Depth <")]
+        [InlineData("Depth ^ 100")]
+        [InlineData("GC:: Depth = 100")]
+        [InlineData("GC ::Depth = 100")]
+        public void IsValidExpression_Invalid_False(string expression)
+        {
+            var isValid = FilterQueryExpression.IsValidExpression(expression);
+            Assert.False(isValid);
+        }
+
+        [Theory]
+        [InlineData("Property = 1,001", "Property", "1,001")]
+        [InlineData("ThreadData Contains ,", "ThreadData", "1,001")]
+        [InlineData("Depth <= 1", "Depth", "1")]
+        [InlineData("Depth >= 1", "Depth", "10")]
+        [InlineData("Depth != 1", "Depth", "10")]
+        [InlineData("Depth < 1", "Depth", "0")]
+        [InlineData("Depth > 1", "Depth", "10")]
+        [InlineData("FakeEvent::Depth > 1", "Depth", "10", "FakeEvent")]
+        public void Match_PropertyAndEventNameProvided_True(string expression, string propertyName, string value, string eventName = "")
+        {
+            FilterQueryExpression filterQueryExpression = new FilterQueryExpression(expression);
+            var fakeTraceEvent = new FilterQueryExpressionTestTraceEvent(propertyName, value, eventName);
+            var matched = filterQueryExpression.Match(fakeTraceEvent);
+            Assert.True(matched);
+        }
+
+        [Theory]
+        [InlineData("Property = 1,001", "Property", "1,002")]
+        [InlineData("Property != 1,001", "Property", "1,001")]
+        [InlineData("Depth = 1", "Depth", "2")]
+        [InlineData("Depth >= 1", "Depth", "0")]
+        [InlineData("Depth <= 1", "Depth", "2")]
+        [InlineData("Depth <= 1", "Property", "2")]
+        [InlineData("Property Contains ,", "Property", "2")]
+        [InlineData("FakeEvent::Depth > 20", "Depth", "2", "FakeEvent")]
+        public void Match_PropertyAndEventNameProvided_False(string expression, string propertyName, string value, string eventName = "")
+        {
+            FilterQueryExpression filterQueryExpression = new FilterQueryExpression(expression);
+            var fakeTraceEvent = new FilterQueryExpressionTestTraceEvent(propertyName, value, eventName);
+            var matched = filterQueryExpression.Match(fakeTraceEvent);
+            Assert.False(matched);
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTreeTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTreeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using TraceEventTests.FilterQueryExpressions;
@@ -69,7 +70,8 @@ namespace TraceEventTests
         {
             private readonly List<object[]> _data = new List<object[]>
             {
-                new object[] { "(Depth <= 10) && (Depth <= 20)", new FilterQueryExpressionTestTraceEvent("Depth", "15") },
+                new object[] { "(Depth >= 10) && (Depth <= 20)", new FilterQueryExpressionTestTraceEvent("Depth", "15") },
+                new object[] { "Depth <= 10 || Depth <= 20", new FilterQueryExpressionTestTraceEvent("Depth", "15") },
                 new object[] { "((Depth <= 10) && (Depth <= 20)) || ((Depth != 15) && (Depth > 5))", new FilterQueryExpressionTestTraceEvent("Depth", "12") },
                 new object[] { "((Depth != 10 && (Depth != 10 && (Depth != 10))))", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
                 new object[] { "((Depth <= 10 && (Depth <= 10 && (Depth != 10))))", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
@@ -77,6 +79,36 @@ namespace TraceEventTests
                 new object[] { "(ThreadData != 1,0033 && ThreadData != 1,002) && (ThreadData = 1001)", new FilterQueryExpressionTestTraceEvent("ThreadData", "1001") },
                 new object[] { "(OldProcessName = test && OldProcessName != test1 || OldProcessName != test2)", new FilterQueryExpressionTestTraceEvent("OldProcessName", "test") },
                 new object[] { "(GC/Start::Depth >= 10 && GC/Start::Depth <= 20)", new FilterQueryExpressionTestTraceEvent("Depth", "15", "GC/Start") },
+                new object[]
+                {
+                    "(GC/Start::Depth = 10) && (ThreadData Contains 10)",
+                    new FilterQueryExpressionTestTraceEvent(propertyNamesToValues: new List<System.Tuple<string, string>>
+                    {
+                        Tuple.Create("Depth", "10"),
+                        Tuple.Create("ThreadData", "10")
+                    },
+                    eventName: "GC/Start")
+                },
+                new object[]
+                {
+                    "((GC/Start::Depth = 10) && (Depth <= 10)) || ((GC/Start::ThreadData != 10) || (Depth >= 10))",
+                    new FilterQueryExpressionTestTraceEvent(propertyNamesToValues: new List<System.Tuple<string, string>>
+                    {
+                        Tuple.Create("Depth", "10"),
+                        Tuple.Create("ThreadData", "10")
+                    },
+                    eventName: "GC/Start")
+                },
+                new object[]
+                {
+                    "((GC/Start::Depth = 10 && (GC/Start::Depth <= 11 && (GC/Start::Depth <= 12 && (Depth <= 13 && (GC/Start::Depth <= 14))))))",
+                    new FilterQueryExpressionTestTraceEvent(propertyNamesToValues: new List<System.Tuple<string, string>>
+                    {
+                        Tuple.Create("Depth", "10"),
+                        Tuple.Create("ThreadData", "10")
+                    },
+                    eventName: "GC/Start")
+                },
             };
 
             public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
@@ -90,6 +122,63 @@ namespace TraceEventTests
             FilterQueryExpressionTree tree = new FilterQueryExpressionTree(expression);
             bool match = tree.Match(filterQueryExpressionTestTraceEvent);
             Assert.True(match);
+        }
+
+        private sealed class FilterQueryExpressionTreeTestData_ComplexExpressions_FalseCases : IEnumerable<object[]> 
+        {
+            private readonly List<object[]> _data = new List<object[]>
+            {
+                new object[] { "(Depth <= 10) && (Depth <= 20)", new FilterQueryExpressionTestTraceEvent("Depth", "15") },
+                new object[] { "((Depth <= 10) && (Depth <= 20)) || ((Depth = 15) && (Depth < 5))", new FilterQueryExpressionTestTraceEvent("Depth", "12") },
+                new object[] { "((Depth = 10 && (Depth = 10 && (Depth = 10))))", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "((Depth >= 10 && (Depth >= 10 && (Depth >= 10))))", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "(ThreadData = 1,0033) && (ThreadData = 1001)", new FilterQueryExpressionTestTraceEvent("ThreadData", "1001") },
+                new object[] { "(ThreadData = 1,0033 && ThreadData != 1,002) && (ThreadData = 1001)", new FilterQueryExpressionTestTraceEvent("ThreadData", "1001") },
+                new object[] { "(OldProcessName != test && OldProcessName = test1 || OldProcessName = test2)", new FilterQueryExpressionTestTraceEvent("OldProcessName", "test") },
+                new object[] { "(GC/Start::Depth >= 10 && GC/Start::Depth >= 20)", new FilterQueryExpressionTestTraceEvent("Depth", "15", "GC/Start") },
+                new object[]
+                {
+                    "(GC/Start::Depth = 10) && (ThreadData Contains 10)",
+                    new FilterQueryExpressionTestTraceEvent(propertyNamesToValues: new List<System.Tuple<string, string>>
+                    {
+                        Tuple.Create("Depth", "10"),
+                        Tuple.Create("ThreadData", "20")
+                    },
+                    eventName: "GC/Start")
+                },
+                new object[]
+                {
+                    "((GC/Start::Depth != 10) && (Depth < 10)) || ((GC/Start::ThreadData != 10) || (Depth > 10))",
+                    new FilterQueryExpressionTestTraceEvent(propertyNamesToValues: new List<System.Tuple<string, string>>
+                    {
+                        Tuple.Create("Depth", "10"),
+                        Tuple.Create("ThreadData", "10")
+                    },
+                    eventName: "GC/Start")
+                },
+                new object[]
+                {
+                    "((GC/Start::Depth != 10 && (GC/Start::Depth = 11 && (GC/Start::Depth = 12 && (Depth = 13 && (GC/Start::Depth = 14))))))",
+                    new FilterQueryExpressionTestTraceEvent(propertyNamesToValues: new List<System.Tuple<string, string>>
+                    {
+                        Tuple.Create("Depth", "10"),
+                        Tuple.Create("ThreadData", "10")
+                    },
+                    eventName: "GC/Start")
+                },
+            };
+
+            public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Theory]
+        [ClassData(typeof(FilterQueryExpressionTreeTestData_ComplexExpressions_FalseCases))]
+        public void Match_ComplexExpressions_False(string expression, FilterQueryExpressionTestTraceEvent filterQueryExpressionTestTraceEvent)
+        { 
+            FilterQueryExpressionTree tree = new FilterQueryExpressionTree(expression);
+            bool match = tree.Match(filterQueryExpressionTestTraceEvent);
+            Assert.False(match);
         }
     }
 }

--- a/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTreeTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/FilterQueryExpressions/FilterQueryExpressionTreeTests.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression;
+using System.Collections;
+using System.Collections.Generic;
+using TraceEventTests.FilterQueryExpressions;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class FilterQueryExpressionTreeTests
+    {
+        private sealed class FilterQueryExpressionTreeTestData_SimpleExpressions_TrueCases : IEnumerable<object[]>
+        {
+            private readonly List<object[]> _data = new List<object[]>
+            {
+                new object[] { "Depth >= 10", new FilterQueryExpressionTestTraceEvent("Depth", "20") },
+                new object[] { "(Depth >= 10)", new FilterQueryExpressionTestTraceEvent("Depth", "20") },
+                new object[] { "Depth >= 10", new FilterQueryExpressionTestTraceEvent("Depth", "20") },
+                new object[] { "Depth <= 10", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "Depth != 10", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "Depth > 10", new FilterQueryExpressionTestTraceEvent("Depth", "25") },
+                new object[] { "Depth >= 10", new FilterQueryExpressionTestTraceEvent("Depth", "25") },
+                new object[] { "ThreadData Contains 10", new FilterQueryExpressionTestTraceEvent("ThreadData", "1001") },
+                new object[] { "GC/Start::Depth = 10", new FilterQueryExpressionTestTraceEvent("Depth", "10", "GC/Start") },
+                new object[] { "(GC/Start::Depth = 10)", new FilterQueryExpressionTestTraceEvent("Depth", "10", "GC/Start") },
+            };
+
+            public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Theory]
+        [ClassData(typeof(FilterQueryExpressionTreeTestData_SimpleExpressions_TrueCases))]
+        public void Match_SimpleExpressions_True(string expression, FilterQueryExpressionTestTraceEvent filterQueryExpressionTestTraceEvent)
+        { 
+            FilterQueryExpressionTree tree = new FilterQueryExpressionTree(expression);
+            bool match = tree.Match(filterQueryExpressionTestTraceEvent);
+            Assert.True(match);
+        }
+
+        private sealed class FilterQueryExpressionTreeTestData_SimpleExpressions_FalseCases : IEnumerable<object[]> 
+        {
+            private readonly List<object[]> _data = new List<object[]>
+            {
+                new object[] { "Depth <= 10", new FilterQueryExpressionTestTraceEvent("Depth", "20") },
+                new object[] { "(Depth <= 10)", new FilterQueryExpressionTestTraceEvent("Depth", "20") },
+                new object[] { "Depth >= 10", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "Depth = 10", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "Depth < 10", new FilterQueryExpressionTestTraceEvent("Depth", "25") },
+                new object[] { "Depth <= 10", new FilterQueryExpressionTestTraceEvent("Depth", "25") },
+                new object[] { "ThreadData Contains 1,0033", new FilterQueryExpressionTestTraceEvent("ThreadData", "1001") },
+                new object[] { "GC/Start::Depth = 10", new FilterQueryExpressionTestTraceEvent("Depth", "1001", "GC/Start") },
+                new object[] { "GC/Start::ThreadData = 1,001", new FilterQueryExpressionTestTraceEvent("Depth", "1001", "GC/Start") },
+            };
+
+            public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Theory]
+        [ClassData(typeof(FilterQueryExpressionTreeTestData_SimpleExpressions_FalseCases))]
+        public void Match_SimpleExpressions_False(string expression, FilterQueryExpressionTestTraceEvent filterQueryExpressionTestTraceEvent)
+        { 
+            FilterQueryExpressionTree tree = new FilterQueryExpressionTree(expression);
+            bool match = tree.Match(filterQueryExpressionTestTraceEvent);
+            Assert.False(match);
+        }
+
+        private sealed class FilterQueryExpressionTreeTestData_ComplexExpressions_TrueCases : IEnumerable<object[]> 
+        {
+            private readonly List<object[]> _data = new List<object[]>
+            {
+                new object[] { "(Depth <= 10) && (Depth <= 20)", new FilterQueryExpressionTestTraceEvent("Depth", "15") },
+                new object[] { "((Depth <= 10) && (Depth <= 20)) || ((Depth != 15) && (Depth > 5))", new FilterQueryExpressionTestTraceEvent("Depth", "12") },
+                new object[] { "((Depth != 10 && (Depth != 10 && (Depth != 10))))", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "((Depth <= 10 && (Depth <= 10 && (Depth != 10))))", new FilterQueryExpressionTestTraceEvent("Depth", "5") },
+                new object[] { "(ThreadData != 1,0033) && (ThreadData = 1001)", new FilterQueryExpressionTestTraceEvent("ThreadData", "1001") },
+                new object[] { "(ThreadData != 1,0033 && ThreadData != 1,002) && (ThreadData = 1001)", new FilterQueryExpressionTestTraceEvent("ThreadData", "1001") },
+                new object[] { "(OldProcessName = test && OldProcessName != test1 || OldProcessName != test2)", new FilterQueryExpressionTestTraceEvent("OldProcessName", "test") },
+                new object[] { "(GC/Start::Depth >= 10 && GC/Start::Depth <= 20)", new FilterQueryExpressionTestTraceEvent("Depth", "15", "GC/Start") },
+            };
+
+            public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Theory]
+        [ClassData(typeof(FilterQueryExpressionTreeTestData_ComplexExpressions_TrueCases))]
+        public void Match_ComplexExpressions_True(string expression, FilterQueryExpressionTestTraceEvent filterQueryExpressionTestTraceEvent)
+        { 
+            FilterQueryExpressionTree tree = new FilterQueryExpressionTree(expression);
+            bool match = tree.Match(filterQueryExpressionTestTraceEvent);
+            Assert.True(match);
+        }
+    }
+}

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/Exceptions.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/Exceptions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
+{
+    public sealed class FilterQueryExpressionParsingException : ArgumentException  
+    {
+        public FilterQueryExpressionParsingException(string message, string query)
+            : base($"FilterQueryExpressionTree: {query} failed to parse: {message}") {}
+    }
+
+    public sealed class FilterQueryExpressionTreeParsingException : ArgumentException  
+    {
+        public FilterQueryExpressionTreeParsingException(string message, string query)
+            : base($"FilterQueryExpressionTree: {query} failed to parse: {message}") {}
+    }
+
+    public sealed class FilterQueryExpressionTreeMatchingException : ArgumentException  
+    {
+        public FilterQueryExpressionTreeMatchingException(string message, string query)
+            : base($"FilterQueryExpressionTree: {query} failed to parse: {message}") {}
+    }
+}

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpression.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpression.cs
@@ -1,0 +1,143 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
+{
+    internal sealed class FilterQueryExpression
+    {
+        private static readonly string[] _separator = new[] { " " };
+        public enum Operator
+        {
+            NotValid,
+            Equal,
+            GreaterThan,
+            GreaterThanOrEqualTo,
+            LessThan,
+            LessThanOrEqualTo,
+            NotEqualTo,
+            Contains
+        };
+
+        public FilterQueryExpression(string exp)
+        {
+            var splits = exp.Split(_separator, StringSplitOptions.RemoveEmptyEntries); 
+            LeftOperand = splits[0];
+            OperatorAsString = splits[1].ToLower();
+            switch (OperatorAsString)
+            {
+                case "=":
+                    Op = Operator.Equal;
+                    break;
+                case "!=":
+                    Op = Operator.NotEqualTo;
+                    break;
+                case "contains":
+                    Op = Operator.Contains;
+                    break;
+                case ">":
+                    Op = Operator.GreaterThan;
+                    break;
+                case ">=":
+                    Op = Operator.GreaterThanOrEqualTo;
+                    break;
+                case "<":
+                    Op = Operator.LessThan;
+                    break;
+                case "<=":
+                    Op = Operator.LessThanOrEqualTo;
+                    break;
+                default:
+                    Op = Operator.NotValid;
+                    break;
+            }
+
+            RightOperand = splits[2];
+            IsDouble = double.TryParse(RightOperand, out var rhsAsDouble);
+            if (IsDouble)
+            {
+                RightOperandAsDouble = rhsAsDouble;
+            }
+        }
+
+        public static bool IsValidExpression(string expression)
+        {
+            var split = expression.Split(_separator, StringSplitOptions.RemoveEmptyEntries);
+            if (split.Length < 3)
+                return false;
+
+            var @operator = split[1].ToLower();
+            return
+                !split[0].Contains("(") &&
+                !split[2].Contains(")") &&
+                (@operator == "=" ||
+                @operator == "!=" ||
+                @operator == ">=" ||
+                @operator == ">" ||
+                @operator == "<=" ||
+                @operator == "<" ||
+                @operator == "contain");
+        }
+
+        public bool Match(TraceEvent @event)
+        {
+            var rhsOperand = FilterQueryUtilities.ExtractPayloadByName(@event, LeftOperand);
+
+            // Payload not found => ignore this trace event.
+            if (rhsOperand == null)
+            {
+                return false;
+            }
+
+            switch (Op)
+            {
+                case Operator.Equal:
+                    return rhsOperand == RightOperand;
+                case Operator.NotEqualTo:
+                    return rhsOperand != RightOperand;
+                case Operator.Contains:
+                    return rhsOperand.Contains(RightOperand);
+
+                case Operator.LessThan:
+                case Operator.LessThanOrEqualTo:
+                case Operator.GreaterThan:
+                case Operator.GreaterThanOrEqualTo:
+                    return HandleDoubleComparisons(this, rhsOperand, Op);
+                default:
+                    throw new ArgumentException("Unidentified Operator.");
+            }
+        }
+
+        internal static bool HandleDoubleComparisons(FilterQueryExpression expression, string rhsOperand, Operator o)
+        {
+            if (!expression.IsDouble)
+            {
+                throw new ArgumentException($"Right Operand: {rhsOperand} is not a double.");
+            }
+
+            if (!double.TryParse(rhsOperand, out double rhsOperandAsDouble))
+            {
+                throw new ArgumentException($"Right Operand: {rhsOperand} is not a double.");
+            }
+
+            switch (o)
+            {
+                case Operator.LessThan:
+                    return rhsOperandAsDouble < expression.RightOperandAsDouble;
+                case Operator.LessThanOrEqualTo:
+                    return rhsOperandAsDouble <= expression.RightOperandAsDouble;
+                case Operator.GreaterThan:
+                    return rhsOperandAsDouble > expression.RightOperandAsDouble;
+                case Operator.GreaterThanOrEqualTo:
+                    return rhsOperandAsDouble >= expression.RightOperandAsDouble;
+                default:
+                    throw new ArgumentException("Unidentified Operator.");
+            }
+        }
+
+        public string LeftOperand { get; }
+        public string OperatorAsString { get; }
+        public Operator Op { get; }
+        public string RightOperand { get; }
+        public double RightOperandAsDouble { get; } = double.NaN;
+        public bool IsDouble { get; }
+    }
+}

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpressionTree.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpressionTree.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
 {
     public sealed class FilterQueryExpressionTree
     {
-        private readonly string _originalExpression;
         private readonly FilterQueryExpression _simpleFilterQueryExpression;
         private readonly Dictionary<char, FilterQueryExpression> _expressionMap;
         private readonly string _postFixExpression;
@@ -26,14 +25,15 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
 
             else
             {
-                _originalExpression = expression;
+                OriginalExpression = expression;
 
                 // Prime Expression -> Post Fix
-                string primedExpression = ShuntingYard.PrimeExpression(_originalExpression, out var expressionMap);
-                _expressionMap = expressionMap;
+                string primedExpression = ShuntingYard.PrimeExpression(OriginalExpression, out var _expressionMap);
                 _postFixExpression = ShuntingYard.ToPostFix(primedExpression);
             }
         }
+
+        public string OriginalExpression { get; }
 
         public bool Match(TraceEvent @event)
         {

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpressionTree.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpressionTree.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
 {
+    /// <summary>
+    /// Class responsible for encapsulating the collection of FilterQueryExpressions and the logic to combine them to deduce if we match on a particular trace event.
+    /// </summary>
     public sealed class FilterQueryExpressionTree
     {
         private readonly FilterQueryExpression _simpleFilterQueryExpression;
@@ -13,41 +16,52 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
         {
             if (string.IsNullOrEmpty(expression))
             {
-                throw new ArgumentException($"{nameof(expression)} is null. Invalid Filter Expression Tree.");
+                throw new FilterQueryExpressionTreeParsingException($"{nameof(expression)} is null.", expression); 
             }
 
-            // Base Case: Simple Expression Without Parentheses.
+            // Faster computation if a single Expression Without Parentheses i.e. one simple expression is provided.
             if (FilterQueryExpression.IsValidExpression(expression) &&
                 (!expression.Contains("(") || expression.Contains(")")))
             {
                 _simpleFilterQueryExpression = new FilterQueryExpression(expression);
             }
 
+            // Compute the PostFix (RPN) representation of the expression for easier logical deduction where perf matters.
             else
             {
                 OriginalExpression = expression;
-
-                // Prime Expression -> Post Fix
-                string primedExpression = ShuntingYard.PrimeExpression(OriginalExpression, out var _expressionMap);
+                string primedExpression = ShuntingYard.PrimeExpression(OriginalExpression, out var expressionMap);
+                _expressionMap = expressionMap; 
                 _postFixExpression = ShuntingYard.ToPostFix(primedExpression);
             }
         }
 
+        /// <summary>
+        /// Keep track of the original expression the user provided.
+        /// </summary>
         public string OriginalExpression { get; }
 
+        /// <summary>
+        /// This method is responsible for matching the entire user specified expression on an event.  
+        /// </summary>
+        /// <param name="event"></param>
+        /// <returns></returns>
         public bool Match(TraceEvent @event)
         {
+            // Handle the simple case where a single simple filter query expression is provided.
             if (_simpleFilterQueryExpression != null)
             {
                 return _simpleFilterQueryExpression.Match(@event);
             }
 
+            // Map each of the expressions to lower-case alphabet and the match result of the expression i.e. a boolean.
             Dictionary<string, bool> convertedExpressionMap = new Dictionary<string, bool>();
             foreach (var kvp in _expressionMap)
             {
                 convertedExpressionMap[kvp.Key.ToString()] = kvp.Value.Match(@event);
             }
 
+            // Conduct a Shunting Yard Match using the modified postfix expression.
             return ShuntingYard.Match(_postFixExpression, convertedExpressionMap);
         }
     }

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpressionTree.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryExpressionTree.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
+{
+    public sealed class FilterQueryExpressionTree
+    {
+        private readonly string _originalExpression;
+        private readonly FilterQueryExpression _simpleFilterQueryExpression;
+        private readonly Dictionary<char, FilterQueryExpression> _expressionMap;
+        private readonly string _postFixExpression;
+
+        public FilterQueryExpressionTree(string expression)
+        {
+            if (string.IsNullOrEmpty(expression))
+            {
+                throw new ArgumentException($"{nameof(expression)} is null. Invalid Filter Expression Tree.");
+            }
+
+            // Base Case: Simple Expression Without Parentheses.
+            if (FilterQueryExpression.IsValidExpression(expression) &&
+                (!expression.Contains("(") || expression.Contains(")")))
+            {
+                _simpleFilterQueryExpression = new FilterQueryExpression(expression);
+            }
+
+            else
+            {
+                _originalExpression = expression;
+
+                // Prime Expression -> Post Fix
+                string primedExpression = ShuntingYard.PrimeExpression(_originalExpression, out var expressionMap);
+                _expressionMap = expressionMap;
+                _postFixExpression = ShuntingYard.ToPostFix(primedExpression);
+            }
+        }
+
+        public bool Match(TraceEvent @event)
+        {
+            if (_simpleFilterQueryExpression != null)
+            {
+                return _simpleFilterQueryExpression.Match(@event);
+            }
+
+            Dictionary<string, bool> convertedExpressionMap = new Dictionary<string, bool>();
+            foreach (var kvp in _expressionMap)
+            {
+                convertedExpressionMap[kvp.Key.ToString()] = kvp.Value.Match(@event);
+            }
+
+            return ShuntingYard.Match(_postFixExpression, convertedExpressionMap);
+        }
+    }
+}

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryUtilities.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryUtilities.cs
@@ -24,14 +24,5 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
 
             return @event.PayloadByName(payloadName)?.ToString(); 
         }
-
-        internal static string ExtractEventName(TraceEvent @event)
-            => @event.EventName;
-
-        internal static string LogQuery(FilterQueryExpressionTree tree, Exception ex)
-            => $"Expression: \"{tree.OriginalExpression}\" excepted with message: {ex}.";
-
-        internal static string LogQuery(FilterQueryExpressionTree tree, FilterQueryExpression exp, Exception ex)
-            => $"Expression: \"{tree.OriginalExpression}\":{exp.ToString()} excepted with message: {ex}.";
     }
 }

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryUtilities.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryUtilities.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
+{
+    public static class FilterQueryUtilities
+    {
+        internal static readonly Dictionary<string, Func<TraceEvent, string>> _specialPayload = new Dictionary<string, Func<TraceEvent, string>>
+            (StringComparer.OrdinalIgnoreCase)
+        {
+            { "ThreadID", (TraceEvent e) => e.ThreadID.ToString() },
+            { "ProcessID", (TraceEvent e) => e.ProcessID.ToString() },
+            { "ProcessName", (TraceEvent e) => e.ProcessName.ToString() },
+            { "ProcessorNumber", (TraceEvent e) => e.ProcessorNumber.ToString() },
+            { "TimeStampRelativeMSec", (TraceEvent e) => e.TimeStampRelativeMSec.ToString() },
+        };
+
+        public static string ExtractPayloadByName(TraceEvent @event, string payloadName)
+        {
+            if (_specialPayload.TryGetValue(payloadName, out var func))
+            {
+                return func(@event);
+            }
+
+            return @event.PayloadByName(payloadName)?.ToString(); 
+        }
+    }
+}

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryUtilities.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/FilterQueryUtilities.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
         internal static readonly Dictionary<string, Func<TraceEvent, string>> _specialPayload = new Dictionary<string, Func<TraceEvent, string>>
             (StringComparer.OrdinalIgnoreCase)
         {
-            { "ThreadID", (TraceEvent e) => e.ThreadID.ToString() },
-            { "ProcessID", (TraceEvent e) => e.ProcessID.ToString() },
-            { "ProcessName", (TraceEvent e) => e.ProcessName.ToString() },
-            { "ProcessorNumber", (TraceEvent e) => e.ProcessorNumber.ToString() },
+            { "ThreadID",              (TraceEvent e) => e.ThreadID.ToString()              },
+            { "ProcessID",             (TraceEvent e) => e.ProcessID.ToString()             },
+            { "ProcessName",           (TraceEvent e) => e.ProcessName.ToString()           },
+            { "ProcessorNumber",       (TraceEvent e) => e.ProcessorNumber.ToString()       },
             { "TimeStampRelativeMSec", (TraceEvent e) => e.TimeStampRelativeMSec.ToString() },
         };
 
-        public static string ExtractPayloadByName(TraceEvent @event, string payloadName)
+        internal static string ExtractPayloadByName(TraceEvent @event, string payloadName)
         {
             if (_specialPayload.TryGetValue(payloadName, out var func))
             {
@@ -24,5 +24,14 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
 
             return @event.PayloadByName(payloadName)?.ToString(); 
         }
+
+        internal static string ExtractEventName(TraceEvent @event)
+            => @event.EventName;
+
+        internal static string LogQuery(FilterQueryExpressionTree tree, Exception ex)
+            => $"Expression: \"{tree.OriginalExpression}\" excepted with message: {ex}.";
+
+        internal static string LogQuery(FilterQueryExpressionTree tree, FilterQueryExpression exp, Exception ex)
+            => $"Expression: \"{tree.OriginalExpression}\":{exp.ToString()} excepted with message: {ex}.";
     }
 }

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/ShuntingYard.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/ShuntingYard.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
+{
+    internal static class ShuntingYard
+    {
+        private sealed class OperatorInfo
+        {
+            public OperatorInfo(char symbol, int precedence, bool rightAssociative)
+            {
+                Symbol = symbol;
+                Precedence = precedence;
+                RightAssociative = rightAssociative;
+            }
+
+            public char Symbol { get; }
+            public int Precedence { get; }
+            public bool RightAssociative { get; }
+        }
+
+        private static readonly Dictionary<char, OperatorInfo> operators = new Dictionary<char, OperatorInfo>
+        {
+            { '&', new OperatorInfo('&', 2, false) },
+            { '|', new OperatorInfo('|', 1, false) }
+        };
+
+        public static string ToPostFix(this string infix)
+        {
+            var stack = new Stack<char>();
+            var output = new List<char>();
+
+            foreach (var token in infix)
+            {
+                if (char.IsLetter(token))
+                {
+                    output.Add(token);
+                }
+
+                if (operators.TryGetValue(token, out var opt1))
+                {
+                    while (stack.Count > 0 && operators.TryGetValue(stack.Peek(), out var op2))
+                    {
+                        int c = opt1.Precedence.CompareTo(op2.Precedence);
+                        if (c < 0 || !opt1.RightAssociative && c <= 0)
+                        {
+                            output.Add(stack.Pop());
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    stack.Push(token);
+                }
+
+                else if (token == '(')
+                {
+                    stack.Push(token);
+                }
+
+                else if (token == ')')
+                {
+                    char top = '\0';
+                    while (stack.Count > 0 && (top = stack.Pop()) != '(')
+                    {
+                        output.Add(top);
+                    }
+
+                    if (top != '(')
+                        throw new ArgumentException("No matching left parentheses.");
+                }
+            }
+
+            while (stack.Count > 0)
+            {
+                var top = stack.Pop();
+                if (!operators.ContainsKey(top)) throw new ArgumentException("No matching right parentheses");
+                output.Add(top);
+            }
+
+            return String.Join(" ", output);
+        }
+
+        private static readonly Regex _operandRegex = new Regex(@"-?[a-z]+");
+
+        public static bool Match(string postfixNotation, Dictionary<string, bool> expressionMap)
+        {
+            // Handle fast path.
+            if (postfixNotation.Length == 1)
+            {
+                return expressionMap["a"];
+            }
+
+            var tokens = new Stack<string>();
+            string[] rawTokens = postfixNotation.Split(' ');
+            foreach (var rawToken in rawTokens)
+            {
+                if (_operandRegex.IsMatch(rawToken))
+                {
+                    tokens.Push(rawToken);
+                }
+
+                else if (rawToken == "|" || rawToken == "&")
+                {
+                    var operand1 = tokens.Pop();
+                    var operand2 = tokens.Pop();
+                    var @operator = rawToken;
+                    var result = EvaluateSingleExpression(operand1, operand2, @operator, expressionMap);
+                    tokens.Push(result.ToString());
+                }
+            }
+
+            if (tokens.Count > 0)
+            {
+                return bool.Parse(tokens.Pop());
+            }
+
+            throw new ArgumentException("Shouldn't get here!");
+        }
+
+        public static bool EvaluateSingleExpression(string operand1, string operand2, string @operator, Dictionary<string, bool> expressionMap)
+        {
+            var exp1 = expressionMap.ContainsKey(operand1) ? expressionMap[operand1] : bool.Parse(operand1);
+            var exp2 = expressionMap.ContainsKey(operand2) ? expressionMap[operand2] : bool.Parse(operand2);
+
+            switch (@operator)
+            {
+                case "|":
+                    return exp1 || exp2;
+                case "&":
+                    return exp1;
+                default:
+                    throw new ArgumentException($"Operator: {@operator} not found.");
+            }
+        }
+
+        public static string PrimeExpression(string expression, out Dictionary<char, FilterQueryExpression> expressionMap)
+        {
+            var returnExpression = expression;
+            returnExpression = returnExpression.Replace("&&", "&").Replace("||", "|");
+
+            expressionMap = new Dictionary<char, FilterQueryExpression>();
+            expression = expression.Replace("&&", "`").Replace("||", "`");
+            expression = expression.Replace("(", "").Replace(")", "");
+
+            var splitExpression = expression.Split('`');
+            char[] alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToLower().ToCharArray();
+            for (int i = 0; i < splitExpression.Length; i++)
+            {
+                // Constrain to 26 expressions.
+                FilterQueryExpression fe = new FilterQueryExpression(splitExpression[i]);
+                var alphabet = alpha[i];
+                expressionMap[alphabet] = fe;
+                returnExpression = returnExpression.Replace(splitExpression[i].TrimStart().TrimEnd(), alphabet.ToString());
+            }
+
+            return returnExpression;
+        }
+    }
+
+}

--- a/src/TraceEvent/TraceUtilities/FilterQueryExpression/ShuntingYard.cs
+++ b/src/TraceEvent/TraceUtilities/FilterQueryExpression/ShuntingYard.cs
@@ -138,6 +138,9 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
             }
         }
 
+        private static char[] Alphabets = Enumerable.Range('a', 26).Select(a => (char)a)
+                                                    .Concat(Enumerable.Range('A', 26).Select(a => (char)a))
+                                                    .ToArray();
         public static string PrimeExpression(string expression, out Dictionary<char, FilterQueryExpression> expressionMap)
         {
             var returnExpression = expression;
@@ -148,12 +151,11 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
             expression = expression.Replace("(", "").Replace(")", "");
 
             var splitExpression = expression.Split('`');
-            char[] alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToLower().ToCharArray();
             for (int i = 0; i < splitExpression.Length; i++)
             {
-                // Constrain to 26 expressions.
+                // Constrain to 52 expressions.
                 FilterQueryExpression fe = new FilterQueryExpression(splitExpression[i]);
-                var alphabet = alpha[i];
+                var alphabet = Alphabets[i];
                 expressionMap[alphabet] = fe;
                 returnExpression = returnExpression.Replace(splitExpression[i].TrimStart().TrimEnd(), alphabet.ToString());
             }
@@ -161,5 +163,4 @@ namespace Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression
             return returnExpression;
         }
     }
-
 }


### PR DESCRIPTION
## Summary

Added the ability to filter events in the event view using boolean expression(s). This PR Addresses a large part of https://github.com/microsoft/perfview/issues/1629 (CC: @Maoni0). In a nutshell, this PR allows the ability to specify a filter query (currently only) in the Columns To Display textbox to apply to all events so that we can easily filter the data to retrieve pertinent events.

## Design Details

In a nutshell, here's what's happening under the hood:

1. If the user specifies a filter query within ``[]`` in the "Columns To Display" textbox, we extract the intended query and create a ``FilterQueryExpressionTree`` out of it based on the string provided by the user.
    * A ``FilterQueryExpressionTree`` encapsulates the collection of ``FilterQueryExpression``s and the matching of the trace event on the collection of these expressions. 
    * ``FilterQueryExpression``s are of the following format: ``LeftOperand Operator RightOperand`` where:
        - ``LeftOperand`` can either be a name of a property to search on in any event e.g. ``ThreadID`` or be specified specifically for a particular event name (we are simply checking if the event name passed in by the user is contained in the full ``EventName`` property of the TraceEvent) by using ``::``. For example: ``CSwitch::OldThreadID``.
        - ``Operator`` can be any of the following: ``!=, =, <, <=, >=, >, Contains``.
        - ``RightOperand`` can either be a ``string`` or a numeric that's used as a ``double``.
    * Multiple ``FilterQuerieExpression``s can be combined using either ``||`` or ``&&``. 
2. The algorithm used to deduce the logical expression is a modification of the [Shunting Yard Algorithm](https://en.wikipedia.org/wiki/Shunting_yard_algorithm) that takes in an infix expression, converts it into it's postfix (aka Reverse Polish Notation (RPN)) equivalent.
    * The design decision to convert to the RPN equivalent is based on making the boolean expression reduction more performant when we iterate through all TraceEvents to discern which ones to display.
3. Once the RPN expression is obtained, and the user invokes a UI update, the entire RPN expression is applied to the TraceEvents and a single boolean is returned on the basis of which, we decide to display or discard the particular event. 

While working on this PR, the solution was prototyped [here](https://github.com/MokoSan/BooleanExpressionParser). A number of unit tests have also been added with this PR.

## Current Implementation Limitations

1. The way I have designed this, I have imposed a restriction of 26 Filter Query Expressions. This is implementation specific and I'll be happy to change this, if need be. The trade-off here was to keep the construction of final RPN expression quick and easy to reduce in the more perf demanding part of the code.
2. To construct an expression, you _have_ to add a space between the Left Operand, Operator and Right Operand. e.g. ``Depth<1`` will not work - instead you'll need to enter: ``Depth < 1``. This is an implementation detail, as well; to construct ``FilterQueryExpression``s, I am splitting on empty spaces to distinguish between the different parts of the expression.
4. Right now, only _one_ query will be used to filter the event i.e. you can't specify multiple ``[..]``s in the Columns To Display textbox.

## Demo

### Demo of Greater + Less Than or Equal to Operators:
https://user-images.githubusercontent.com/4951960/168762353-416a619c-0c2f-4b59-887c-213a7fe2f77f.mp4

### Demo of More Complex Operations With A Bunch of Nesting:
https://user-images.githubusercontent.com/4951960/168765726-f6644215-77e3-4f5a-a70f-a1359a82cdc0.mp4

Some of the queries I demo'd based on the ``GC/Start`` and ``GC/Stop`` events are:
1. ``[(Count > 10 && (Depth >= -1) && (Count <= 30) && (Count <= 30 || ProcessorNumber = 2))] Count ProcessorNumber Depth``
2. ``[(Count > 10  && (Count <= 30) && (Count <= 30 || ProcessorNumber = 2))] Count ProcessorNumber Depth``
5. ``[(Count > 10  && (Count <= 30) && (Count <= 30 || ProcessorNumber = 2))] Count ProcessorNumber``
6. ``[(Count > 10  && (Count <= 30)  && (Count <= 30 || ProcessorNumber = 2))] Count ProcessorNumber``

Happy to address any feedback! 