### PR TITLE
Update Minimal Rundown Default Keyword

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3498,12 +3498,11 @@ namespace PerfView
                     if (parsedArgs.ClrEvents != ClrTraceEventParser.Keywords.None)
                     {
                         // Always enable minimal rundown, which ensures that we get the runtime start event.
-                        // We use the keyword 0x800000000000 which does not match any valid keyword in the rundown provider.
-                        // Choosing 0 results in enabling all keywords based on the logic that checks for keyword status in the runtime.
-                        // NOTE: This used to be 0x40000000 which matched the ClrStack keyword in the main provider.  This resulted in
-                        // lots of ClrStack/Walk events that couldn't be matched with Clr events, because for V2 rundown, we enable
-                        // the Clr provider.
-                        var rundownKeywords = (ClrRundownTraceEventParser.Keywords)0x800000000000;
+                        // .NET Core requires that StartEnumeration or ForceEndRundown is specified in order
+                        // to get the runtime start event.  For minimal rundown, just enabling ForceEndRundown
+                        // should be enough to get the rundown event for both .NET Framework and .NET Core
+                        // without going down any expensive rundown codepaths.
+                        var rundownKeywords = ClrRundownTraceEventParser.Keywords.ForceEndRundown;
 
                         // Only consider forcing suppression of these keywords if full rundown is enabled.
                         if (!parsedArgs.NoRundown && !parsedArgs.NoClrRundown)


### PR DESCRIPTION
The minimal rundown keyword should be `ForceEndRundown` instead of a non-existent keyword.  This is required in order to support gathering the runtime version events from .NET Core.  .NET Core no longer unconditionally emits the runtime version event without actually asking for rundown, however, if we only specify `ForceEndRundown`, the runtime will skip the expensive parts of rundown and just emit the runtime version event.