### PR TITLE
Add TraceEventSource finalizer

### DIFF
--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -323,6 +323,14 @@ namespace Microsoft.Diagnostics.Tracing
         public bool DataLifetimeEnabled() { return DataLifetimeMsec > 0; }
 
         /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~TraceEventSource()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
         /// Closes any files and cleans up any resources associated with this TraceEventSource
         /// </summary>
         public void Dispose()


### PR DESCRIPTION
This abstract class implements IDisposable and has a `protected virtual Dispose(bool disposing)` method, but it is missing a finalizer. Without the finalizer, dangling references will not have their native resources cleaned up.
In particular, an ETWTraceEventSource can leak native handles to open .etl files, thereby locking them on disk.