### PR TITLE
Fix random test case failures

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -6035,9 +6035,10 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             if (_skipCount == 0)
             {
                 CheckJitTables();
-                Debug.Assert(preCount + 1 == JitTableCount());
+                Debug.Assert(preCount + 1 == JitTableCount(), "JitTableCount mismatch");
                 _skipCount = 32;
             }
+
             --_skipCount;
 #endif
         }
@@ -6063,7 +6064,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// time a method is added. This field counts down each time <see cref="InsertJITTEDMethod"/> is called; when it
         /// reaches zero the sanity checks are run and it is reset to an unspecified positive value.
         /// </summary>
-        private static int _skipCount;
+        private int _skipCount;
 
         private int JitTableCount()
         {


### PR DESCRIPTION
We see intermittent test case failures in the CI Debug build due to a Debug.Assert failure.
The call-stack indicates the problem is with the JitTableCount check in Tracing.Etlx.TraceProcess.InsertJITTEDMethod.

Here's my analysis:

The check is guarded by a `_skipCount` counter. That counter is a static variable that counts down from 32 to zero.

If the `_skipCount` is zero at the top of the method, we compute a `preCount` based on the total JIT table size.
At the bottom of the method, when `_skipCount` is still zero we check that the new total table size has increased by one (`preCount + 1`).

My hypothesis is that when tests run concurrently, we can get multiple threads modifying the `_skipCount` variable. Since it's a shared (static) variable, this leads to the following race condition:
1. _skipCount is at 1.
2. Thread A enters the method, _skipCount is non zero, so preCount is initialized to zero.
3. Thread B enters the method, _skipCount is also non-zero, so preCount is initialized to zero.
4. Thread A proceeds to the end of the method and decrements _skipCount. Now it is zero.
5. Thread B proceeds to the end of the method and discovers _skipCount is zero, so it computes the new JitTableCount and compares it with the previous value (preCount). Unfortunately, preCount isn't accurate because _skipCount was non-zero in step 3 and preCount was never initialized.

If this hypothesis is correct, there are several ways to fix this. The simplest is to make _skipCount an instance (non-static) field.
Another would be to decrement and check _skipCount just once at the top of the method; initializing `preCount` to a sentinel value (-1, say) indicating that the debug check at the bottom should be skipped.