### PR TITLE
Properly quote EventCounter payload parsing for graphs

### DIFF
--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -571,12 +571,12 @@ namespace PerfView
         }
 
         private const string PayloadToken = "Payload=\"{";
-        private const string PayloadTokenNetCore = "Payload:{";
-        private const string NameToken = "Name:";
-        private const string DisplayNameToken = "DisplayName:";
-        private const string MeanToken = "Mean:";
-        private const string IncrementToken = "Increment:";
-        private const string IntervalToken = "IntervalSec:";
+        private const string PayloadTokenNetCore = "Payload\":{";
+        private const string NameToken = "Name\":";
+        private const string DisplayNameToken = "DisplayName\":";
+        private const string MeanToken = "Mean\":";
+        private const string IncrementToken = "Increment\":";
+        private const string IntervalToken = "IntervalSec\":";
 
         private Dictionary<string, List<Tuple<double, double>>> BuildCounters(EventSource source)
         {


### PR DESCRIPTION
fixes #1759 

Now that the generated EventCounter payload text is properly JSON-quoted, needed to update the EventCounter graph-generating code to be aware of the added quotes