### PR TITLE
Add option: Do not truncate/shorten stack frames on paste

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -106,7 +106,7 @@
                 </MenuItem>
                 <MenuItem Header="_Options">
                     <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
-                    <MenuItem Header="Do not truncate lines pasted from the Stack Viewer window" x:Name="Option_DoNotTruncateStackViewerLinesOnPaste" IsCheckable="True" Click="ToggleDoNotTruncateStackViewerLinesOnPaste" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
+                    <MenuItem Header="Do not shorten frames copied from stacks windows" x:Name="Option_DoNotTruncateStackViewerLinesOnPaste" IsCheckable="True" Click="ToggleDoNotTruncateStackViewerLinesOnPaste" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
                 </MenuItem>
                 <MenuItem Header="_Help">
                     <MenuItem Header="_Help on Main View" Command="Help" CommandParameter="MainViewerQuickStart" />

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -106,6 +106,7 @@
                 </MenuItem>
                 <MenuItem Header="_Options">
                     <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
+                    <MenuItem Header="Do not truncate lines pasted from the Stack Viewer window" x:Name="Option_DoNotTruncateStackViewerLinesOnPaste" IsCheckable="True" Click="ToggleDoNotTruncateStackViewerLinesOnPaste" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
                 </MenuItem>
                 <MenuItem Header="_Help">
                     <MenuItem Header="_Help on Main View" Command="Help" CommandParameter="MainViewerQuickStart" />

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -106,7 +106,7 @@
                 </MenuItem>
                 <MenuItem Header="_Options">
                     <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
-                    <MenuItem Header="Do not shorten frames copied from stacks windows" x:Name="Option_DoNotTruncateStackViewerLinesOnPaste" IsCheckable="True" Click="ToggleDoNotTruncateStackViewerLinesOnPaste" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
+                    <MenuItem Header="Do not shorten frames copied from stack windows" x:Name="Option_DoNotTruncateStackViewerLinesOnPaste" IsCheckable="True" Click="ToggleDoNotTruncateStackViewerLinesOnPaste" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
                 </MenuItem>
                 <MenuItem Header="_Help">
                     <MenuItem Header="_Help on Main View" Command="Help" CommandParameter="MainViewerQuickStart" />

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -106,7 +106,7 @@
                 </MenuItem>
                 <MenuItem Header="_Options">
                     <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
-                    <MenuItem Header="Do not shorten frames copied from stack windows" x:Name="Option_DoNotTruncateStackViewerLinesOnPaste" IsCheckable="True" Click="ToggleDoNotTruncateStackViewerLinesOnPaste" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
+                    <MenuItem Header="Do not shorten frames copied from stack windows" x:Name="Option_DoNotCompressStackFramesOnCopy" IsCheckable="True" Click="ToggleDoNotCompressStackFramesOnCopy" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
                 </MenuItem>
                 <MenuItem Header="_Help">
                     <MenuItem Header="_Help on Main View" Command="Help" CommandParameter="MainViewerQuickStart" />

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1126,6 +1126,7 @@ namespace PerfView
 
             // Initialize configuration options.
             InitializeOpenToLastUsedDirectory();
+            InitializeDoNotTruncateStackViewerLinesOnPaste();
 
             InitializeFeedback();
         }
@@ -1155,6 +1156,25 @@ namespace PerfView
                 path = App.UserConfigData["Directory"] ?? ".";
             }
             OpenPath(path);
+        }
+
+        public void InitializeDoNotTruncateStackViewerLinesOnPaste()
+        {
+            bool currentValue;
+            bool.TryParse(App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"], out currentValue);
+            Option_DoNotTruncateStackViewerLinesOnPaste.IsChecked = currentValue;
+        }
+
+        /// <summary>
+        /// Toggles the option to not truncate/minimize stack frame lines copied from the stack viewer window.
+        /// </summary>
+        public void ToggleDoNotTruncateStackViewerLinesOnPaste(object sender, RoutedEventArgs e)
+        {
+            bool currentValue;
+            bool.TryParse(App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"], out currentValue);
+            bool newValue = !currentValue;
+            App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"] = newValue.ToString();
+            Option_DoNotTruncateStackViewerLinesOnPaste.IsChecked = newValue;
         }
 
         /// <summary>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1126,7 +1126,7 @@ namespace PerfView
 
             // Initialize configuration options.
             InitializeOpenToLastUsedDirectory();
-            InitializeDoNotTruncateStackViewerLinesOnPaste();
+            InitializeDoNotCompressStackFramesOnCopy();
 
             InitializeFeedback();
         }
@@ -1158,25 +1158,27 @@ namespace PerfView
             OpenPath(path);
         }
         /// <summary>
-        /// Initial read-in of the user settings to check if they had previously opted-in for the DoNotTruncateStackViewerLinesOnPaste option
+        /// Initial read-in of the user settings to check if they had previously opted-in for the DoNotCompressStackFramesOnCopy option
         /// </summary>
-        public void InitializeDoNotTruncateStackViewerLinesOnPaste()
+        public void InitializeDoNotCompressStackFramesOnCopy()
         {
             bool currentValue;
-            bool.TryParse(App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"], out currentValue);
-            Option_DoNotTruncateStackViewerLinesOnPaste.IsChecked = currentValue;
+            bool.TryParse(App.UserConfigData["DoNotCompressStackFramesOnCopy"], out currentValue);
+            Option_DoNotCompressStackFramesOnCopy.IsChecked = currentValue;
+            PerfDataGrid.DoNotCompressStackFrames = currentValue;
         }
 
         /// <summary>
-        /// Toggles the option to not truncate/minimize stack frame lines copied from the stack viewer window.
+        /// Toggles the option to compress stack frame lines copied from the stack viewer window.
         /// </summary>
-        public void ToggleDoNotTruncateStackViewerLinesOnPaste(object sender, RoutedEventArgs e)
+        public void ToggleDoNotCompressStackFramesOnCopy(object sender, RoutedEventArgs e)
         {
             bool currentValue;
-            bool.TryParse(App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"], out currentValue);
+            bool.TryParse(App.UserConfigData["DoNotCompressStackFramesOnCopy"], out currentValue);
             bool newValue = !currentValue;
-            App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"] = newValue.ToString();
-            Option_DoNotTruncateStackViewerLinesOnPaste.IsChecked = newValue;
+            App.UserConfigData["DoNotCompressStackFramesOnCopy"] = newValue.ToString();
+            Option_DoNotCompressStackFramesOnCopy.IsChecked = newValue;
+            PerfDataGrid.DoNotCompressStackFrames = newValue;
         }
 
         /// <summary>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1157,7 +1157,9 @@ namespace PerfView
             }
             OpenPath(path);
         }
-
+        /// <summary>
+        /// Initial read-in of the user settings to check if they had previously opted-in for the DoNotTruncateStackViewerLinesOnPaste option
+        /// </summary>
         public void InitializeDoNotTruncateStackViewerLinesOnPaste()
         {
             bool currentValue;

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
@@ -18,6 +18,7 @@ namespace PerfView
     public partial class PerfDataGrid : UserControl
     {
         public static bool NoPadOnCopyToClipboard = false;
+        public static bool DoNotCompressStackFrames = false;
 
         public PerfDataGrid()
         {
@@ -245,8 +246,8 @@ namespace PerfView
                 return content;
             }
 
-            // Check if the user option is set to not truncate/shorten content
-            if (bool.TryParse(App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"], out bool doNotTruncateLines) && doNotTruncateLines)
+            // Check if the user option is set to not compress stack frames when copying
+            if (DoNotCompressStackFrames)
             {
                 return content;
             }

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
@@ -245,7 +245,7 @@ namespace PerfView
                 return content;
             }
 
-            // Check if the user option is set to not truncate content
+            // Check if the user option is set to not truncate/shorten content
             if (bool.TryParse(App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"], out bool doNotTruncateLines) && doNotTruncateLines)
             {
                 return content;

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml.cs
@@ -245,6 +245,12 @@ namespace PerfView
                 return content;
             }
 
+            // Check if the user option is set to not truncate content
+            if (bool.TryParse(App.UserConfigData["DoNotTruncateStackViewerLinesOnPaste"], out bool doNotTruncateLines) && doNotTruncateLines)
+            {
+                return content;
+            }
+
             // Trim method names !*.XXX.YYY(*) -> !XXX.YYY
             content = Regex.Replace(content, @"![\w\.]+\.(\w+\.\w+)\(.*\)", "!$1");
             if (content.Length < 70)


### PR DESCRIPTION
This change adds an option to the main PerfView "Options" dropdown labeled:
"Do not shorten frames copied from stack windows" (this can be changed if there is other better wording)

This option allows the user to opt-in to paste frames from stack windows as-is and unchanged.

Without option enabled (current behavior):
```
+ System.Private.CoreLib.il!AsyncTaskMethodBuilder.Start
 + System.Private.CoreLib.il!AsyncMethodBuilderCore.Start
  + Microsoft.AspNetCore.Server.Kestrel.Core.il!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol+<ProcessRequestsAsync>d__213`1[System.__Canon].MoveNext()
   + Microsoft.AspNetCore.Server.Kestrel.Core.il!HttpProtocol.ProcessRequests
    + System.Private.CoreLib.il!AsyncTaskMethodBuilder.Start
     + System.Private.CoreLib.il!AsyncMethodBuilderCore.Start
      + Microsoft.AspNetCore.Server.Kestrel.Core.il!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol+<ProcessRequests>d__214`1[System.__Canon].MoveNext()
       + Microsoft.AspNetCore.Hosting.il!HostingApplication.ProcessRequestAsync
        + Microsoft.AspNetCore.HostFiltering.il!HostFilteringMiddleware.Invoke
         + Microsoft.AspNetCore.Diagnostics.il!ExceptionHandlerMiddleware.Invoke
          + Microsoft.AspNetCore.HttpsPolicy.il!HstsMiddleware.Invoke
           + Microsoft.AspNetCore.StaticFiles.il!StaticFileMiddleware.Invoke
            + Microsoft.AspNetCore.Routing.il!EndpointRoutingMiddleware.Invoke
             + Microsoft.AspNetCore.Routing.il!EndpointRoutingMiddleware.SetRoutingAndContinue
              + Microsoft.AspNetCore.Routing.il!EndpointMiddleware.Invoke
               + Microsoft.AspNetCore.Mvc.Core.il!Microsoft.AspNetCore.Mvc.Routing.ActionEndpointFactory+<>c__DisplayClass7_0.<CreateRequestDelegate>b__0(class Microsoft.AspNetCore.Http.HttpContext)
                + Microsoft.AspNetCore.Mvc.Core.il!ResourceInvoker.InvokeAsync
                 + Microsoft.AspNetCore.Mvc.Core.il!Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(class Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker)
                  + System.Private.CoreLib.il!AsyncTaskMethodBuilder.Start
```

With option enabled:
```
+ System.Private.CoreLib.il!System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(!!0&)
 + System.Private.CoreLib.il!System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&)
  + Microsoft.AspNetCore.Server.Kestrel.Core.il!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol+<ProcessRequestsAsync>d__213`1[System.__Canon].MoveNext()
   + Microsoft.AspNetCore.Server.Kestrel.Core.il!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests(class Microsoft.AspNetCore.Hosting.Server.IHttpApplication`1<!!0>)
    + System.Private.CoreLib.il!System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(!!0&)
     + System.Private.CoreLib.il!System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&)
      + Microsoft.AspNetCore.Server.Kestrel.Core.il!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol+<ProcessRequests>d__214`1[System.__Canon].MoveNext()
       + Microsoft.AspNetCore.Hosting.il!Microsoft.AspNetCore.Hosting.HostingApplication.ProcessRequestAsync(class Context)
        + Microsoft.AspNetCore.HostFiltering.il!Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware.Invoke(class Microsoft.AspNetCore.Http.HttpContext)
         + Microsoft.AspNetCore.Diagnostics.il!Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware.Invoke(class Microsoft.AspNetCore.Http.HttpContext)
          + Microsoft.AspNetCore.HttpsPolicy.il!Microsoft.AspNetCore.HttpsPolicy.HstsMiddleware.Invoke(class Microsoft.AspNetCore.Http.HttpContext)
           + Microsoft.AspNetCore.StaticFiles.il!Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware.Invoke(class Microsoft.AspNetCore.Http.HttpContext)
            + Microsoft.AspNetCore.Routing.il!Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.Invoke(class Microsoft.AspNetCore.Http.HttpContext)
             + Microsoft.AspNetCore.Routing.il!Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.SetRoutingAndContinue(class Microsoft.AspNetCore.Http.HttpContext)
              + Microsoft.AspNetCore.Routing.il!Microsoft.AspNetCore.Routing.EndpointMiddleware.Invoke(class Microsoft.AspNetCore.Http.HttpContext)
               + Microsoft.AspNetCore.Mvc.Core.il!Microsoft.AspNetCore.Mvc.Routing.ActionEndpointFactory+<>c__DisplayClass7_0.<CreateRequestDelegate>b__0(class Microsoft.AspNetCore.Http.HttpContext)
                + Microsoft.AspNetCore.Mvc.Core.il!Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeAsync()
                 + Microsoft.AspNetCore.Mvc.Core.il!Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(class Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker)
                  + System.Private.CoreLib.il!System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start(!!0&)
```

This will take immediate effect as well due to how PerfView saves and loads those user settings. So you can have a set of stack frames highlighted, copy and paste them one way, then flip the setting in the main window and copy/paste again with the change taking effect.