### PR TITLE
Build the HeapDumpDLL project for netstandard20

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,8 +23,11 @@
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
     <FastSerializationVersion>3.0.5</FastSerializationVersion>
+    <HeapDumpDllVersion>3.0.5</HeapDumpDllVersion>
+    <MemoryGraphVersion>3.0.5</MemoryGraphVersion>
     <PerfViewVersion>3.0.5</PerfViewVersion>
     <TraceEventVersion>3.0.5</TraceEventVersion>
+    <UtilitiesVersion>3.0.5</UtilitiesVersion>
   </PropertyGroup>
 
   <!-- versions of dependencies that more than one project use -->

--- a/src/HeapDumpDLL/HeapDumpDLL.csproj
+++ b/src/HeapDumpDLL/HeapDumpDLL.csproj
@@ -11,6 +11,7 @@
     <Company>Microsoft</Company>
     <Description>General Utility library</Description>
     <Copyright>Copyright © Microsoft 2010</Copyright>
+    <Version>$(HeapDumpDllVersion)</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/HeapDumpDLL/HeapDumpDLL.csproj
+++ b/src/HeapDumpDLL/HeapDumpDLL.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard20</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.HeapDump</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.HeapDump</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -34,17 +34,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\HeapDump\*.cs" />
+    <Compile Include="..\HeapDump\GCHeapDump.cs" />
     <Compile Include="..\HeapDump\Utilities\*.cs" />
-    <Compile Include="..\HeapDump\Debugger\**\*.cs" />
     <Compile Include="..\HeapDumpCommon\DotNetHeapInfo.cs" />
     <Compile Include="..\PerfView\memory\ETWClrProfilerTraceEventParser.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptDumpGraph.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptHeapDumper.cs" />
     <Compile Include="..\PerfView\PerfViewLogger.cs" />
-    <Compile Include="..\PerfView\Triggers.cs" />
     <Compile Include="..\ETWHeapDump\DotNetHeapDumper.cs" />
     <Compile Include="..\ETWHeapDump\DotNetHeapDumpGraphReader.cs" />
+  </ItemGroup>
+
+  <!-- Only include these files in the net462 version because there are some non-netstandard dependencies. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <Compile Include="..\HeapDump\CollectionMetadata.cs" />
+    <Compile Include="..\HeapDump\Debugger\**\*.cs" />
+    <Compile Include="..\HeapDump\GCHeapDumper.cs" />
+    <Compile Include="..\HeapDump\HeapDumpException.cs" />
+    <Compile Include="..\HeapDump\HeapDumpHResult.cs" />
+    <Compile Include="..\PerfView\Triggers.cs" />
   </ItemGroup>
 
   <!-- ******************* Signing Support *********************** -->

--- a/src/MemoryGraph/MemoryGraph.csproj
+++ b/src/MemoryGraph/MemoryGraph.csproj
@@ -10,6 +10,7 @@
     <Company>Microsoft</Company>
     <Description>MemoryGraph library</Description>
     <Copyright>Copyright © Microsoft 2010</Copyright>
+    <Version>$(MemoryGraphVersion)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Utilities/Utilities.csproj
+++ b/src/Utilities/Utilities.csproj
@@ -10,6 +10,7 @@
     <Company>Microsoft</Company>
     <Description>Utility library</Description>
     <Copyright>Copyright © Microsoft 2010</Copyright>
+    <Version>$(UtilitiesVersion)</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Build the HeapDumpDLL project against the netstandard20 target framework.

Does not include the `GCHeapDumper` and associated code because some of its dependencies are not available in the netstandard20 set of APIs.