### PR TITLE
Linux: Merge Process Names

### DIFF
--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
 
         private IEnumerable<LinuxEvent> NextEvent(Regex regex, FastStream source)
         {
-
+            StringBuilder sb = new StringBuilder();
             string line = string.Empty;
 
             while (true)
@@ -337,8 +337,6 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                     break;
 
                 EventKind eventKind = EventKind.Cpu;
-
-                StringBuilder sb = new StringBuilder();
 
                 // Fetch Command (processName) - Stops when it sees the pattern \s+\d+/\d
                 int idx = FindEndOfProcessCommand(source);

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptProcessNameBuilder.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptProcessNameBuilder.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.Diagnostics.Tracing.Stacks;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Tracing.StackSources
+{
+    internal sealed class LinuxPerfScriptProcessNameBuilder
+    {
+        private static readonly string[] IgnoredNames = new string[]
+            {
+                ".NET Finalizer",
+                ".NET Tiered Compilation Worker",
+                ".NET BGC",
+                ".NET Server GC"
+            };
+
+        private Dictionary<StackSourceFrameIndex, HashSet<string>> _candidateProcessNames = new Dictionary<StackSourceFrameIndex, HashSet<string>>();
+        private Dictionary<StackSourceFrameIndex, string> _cachedProcessNames = new Dictionary<StackSourceFrameIndex, string>();
+        private Dictionary<StackSourceFrameIndex, int> _processIds = new Dictionary<StackSourceFrameIndex, int>();
+
+        internal void SaveProcessName(StackSourceFrameIndex frameIndex, string processName, int processId)
+        {
+            if (!_candidateProcessNames.TryGetValue(frameIndex, out HashSet<string> processNames))
+            {
+                processNames = new HashSet<string>();
+                _candidateProcessNames.Add(frameIndex, processNames);
+            }
+
+            processNames.Add(processName);
+
+            _processIds[frameIndex] = processId;
+        }
+
+        internal string GetProcessName(StackSourceFrameIndex frameIndex)
+        {
+            if (!_cachedProcessNames.TryGetValue(frameIndex, out string processName))
+            {
+                processName = BuildProcessName(frameIndex);
+                _cachedProcessNames.Add(frameIndex, processName);
+            }
+
+            return processName;
+        }
+
+        private string BuildProcessName(StackSourceFrameIndex frameIndex)
+        {
+            if (_candidateProcessNames.TryGetValue(frameIndex, out HashSet<string> processNames))
+            {
+                int processId = _processIds[frameIndex];
+
+                string[] names = processNames.ToArray();
+                if (names.Length == 0)
+                {
+                    Debug.Assert(false);
+                    return $"Process Unknown (0)";
+                }
+                else if (names.Length == 1)
+                {
+                    return $"Process {names[0]} ({processId})";
+                }
+                else
+                {
+                    bool addDelimeter = false;
+                    StringBuilder builder = new StringBuilder();
+                    builder.Append("Process ");
+
+                    // Try to build a process name that doesn't include the ignored frames.
+                    for (int i = 0; i < names.Length; i++)
+                    {
+                        bool skip = false;
+                        foreach (string ignoredFrame in IgnoredNames)
+                        {
+                            if (ignoredFrame.Equals(names[i]))
+                            {
+                                skip = true;
+                                break;
+                            }
+                        }
+
+                        if (skip)
+                        {
+                            continue;
+                        }
+
+                        if (addDelimeter)
+                        {
+                            builder.Append(";");
+                        }
+
+                        builder.Append(names[i]);
+                        addDelimeter = true;
+                    }
+
+                    if (!addDelimeter)
+                    {
+                        // If we threw away all of the possible process names, don't ignore them
+                        // and just build a process name with all available options.
+                        for (int i = 0; i < names.Length; i++)
+                        {
+                            if (addDelimeter)
+                            {
+                                builder.Append(";");
+                            }
+
+                            builder.Append(names[i]);
+                            addDelimeter = true;
+                        }
+                    }
+                    builder.Append($" ({processId})");
+
+                    return builder.ToString();
+                }
+            }
+            else
+            {
+                Debug.Assert(false);
+                return "Process Unknown (0)";
+            }
+        }
+    }
+}

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
@@ -439,7 +439,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
 
             Frame currentFrame = frameIterator.Current;
 
-            if (currentFrame.Kind == FrameKind.ProcessFrame)
+            if (currentFrame != null && currentFrame.Kind == FrameKind.ProcessFrame)
             {
                 ProcessFrame processFrame = (ProcessFrame)currentFrame;
 

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
@@ -274,6 +274,12 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             this.doThreadTime = doThreadTime;
             currentStackIndex = 0;
 
+            Interner.FrameNameLookup = new Func<StackSourceFrameIndex, bool, string>((frameIndex, fullModule) =>
+            {
+                // The frame index is reliably off by one in this lookup.
+                return processNameBuilder.GetProcessName(frameIndex + 1);
+            });
+
             ZipArchive archive;
             using (Stream stream = GetPerfScriptStream(path, out archive))
             {
@@ -390,6 +396,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
         protected readonly FastStream masterSource;
         protected readonly bool doThreadTime;
         protected readonly int BufferSize = 262144;
+        internal readonly LinuxPerfScriptProcessNameBuilder processNameBuilder = new LinuxPerfScriptProcessNameBuilder();
 
         #region private
         private void InternAllLinuxEvents(Stream stream)
@@ -430,7 +437,25 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                 frameDisplayName = frameIterator.Current.DisplayName;
             }
 
-            frameIndex = InternFrame(frameDisplayName);
+            Frame currentFrame = frameIterator.Current;
+
+            if (currentFrame.Kind == FrameKind.ProcessFrame)
+            {
+                ProcessFrame processFrame = (ProcessFrame)currentFrame;
+
+                // Intern a name-agnostic frame so that all process frames for a PID intern to the same index.
+                frameIndex = InternFrame($"Process {processFrame.ID}");
+
+                // Re-intern the frame as a derived frame, so that on resolution, FrameNameLookup() gets called.
+                frameIndex = Interner.FrameIntern(frameIndex, string.Empty);
+
+                // Map the frameIndex to the candidate process name.  This gets consumed in FrameNameLookup().
+                processNameBuilder.SaveProcessName(frameIndex, processFrame.Name, processFrame.ID);
+            }
+            else
+            {
+                frameIndex = InternFrame(frameDisplayName);
+            }
 
             stackIndex = InternCallerStack(frameIndex, InternFrames(frameIterator, stackIndex, processID));
 

--- a/src/TraceEvent/Stacks/Stacks.cs
+++ b/src/TraceEvent/Stacks/Stacks.cs
@@ -987,7 +987,12 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                     baseName = "Frame " + ((int)baseFrameIndex).ToString();
                 }
 
-                return baseName + " " + frameName;
+                if(!string.IsNullOrEmpty(frameName))
+                {
+                    return baseName + " " + frameName;
+                }
+
+                return baseName;
             }
             var moduleName = m_moduleIntern[m_frameIntern[frameIndexOffset].ModuleIndex - m_moduleStackStartIndex];
             if (moduleName.Length == 0)

--- a/src/TraceEvent/TraceEvent.Tests/LinuxStackSource/ProcessNameBuilderTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/LinuxStackSource/ProcessNameBuilderTests.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.Diagnostics.Tracing.Stacks;
+using Microsoft.Diagnostics.Tracing.StackSources;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class ProcessNameBuilderTests
+    {
+        [Fact]
+        public void SingleProcessName()
+        {
+            StackSourceFrameIndex frameIndex = (StackSourceFrameIndex)0x10;
+
+            LinuxPerfScriptProcessNameBuilder builder = new LinuxPerfScriptProcessNameBuilder();
+            builder.SaveProcessName(frameIndex, "test-process-name", 100);
+            string processName = builder.GetProcessName(frameIndex);
+            Assert.Equal("Process test-process-name (100)", processName);
+        }
+
+        [Fact]
+        public void SingleIgnoredName()
+        {
+            StackSourceFrameIndex frameIndex = (StackSourceFrameIndex)0x10;
+
+            LinuxPerfScriptProcessNameBuilder builder = new LinuxPerfScriptProcessNameBuilder();
+            builder.SaveProcessName(frameIndex, ".NET Finalizer", 100);
+            string processName = builder.GetProcessName(frameIndex);
+            Assert.Equal("Process .NET Finalizer (100)", processName);
+        }
+
+        [Fact]
+        public void MultipleWithNoIgnoredNames()
+        {
+            StackSourceFrameIndex frameIndex = (StackSourceFrameIndex)0x10;
+
+            LinuxPerfScriptProcessNameBuilder builder = new LinuxPerfScriptProcessNameBuilder();
+            builder.SaveProcessName(frameIndex, "test-process-name-1", 100);
+            builder.SaveProcessName(frameIndex, "test-process-name-2", 100);
+            builder.SaveProcessName(frameIndex, "test-process-name-3", 100);
+            builder.SaveProcessName(frameIndex, "test-process-name-4", 100);
+            string processName = builder.GetProcessName(frameIndex);
+            Assert.Equal("Process test-process-name-1;test-process-name-2;test-process-name-3;test-process-name-4 (100)", processName);
+        }
+
+        [Fact]
+        public void MultipleWithIgnoredNames()
+        {
+            StackSourceFrameIndex frameIndex = (StackSourceFrameIndex)0x10;
+
+            LinuxPerfScriptProcessNameBuilder builder = new LinuxPerfScriptProcessNameBuilder();
+            builder.SaveProcessName(frameIndex, "test-process-name-1", 100);
+            builder.SaveProcessName(frameIndex, ".NET Finalizer", 100);
+            builder.SaveProcessName(frameIndex, ".NET Tiered Compilation Worker", 100);
+            builder.SaveProcessName(frameIndex, ".NET BGC", 100);
+            builder.SaveProcessName(frameIndex, ".NET Server GC", 100);
+            builder.SaveProcessName(frameIndex, "test-process-name-2", 100);
+            string processName = builder.GetProcessName(frameIndex);
+            Assert.Equal("Process test-process-name-1;test-process-name-2 (100)", processName);
+        }
+
+        [Fact]
+        public void MultipleWithOnlyIgnoredNames()
+        {
+            StackSourceFrameIndex frameIndex = (StackSourceFrameIndex)0x10;
+
+            LinuxPerfScriptProcessNameBuilder builder = new LinuxPerfScriptProcessNameBuilder();
+            builder.SaveProcessName(frameIndex, ".NET Finalizer", 100);
+            builder.SaveProcessName(frameIndex, ".NET Tiered Compilation Worker", 100);
+            builder.SaveProcessName(frameIndex, ".NET BGC", 100);
+            builder.SaveProcessName(frameIndex, ".NET Server GC", 100);
+            string processName = builder.GetProcessName(frameIndex);
+            Assert.Equal("Process .NET Finalizer;.NET Tiered Compilation Worker;.NET BGC;.NET Server GC (100)", processName);
+        }
+
+        [Fact]
+        public void MultipleProcesses()
+        {
+            StackSourceFrameIndex frameIndex1 = (StackSourceFrameIndex)0x10;
+            StackSourceFrameIndex frameIndex2 = (StackSourceFrameIndex)0x20;
+
+            LinuxPerfScriptProcessNameBuilder builder = new LinuxPerfScriptProcessNameBuilder();
+            builder.SaveProcessName(frameIndex1, "test-process-name", 100);
+            builder.SaveProcessName(frameIndex2, "test-process-name-2", 200);
+            string processName = builder.GetProcessName(frameIndex1);
+            Assert.Equal("Process test-process-name (100)", processName);
+            processName = builder.GetProcessName(frameIndex2);
+            Assert.Equal("Process test-process-name-2 (200)", processName);
+        }
+    }
+}


### PR DESCRIPTION
Existing behavior causes traces captured with perfcollect to show an incorrect list of processes.  Many of the process names are actually thread names, and so looking at usage for a single process requires a user to multi-select all of the rows whose PIDs match the one they want.

With this change, each row in the process selection dialog will represent one process.  We do our best to select the right process name.  If we can't, we'll show multiple of them with a semi-colon delimiter.