### PR TITLE
Add GCAllocationKind.Pinned

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -12801,6 +12801,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
     {
         Small = 0x0,
         Large = 0x1,
+        Pinned = 0x2
     }
     public enum GCType
     {


### PR DESCRIPTION
Support the `Pinned` value for `GCAllocationKind` fields on allocation events.