### PR TITLE
Explicitly Version FastSerialization

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,6 +22,7 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
+    <FastSerializationVersion>3.0.0</FastSerializationVersion>
     <PerfViewVersion>3.0.0</PerfViewVersion>
     <TraceEventVersion>3.0.0</TraceEventVersion>
   </PropertyGroup>

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -11,6 +11,9 @@
     <Company>Microsoft</Company>
     <Description>Serialization library for TraceEvent.</Description>
     <Copyright>Copyright © Microsoft 2010</Copyright>
+    <Version>$(FastSerializationVersion)</Version>
+    <FileVersion>$(FastSerializationVersion)</FileVersion>
+    <InformationalVersion>$(FastSerializationVersion)</InformationalVersion>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
FastSerialization does not currently have an explicit version set, so it is always 1.0.0.0.  Breaking changes to FastSerialization can break when there are apps that have conflicting copies of FastSerialization with different versions.

This change allows us to explicitly version FastSerialization and sets the version number to 3.0.0.