### PR TITLE
Update to ClrMD 2.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,7 @@
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.23</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>0.1.1</MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>2.0.226801</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>2.1.327703</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.4.0</XunitVersion>
     <XunitRunnerVisualstudioVersion>2.4.0</XunitRunnerVisualstudioVersion>
   </PropertyGroup>

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -285,8 +285,7 @@ public class GCHeapDumper
     {
         List<ClrRuntime> runtimes = new List<ClrRuntime>();
 
-        DataTarget dataTarget = null;
-
+        DataTarget dataTarget;
         if (string.IsNullOrWhiteSpace(processDumpFile))
         {
             try
@@ -300,7 +299,12 @@ public class GCHeapDumper
         }
         else
         {
-            dataTarget = DataTarget.LoadDump(processDumpFile);
+            CacheOptions cacheOptions = new CacheOptions()
+            {
+                UseOSMemoryFeatures = false // disable AWE
+            };
+
+            dataTarget = DataTarget.LoadDump(processDumpFile, cacheOptions);
         }
 
         if (dataTarget.DataReader.PointerSize != IntPtr.Size)
@@ -1487,7 +1491,7 @@ public class GCHeapDumper
 
                 m_children.Clear();
 
-                foreach (var childObj in obj.EnumerateReferences(carefully: true, considerDependantHandles: true))
+                foreach (ulong childObj in obj.EnumerateReferenceAddresses(carefully: true, considerDependantHandles: true))
                     m_children.Add(m_gcHeapDump.MemoryGraph.GetNodeIndex(childObj));
 
                 var objNodeIdx = m_gcHeapDump.MemoryGraph.GetNodeIndex(obj);

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -33,6 +33,7 @@
 
     <!-- These are required for ClrMD and are here so that we can embed the assemblies into PerfView. -->
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -272,6 +272,20 @@
       <Link>HeapDump\System.Memory.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net462\System.Net.Http.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\HeapDump\System.Net.Http.dll</LogicalName>
+      <Link>HeapDump\System.Net.Http.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net462\System.Numerics.Vectors.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\HeapDump\System.Numerics.Vectors.dll</LogicalName>
+      <Link>HeapDump\System.Numerics.Vectors.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(NuGetPackageRoot)\System.Reflection.Metadata\5.0.0\lib\net461\System.Reflection.Metadata.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -364,7 +364,7 @@
       <Link>Microsoft.Diagnostics.Tracing.TraceEvent.xml</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\Microsoft.Diagnostics.Runtime\$(MicrosoftDiagnosticsRuntimeVersion)\lib\net461\Microsoft.Diagnostics.Runtime.dll">
+    <EmbeddedResource Include="$(NuGetPackageRoot)\Microsoft.Diagnostics.Runtime\$(MicrosoftDiagnosticsRuntimeVersion)\lib\netstandard2.0\Microsoft.Diagnostics.Runtime.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\x86\Microsoft.Diagnostics.Runtime.dll</LogicalName>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -72,7 +72,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
 
   <!-- *** SourceLink Support *** -->
   <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
Version bump ClrMD to 2.1.

- Disable AWE reader.
- Use ClrObject.EnumerateReferenceAddresses to avoid looking up the type when we do not need it.