### PR TITLE
Fix a few bugs related to object generation detection

### DIFF
--- a/src/HeapDumpCommon/DotNetHeapInfo.cs
+++ b/src/HeapDumpCommon/DotNetHeapInfo.cs
@@ -52,6 +52,11 @@ public class DotNetHeapInfo : IFastSerializable
             }
         }
 
+        if (obj < m_lastSegment.Gen4End)
+        {
+            return 4;
+        }
+
         if (obj < m_lastSegment.Gen3End)
         {
             return 3;
@@ -126,6 +131,7 @@ public class GCHeapDumpSegment : IFastSerializable
         serializer.Write((long)Gen1End);
         serializer.Write((long)Gen2End);
         serializer.Write((long)Gen3End);
+        serializer.Write((long)Gen4End);
     }
 
     void IFastSerializable.FromStream(Deserializer deserializer)
@@ -136,6 +142,16 @@ public class GCHeapDumpSegment : IFastSerializable
         Gen1End = (Address)deserializer.ReadInt64();
         Gen2End = (Address)deserializer.ReadInt64();
         Gen3End = (Address)deserializer.ReadInt64();
+        // 
+        // TODO: Backward compatibility - changing serialization format should require bumping version and code paths to deal with 
+        // missing values. How?
+        //
+        // In case this value was not saved, there could be two cases:
+        // Case 1: We are running on a runtime without POH, in that case, initializing that to Start works.
+        // Case 2: We are running on a runtime with POH, in that case, POH segments were saved as if
+        //         they were Gen2, there is no way to differentiate, so just pretend they are Gen2.
+        //
+        Gen4End = (Address)deserializer.ReadInt64();
     }
     #endregion
 }

--- a/src/HeapDumpCommon/DotNetHeapInfo.cs
+++ b/src/HeapDumpCommon/DotNetHeapInfo.cs
@@ -112,7 +112,7 @@ public class DotNetHeapInfo : IFastSerializable
     #endregion
 }
 
-public class GCHeapDumpSegment : IFastSerializable
+public class GCHeapDumpSegment : IFastSerializable, IFastSerializableVersion
 {
     public Address Start { get; internal set; }
     public Address End { get; internal set; }
@@ -121,6 +121,12 @@ public class GCHeapDumpSegment : IFastSerializable
     public Address Gen2End { get; internal set; }
     public Address Gen3End { get; internal set; }
     public Address Gen4End { get; internal set; }
+
+    public int Version => 1;
+
+    public int MinimumVersionCanRead => 0;
+
+    public int MinimumReaderVersion => 1;
 
     #region private
     void IFastSerializable.ToStream(Serializer serializer)
@@ -142,16 +148,10 @@ public class GCHeapDumpSegment : IFastSerializable
         Gen1End = (Address)deserializer.ReadInt64();
         Gen2End = (Address)deserializer.ReadInt64();
         Gen3End = (Address)deserializer.ReadInt64();
-        // 
-        // TODO: Backward compatibility - changing serialization format should require bumping version and code paths to deal with 
-        // missing values. How?
-        //
-        // In case this value was not saved, there could be two cases:
-        // Case 1: We are running on a runtime without POH, in that case, initializing that to Start works.
-        // Case 2: We are running on a runtime with POH, in that case, POH segments were saved as if
-        //         they were Gen2, there is no way to differentiate, so just pretend they are Gen2.
-        //
-        Gen4End = (Address)deserializer.ReadInt64();
+        if (deserializer.VersionBeingRead >= 1)
+        {
+            Gen4End = (Address)deserializer.ReadInt64();
+        }
     }
     #endregion
 }

--- a/src/PerfView/memory/GenerationAwareMemoryGraph.cs
+++ b/src/PerfView/memory/GenerationAwareMemoryGraph.cs
@@ -138,6 +138,10 @@ namespace Graphs
                     {
                         typeName = string.Format("LOH: {0}", nodeType.Name);
                     }
+                    else if (generation == 4)
+                    {
+                        typeName = string.Format("POH: {0}", nodeType.Name);
+                    }
                     else
                     {
                         typeName = string.Format("Gen{0}: {1}", generation, nodeType.Name);


### PR DESCRIPTION
@Maoni0 reported that generational aware analysis in PerfView is not working for full core dumps. After debugging for a while, I have found a few bugs related to generation detection. This PR fixes some of them, the remaining ones are in ClrMD and are fixed [there](https://github.com/microsoft/clrmd/pull/1035).

**Note** - I changed the serialization format by adding information about POH, which I need help with backward compatibility. The CI failures are related to this.

@tommcdon - This might need to be replicated for `dotnet-gcdump`