### PR TITLE
Switch GC Dump Format to 64-bit and Disable Default Sampling

### DIFF
--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -809,7 +809,7 @@ public class GCHeapDumper
     private bool TryGetJavaScriptDump(int processID)
     {
         m_log.WriteLine("*****  Attempting a ETW based JavaScript Heap Dump.");
-        m_gcHeapDump.MemoryGraph = new MemoryGraph(10000);     // TODO Can we be more accurate?  
+        m_gcHeapDump.MemoryGraph = new MemoryGraph(10000, isVeryLargeGraph:true);     // TODO Can we be more accurate?  
         // m_gotJScriptData = JavaScriptHeapDumper.Dump(processID, m_gcHeapDump.MemoryGraph, m_log);
 
         if (SaveETL)
@@ -848,7 +848,7 @@ public class GCHeapDumper
 
         if (m_gcHeapDump.MemoryGraph == null)
         {
-            m_gcHeapDump.MemoryGraph = new MemoryGraph(10000);     // TODO Can we be more accurate?  
+            m_gcHeapDump.MemoryGraph = new MemoryGraph(10000, isVeryLargeGraph: true);     // TODO Can we be more accurate?  
         }
 
         m_gcHeapDump.DotNetHeapInfo = new DotNetHeapInfo();

--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -253,13 +253,8 @@ internal class Program
             }
             return 0;
             Usage:
-#if FEATURE_SAMPLING
             Console.WriteLine("Usage: HeapDump [/MaxDumpCountK=n /Freeze] ProcessIdOrName OutputHeapDumpFile");
             Console.WriteLine("Usage: HeapDump [/MaxDumpCountK=n] /processDump  DumpFile OutputHeapDumpFile");
-#else
-            Console.WriteLine("Usage: HeapDump [/Freeze] ProcessIdOrName OutputHeapDumpFile");
-            Console.WriteLine("Usage: HeapDump /processDump  DumpFile OutputHeapDumpFile");
-#endif
             Console.WriteLine("Usage: HeapDump /forceGC ProcessIdOrName");
             return 1;
         }

--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -253,8 +253,13 @@ internal class Program
             }
             return 0;
             Usage:
+#if FEATURE_SAMPLING
             Console.WriteLine("Usage: HeapDump [/MaxDumpCountK=n /Freeze] ProcessIdOrName OutputHeapDumpFile");
             Console.WriteLine("Usage: HeapDump [/MaxDumpCountK=n] /processDump  DumpFile OutputHeapDumpFile");
+#else
+            Console.WriteLine("Usage: HeapDump [/Freeze] ProcessIdOrName OutputHeapDumpFile");
+            Console.WriteLine("Usage: HeapDump /processDump  DumpFile OutputHeapDumpFile");
+#endif
             Console.WriteLine("Usage: HeapDump /forceGC ProcessIdOrName");
             return 1;
         }

--- a/src/PerfView.Tests/GraphSerialization/GraphSerializationTests.cs
+++ b/src/PerfView.Tests/GraphSerialization/GraphSerializationTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Xunit;
 using System.Linq;
+using FastSerialization;
 using PerfView.TestUtilities;
 
 namespace PerfViewTests.GraphSerialization
@@ -21,7 +22,13 @@ namespace PerfViewTests.GraphSerialization
         {
             PrepareTestData();
 
-            GCHeapDump gcDump = new GCHeapDump($"{TestDataDir}\\{gcDumpFileName}.gcdump");
+            // The test inputs are 32-bit files, so specify that here.
+            GCHeapDump gcDump = new GCHeapDump(
+                $"{TestDataDir}\\{gcDumpFileName}.gcdump",
+                new SerializationConfiguration()
+                {
+                    StreamLabelWidth = StreamLabelWidth.FourBytes
+                });
 
             string xmlFile = $"{OutputDir}\\{gcDumpFileName}.gcdump.xml";
             using (StreamWriter writer = File.CreateText(xmlFile))

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -69,9 +69,7 @@ namespace PerfView
         public bool SaveETL;                // Save the ETL file when dumping the JS heap
         public bool DumpData;               // Dump the heap data as well as the connectivity info
         public bool Freeze;                 // Freeze the process while the dump is taken
-#if FEATURE_SAMPLING
-        public int MaxDumpCountK = 250;     // Maximum size of the File to generate.   We sample aggressively enough to try to hit this count of objects in the file
-#endif
+        public int MaxDumpCountK = -1;     // Maximum size of the File to generate.   We sample aggressively enough to try to hit this count of objects in the file
         public int MaxNodeCountK;           // Maximum size to even look at in the heap 
 
 #if CROSS_GENERATION_LIVENESS

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -69,7 +69,9 @@ namespace PerfView
         public bool SaveETL;                // Save the ETL file when dumping the JS heap
         public bool DumpData;               // Dump the heap data as well as the connectivity info
         public bool Freeze;                 // Freeze the process while the dump is taken
+#if FEATURE_SAMPLING
         public int MaxDumpCountK = 250;     // Maximum size of the File to generate.   We sample aggressively enough to try to hit this count of objects in the file
+#endif
         public int MaxNodeCountK;           // Maximum size to even look at in the heap 
 
 #if CROSS_GENERATION_LIVENESS
@@ -628,8 +630,10 @@ namespace PerfView
             parser.DefineParameter("Process", ref ProcessParam, "The process ID or Process Name (Exe without extension) of the process  take a heap snapshot.");
             parser.DefineOptionalParameter("DataFile", ref DataFile, "The name of the file to place the heap snapshot.");
             parser.DefineOptionalQualifier("SaveETL", ref SaveETL, "Save an ETL file along with the GCDump file when dumping the JS Heap.");
+#if FEATURE_SAMPING
             parser.DefineOptionalQualifier("MaxDumpCountK", ref MaxDumpCountK,
                 "The maximum number of objects (in K or thousands) to place int the .gcDump file.   Sample sufficiently to hit this metric.");
+#endif
             parser.DefineOptionalQualifier("Freeze", ref Freeze, "Freeze the dump while data is taken.");
 
             parser.DefineParameterSet("ForceGC", ref DoCommand, App.CommandProcessor.ForceGC,

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1806,10 +1806,12 @@ namespace PerfView
                 qualifiers += " /DumpData";
             }
 
+#if FEATURE_SAMPLING
             if (parsedArgs.MaxDumpCountK > 0)
             {
                 qualifiers += " /MaxDumpCountK=" + parsedArgs.MaxDumpCountK;
             }
+#endif
 
             if (parsedArgs.MaxNodeCountK > 0)
             {
@@ -1935,7 +1937,7 @@ namespace PerfView
         }
         public void CreateExtensionProject(CommandLineArgs parsedArgs)
         {
-#if !PERFVIEW_COLLECT 
+#if !PERFVIEW_COLLECT
             // We do this to avoid a common mistake where people will create extensions on shared copies of perfView.  
             if (PerfViewExtensibility.Extensions.ExtensionsDirectory.StartsWith(@"\\") ||
                 PerfViewExtensibility.Extensions.ExtensionsDirectory.StartsWith(SupportFiles.SupportFileDir, StringComparison.OrdinalIgnoreCase))
@@ -3132,10 +3134,12 @@ namespace PerfView
                 cmdLineArgs += " /DumpData";
             }
 
+#if FEATURE_SAMPLING
             if (parsedArgs.MaxDumpCountK != 250)
             {
                 cmdLineArgs += " /MaxDumpCountK=" + parsedArgs.MaxDumpCountK;
             }
+#endif
 
             if (parsedArgs.MaxNodeCountK != 0)
             {

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1806,12 +1806,10 @@ namespace PerfView
                 qualifiers += " /DumpData";
             }
 
-#if FEATURE_SAMPLING
-            if (parsedArgs.MaxDumpCountK > 0)
+            if (parsedArgs.MaxDumpCountK != -1)
             {
                 qualifiers += " /MaxDumpCountK=" + parsedArgs.MaxDumpCountK;
             }
-#endif
 
             if (parsedArgs.MaxNodeCountK > 0)
             {
@@ -3134,14 +3132,12 @@ namespace PerfView
                 cmdLineArgs += " /DumpData";
             }
 
-#if FEATURE_SAMPLING
-            if (parsedArgs.MaxDumpCountK != 250)
+            if (parsedArgs.MaxDumpCountK != -1)
             {
                 cmdLineArgs += " /MaxDumpCountK=" + parsedArgs.MaxDumpCountK;
             }
-#endif
 
-            if (parsedArgs.MaxNodeCountK != 0)
+            if (parsedArgs.MaxNodeCountK != -1)
             {
                 cmdLineArgs += " /MaxNodeCountK=" + parsedArgs.MaxNodeCountK;
             }

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml
@@ -118,10 +118,10 @@
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
 
-            <!-- <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="5,0,5,0" ToolTip="If the heap has more object than this (in Kilo objects) than this, only a sample is taken." >
+            <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="5,0,5,0" ToolTip="If the heap has more object than this (in Kilo objects) than this, only a sample is taken." >
                         <Hyperlink Command="Help" CommandParameter="MaxDumpTextBox">Max Dump<LineBreak/>K Objs:</Hyperlink>
             </TextBlock>
-            <TextBox Grid.Column="2" Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0"/> -->
+            <TextBox Grid.Column="2" Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0"/>
 
             <TextBlock Grid.Column="3" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked the process will be frozen during the dump.">
                     <Hyperlink Command="Help" CommandParameter="FreezeCheckBox">Freeze:</Hyperlink>

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml
@@ -118,12 +118,11 @@
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
 
-
-            <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="5,0,5,0" ToolTip="If the heap has more object than this (in Kilo objects) than this, only a sample is taken." >
+            <!-- <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="5,0,5,0" ToolTip="If the heap has more object than this (in Kilo objects) than this, only a sample is taken." >
                         <Hyperlink Command="Help" CommandParameter="MaxDumpTextBox">Max Dump<LineBreak/>K Objs:</Hyperlink>
             </TextBlock>
-            <TextBox Grid.Column="2" Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0"/>
-            
+            <TextBox Grid.Column="2" Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0"/> -->
+
             <TextBlock Grid.Column="3" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked the process will be frozen during the dump.">
                     <Hyperlink Command="Help" CommandParameter="FreezeCheckBox">Freeze:</Hyperlink>
             </TextBlock>

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
@@ -31,7 +31,9 @@ namespace PerfView.Dialogs
             FreezeCheckBox.IsChecked = m_args.Freeze;
             SaveETLCheckBox.IsChecked = m_args.SaveETL;
             // DumpDataCheckBox.IsChecked = m_args.DumpData;
+#if FEATURE_SAMPLING
             MaxDumpTextBox.Text = m_args.MaxDumpCountK.ToString();
+#endif
 
             if (args.ProcessDumpFile != null)
             {
@@ -140,6 +142,7 @@ namespace PerfView.Dialogs
             m_args.Freeze = FreezeCheckBox.IsChecked ?? false;
             m_args.SaveETL = SaveETLCheckBox.IsChecked ?? false;
             m_args.DumpData = false;  // TODO FIX NOW actually use
+#if FEATURE_SAMPLING
             if (!int.TryParse(MaxDumpTextBox.Text, out m_args.MaxDumpCountK))
             {
                 StatusBar.LogError("Could not parse MaxDump " + MaxDumpTextBox.Text);
@@ -160,6 +163,7 @@ namespace PerfView.Dialogs
                     return;
                 }
             }
+#endif
 
             m_args.NoView = true;
             m_tookASnapshot = true;

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
@@ -31,9 +31,7 @@ namespace PerfView.Dialogs
             FreezeCheckBox.IsChecked = m_args.Freeze;
             SaveETLCheckBox.IsChecked = m_args.SaveETL;
             // DumpDataCheckBox.IsChecked = m_args.DumpData;
-#if FEATURE_SAMPLING
-            MaxDumpTextBox.Text = m_args.MaxDumpCountK.ToString();
-#endif
+            MaxDumpTextBox.Text = m_args.MaxDumpCountK > 0 ? m_args.MaxDumpCountK.ToString() : string.Empty;
 
             if (args.ProcessDumpFile != null)
             {
@@ -142,28 +140,11 @@ namespace PerfView.Dialogs
             m_args.Freeze = FreezeCheckBox.IsChecked ?? false;
             m_args.SaveETL = SaveETLCheckBox.IsChecked ?? false;
             m_args.DumpData = false;  // TODO FIX NOW actually use
-#if FEATURE_SAMPLING
-            if (!int.TryParse(MaxDumpTextBox.Text, out m_args.MaxDumpCountK))
+            if (!string.IsNullOrEmpty(MaxDumpTextBox.Text) && !int.TryParse(MaxDumpTextBox.Text, out m_args.MaxDumpCountK))
             {
                 StatusBar.LogError("Could not parse MaxDump " + MaxDumpTextBox.Text);
                 return;
             }
-
-            if (m_args.MaxDumpCountK >= 10000)
-            {
-                var response = MessageBox.Show("WARNING: you have selected a Max Dump Count larger than 10M objects.\r\n" +
-                    "You should only need 100K to do a good job, even at 10M the GUI will be very sluggish.\r\n" +
-                    "Consider canceling and picking a smaller value.", "Max Dump Size Too Big",
-                    MessageBoxButton.OKCancel);
-                if (response != MessageBoxResult.OK)
-                {
-                    StatusBar.Log("Memory collection canceled.");
-                    Close();
-                    GuiApp.MainWindow.Focus();
-                    return;
-                }
-            }
-#endif
 
             m_args.NoView = true;
             m_tookASnapshot = true;

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -8410,7 +8410,23 @@ table {
                     }
                     else
                     {
-                        m_gcDump = new GCHeapDump(FilePath);
+                        try
+                        {
+                            m_gcDump = new GCHeapDump(FilePath);
+                        }
+                        catch (Exception ex)
+                        {
+                            log.WriteLine($"Error loading gcdump file '{FilePath}' as a 64-bit file.\nException: {ex}");
+
+                            // Attempt to load the dump as a 32-bit file.
+                            log.WriteLine("Attempting to load the gcdump as a 32-bit file.");
+                            m_gcDump = new GCHeapDump(
+                                FilePath,
+                                new FastSerialization.SerializationConfiguration()
+                                {
+                                    StreamLabelWidth = FastSerialization.StreamLabelWidth.FourBytes
+                                });
+                        }
 
                         // set it up so we resolve any types 
                         var resolver = new TypeNameSymbolResolver(FilePath, log);


### PR DESCRIPTION
Provides more complete heap dumps without sampling.  For very large dumps, this can result in a more sluggish UI, but the benefit of the complete data outweighs the UI sluggishness.  UI perf, specifically StackWindow perf, may also be a place to invest in going forward.

 - Switches the serialization format of `.gcdump` files to 64-bit from their previous 32-bit format.
 - Allows PerfView to try opening `.gcdump` files as 32-bit for backwards compatibility.
 - Disables sampling by default.  Sampling can still be used via the UI and command line.