### PR TITLE
Embed System.Runtime.InteropServices.RuntimeInformation.dll 4.0.2.0 into PerfView

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -302,6 +302,13 @@
       <Link>HeapDump\System.ValueTuple.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\HeapDump\$(OutDir)\System.Runtime.InteropServices.RuntimeInformation.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\HeapDump\System.Runtime.InteropServices.RuntimeInformation.dll</LogicalName>
+      <Link>HeapDump\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\HeapDump\$(OutDir)\HeapDump.exe">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>


### PR DESCRIPTION
Fixes broken HeapDump.exe.  CLRMD 2.1 is built against `netstandard20` which uses version 4.0.2.0, which is not currently embedded into PerfView.