### PR TITLE
Plumb Default Provider Options Through ParseProviderSpecs

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3229,7 +3229,7 @@ namespace PerfView
                 wildCardFileName = Command.FindOnPath(GetExeName(commandLine));
             }
 
-            var parsedProviders = ProviderParser.ParseProviderSpecs(providerSpecs, wildCardFileName, LogFile);
+            var parsedProviders = ProviderParser.ParseProviderSpecs(providerSpecs, wildCardFileName, options, LogFile);
             foreach (var parsedProvider in parsedProviders)
             {
                 if (parsedProvider.Level == TraceEventLevel.Always && parsedProvider.MatchAnyKeywords == 0)
@@ -3478,7 +3478,7 @@ namespace PerfView
                     {
                         if (parsedArgs.Providers != null)
                         {
-                            var parsedProviders = ProviderParser.ParseProviderSpecs(parsedArgs.Providers, null, LogFile);
+                            var parsedProviders = ProviderParser.ParseProviderSpecs(parsedArgs.Providers, null, null, LogFile);
                             foreach (var parsedProvider in parsedProviders)
                             {
                                 // turn it on in the Rundown Session, this will dump the manifest into the rundown information. 
@@ -3649,7 +3649,7 @@ namespace PerfView
         /// <summary>
         /// TODO FIX NOW document
         /// </summary>
-        public static List<ParsedProvider> ParseProviderSpecs(string[] providerSpecs, string wildCardFileName, TextWriter log = null)
+        public static List<ParsedProvider> ParseProviderSpecs(string[] providerSpecs, string wildCardFileName, TraceEventProviderOptions inputOptions, TextWriter log = null)
         {
             var ret = new List<ParsedProvider>();
 
@@ -3660,7 +3660,7 @@ namespace PerfView
                     log.WriteLine("Parsing ETW Provider Spec: {0}", providerSpec);
                 }
 
-                TraceEventProviderOptions options = new TraceEventProviderOptions();
+                TraceEventProviderOptions options = inputOptions.Clone() ?? new TraceEventProviderOptions();
                 TraceEventLevel level = TraceEventLevel.Verbose;
                 ulong matchAnyKeywords = unchecked((ulong)-1);
 

--- a/src/PerfView/UserCommands.cs
+++ b/src/PerfView/UserCommands.cs
@@ -774,7 +774,7 @@ namespace PerfViewExtensibility
 
                 // Enable all the providers the users asked for
 
-                var parsedProviders = ProviderParser.ParseProviderSpecs(etwProviderNames.Split(','), null, LogFile);
+                var parsedProviders = ProviderParser.ParseProviderSpecs(etwProviderNames.Split(','), null, null, LogFile);
                 foreach (var parsedProvider in parsedProviders)
                 {
                     LogFile.WriteLine("Enabling provider {0}:{1:x}:{2}", parsedProvider.Name, (ulong)parsedProvider.MatchAnyKeywords, parsedProvider.Level);


### PR DESCRIPTION
`TraceEventProviderOptions` is the class that is used to configure options when enabling or disabling a provider.  Several commandline arguments can be used to modify fields on this class.  Specific options can also be specified per-provider via `/Providers` and `/OnlyProviders`.

Prior to this change, command line arguments that modified `TraceEventProviderOptions` were not applied to the options applied to providers enabled via `/Providers` and `/OnlyProviders`.  This change propagates all changes that modify `TraceEventProviderOptions` to the options set for providers enabled via `/Providers` and `/OnlyProviders`.  Those that are configurable as part of the provider spec (providerguid:keywords:level:stack...) can be overridden on a per-provider basis via `/Providers` and `/OnlyProviders'.

This fixes a bug that was reported where `/EnableEventsInContainers` and `/EnableSourceContainerTracking` were specified, but not applied to providers specified by `/Providers` and `/OnlyProviders`.