### PR TITLE
User Ordinal Comparison for GC Event Detection

### DIFF
--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -2931,7 +2931,7 @@ namespace Microsoft.Diagnostics.Tracing
                 }
 
                 // We register the same name for old classic and manifest for some old GC events (
-                if (eventName.StartsWith("GC") && template.ID == (TraceEventID)0xFFFF &&
+                if (eventName.StartsWith("GC", StringComparison.Ordinal) && template.ID == (TraceEventID)0xFFFF &&
                     (template.ProviderGuid == ClrTraceEventParser.ProviderGuid || template.providerGuid == ClrTraceEventParser.NativeProviderGuid))
                 {
                     return;


### PR DESCRIPTION
I.e. GCHeapStats fails in CZ locale, because CH is actual letter.