### PR TITLE
Ignore Failures When Saving the Log File

### DIFF
--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -1004,7 +1004,14 @@ namespace PerfViewExtensibility
             // TODO remember the status log even when we don't have a gui. 
 #if !PERFVIEW_COLLECT
             if (GuiApp.MainWindow != null)
+            try
+            {
                 GuiState.Log = File.ReadAllText(App.LogFileName);
+            }
+            catch
+            {
+                // Ignore failures.
+            }
 #endif
 
             Action<XmlWriter> additionalData = null;

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -1011,6 +1011,7 @@ namespace PerfViewExtensibility
             catch
             {
                 // Ignore failures.
+                GuiState.Log = string.Empty;
             }
 #endif
 


### PR DESCRIPTION
Fixes #1669.

When running the SaveCPUStacks user command, it is possible for the PerfView log to be locked.  If this happens, ignore the failure and proceed with saving the stacks.