### PR TITLE
Add UserCommand to save the CPUStacks view as a CSV

### DIFF
--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -1000,6 +1000,11 @@ namespace PerfViewExtensibility
         /// <param name="outputFileName"> The file name the data will be written to </param>
         public void SaveAsCsvByName(string outputFileName)
         {
+            if (string.IsNullOrEmpty(outputFileName))
+            {
+                throw new ArgumentException($"{nameof(outputFileName)} is null or empty.");
+            }
+
             if (File.Exists(outputFileName))
             {
                 File.Delete(outputFileName);
@@ -1011,15 +1016,14 @@ namespace PerfViewExtensibility
                 foreach (var callTreeNode in callTree)
                 {
                     var frameUpdated = callTreeNode.Name.Replace(",", ";");
-                    csvFile.Write("{0},{1},{2},{3},{4},{5},{6},{7}\r\n",
-                        frameUpdated,
-                        callTreeNode.ExclusiveMetric,
-                        callTreeNode.ExclusiveMetricPercent,
-                        callTreeNode.InclusiveCount,
-                        callTreeNode.InclusiveMetricPercent,
-                        callTreeNode.ExclusiveFoldedMetric,
-                        callTreeNode.FirstTimeRelativeMSec,
-                        callTreeNode.LastTimeRelativeMSec);
+                    csvFile.WriteLine($"{frameUpdated}," +
+                        $"{callTreeNode.ExclusiveMetric}," +
+                        $"{callTreeNode.ExclusiveMetricPercent}," +
+                        $"{callTreeNode.InclusiveCount}," +
+                        $"{callTreeNode.InclusiveMetricPercent}," +
+                        $"{callTreeNode.ExclusiveFoldedMetric}," +
+                        $"{callTreeNode.FirstTimeRelativeMSec}," +
+                        $"{callTreeNode.LastTimeRelativeMSec}");
                 }
             }
         }

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -995,6 +995,36 @@ namespace PerfViewExtensibility
         }
 
         /// <summary>
+        /// Saves the stacks as a CSV in the same format as it would appear in the CPUStacks GUI
+        /// </summary>
+        /// <param name="outputFileName"> The file name the data will be written to </param>
+        public void SaveAsCsvByName(string outputFileName)
+        {
+            if (File.Exists(outputFileName))
+            {
+                File.Delete(outputFileName);
+            }
+            using (var csvFile = File.CreateText(outputFileName))
+            {
+                csvFile.Write("Name,Exc,Exc%,Inc,Inc%,Fold,First,Last\r\n");
+                var callTree = ByName;
+                foreach (var callTreeNode in callTree)
+                {
+                    var frameUpdated = callTreeNode.Name.Replace(",", ";");
+                    csvFile.Write("{0},{1},{2},{3},{4},{5},{6},{7}\r\n",
+                        frameUpdated,
+                        callTreeNode.ExclusiveMetric,
+                        callTreeNode.ExclusiveMetricPercent,
+                        callTreeNode.InclusiveCount,
+                        callTreeNode.InclusiveMetricPercent,
+                        callTreeNode.ExclusiveFoldedMetric,
+                        callTreeNode.FirstTimeRelativeMSec,
+                        callTreeNode.LastTimeRelativeMSec);
+                }
+            }
+        }
+
+        /// <summary>
         /// Saves the stacks as a XML file (or a ZIPed XML file).  Only samples that pass the filter are saved.
         /// Also all interesting symbolic names should be resolved first because it is impossible to resolve them 
         /// later.   The saved samples CAN be regrouped later, however.  

--- a/src/PerfView/SupportFiles/PerfView.xml
+++ b/src/PerfView/SupportFiles/PerfView.xml
@@ -29,6 +29,12 @@
             is put into the file to a single process.  
             </summary>
         </member>
+		<member name="M:PerfViewExtensibility.Commands.SaveCPUStacksAsCsv(System.String,System.String)">
+            <summary>
+            Save the CPU stacks from 'etlFileName' as a CSV list to allow for easier to parse data.
+			If the /process qualifier is present use it to narrow what is put into the file to a single process.  
+            </summary>
+        </member>
         <member name="M:PerfViewExtensibility.Commands.SaveScenarioCPUStacks(System.String)">
             <summary>
             Save the CPU stacks for a set of traces.

--- a/src/PerfView/UserCommands.cs
+++ b/src/PerfView/UserCommands.cs
@@ -231,17 +231,63 @@ namespace PerfViewExtensibility
         }
 
         /// <summary>
-        /// Save the entire CPU stacks from 'etlFileName' as a csv.  If the /process qualifier is present use it to narrow what
-        /// is put into the file to a single process.
+        /// Returns the process with the most amount of CpuMsec time.  Should this time be equal, the oldest ID is prioritized
         /// </summary>
-        public void SaveCPUStacksAsCsv(string etlFileName, string processName = null, string warmSymbolLookupMinimumValue = "10")
+        /// <param name="processName"> The process name to look for in the stacks </param>
+        /// <returns> The process with the greatest cpuMSec, or the oldest process if there was a tie. </returns>
+        TraceProcess ProcessWithGreatestCpuMSec(ETLDataFile etlDataFile, string processName)
+        {
+            if (etlDataFile == null || string.IsNullOrWhiteSpace(processName))
+            {
+                return null;
+            }
+            float greatestMSec = 0.0f;
+            TraceProcess ret = null;
+            for (int i = 0; i < etlDataFile.Processes.Count; i++)
+            {
+                TraceProcess process = etlDataFile.Processes[(ProcessIndex)i];
+                if (string.Compare(process.Name, processName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    if (greatestMSec == process.CPUMSec && (ret == null || process.ProcessID < ret.ProcessID))
+                    {
+                        ret = process;
+                        greatestMSec = process.CPUMSec;
+                    }
+                    else if (greatestMSec < process.CPUMSec)
+                    {
+                        ret = process;
+                        greatestMSec = process.CPUMSec;
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Save the entire CPU stacks from 'etlFileName' as a csv.  If the /process qualifier is present use it to narrow what
+        /// is put into the file to a single process.  If warmSymbolLookupMinimumValue is present, then PerfView will lookup symbols 
+        /// if that many trace events from a library are found.  If processLookupMethod can be specified as GreatestMSec to
+        /// instead get the process with the greatest msec as opposed to the last process with a name.
+        /// </summary>
+        /// <param name="etlFileName"> The name of the etl file to convert to a csv </param>
+        /// <param name="processName"> The process name to filter on </param>
+        /// <param name="warmSymbolLookupMinimumValue"> The number of trace events needed to lookup symbols </param>
+        /// <param name="processLookupMethod"> The lookup method to use to filter processes </param>
+        public void SaveCPUStacksAsCsv(string etlFileName, string processName = null, string warmSymbolLookupMinimumValue = "10", string processLookupMethod = "LastProcess")
         {
             using (var etlFile = OpenETLFile(etlFileName))
             {
                 TraceProcess process = null;
                 if (processName != null)
                 {
-                    process = etlFile.Processes.ProcessWithGreatestCpuMSec(processName);
+                    if (processLookupMethod == "GreatestMSec")
+                    {
+                        process = ProcessWithGreatestCpuMSec(etlFile, processName);
+                    }
+                    else
+                    {
+                        process = etlFile.Processes.LastProcessWithName(processName);
+                    }
                     if (process == null)
                     {
                         throw new ApplicationException("Could not find process named " + processName);
@@ -1548,7 +1594,6 @@ namespace PerfViewExtensibility
             }
 
             var stacks = etlFile.CPUStacks();
-            stacks.Filter = new FilterParams();
 
             // Look up symbols (even on the symbol server) for modules with more than the requested number of samples
             stacks.LookupWarmSymbols(warmSymbolLookupMinimumValue);

--- a/src/PerfView/UserCommands.cs
+++ b/src/PerfView/UserCommands.cs
@@ -1538,8 +1538,7 @@ namespace PerfViewExtensibility
         /// </summary>
         /// <param name="etlFile">The ETL file to save.</param>
         /// <param name="process">The process to save. If null, save all processes.</param>
-        /// <param name="filter">The filter to apply to the stacks. If null, apply no filter.</param>
-        private static void SaveCPUStacksForProcessAsCsv(ETLDataFile etlFile, TraceProcess process = null, FilterParams filter = null)
+        private static void SaveCPUStacksForProcessAsCsv(ETLDataFile etlFile, TraceProcess process = null)
         {
             // Focus on a particular process if the user asked for it via command line args.
             if (process != null)
@@ -1547,13 +1546,8 @@ namespace PerfViewExtensibility
                 etlFile.SetFilterProcess(process);
             }
 
-            if (filter == null)
-            {
-                filter = new FilterParams();
-            }
-
             var stacks = etlFile.CPUStacks();
-            stacks.Filter = filter;
+            stacks.Filter = new FilterParams();
             stacks.LookupWarmSymbols(10); // Look up symbols (even on the symbol server) for modules with more than 10 inclusive samples
             stacks.GuiState.Notes = string.Format("Created by SaveCPUStacksAsCsv from {0} on {1}", etlFile.FilePath, DateTime.Now);
 

--- a/src/PerfView/UserCommands.cs
+++ b/src/PerfView/UserCommands.cs
@@ -1539,8 +1539,7 @@ namespace PerfViewExtensibility
         /// <param name="etlFile">The ETL file to save.</param>
         /// <param name="process">The process to save. If null, save all processes.</param>
         /// <param name="filter">The filter to apply to the stacks. If null, apply no filter.</param>
-        /// <param name="outputName">The name of the file to output data to. If null, use the default.</param>
-        private static void SaveCPUStacksForProcessAsCsv(ETLDataFile etlFile, TraceProcess process = null, FilterParams filter = null, string outputName = null)
+        private static void SaveCPUStacksForProcessAsCsv(ETLDataFile etlFile, TraceProcess process = null, FilterParams filter = null)
         {
             // Focus on a particular process if the user asked for it via command line args.
             if (process != null)
@@ -1555,12 +1554,12 @@ namespace PerfViewExtensibility
 
             var stacks = etlFile.CPUStacks();
             stacks.Filter = filter;
-            stacks.LookupWarmSymbols(10); // Look up symbols (even on the symbol server) for modules with more than 50 inclusive samples
+            stacks.LookupWarmSymbols(10); // Look up symbols (even on the symbol server) for modules with more than 10 inclusive samples
             stacks.GuiState.Notes = string.Format("Created by SaveCPUStacksAsCsv from {0} on {1}", etlFile.FilePath, DateTime.Now);
 
             // Derive the output file name from the input file name.
             var stackSourceFileName = PerfViewFile.ChangeExtension(etlFile.FilePath, ".perfView.csv");
-            stacks.SaveAsCsvByName(outputName ?? stackSourceFileName);
+            stacks.SaveAsCsvByName(stackSourceFileName);
             LogFile.WriteLine("[Saved {0} to {1}]", etlFile.FilePath, stackSourceFileName);
         }
 

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -5301,6 +5301,36 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             }
             return null;
         }
+
+        /// <summary>
+        /// Returns the process with the most amount of CpuMsec time.  Should this time be equal, the oldest ID is prioritized
+        /// </summary>
+        /// <param name="processName"> The process name to look for in the stacks </param>
+        /// <returns> The process with the greatest cpuMSec, or the oldest process if there was a tie. </returns>
+        public TraceProcess ProcessWithGreatestCpuMSec(string processName)
+        {
+            float greatestMSec = 0.0f;
+            TraceProcess ret = null;
+            for (int i = 0; i < Count; i++)
+            {
+                TraceProcess process = processes[i];
+                if (string.Compare(process.Name, processName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    if (greatestMSec == process.CPUMSec && (ret == null || process.ProcessID < ret.ProcessID))
+                    {
+                        ret = process;
+                        greatestMSec = process.CPUMSec;
+                    }
+                    else if (greatestMSec < process.CPUMSec)
+                    {
+                        ret = process;
+                        greatestMSec = process.CPUMSec;
+                    }
+                }
+            }
+            return ret;
+        }
+
         /// <summary>
         /// Find the last process in the trace that has the process name 'processName' and whose process
         /// start time is after the given point in time.

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -5303,35 +5303,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
 
         /// <summary>
-        /// Returns the process with the most amount of CpuMsec time.  Should this time be equal, the oldest ID is prioritized
-        /// </summary>
-        /// <param name="processName"> The process name to look for in the stacks </param>
-        /// <returns> The process with the greatest cpuMSec, or the oldest process if there was a tie. </returns>
-        public TraceProcess ProcessWithGreatestCpuMSec(string processName)
-        {
-            float greatestMSec = 0.0f;
-            TraceProcess ret = null;
-            for (int i = 0; i < Count; i++)
-            {
-                TraceProcess process = processes[i];
-                if (string.Compare(process.Name, processName, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    if (greatestMSec == process.CPUMSec && (ret == null || process.ProcessID < ret.ProcessID))
-                    {
-                        ret = process;
-                        greatestMSec = process.CPUMSec;
-                    }
-                    else if (greatestMSec < process.CPUMSec)
-                    {
-                        ret = process;
-                        greatestMSec = process.CPUMSec;
-                    }
-                }
-            }
-            return ret;
-        }
-
-        /// <summary>
         /// Find the last process in the trace that has the process name 'processName' and whose process
         /// start time is after the given point in time.
         /// <para>A process's name is the file name of the EXE without the extension.</para>


### PR DESCRIPTION
This PR adds a UserCommand to get PerfView data in a CSV format that is easy to understand since it directly correlates to the CPUStacks view and reuses the math PerfView already does when loading in the trace and outputs the data to a CSV.
This PR also adds another method of getting the process which is by the most amount of CPU msec used in the trace.

cc: @slevenstein who helped me understand how to get this data from within the PerfView application and wrote the basis which I iterated on and improved