### PR TITLE
Fix CaptureStateOnSetFileName By Looking Up Enabled Providers on Attach

### DIFF
--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -820,6 +820,18 @@ namespace Microsoft.Diagnostics.Tracing
             public long MatchAllKeyword;
         };
 
+        internal struct TRACE_GROUP_INFO
+        {
+            public ulong InstanceCount;
+            public ulong TraceEnableInfos;
+        };
+
+        internal struct TRACE_GROUP_INFO_GUIDS
+        {
+            public ulong GuidCount;
+            public ulong ProviderGuids;
+        };
+
         [DllImport("advapi32.dll")]
         internal static extern int EnumerateTraceGuidsEx(
         TRACE_QUERY_INFO_CLASS TraceQueryInfoClass,


### PR DESCRIPTION
On `TraceEventSession` attach, the set of enabled providers is not looked up from ETW, which means that users that call `SetFileName` and have `CaptureStateOnSetFileName == true` do not actively make the calls to invoke the capture state command.

Fixes `CaptureStateOnSetFileName` by calling `EnumerateTraceGuidsEx` to fill the dictionary of enabled providers on session attach.