### PR TITLE
Add a Link to the Microsoft Privacy Policy

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -140,6 +140,7 @@
                     <MenuItem Header="Viewing External Data" Command="{x:Static src:MainWindow.UsersGuideCommand}" CommandParameter="ViewingExternalData"/>
                     <MenuItem Header="Using EventSources" Command="{x:Static src:MainWindow.UsersGuideCommand}" CommandParameter="UsingEventSources"/>
                     <MenuItem Header="_Release Notes" Click="DoReleaseNotes"/>
+                    <MenuItem Header="Privacy Policy" Click="DoPrivacyPolicy" />
                     <MenuItem Header="_About" Click="DoAbout"/>
                 </MenuItem>
             </Menu>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -2029,6 +2029,12 @@ namespace PerfView
             Directory.Focus();
         }
 
+        private void DoPrivacyPolicy(object sender, RoutedEventArgs e)
+        {
+            StatusBar.Log("Displaying the privacy policy.");
+            Process.Start("https://privacy.microsoft.com/en-us/privacystatement");
+        }
+
         private void UpdateFileFilter()
         {
             var filterText = FileFilterTextBox.Text;


### PR DESCRIPTION
Adding a link to the standard Microsoft Privacy Policy within PerfView's help menu, which is standard Microsoft policy.

**PerfView does not collect any data from users.**