### PR TITLE
Fix Generation Aware Heap Snapshots When Using Regions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,7 @@
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.24</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>0.1.1</MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>2.1.327703</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>2.2.343001</MicrosoftDiagnosticsRuntimeVersion>
     <XunitVersion>2.4.0</XunitVersion>
     <XunitRunnerVisualstudioVersion>2.4.0</XunitRunnerVisualstudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
Consume the latest version of ClrMD, which fixes generation bounds reporting when using regions, which is enabled by default on .NET 7.

cc: @Maoni0, @cshung, @leculver 