### PR TITLE
Use Encoded String in Regression Report

### DIFF
--- a/src/PerfView/OverweightReport.cs
+++ b/src/PerfView/OverweightReport.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Diagnostics.Tracing.Stacks;
+using Microsoft.Diagnostics.Tracing.Stacks;
 using PerfView.GuiUtilities;
 using PerfViewExtensibility;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Web;
 
 namespace PerfView
 {
@@ -124,8 +125,10 @@ namespace PerfView
                             continue;
                         }
 
+                        var name = HttpUtility.HttpEncode(r.name);
+
                         w.WriteLine("<tr><td>{0}</td><td><a href='command:ShowBaseStacks,{0}' title='View Callers of {0} in Base Stacks'>{1:f1}</a></td><td><a href='command:ShowStacks,{0}' title='View Callers of {0} in Test Stacks'>{2:f1}</a></td><td>{3:f1}</td><td>{4:f2}</td><td>{5:f2}</td><td>{6}</td></tr>",
-                            r.name,
+                            name,
                             r.before,
                             r.after,
                             r.delta,

--- a/src/PerfView/OverweightReport.cs
+++ b/src/PerfView/OverweightReport.cs
@@ -125,7 +125,7 @@ namespace PerfView
                             continue;
                         }
 
-                        var encodedName = HttpUtility.HttpEncode(r.name);
+                        var encodedName = HttpUtility.HtmlEncode(r.name);
 
                         w.WriteLine("<tr><td>{0}</td><td><a href='command:ShowBaseStacks,{0}' title='View Callers of {0} in Base Stacks'>{1:f1}</a></td><td><a href='command:ShowStacks,{0}' title='View Callers of {0} in Test Stacks'>{2:f1}</a></td><td>{3:f1}</td><td>{4:f2}</td><td>{5:f2}</td><td>{6}</td></tr>",
                             encodedName,

--- a/src/PerfView/OverweightReport.cs
+++ b/src/PerfView/OverweightReport.cs
@@ -125,10 +125,10 @@ namespace PerfView
                             continue;
                         }
 
-                        var name = HttpUtility.HttpEncode(r.name);
+                        var encodedName = HttpUtility.HttpEncode(r.name);
 
                         w.WriteLine("<tr><td>{0}</td><td><a href='command:ShowBaseStacks,{0}' title='View Callers of {0} in Base Stacks'>{1:f1}</a></td><td><a href='command:ShowStacks,{0}' title='View Callers of {0} in Test Stacks'>{2:f1}</a></td><td>{3:f1}</td><td>{4:f2}</td><td>{5:f2}</td><td>{6}</td></tr>",
-                            name,
+                            encodedName,
                             r.before,
                             r.after,
                             r.delta,

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management" />
     <Reference Include="System.Printing" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>


### PR DESCRIPTION
When I used the regression report tool on two GC Dumps from an x64 Mac, it would try to make tags out of frames such as "Lib<</Applications/Example.app/Lib!Task<Example>>>" and turn it into things such as "LIB<>>". This change encodes reserved HTML characters, which should prevent this (In my example, it properly shows the original frame)