### PR TITLE
Add null check for Disposing EventPipeEventSource deserializer

### DIFF
--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -127,7 +127,10 @@ namespace Microsoft.Diagnostics.Tracing
 
         protected override void Dispose(bool disposing)
         {
-            _deserializer.Dispose();
+            if (_deserializer != null)
+            {
+                _deserializer.Dispose();
+            }
 
             base.Dispose(disposing);
         }


### PR DESCRIPTION
When running the UserCommand `NetperfToSpeedScope` with an invalid file name, PerfView crashes due to _deserializer being null.  When applied, this PR will do a null check before attempting to dispose of the object.