### PR TITLE
[TraceEvent] Extend RuntimeSku to recognize Mono

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -12696,6 +12696,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         None = 0,
         DesktopClr = 0x1,
         CoreClr = 0x2,
+        Mono = 0x4,
     }
     [Flags]
     public enum ExceptionThrownFlags


### PR DESCRIPTION
In dotnet/runtime, https://github.com/dotnet/runtime/pull/71657 and https://github.com/dotnet/runtime/pull/71359 extend RuntimeSku in EventTrace to recognize Mono runtime as `0x4`. Adding the same extension here so that the value shows up as `Mono` instead of `4`.