### PR TITLE
Don't include binder events in default CLR events

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             /// <summary>
             /// Recommend default flags (good compromise on verbosity).  
             /// </summary>
-            Default = GC | Type | GCHeapSurvivalAndMovement | Binder | Loader | Jit | NGen | SupressNGen
+            Default = GC | Type | GCHeapSurvivalAndMovement | Loader | Jit | NGen | SupressNGen
                          | StopEnumeration | Security | AppDomainResourceManagement | Exception | Threading | Contention | Stack | JittedMethodILToNativeMap
                          | ThreadTransfer | GCHeapAndTypeNames | Codesymbols | Compilation,
 


### PR DESCRIPTION
The binder events - for Fusion in .NET Framework and assembly load tracing in .NET Core/5+ - are for the targeted scenario of assembly bind tracing. They aren't generally helpful to have on by default and can come with a [significant performance cost](https://github.com/dotnet/runtime/issues/78539). This removes the binder events from `ClrTraceEventParser.Keywords.Default`, since I don't think those intentionally verbose events make sense in the default set.