### PR TITLE
Target netcoreapp3.1 in PerfViewCollect since 2.1 is out of support

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET Core SDK 2.1.505'
+      displayName: 'Use .NET Core SDK 3.1'
       inputs:
-        version: 2.1.505
+        version: 3.1.x
 
     - task: NuGetCommand@2
       displayName: 'NuGet Restore PerfView.sln'
@@ -74,9 +74,9 @@ jobs:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET Core SDK 2.1.505'
+      displayName: 'Use .NET Core SDK 3.1'
       inputs:
-        version: 2.1.505
+        version: 3.1.x
 
     - task: NuGetCommand@2
       displayName: 'NuGet Restore PerfView.sln'

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -6264,7 +6264,7 @@
     </ul>
     <p>
         This last command will build the PerfViewCollect application as a self contained application. The tool
-        tells you where it put it, but it should be in src\PerfViewCollect\bin\Release\netcoreapp2.0\win-x64\publish.
+        tells you where it put it, but it should be in src\PerfViewCollect\bin\Release\netcoreapp3.1\win-x64\publish.
         The tool is the PerfViewCollect.exe in that directory.  You can do a PerfViewCollect /? to get some help
         (but it will be exactly the same command line help for PerfView.exe).
     </p>

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>PerfView</RootNamespace>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>


### PR DESCRIPTION
This also eliminates a warning from the IDE when you load PerfView.sln on a machine without the .NET Core 2.1 runtime