### PR TITLE
Check all instances of loaded images for NGEN PDB generation

### DIFF
--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -270,12 +270,9 @@ namespace Microsoft.Diagnostics.Tracing
             // Get the name of all DLLS (in the file, and the set of all address-process pairs in the file.   
             using (var source = new ETWTraceEventSource(etlFile))
             {
-                var handledImageGroupFiles = new HashSet<string>();
                 source.Kernel.ImageGroup += delegate (ImageLoadTraceData data)
                 {
                     var fileName = data.FileName;
-                    if (!handledImageGroupFiles.Add(fileName))
-                        return;
 
                     if (fileName.IndexOf(".ni.", StringComparison.OrdinalIgnoreCase) < 0)
                     {


### PR DESCRIPTION
As part of trace zip, `ZippedETLWriter` generates the list of NGEN images that need PDBs created and then generates them.  It creates this list by tracking the set of per-process image loads, and then comparing the address space of each of the images to CPU sample and stack hits.

There is an optimization when generating the list of images that only includes the first instance of any given image in the list, which is incorrect because all of the comparisons are per-process since they operate over per-process virtual address space.

This change removes the optimization and forces the code to consider every possible NGEN image for each process.