### PR TITLE
Fix Heap Count in GCStats

### DIFF
--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -562,12 +562,19 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
 
                                 foreach (var procThread in traceProc.Threads)
                                 {
-                                    if ((procThread.ThreadInfo != null) && (procThread.ThreadInfo.StartsWith(".NET Server GC")))
+                                    if (procThread.ThreadInfo == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    // .NET Server Threads' ThreadInfo can be either ".NET Server GC Thread (#)" or ".NET Server GC".
+                                    // Both should be accumulated to correctly compute the heap count. 
+                                    if (procThread.ThreadInfo.StartsWith(".NET Server GC"))
                                     {
                                         mang.GC.m_stats.HeapCount++;
                                     }
 
-                                    if ((procThread.ThreadInfo != null) && (procThread.ThreadInfo.StartsWith(".NET Server GC Thread")))
+                                    if (procThread.ThreadInfo.StartsWith(".NET Server GC Thread"))
                                     {
                                         int startIndex = procThread.ThreadInfo.IndexOf('(');
                                         int endIndex = procThread.ThreadInfo.IndexOf(')');

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -572,16 +572,17 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
                                     if (procThread.ThreadInfo.StartsWith(".NET Server GC"))
                                     {
                                         mang.GC.m_stats.HeapCount++;
-                                    }
 
-                                    if (procThread.ThreadInfo.StartsWith(".NET Server GC Thread"))
-                                    {
-                                        int startIndex = procThread.ThreadInfo.IndexOf('(');
-                                        int endIndex = procThread.ThreadInfo.IndexOf(')');
-                                        string heapNumString = procThread.ThreadInfo.Substring(startIndex + 1, (endIndex - startIndex - 1));
-                                        int heapNum = int.Parse(heapNumString);
-                                        mang.GC.m_stats.serverGCThreads[procThread.ThreadID] = heapNum;
-                                        mang.GC.m_stats.ServerGcHeap2ThreadId[heapNum] = procThread.ThreadID;
+                                        // When the heap # is available, use it.
+                                        if (procThread.ThreadInfo.StartsWith(".NET Server GC Thread"))
+                                        {
+                                            int startIndex = procThread.ThreadInfo.IndexOf('(');
+                                            int endIndex = procThread.ThreadInfo.IndexOf(')');
+                                            string heapNumString = procThread.ThreadInfo.Substring(startIndex + 1, (endIndex - startIndex - 1));
+                                            int heapNum = int.Parse(heapNumString);
+                                            mang.GC.m_stats.serverGCThreads[procThread.ThreadID] = heapNum;
+                                            mang.GC.m_stats.ServerGcHeap2ThreadId[heapNum] = procThread.ThreadID;
+                                        }
                                     }
                                 }
                             }

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -562,10 +562,13 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
 
                                 foreach (var procThread in traceProc.Threads)
                                 {
-                                    if ((procThread.ThreadInfo != null) && (procThread.ThreadInfo.StartsWith(".NET Server GC Thread")))
+                                    if ((procThread.ThreadInfo != null) && (procThread.ThreadInfo.StartsWith(".NET Server GC")))
                                     {
                                         mang.GC.m_stats.HeapCount++;
+                                    }
 
+                                    if ((procThread.ThreadInfo != null) && (procThread.ThreadInfo.StartsWith(".NET Server GC Thread")))
+                                    {
                                         int startIndex = procThread.ThreadInfo.IndexOf('(');
                                         int endIndex = procThread.ThreadInfo.IndexOf(')');
                                         string heapNumString = procThread.ThreadInfo.Substring(startIndex + 1, (endIndex - startIndex - 1));


### PR DESCRIPTION
The issue was we weren't counting all Server GC threads. The right way to aggregate is to look at threads with ThreadInfo of the form: 

1. .NET Server GC Thread ({ThreadNumber})
2. .NET Server GC

We were previously not accumulating the latter and as a result, our Heap Counts were wrong and not consistent with the Raw Data. 

In terms of testing, I made sure that GLAD wasn't effected by creating a console app that simply tested that the right heap count was obtained:

```csharp
using Microsoft.Diagnostics.Tracing.Etlx;

using Etlx = Microsoft.Diagnostics.Tracing.Etlx;
using Microsoft.Diagnostics.Tracing.Analysis;
using Microsoft.Diagnostics.Tracing.Analysis.GC;
using System.Diagnostics;

var TRACE_PATH = @"C:\\Traces\\GCTraces\\XAP_AATest\\GCCollectOnly_Better.etlx";

Etlx.TraceLog traceLog = Etlx.TraceLog.OpenOrConvert(TRACE_PATH);
Etlx.TraceLogEventSource eventSource = traceLog.Events.GetSource();
eventSource.NeedLoadedDotNetRuntimes();
eventSource.Process();
Microsoft.Diagnostics.Tracing.Analysis.TraceProcess devenv = eventSource.Processes().First(p => string.CompareOrdinal(p.Name, "ApplicationHost") == 0);
TraceLoadedDotNetRuntime managedProcess = devenv.LoadedDotNetRuntime();
Debug.Assert(managedProcess.GC.Stats().HeapCount == 100); // Didn't except.
```

CC: @Maoni0 