### PR TITLE
Add support for last branch recording

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -745,7 +745,7 @@ namespace PerfView
                 switch (entry.ToLowerInvariant())
                 {
                     case "stackmode": flags |= LbrFilterFlags.CallstackEnable; break;
-                    case "conditionalbranches": flags |= LbrFilterFlags.FilterNearRelCall; break;
+                    case "conditionalbranches": flags |= LbrFilterFlags.FilterJcc; break;
                     case "nearrelativecalls": flags |= LbrFilterFlags.FilterNearRelCall; break;
                     case "nearindirectcalls": flags |= LbrFilterFlags.FilterNearIndCall; break;
                     case "nearreturns": flags |= LbrFilterFlags.FilterNearRet; break;

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Utilities;
 
 namespace PerfView
@@ -108,6 +110,8 @@ namespace PerfView
 
         // Start options.
         public bool StackCompression = true;    // Use compresses stacks when collecting traces. 
+        public CommandLineLbrSources LastBranchRecordingSources;
+        public CommandLineLbrFilters LastBranchRecordingFilters;
         public int BufferSizeMB = 256;
         public int CircularMB;
         public bool InMemoryCircularBuffer;         // Uses EVENT_TRACE_BUFFERING_MODE for an in-memory circular buffer
@@ -274,6 +278,13 @@ namespace PerfView
             parser.DefineOptionalQualifier("CircularMB", ref CircularMB, "Do Circular logging with a file size in MB.  Zero means non-circular.");
             parser.DefineOptionalQualifier("InMemoryCircularBuffer", ref InMemoryCircularBuffer, "Keeps the circular buffer in memory until the session is stopped.");
             parser.DefineOptionalQualifier("StackCompression", ref StackCompression, "Use stack compression (only on Win 8+) to make collected file smaller.");
+            parser.DefineOptionalQualifier("LbrSources", ref LastBranchRecordingSources,
+                $"Turn on LBR sampling from these sources (comma-separated numeric hex values with 0x prefix or 'PmcInterrupt'). At most {TraceEventSession.GetMaxLastBranchRecordingSources()} sources are supported.");
+            parser.DefineOptionalQualifier(
+                "LbrFilters",
+                ref LastBranchRecordingFilters,
+                "Filters to use with LBR sampling (comma-separated). Unspecified means no filtering. " +
+                "Valid filters are: StackMode, ConditionalBranches, NearRelativeCalls, NearIndirectCalls, NearReturns, NearIndirectJumps, NearRelativeJumps, FarBranches, Kernel, User");
             parser.DefineOptionalQualifier("MaxCollectSec", ref MaxCollectSec,
                 "Turn off collection (and kill the program if perfView started it) after this many seconds. Zero means no timeout.");
             parser.DefineOptionalQualifier("StopOnPerfCounter", ref StopOnPerfCounter,
@@ -679,5 +690,91 @@ namespace PerfView
             parser.DefineOptionalParameter("DataFile", ref DataFile, "ETL or ETLX file containing profile data.");
         }
         #endregion
-    };
+    }
+
+    public class CommandLineLbrSources
+    {
+        public string Text { get; private set; }
+        public uint[] Parsed { get; private set; }
+
+        public static CommandLineLbrSources Parse(string text)
+        {
+            var sources = new List<uint>();
+            foreach (string entry in text.Split(','))
+            {
+                bool success;
+                uint source = 0;
+                string trimmed = entry.Trim();
+                if (trimmed.StartsWith("0x"))
+                {
+                    success = uint.TryParse(trimmed.Substring(2), NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo, out source);
+                }
+                else
+                {
+                    success = Enum.TryParse(trimmed, true, out LbrSource enumSource);
+                    source = (uint)enumSource;
+                }
+
+                if (!success)
+                    throw new CommandLineParserException($"/LbrSources: Could not parse '{entry}'");
+
+                sources.Add(source);
+            }
+
+            int maxSources = TraceEventSession.GetMaxLastBranchRecordingSources();
+            if (sources.Count > maxSources)
+                throw new CommandLineParserException($"/LbrSources: At most {maxSources} sources can be specified");
+
+            return new CommandLineLbrSources { Text = text, Parsed = sources.ToArray() };
+        }
+
+        public override string ToString() => Text;
+    }
+
+    public class CommandLineLbrFilters
+    {
+        public string Text { get; private set; }
+        public LbrFilterFlags Parsed { get; private set; }
+
+        public static CommandLineLbrFilters Parse(string text)
+        {
+            LbrFilterFlags flags = 0;
+            foreach (string entry in text.Split(','))
+            {
+                // Parse using same names as xperf.
+                switch (entry.ToLowerInvariant())
+                {
+                    case "stackmode": flags |= LbrFilterFlags.CallstackEnable; break;
+                    case "conditionalbranches": flags |= LbrFilterFlags.FilterNearRelCall; break;
+                    case "nearrelativecalls": flags |= LbrFilterFlags.FilterNearRelCall; break;
+                    case "nearindirectcalls": flags |= LbrFilterFlags.FilterNearIndCall; break;
+                    case "nearreturns": flags |= LbrFilterFlags.FilterNearRet; break;
+                    case "nearindirectjumps": flags |= LbrFilterFlags.FilterNearIndJmp; break;
+                    case "nearrelativejumps": flags |= LbrFilterFlags.FilterNearRelJmp; break;
+                    case "farbranches": flags |= LbrFilterFlags.FilterFarBranch; break;
+                    case "kernel": flags |= LbrFilterFlags.FilterKernel; break;
+                    case "user": flags |= LbrFilterFlags.FilterUser; break;
+                    default: throw new CommandLineParserException($"Could not parse '{entry}' as an LBR filter");
+                }
+            }
+
+            const LbrFilterFlags callstackAllowedFlags =
+                LbrFilterFlags.CallstackEnable | LbrFilterFlags.FilterKernel | LbrFilterFlags.FilterUser;
+            if ((flags & LbrFilterFlags.CallstackEnable) != 0 &&
+                (flags & ~callstackAllowedFlags) != 0)
+            {
+                throw new CommandLineParserException("/LbrFilters: Only 'Kernel' or 'User' can be specified alongside 'StackMode'");
+            }
+
+            const LbrFilterFlags kernelUser = LbrFilterFlags.FilterKernel | LbrFilterFlags.FilterUser;
+            if ((flags & kernelUser) == kernelUser)
+            {
+                throw new CommandLineParserException("/LbrFilters: Only one of 'Kernel' or 'User' can be specified");
+            }
+
+            return new CommandLineLbrFilters { Text = text, Parsed = flags };
+        }
+
+        public override string ToString() => Text;
+    }
 }

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -480,6 +480,8 @@ namespace PerfView
 
                     kernelModeSession.BufferSizeMB = parsedArgs.BufferSizeMB;
                     kernelModeSession.StackCompression = parsedArgs.StackCompression;
+                    kernelModeSession.LastBranchRecordingProfileSources = parsedArgs.LastBranchRecordingSources?.Parsed;
+                    kernelModeSession.LastBranchRecordingFilters = parsedArgs.LastBranchRecordingFilters?.Parsed ?? LbrFilterFlags.None;
                     kernelModeSession.CpuSampleIntervalMSec = parsedArgs.CpuSampleMSec;
                     if (parsedArgs.CircularMB != 0)
                     {
@@ -2795,6 +2797,16 @@ namespace PerfView
             if (parsedArgs.StackCompression)
             {
                 cmdLineArgs += " /StackCompression";
+            }
+
+            if (parsedArgs.LastBranchRecordingSources != null)
+            {
+                cmdLineArgs += " " + Command.Quote("/LbrSources:" + parsedArgs.LastBranchRecordingSources.Text);
+            }
+
+            if (parsedArgs.LastBranchRecordingFilters != null)
+            {
+                cmdLineArgs += " " + Command.Quote("/LbrFilters:" + parsedArgs.LastBranchRecordingFilters.Text);
             }
 
             if (parsedArgs.CircularMB != 0)

--- a/src/TraceEvent/Parsers/KernelTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/KernelTraceEventParser.cs
@@ -3,11 +3,13 @@
 using FastSerialization;
 using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Session;
 using Microsoft.Diagnostics.Tracing.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Utilities;
@@ -2315,6 +2317,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 source.UnregisterEventTemplate(value, 47, PerfInfoTaskGuid);
             }
         }
+        public event Action<LastBranchRecordTraceData> LastBranchRecordingSample
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                source.RegisterEventTemplate(new LastBranchRecordTraceData(value, 0xFFFF, 0, "LastBranchRecording", LbrProviderGuid, 32, "Sample", ProviderGuid, ProviderName, State));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 0, LbrProviderGuid);
+            }
+        }
+
 #if false       // TODO FIX NOW remove (it is not used and is not following conventions on array fields.   
         public event Action<BatchedSampledProfileTraceData> PerfInfoBatchedSample
         {
@@ -2881,7 +2896,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[194];
+                var templates = new TraceEvent[195];
                 templates[0] = new EventTraceHeaderTraceData(null, 0xFFFF, 0, "EventTrace", EventTraceTaskGuid, 0, "Header", ProviderGuid, ProviderName, null);
                 templates[1] = new HeaderExtensionTraceData(null, 0xFFFF, 0, "EventTrace", EventTraceTaskGuid, 5, "Extension", ProviderGuid, ProviderName, null);
                 templates[2] = new HeaderExtensionTraceData(null, 0xFFFF, 0, "EventTrace", EventTraceTaskGuid, 32, "EndExtension", ProviderGuid, ProviderName, null);
@@ -3081,6 +3096,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[191] = new ObjectNameTraceData(null, 0xFFFF, 0, "Object", ObjectTaskGuid, 39, "HandleDCEnd", ProviderGuid, ProviderName, null);
                 templates[192] = new ISRTraceData(null, 0xFFFF, 11, "PerfInfo", PerfInfoTaskGuid, 50, "ISR", ProviderGuid, ProviderName, null);
                 templates[193] = new ThreadSetNameTraceData(null, 0xFFFF, 2, "Thread", ThreadTaskGuid, 72, "SetName", ProviderGuid, ProviderName);
+                templates[194] = new LastBranchRecordTraceData(null, 0xFFFF, 0, "LastBranchRecording", LbrProviderGuid, 32, "Sample", ProviderGuid, ProviderName, null);
+
                 s_templates = templates;
             }
             foreach (var template in s_templates)
@@ -3137,6 +3154,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         internal static readonly Guid ReadyThreadTaskGuid = new Guid(unchecked((int)0x3d6fa8d1), unchecked((short)0xfe05), unchecked((short)0x11d0), 0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c);
         internal static readonly Guid SysConfigTaskGuid = new Guid(unchecked((int)0x9b79ee91), unchecked((short)0xb5fd), 0x41c0, 0xa2, 0x43, 0x42, 0x48, 0xe2, 0x66, 0xe9, 0xD0);
         internal static readonly Guid ObjectTaskGuid = new Guid(unchecked((int)0x89497f50), unchecked((short)0xeffe), 0x4440, 0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7);
+        internal static readonly Guid LbrProviderGuid = new Guid(unchecked((int)0x99134383), unchecked((short)0x5248), 0x43fc, 0x83, 0x4b, 0x52, 0x94, 0x54, 0xe7, 0x5d, 0xf3);
         #endregion
     }
     #region private types
@@ -13873,5 +13891,218 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Kernel
         }
         private Action<VolumeMappingTraceData> Action;
         #endregion
+    }
+
+    public sealed class LastBranchRecordTraceData : TraceEvent
+    {
+        // Event is:
+        //
+        // ulong TimeStamp
+        // uint ProcessId
+        // uint ThreadId
+        // LbrFilterFlags Filters
+        // LbrEntry Entries[]; <- rest of event
+        //
+        // where LbrEntry is
+        // Ptr FromAddress
+        // Ptr ToAddress
+        // Ptr Reserved
+        //
+        // Note that LbrEntry is thus pointer aligned inside the event.
+
+        private const int HeaderSize32 = 8 + 4 + 4 + 4;
+        private const int HeaderSize64 = 8 + 4 + 4 + 4 + /* alignment */ 4;
+
+        public new DateTime TimeStamp => traceEventSource.QPCTimeToDateTimeUTC(GetInt64At(0)).ToLocalTime();
+        public new double TimeStampRelativeMSec => traceEventSource.QPCTimeToRelMSec(GetInt64At(0));
+        public LbrFilterFlags Filters => (LbrFilterFlags)GetInt32At(16);
+
+        public int NumBranches
+        {
+            get
+            {
+                if (PointerSize == 8)
+                {
+                    return (EventDataLength - HeaderSize64) / (sizeof(ulong) * 3);
+                }
+                else
+                {
+                    return (EventDataLength - HeaderSize32) / (sizeof(uint) * 3);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Insert all the branches from this event into the specified span.
+        /// Branches are in chronological order with the most recent taken branch first.
+        /// </summary>
+        public unsafe void GetBranches(Span<Branch> branches)
+        {
+            if (PointerSize == 8)
+            {
+                int numBranches = (EventDataLength - HeaderSize64) / (sizeof(ulong) * 3);
+                if (branches.Length != numBranches)
+                {
+                    throw new ArgumentException($"Expected span of {numBranches} branches", nameof(branches));
+                }
+
+                ulong* pBranch = (ulong*)(DataStart + HeaderSize64);
+                for (int i = 0; i < branches.Length; i++)
+                {
+                    branches[i] = new Branch(Unsafe.ReadUnaligned<ulong>(&pBranch[0]), Unsafe.ReadUnaligned<ulong>(&pBranch[1]));
+                    pBranch += 3;
+                }
+            }
+            else
+            {
+                int numBranches = (EventDataLength - HeaderSize32) / (sizeof(uint) * 3);
+                if (branches.Length != numBranches)
+                {
+                    throw new ArgumentException($"Expected span of {numBranches} branches", nameof(branches));
+                }
+
+                uint* pBranch = (uint*)(DataStart + HeaderSize32);
+                for (int i = 0; i < branches.Length; i++)
+                {
+                    branches[i] = new Branch(Unsafe.ReadUnaligned<uint>(&pBranch[0]), Unsafe.ReadUnaligned<uint>(&pBranch[1]));
+                    pBranch += 3;
+                }
+            }
+        }
+
+        public Branch[] GetBranches()
+        {
+            Branch[] branches = new Branch[NumBranches];
+            GetBranches(branches);
+            return branches;
+        }
+
+        public unsafe Branch GetBranch(int index)
+        {
+            if (index >= NumBranches)
+            {
+                throw new ArgumentOutOfRangeException("The branch index must be less than the number of branches", nameof(index));
+            }
+
+            if (PointerSize == 8)
+            {
+                ulong* pBranch = (ulong*)(DataStart + HeaderSize64) + (index * 3);
+                return new Branch(Unsafe.ReadUnaligned<ulong>(&pBranch[0]), Unsafe.ReadUnaligned<ulong>(&pBranch[1]));
+            }
+            else
+            {
+                uint* pBranch = (uint*)(DataStart + HeaderSize32) + (index * 3);
+                return new Branch(Unsafe.ReadUnaligned<uint>(&pBranch[0]), Unsafe.ReadUnaligned<uint>(&pBranch[1]));
+            }
+        }
+
+        #region Private
+        internal LastBranchRecordTraceData(Action<LastBranchRecordTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName, KernelTraceEventParserState state)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            NeedsFixup = true;
+            Action = action;
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<LastBranchRecordTraceData>)value; }
+        }
+        protected internal override void Dispatch()
+        {
+            Debug.Assert(Version >= 2);
+#if DEBUG
+            int headerSize = PointerSize == 8 ? HeaderSize64 : HeaderSize32;
+            Debug.Assert(EventDataLength >= headerSize && (EventDataLength - headerSize) % (PointerSize * 3) == 0);
+#endif
+            Action(this);
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "Filters", Filters.ToString());
+            XmlAttrib(sb, "NumBranches", NumBranches);
+            sb.AppendLine(">");
+
+            Span<Branch> branches = stackalloc Branch[NumBranches];
+            GetBranches(branches);
+            foreach (Branch branch in branches)
+            {
+                sb.Append("  <Branch");
+                XmlAttribHex(sb, "Source", branch.Source);
+                XmlAttribHex(sb, "Target", branch.Target);
+                sb.AppendLine(" />");
+            }
+            sb.Append("</Event>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                {
+                    payloadNames = new string[] { "Filters", "NumBranches", };
+                }
+
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return Filters;
+                case 1:
+                    return NumBranches;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        private event Action<LastBranchRecordTraceData> Action;
+        protected internal override void SetState(object newState) { state = (KernelTraceEventParserState)newState; }
+        private KernelTraceEventParserState state;
+
+        internal override bool LogCodeAddresses(Func<TraceEvent, ulong, bool> callBack)
+        {
+            bool result = true;
+            Span<Branch> branches = stackalloc Branch[NumBranches];
+            GetBranches(branches);
+            foreach (Branch branch in branches)
+            {
+                result &= callBack(this, branch.Source);
+                result &= callBack(this, branch.Target);
+            }
+
+            return result;
+        }
+
+        internal override unsafe void FixupData()
+        {
+            Debug.Assert(eventRecord->EventHeader.ProcessId == -1);
+            eventRecord->EventHeader.ProcessId = GetInt32At(8);
+            eventRecord->EventHeader.ThreadId = GetInt32At(12);
+        }
+
+        #endregion
+    }
+
+    public struct Branch
+    {
+        public Address Source { get; }
+        public Address Target { get; }
+
+        public Branch(Address source, Address target)
+        {
+            Source = source;
+            Target = target;
+        }
+
+        public override string ToString() => $"{Source} -> {Target}";
     }
 }

--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -255,21 +255,23 @@ namespace Microsoft.Diagnostics.Tracing
 
         internal enum TRACE_INFO_CLASS
         {
-            TraceGuidQueryList,                     // Get Guids of all providers registered on the computer
-            TraceGuidQueryInfo,                     // Query information that each session a particular provider.  
-            TraceGuidQueryProcess,                  // Query an array of GUIDs of the providers that registered themselves in the same process as the calling process
-            TraceStackTracingInfo,                  // This is the last one supported on Win7
+            TraceGuidQueryList = 0,                     // Get Guids of all providers registered on the computer
+            TraceGuidQueryInfo = 1,                     // Query information that each session a particular provider.  
+            TraceGuidQueryProcess = 2,                  // Query an array of GUIDs of the providers that registered themselves in the same process as the calling process
+            TraceStackTracingInfo = 3,                  // This is the last one supported on Win7
             // Win 8 
-            TraceSystemTraceEnableFlagsInfo,        // Turns on kernel event logger
-            TraceSampledProfileIntervalInfo,        // TRACE_PROFILE_INTERVAL (allows you to set the sampling interval) (Set, Get)
+            TraceSystemTraceEnableFlagsInfo = 4,        // Turns on kernel event logger
+            TraceSampledProfileIntervalInfo = 5,        // TRACE_PROFILE_INTERVAL (allows you to set the sampling interval) (Set, Get)
 
-            TraceProfileSourceConfigInfo,           // int array, turns on all listed sources.  (Set)
-            TraceProfileSourceListInfo,             // PROFILE_SOURCE_INFO linked list (converts names to source numbers) (Get)
+            TraceProfileSourceConfigInfo = 6,           // int array, turns on all listed sources.  (Set)
+            TraceProfileSourceListInfo = 7,             // PROFILE_SOURCE_INFO linked list (converts names to source numbers) (Get)
 
             // Used to collect extra info on other events (currently only context switch).  
-            TracePmcEventListInfo,                  // CLASSIC_EVENT_ID array (Works like TraceStackTracingInfo)
-            TracePmcCounterListInfo,                // int array
-            MaxTraceSetInfoClass
+            TracePmcEventListInfo = 8,                  // CLASSIC_EVENT_ID array (Works like TraceStackTracingInfo)
+            TracePmcCounterListInfo = 9,                // int array
+
+            TraceLbrConfigurationInfo = 20,             // Filter flags
+            TraceLbrEventListInfo = 21,                 // int array
         };
 
         internal struct CLASSIC_EVENT_ID

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1273,7 +1273,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                     throw new InvalidOperationException("Property can't be changed after a provider has started.");
                 }
 
-                m_LastBranchRecordingProfileSources = (uint[])value.Clone();
+                m_LastBranchRecordingProfileSources = (uint[])value?.Clone();
             }
         }
 

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -750,6 +750,11 @@ namespace Microsoft.Diagnostics.Tracing.Session
             if (sources == null || sources.Length == 0)
                 return;
 
+            if (!OperatingSystemVersion.AtLeast(OperatingSystemVersion.Win10))
+            {
+                throw new NotSupportedException("Last branch recording is only supported on Windows 10 19H1+ and Windows Server 1903+");
+            }
+
             uint filters = (uint)m_LastBranchRecordingFilters;
             int error = TraceEventNativeMethods.TraceSetInformation(m_SessionHandle, TraceEventNativeMethods.TRACE_INFO_CLASS.TraceLbrConfigurationInfo, &filters, sizeof(uint));
             Marshal.ThrowExceptionForHR(TraceEventNativeMethods.GetHRFromWin32(error));

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -738,8 +738,28 @@ namespace Microsoft.Diagnostics.Tracing.Session
                     ETWControl.EnableStackCaching(m_SessionHandle);
                 }
 
+                EnableLastBranchRecordingIfConfigured();
+
                 return ret;
             }
+        }
+
+        private unsafe void EnableLastBranchRecordingIfConfigured()
+        {
+            uint[] sources = m_LastBranchRecordingProfileSources;
+            if (sources == null || sources.Length == 0)
+                return;
+
+            uint filters = (uint)m_LastBranchRecordingFilters;
+            int error = TraceEventNativeMethods.TraceSetInformation(m_SessionHandle, TraceEventNativeMethods.TRACE_INFO_CLASS.TraceLbrConfigurationInfo, &filters, sizeof(uint));
+            Marshal.ThrowExceptionForHR(TraceEventNativeMethods.GetHRFromWin32(error));
+
+            fixed (uint* pSources = sources)
+            {
+                error = TraceEventNativeMethods.TraceSetInformation(m_SessionHandle, TraceEventNativeMethods.TRACE_INFO_CLASS.TraceLbrEventListInfo, pSources, sources.Length * sizeof(uint));
+            }
+
+            Marshal.ThrowExceptionForHR(TraceEventNativeMethods.GetHRFromWin32(error));
         }
 
         // OS Heap Provider support.  
@@ -1229,6 +1249,48 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 }
 
                 m_StackCompression = value;
+            }
+        }
+
+        /// <summary>
+        /// The profile sources to use for capturing LBR with the kernel
+        /// provider. Last branch recording is enabled when this array is
+        /// non-empty. Supported on Windows 10 19H1+ and Windows Server 1903+.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// At most <see cref="GetMaxLastBranchRecordingSources()"/> sources
+        /// can be specified at the same time. See <see cref="LbrSource"/> for
+        /// an incomplete list of valid sources.
+        /// </remarks>
+        public uint[] LastBranchRecordingProfileSources
+        {
+            get { return m_LastBranchRecordingProfileSources; }
+            set
+            {
+                if (IsActive)
+                {
+                    throw new InvalidOperationException("Property can't be changed after a provider has started.");
+                }
+
+                m_LastBranchRecordingProfileSources = (uint[])value.Clone();
+            }
+        }
+
+        /// <summary>
+        /// Filters to use for LBR sampling. Can be <see cref="LbrFilterFlags.None"/>.
+        /// </summary>
+        public LbrFilterFlags LastBranchRecordingFilters
+        {
+            get { return m_LastBranchRecordingFilters; }
+            set
+            {
+                if (IsActive)
+                {
+                    throw new InvalidOperationException("Property can't be changed after a provider has started.");
+                }
+
+                m_LastBranchRecordingFilters = value;
             }
         }
 
@@ -2391,6 +2453,15 @@ namespace Microsoft.Diagnostics.Tracing.Session
             }
         }
 
+        /// <summary>
+        /// Get the max number of last branch recording sources that can be specified at the same time.
+        /// </summary>
+        public static int GetMaxLastBranchRecordingSources()
+        {
+            const int ETW_MAX_LBR_EVENTS = 4;
+            return ETW_MAX_LBR_EVENTS;
+        }
+
         internal const int MaxNameSize = 1024;
         private const int MaxExtensionSize = 256;
         private static readonly int PropertiesSize = sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES) + 2 * MaxNameSize * sizeof(char) + MaxExtensionSize;
@@ -2407,6 +2478,9 @@ namespace Microsoft.Diagnostics.Tracing.Session
 
         private float m_CpuSampleIntervalMSec;
         private bool m_StackCompression;
+        private uint[] m_LastBranchRecordingProfileSources;
+        private LbrFilterFlags m_LastBranchRecordingFilters;
+
         private bool m_restarted;
 
         // Internal state
@@ -3190,6 +3264,33 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// Take a stack trace with the event
         /// </summary>
         Stacks = 1,
+    }
+
+    /// <summary>
+    /// Incomplete list of sources that can specify LBR recording (same sources as for stack walking).
+    /// </summary>
+    public enum LbrSource
+    {
+        PmcInterrupt = 0x0F00 | 0x2F, // EVENT_TRACE_GROUP_PERFINFO | 0x2f
+    }
+
+    /// <summary>
+    /// Filters what branches are recorded with LBR.
+    /// </summary>
+    [Flags]
+    public enum LbrFilterFlags
+    {
+        None = 0,
+        FilterKernel = 1 << 0,
+        FilterUser = 1 << 1,
+        FilterJcc = 1 << 2,
+        FilterNearRelCall = 1 << 3,
+        FilterNearIndCall = 1 << 4,
+        FilterNearRet = 1 << 5,
+        FilterNearIndJmp = 1 << 6,
+        FilterNearRelJmp = 1 << 7,
+        FilterFarBranch = 1 << 8,
+        CallstackEnable = 1 << 9,
     }
 }
 


### PR DESCRIPTION
Add /LbrSources and /LbrFilters command line options. When the former is specified, last branch recording is enabled from the specified sources (comma-separated string of numeric source IDs or "PmcInterrupt"). /LbrFilters can optionally be specified to filter which branches are recorded (comma-separated list using same syntax as xperf).

No special parsing of these events yet, but this at least allows recording them.