### PR TITLE
Add more checks for managed processes

### DIFF
--- a/src/TraceEvent/AutomatedAnalysis/Extensions.cs
+++ b/src/TraceEvent/AutomatedAnalysis/Extensions.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
 
         public static bool ManagedProcess(this TraceProcess process)
         {
-            return process.LoadedModules.Where(module =>
+            return process.LoadedModules.Any(module =>
                     module is TraceManagedModule ||
                     module.Name.Equals("clr", StringComparison.OrdinalIgnoreCase) ||
                     module.Name.Equals("coreclr", StringComparison.OrdinalIgnoreCase) ||
                     module.Name.Equals("mscorwks", StringComparison.OrdinalIgnoreCase) ||
-                    module.Name.Equals("System.Private.CoreLib", StringComparison.OrdinalIgnoreCase)).Count() > 0;
+                    module.Name.Equals("System.Private.CoreLib", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/TraceEvent/AutomatedAnalysis/Extensions.cs
+++ b/src/TraceEvent/AutomatedAnalysis/Extensions.cs
@@ -29,9 +29,11 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         public static bool ManagedProcess(this TraceProcess process)
         {
             return process.LoadedModules.Where(module =>
+                    module is TraceManagedModule ||
                     module.Name.Equals("clr", StringComparison.OrdinalIgnoreCase) ||
                     module.Name.Equals("coreclr", StringComparison.OrdinalIgnoreCase) ||
-                    module.Name.Equals("mscorwks", StringComparison.OrdinalIgnoreCase)).Count() > 0;
+                    module.Name.Equals("mscorwks", StringComparison.OrdinalIgnoreCase) ||
+                    module.Name.Equals("System.Private.CoreLib", StringComparison.OrdinalIgnoreCase)).Count() > 0;
         }
     }
 }


### PR DESCRIPTION
A .nettrace file collected for an Asp.Net 6 app running on Azure App Service for Linux does not have coreclr as part of its loaded modules list. 