### PR TITLE
Remove Duplicate PackageReference for MicroBuild

### DIFF
--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -27,7 +27,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
     <PackageReference Include="PerfView.SupportFiles" Version="$(PerfViewSupportFilesVersion)" PrivateAssets="all" />
 


### PR DESCRIPTION
Fixes the following build warning:

```
"C:\src\perfview\src\HeapDump\HeapDump.csproj" (rebuild target) (1) ->
"C:\src\perfview\src\HeapDump\HeapDump.csproj" (Clean target) (1:2) ->
(CollectPackageReferences target) ->
  C:\src\perfview\src\HeapDump\HeapDump.csproj : warning NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: MicroBuild.Core 0.2.0, MicroBuild.Core 0.2.0.
```