### PR TITLE
Update System.Reflection.Metadata to 1.8.1

### DIFF
--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -70,7 +70,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.8.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
 


### PR DESCRIPTION
`System.Reflection.Metadata` 1.8.1 is the first package to include an explicit
`net461` which allows the build to target inbox `System.*` dlls.
Specifically, this PR will cause the  `System.Net.Http` reference to drop down from `4.2.0.0` to
the correct version of `4.0.0.0`.

From the `GetDependsOnNETStandard` task in the binlog (previous output was `true`):

```
GetDependsOnNETStandard
    Assembly = C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\Microsoft.NET.Build.Extensions\\tools\net472\Microsoft.NET.Build.Extensions.Tasks.dll
    Parameters
        References
            System.IO.Compression
            System.Net.Http
...
    OutputProperties
        DependsOnNETStandard = False
```