### PR TITLE
Remove PEFile Size Check in TraceModuleUnchanged

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -8721,11 +8721,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     log.WriteLine("The local file {0} has a mismatched Timestamp value found {1} != expected {2}", moduleFilePath, file.Header.TimeDateStampSec, moduleFile.ImageId);
                     return false;
                 }
-                if (file.Header.SizeOfImage != (uint)moduleFile.ImageSize)
-                {
-                    log.WriteLine("The local file {0} has a mismatched size found {1} != expected {2}", moduleFilePath, file.Header.SizeOfImage, moduleFile.ImageSize);
-                    return false;
-                }
             }
             return true;
         }


### PR DESCRIPTION
When a trace has not been merged TraceEvent does three extra checks to confirm that the on-disk binary matches the one that was present during the trace.  It compares:

 - CheckSum
 - ImageID
 - File size

This change removes the file size check as it is not necessary, and is breaking in some scenarios where the loaded image size doesn't match the size in the PE header.