### PR TITLE
Fix typos in TraceEvent library

### DIFF
--- a/src/TraceEvent/Samples/00_AllSamples.cs
+++ b/src/TraceEvent/Samples/00_AllSamples.cs
@@ -23,7 +23,7 @@ namespace TraceEventSamples
         {
             Console.WriteLine("****************************************************************************");
             Console.WriteLine("We are about Running all demos in order.");
-            Console.WriteLine("This takes a miniute or two and is often not that interesting.");
+            Console.WriteLine("This takes a minute or two and is often not that interesting.");
             Console.WriteLine("The intent is that you will find the samples that you are most interested in");
             Console.WriteLine("and modify 00_AllSamples.cs to simply select the demos of interest.");
             Console.WriteLine("If run in a debugger, the program will break after each demo.");

--- a/src/TraceEvent/Stacks/CallTree.cs
+++ b/src/TraceEvent/Stacks/CallTree.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     public class CallTree
     {
         /// <summary>
-        /// Creates an empty call tree, indicating the scaling policy of the metric.   You populate it by assigning a StackSOurce to the tree.  
+        /// Creates an empty call tree, indicating the scaling policy of the metric.   You populate it by assigning a StackSource to the tree.  
         /// </summary>
         public CallTree(ScalingPolicyKind scalingPolicy)
         {
@@ -90,7 +90,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 
         /// <summary>
         /// An upper bound for the node indexes in the call tree.  (All indexes
-        /// are strictly less than this number)   Thus ASSSUMING YOU DON'T ADD
+        /// are strictly less than this number)   Thus ASSUMING YOU DON'T ADD
         /// NEW NODES, an array of this size can be used to index the nodes (and 
         /// thus lookup nodes by index or to store additional information about a node).  
         /// </summary>
@@ -144,7 +144,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             m_root.CheckClassInvarients();
 
-            // If we filter by whole trace metric we need to cacluate the byID sums.  
+            // If we filter by whole trace metric we need to calculate the byID sums.  
             Dictionary<int, CallTreeNodeBase> sumByID = null;
             if (useWholeTraceMetric)
             {
@@ -159,14 +159,14 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// Cause the children of each CallTreeNode in the CallTree to be sorted (accending) based on comparer
+        /// Cause the children of each CallTreeNode in the CallTree to be sorted (ascending) based on comparer
         /// </summary>
         public void Sort(IComparer<CallTreeNode> comparer)
         {
             m_root.SortAll(comparer);
         }
         /// <summary>
-        /// Sorting by InclusiveMetric Decending is so common, provide a shortcut.  
+        /// Sorting by InclusiveMetric Descending is so common, provide a shortcut.  
         /// </summary>
         public void SortInclusiveMetricDecending()
         {
@@ -177,7 +177,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 {
                     return ret;
                 }
-                // Sort by first sample time (assending) if the counts are the same.  
+                // Sort by first sample time (ascending) if the counts are the same.  
                 return x.FirstTimeRelativeMSec.CompareTo(y.FirstTimeRelativeMSec);
             });
 
@@ -190,8 +190,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// </summary>
         public ScalingPolicyKind ScalingPolicy { get; private set; }
         /// <summary>
-        /// The nodes in the calltree have histograms in time, all of these histograms share a controller that
-        /// contains sharable information.   This propertly returns that TimeHistogramController
+        /// The nodes in the CallTree have histograms in time, all of these histograms share a controller that
+        /// contains sharable information.   This property returns that TimeHistogramController
         /// </summary>
         public TimeHistogramController TimeHistogramController
         {
@@ -207,9 +207,9 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             }
         }
         /// <summary>
-        /// The nodes in the calltree have histograms indexed by scenario (which is user defiend), 
+        /// The nodes in the CallTree have histograms indexed by scenario (which is user defined), 
         /// all of these histograms share a controller that contains sharable information.   
-        /// This propertly returns that ScenarioHistogramController
+        /// This property returns that ScenarioHistogramController
         /// </summary>
         public ScenarioHistogramController ScenarioHistogram
         {
@@ -253,7 +253,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// Write an XML representtaion of the CallTree to 'writer'
+        /// Write an XML representation of the CallTree to 'writer'
         /// </summary>
         public void ToXml(TextWriter writer)
         {
@@ -262,7 +262,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             writer.WriteLine("</CallTree>");
         }
         /// <summary>
-        /// An XML representtaion of the CallTree (for debugging)
+        /// An XML representation of the CallTree (for debugging)
         /// </summary>
         public override string ToString()
         {
@@ -374,7 +374,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             var sampleEndTime = sample.TimeRelativeMSec;
             if (ScalingPolicy == ScalingPolicyKind.TimeMetric)
             {
-                // The sample ends at the end of its metric, however we trucate at the end of the range.  
+                // The sample ends at the end of its metric, however we truncate at the end of the range.  
 
                 // The Math.Abs is a bit of a hack.  The problem is that that sample does not
                 // represent time for a DIFF (because we negated it) but I rely on the fact 
@@ -763,8 +763,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// It calls 'callback' on a set of trees that taken as a whole have all the samples
         /// in 'node'.  
         /// 
-        /// Note you ave to be careful when using this for inclusive summation of byname nodes because 
-        /// you will get trees that 'overlap' (bname nodes might refer into the 'middle' of another
+        /// Note you have to be careful when using this for inclusive summation of ByName nodes because 
+        /// you will get trees that 'overlap' (ByName nodes might refer into the 'middle' of another
         /// call tree).   This can be avoided pretty easily by simply stopping inclusive traversal 
         /// whenever a tree node with that ID occurs (see GetSamples for an example). 
         /// </summary>
@@ -817,7 +817,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// The GUI sadly holds on to Call things in the model in its cache, and call tree nodes have linkes to whole
+        /// The GUI sadly holds on to Call things in the model in its cache, and call tree nodes have links to whole
         /// call tree.  To avoid the GUI cache from holding on to the ENTIRE MODEL, we neuter the nodes when we are
         /// done with them so that even if they are pointed to by the GUI cache it does not hold onto most of the 
         /// (dead) model.    FreeMemory does this neutering.  
@@ -918,10 +918,10 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// To avoid double-counting for byname nodes, with we can be told to exclude any children with a particular ID 
+        /// To avoid double-counting for ByName nodes, with we can be told to exclude any children with a particular ID 
         /// (the ID of the ByName node itself) if are doing the inclusive case.   The goal is to count every reachable
         /// tree exactly once.  We do this by conceptually 'marking' each node with ID at the top level (when they are 
-        /// enumerated as children of the Byname node), and thus any node with that excludeChildrenWithID is conceptually
+        /// enumerated as children of the ByName node), and thus any node with that excludeChildrenWithID is conceptually
         /// marked if you encounter it as a child in the tree itself (so you should exclude it).  The result is that 
         /// every node is visited exactly once (without the expense of having a 'visited' bit).  
         /// </summary>
@@ -1189,7 +1189,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// Sort the childre of every node in the te
+        /// Sort the children of every node in the tree
         /// </summary>
         /// <param name="comparer"></param>
         internal void SortAll(IComparer<CallTreeNode> comparer, RecursionGuard recursionGuard = default(RecursionGuard))
@@ -1344,7 +1344,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// Some calltrees already fill in their children, others do so lazily, in which case they 
+        /// Some CallTrees already fill in their children, others do so lazily, in which case they 
         /// override this method.  
         /// </summary>
         protected virtual List<CallTreeNode> GetCallees() { return null; }
@@ -1405,7 +1405,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             return nodesFolded;
         }
 
-        // TODO FIX NOW: decide what to do here, we originally did a recursive IsFolable but that causes very little folding. 
+        // TODO FIX NOW: decide what to do here, we originally did a recursive IsFoldable but that causes very little folding. 
         private bool IsFoldable(float minInclusiveMetric, Dictionary<int, CallTreeNodeBase> sumByID)
         {
             return Math.Abs(sumByID[(int)m_id].InclusiveMetric) < minInclusiveMetric;
@@ -1460,7 +1460,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             {
                 if (m_callees != null)
                 {
-                    // Optimization.   If we have large fanout, we create a dictionary 
+                    // Optimization.   If we have large fan-out, we create a dictionary 
                     if (m_callees.Count > 16)
                     {
                         // Do we have the dictionary of dictionaries? If not make one
@@ -1519,7 +1519,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 
                 m_callees.Add(callee);
 
-                // If this node had large fanout also add it to that lookup table.  
+                // If this node had large fan-out also add it to that lookup table.  
                 if (calleeLookup != null)
                 {
                     calleeLookup[callee.m_id] = callee;
@@ -1602,7 +1602,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     }
 
     /// <summary>
-    /// A CallerCalleeNode gives statistics that focus on a NAME.  (unlike calltrees that use ID)
+    /// A CallerCalleeNode gives statistics that focus on a NAME.  (unlike CallTrees that use ID)
     /// It takes all stackSource that have callStacks that include that treeNode and compute the metrics for
     /// all the callers and all the callees for that treeNode.  
     /// </summary>
@@ -1683,7 +1683,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         public IList<CallTreeNodeBase> Callees { get { return m_callees; } }
 
         /// <summary>
-        /// wrtites an XML representation of the call tree Node  it 'writer'
+        /// Writes an XML representation of the call tree Node  it 'writer'
         /// </summary>
         public void ToXml(TextWriter writer, string indent)
         {
@@ -1740,7 +1740,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         #region private
         /// <summary>
         /// A caller callee view is a summation which centers around one 'focus' node which is represented by the CallerCalleeNode.
-        /// This node has a caller and callee list, and these nodes (as well as the CallerCalleNode itself) represent the aggregation
+        /// This node has a caller and callee list, and these nodes (as well as the CallerCalleeNode itself) represent the aggregation
         /// over the entire tree.
         /// 
         /// AccumulateSamplesForNode is the routine that takes a part of a aggregated call tree (represented by 'treeNode' and adds
@@ -1748,7 +1748,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// 
         /// 'recursionsCount' is the number of times the focus node name has occurred in the path from 'treeNode' to the root.   In 
         /// addition to setting the CallerCalleeNode aggregation, it also returns a 'weightedSummary' inclusive aggregation 
-        /// FOR JUST treeNode (the CallerCalleNode is an aggregation over the entire call tree accumulated so far).  
+        /// FOR JUST treeNode (the CallerCalleeNode is an aggregation over the entire call tree accumulated so far).  
         /// 
         /// The key problem for this routine to avoid is double counting of inclusive samples in the face of recursive functions. 
         /// Thus all samples are weighted by the recursion count before being included in 'weightedSummaryRet (as well as in
@@ -1789,7 +1789,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             bool isUniformRet = true;
 
             // Compute the weighting.   This is either 0 if we have not yet seen the focus node, or
-            // 1/recusionCount if we have (splitting all samples equally among each of the samples)
+            // 1/recursionCount if we have (splitting all samples equally among each of the samples)
             double weightedSummaryScaleRet = 0;
             CallTreeNodeBase weightedSummaryRet = null;          // If the weight is zero, we don't care about the value
             if (recursionCount > 0)
@@ -1803,7 +1803,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             }
 
             // Get all the samples for the children and set the calleeSum information  We also set the
-            // information in the CallerCalleNode's Callees list.  
+            // information in the CallerCalleeNode's Callees list.  
             if (treeNode.Callees != null)
             {
                 for (int i = 0; i < treeNode.m_callees.Count; i++)
@@ -1837,7 +1837,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                         {
                             isUniformRet = false;       // We ourselves are not uniform.  
 
-                            // We can no longer use the optimization of using the treenode itself as our weighted
+                            // We can no longer use the optimization of using the TreeNode itself as our weighted
                             // summary node because we need to write to it.   Thus replace the node with a copy.  
                             if (weightedSummaryRet == treeNode)
                             {
@@ -1916,7 +1916,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     /// <summary>
     /// AggregateCallTreeNode supports a multi-level caller-callee view.   
     /// 
-    /// It does this by allow you to take any 'focus' node (typically a byname node)
+    /// It does this by allow you to take any 'focus' node (typically a ByName node)
     /// and compute a tree of its callers and a tree of its callees.   You do this
     /// by passing the node of interested to either the 'CallerTree' or 'CalleeTrees'.
     /// 
@@ -1930,7 +1930,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     public sealed class AggregateCallTreeNode : CallTreeNode
     {
         /// <summary>
-        /// Given any node (typically a byName node, but it works on any node), Create a 
+        /// Given any node (typically a ByName node, but it works on any node), Create a 
         /// tree rooted at 'node' that represents the callers of that node.  
         /// </summary>
         public static CallTreeNode CallerTree(CallTreeNodeBase node)
@@ -1945,7 +1945,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             return ret;
         }
         /// <summary>
-        /// Given any node (typically a byName node, but it works on any node), Create a 
+        /// Given any node (typically a ByName node, but it works on any node), Create a 
         /// tree rooted at 'node' that represents the callees of that node.  
         /// </summary>
         public static CallTreeNode CalleeTree(CallTreeNodeBase node)
@@ -2098,7 +2098,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             childWithID.m_trees.Add(treeNode);
 
             // And compute our statistics.  
-            // We pass addExclusive=false to CombindByIdSamples because callers never have exclusive samples
+            // We pass addExclusive=false to CombineByIdSamples because callers never have exclusive samples
             // associated with them (because all samples occurred lower in the stack
             childWithID.CombineByIdSamples(treeNode, true, 1, false);
 
@@ -2118,8 +2118,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// <summary>
         /// An aggregateCallTreeNode is exactly that, the sum of several callTrees
         /// (each of which represent a number of individual samples).    Thus we had to 
-        /// take each sample (which is 'treenode' and merge it into the aggregate.
-        /// We do this one at a time.   Thus we call MergeCallee for each calltree 
+        /// take each sample (which is 'TreeNode' and merge it into the aggregate.
+        /// We do this one at a time.   Thus we call MergeCallee for each CallTree 
         /// in our list and we find the 'callees' of each of those nodes, and create 
         /// aggregates for the children (which is in calleeList).   
         /// 
@@ -2182,7 +2182,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// and subtracting out any nodes that match 'idToExclude'.   
         /// 
         /// As an optimization this routine also sets the m_recursion bit 'statsRet' if anywhere in 'treeCallee' we do find an id to 
-        /// exclude.  That way in a common case (where there is no instances of 'idToExclude') we don't have to actualy walk the
+        /// exclude.  That way in a common case (where there is no instances of 'idToExclude') we don't have to actually walk the
         /// tree the second time (we simply know that there is no adjustment necessary.   
         /// </summary>
         private static void SubtractOutTrees(CallTreeNode treeCallee, StackSourceFrameIndex idToExclude, AggregateCallTreeNode statsRet)

--- a/src/TraceEvent/Stacks/FilterStacks.cs
+++ b/src/TraceEvent/Stacks/FilterStacks.cs
@@ -232,7 +232,7 @@ namespace Diagnostics.Tracing.StackSources
     }
 
     /// <summary>
-    /// A FilterStackSouce morphs one stack filters or groups the stacks of one stack source to form a new
+    /// A FilterStackSource morphs one stack filters or groups the stacks of one stack source to form a new
     /// stack source.   It is very powerful mechanism.  
     /// </summary>
     public class FilterStackSource : StackSource
@@ -293,7 +293,7 @@ namespace Diagnostics.Tracing.StackSources
             m_frameIdToFrameInfo = new FrameInfo[m_baseStackSource.CallFrameIndexLimit];
             m_GroupNameToFrameInfo = new Dictionary<string, StackSourceFrameIndex>();
 
-            // Intialize the StackInfo cache (and the IncPathsMatchedSoFarStorage variable)
+            // Initialize the StackInfo cache (and the IncPathsMatchedSoFarStorage variable)
             m_stackInfoCache = new StackInfo[StackInfoCacheSize];
             for (int i = 0; i < m_stackInfoCache.Length; i++)
             {
@@ -867,7 +867,7 @@ namespace Diagnostics.Tracing.StackSources
                 var pat = new Regex(ToDotNetRegEx(patStr), RegexOptions.IgnoreCase);    // TODO perf bad if you compile!
                 groups[i] = new GroupPattern(pat, replaceStr, op);
 
-                // TODO IsModuleEntry is an experiemental thing.  Remove after gathering data.  
+                // TODO IsModuleEntry is an experimental thing.  Remove after gathering data.  
                 if (stringGroup == "{%}!=>module $1")
                 {
                     groups[i].IsModuleEntry = true;
@@ -894,7 +894,7 @@ namespace Diagnostics.Tracing.StackSources
                     continue;
                 }
 
-                // TODO IsModuleEntry is an experiemental thing.  Remove after gathering data.  
+                // TODO IsModuleEntry is an experimental thing.  Remove after gathering data.  
                 if (candidateGroup.IsModuleEntry)
                 {
                     int bangIdx = frameName.IndexOf('!');
@@ -1066,7 +1066,7 @@ namespace Diagnostics.Tracing.StackSources
             str = Regex.Escape(str);                // Assume everything is ordinary
             str = str.Replace(@"%", @"[.\w\d?]*");  // % means any number of alpha-numeric chars. 
             str = str.Replace(@"\*", @".*");        // * means any number of any characters.  
-            str = str.Replace(@"\^", @"^");         // ^ means anchor at the begining.  
+            str = str.Replace(@"\^", @"^");         // ^ means anchor at the beginning.  
             str = str.Replace(@"\|", @"|");         // | means is the or operator  
             str = str.Replace(@"\{", "(");
             str = str.Replace("}", ")");

--- a/src/TraceEvent/Stacks/Histogram.cs
+++ b/src/TraceEvent/Stacks/Histogram.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     /// <summary>
     /// A Histogram is logically an array of floating point values.  Often they
     /// represent frequency, but it can be some other metric.  The X axis can 
-    /// represent different things (time, scenario).  It is the HisogramContoller
+    /// represent different things (time, scenario).  It is the HistogramController
     /// which understands what the X axis is.   Histograms know their HistogramController
     /// but not the reverse.  
     /// 
-    /// Often Histograms are sparse (most array elements are zero), so the represnetation
-    /// is designed to optimzed for this case (an array of non-zero index, value pairs). 
+    /// Often Histograms are sparse (most array elements are zero), so the representation
+    /// is designed to optimized for this case (an array of non-zero index, value pairs). 
     /// </summary>
     public class Histogram : IEnumerable<float>
     {
@@ -168,14 +168,14 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// Implementes IEnumerable interface
+        /// Implements IEnumerable interface
         /// </summary>
         public IEnumerator<float> GetEnumerator()
         {
             return GetEnumerable().GetEnumerator();
         }
         /// <summary>
-        /// Implementes IEnumerable interface
+        /// Implements IEnumerable interface
         /// </summary>
         IEnumerator IEnumerable.GetEnumerator() { throw new NotImplementedException(); }
 
@@ -205,13 +205,13 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     }
 
     /// <summary>
-    /// A Histogram is conceputually an array of floating point values.   A Histogram Controller
+    /// A Histogram is conceptually an array of floating point values.   A Histogram Controller
     /// contains all the information besides the values themselves need to understand the array
     /// of floating point value.   There are a lot of Histograms, however they all tend to share
     /// the same histogram controller.   Thus Histograms know their Histogram controller, but not
     /// the reverse.  
     /// 
-    /// Thus HistogramContoller is a abstract class (we have one for time, and one for scenarios).  
+    /// Thus HistogramController is a abstract class (we have one for time, and one for scenarios).  
     ///
     /// HistogramControllers are responsible for:
     /// 
@@ -244,7 +244,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         public int BucketCount { get; protected set; }
         /// <summary>
         /// The number of characters in the display string for histograms controlled by this HistogramController.
-        /// Buckets are a logial concept, where CharacterCount is a visual concept (how many you can see on the 
+        /// Buckets are a logical concept, where CharacterCount is a visual concept (how many you can see on the 
         /// screen right now).  
         /// </summary>
         public int CharacterCount { get; protected set; }
@@ -339,7 +339,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 else if (metric < 0)
                 {
                     valueBucket = -valueBucket;
-                    // TODO we are not symetric, we use digits on the positive side but not negative.  
+                    // TODO we are not symmetric, we use digits on the positive side but not negative.  
                     if (valueBucket < 25)
                     {
                         val = (char)('a' + valueBucket);          // We go through the alphabet too.

--- a/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
+++ b/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     internal static class StackSourceWriterHelper
     {
         /// <summary>
-        /// we want to identify the thread for every sample to prevent from 
-        /// overlaping of samples for the concurrent code so we group the samples by Threads
-        /// this method also sorts the samples by relative time (ascending)
+        /// We want to identify the thread for every sample to prevent the 
+        /// overlapping of samples for the concurrent code so we group the samples by Threads.
+        /// This method also sorts the samples by relative time (ascending).
         /// </summary>
         internal static IReadOnlyDictionary<ThreadInfo, List<Sample>> GetSortedSamplesPerThread(StackSource stackSource)
         {

--- a/src/TraceEvent/Stacks/Stacks.cs
+++ b/src/TraceEvent/Stacks/Stacks.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// </summary>
         public abstract void ForEach(Action<StackSourceSample> callback);
         /// <summary>
-        /// If this is overridden to return true, then during the 'Foeach' callback you can save references
+        /// If this is overridden to return true, then during the 'ForEach' callback you can save references
         /// to the samples you are given because they will not be overridden by the stack source.  If this is
         /// false you must make a copy of the sample if you with to remember it.  
         /// </summary>
@@ -173,8 +173,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         /// </summary>
         public virtual double SampleTimeRelativeMSecLimit { get { return 0; } }
         /// <summary>
-        /// In addition to Time and Metric a sample can have a Scneario number associated with it.   ScenarioCount 
-        /// returns the number of such scnearios.   Returning 0 implies no scenario support.  
+        /// In addition to Time and Metric a sample can have a Scenario number associated with it.   ScenarioCount 
+        /// returns the number of such scenarios.   Returning 0 implies no scenario support.  
         /// </summary>
         public virtual int ScenarioCount { get { return 0; } }
         /// <summary>
@@ -233,11 +233,11 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     public enum RefDirection
     {
         /// <summary>
-        /// Indicates that you are interested in referneces FROM the node of interest
+        /// Indicates that you are interested in references FROM the node of interest
         /// </summary>
         From,
         /// <summary>
-        /// Indicates that you are interested in referneces TO the node of interest
+        /// Indicates that you are interested in references TO the node of interest
         /// </summary>
         To
     };
@@ -247,8 +247,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     /// at this information.  We don't use normal objects to represent these but rather give each stack (and frame) a unique
     /// (dense) index.   This has a number of advantages over using objects to represent the stack.
     /// 
-    ///     * Indexes are very serialization friendly, and this data will be presisted.  Thus indexes are the natural form for data on disk. 
-    ///     * It allows the data to be read from the serialized format (disk) lazily in a very straightfoward fashion, keeping only the
+    ///     * Indexes are very serialization friendly, and this data will be persisted.  Thus indexes are the natural form for data on disk. 
+    ///     * It allows the data to be read from the serialized format (disk) lazily in a very straightforward fashion, keeping only the
     ///         hottest elements in memory.  
     ///     * Users of this API can associate additional data with the call stacks or frames trivially and efficiently simply by
     ///         having an array indexed by the stack or frame index.   
@@ -265,7 +265,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         public abstract StackSourceCallStackIndex GetCallerIndex(StackSourceCallStackIndex callStackIndex);
         /// <summary>
         /// For efficiency, m_frames are assumed have a integer ID instead of a string name that
-        /// is unique to the frame.  Note that it is expected that GetFrameIndex(x) == GetFrameId(y) 
+        /// is unique to the frame.  Note that it is expected that GetFrameIndex(x) == GetFrameIndex(y) 
         /// then GetFrameName(x) == GetFrameName(y).   The converse does NOT have to be true (you 
         /// can reused the same name for distinct m_frames, however this can be confusing to your
         /// users, so be careful.  
@@ -373,7 +373,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     /// 
     /// StackSource.ProductSamples push these.  
     /// 
-    /// In general StackSourceSample are NOT immutable but expected to be overwritted frequently.  Thus you need to copy 
+    /// In general StackSourceSample are NOT immutable but expected to be overwritten frequently.  Thus you need to copy 
     /// the sample if you want to keep a reference to it.      
     /// </summary>
     public class StackSourceSample
@@ -418,7 +418,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 Metric, TimeRelativeMSec, StackIndex, SampleIndex);
         }
         /// <summary>
-        /// Returns an XML string representing the sample, howevever this one can actually expand the stack because it is given the source
+        /// Returns an XML string representing the sample, however this one can actually expand the stack because it is given the source
         /// </summary>
         public string ToString(StackSourceStacks source)
         {
@@ -479,11 +479,11 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
     public enum StackSourceFrameIndex
     {
         /// <summary>
-        /// Pseduo-node representing the root of all stacks
+        /// Pseudo-node representing the root of all stacks
         /// </summary>
         Root = 0,
         /// <summary>
-        /// Pseduo-frame that represents the caller of all broken stacks. 
+        /// Pseudo-frame that represents the caller of all broken stacks. 
         /// </summary>
         Broken = 1,
         /// <summary>
@@ -560,7 +560,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             return sampleCopy;
         }
         /// <summary>
-        /// Create a clone of the given stack soruce.  
+        /// Create a clone of the given stack source.  
         /// </summary>
         /// <param name="source"></param>
         /// <returns></returns>
@@ -703,7 +703,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             // You can confirm that XperfView does get exactly what PerfView does for total and exclusive counts.
             // Doing a diff more than that is time consuming.  
 
-            // Sort by time assending, then by metric decending (positive before baseline)
+            // Sort by time ascending, then by metric descending (positive before baseline)
             ret.m_samples.Sort(delegate(StackSourceSample x, StackSourceSample y)
             {
                 return x.TimeRelativeMSec.CompareTo(y.TimeRelativeMSec);

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -88,7 +88,7 @@ using Address = System.UInt64;
 // used by user code WITHOUT changing the code associated with TraceEventSource. Unfortunately, it
 // has a discoverability drawback. Given a TraceEventSource (like ETWTraceEventSource), it is difficult
 // discover that you need classes like KernelTraceEventParser to do anything useful with the
-// source. As a concession to discoverabilty, TraceEventSource provides properties ('Kernel' and CLR)
+// source. As a concession to discoverability, TraceEventSource provides properties ('Kernel' and CLR)
 // for two 'well known' parsers. Thus the above example can be written
 // 
 // * ETWTraceEventSource source = new ETWTraceEventSource("output.etl"); // open an ETL file
@@ -4399,7 +4399,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// There is some work needed to prepare the generic unhandledTraceEvent that we defer
         /// late (since we often don't care about unhandled events)  
         /// 
-        /// TODO this is probably not worht the complexity...
+        /// TODO this is probably not worth the complexity...
         /// </summary>
         internal void PrepForCallback()
         {
@@ -4519,7 +4519,7 @@ namespace Microsoft.Diagnostics.Tracing
     public static class ObservableExtensions
     {
         /// <summary>
-        /// Returns an IObjservable that observes all events that 'parser' knows about that  return a T.  If eventName is
+        /// Returns an IObservable that observes all events that 'parser' knows about that  return a T.  If eventName is
         /// non-null, the event's name must match 'eventName', but if eventName is null, any event that returns a T is observed. 
         /// <para>
         /// This means that Observe{TraceEvent}(parser) will observe all events that the parser can parse.  
@@ -4533,7 +4533,7 @@ namespace Microsoft.Diagnostics.Tracing
             return parser.Observe<T>(s => s == eventName);
         }
         /// <summary>
-        /// Returns an IObjservable that observes all events that 'parser' knows about that return a T and whose event
+        /// Returns an IObservable that observes all events that 'parser' knows about that return a T and whose event
         /// name matches the 'eventNameFilter' predicate.  
         /// 
         /// Note that unlike the methods on TraceEventParser, the TraceEvent object returned is already Cloned() and thus can be 
@@ -4651,7 +4651,7 @@ namespace Microsoft.Diagnostics.Tracing
 
                     // Add the event callback handler
                     m_observable.m_addHander(m_callback, this);
-                    // And the comleted callback handler
+                    // And the completed callback handler
                     m_observable.m_source.Completed += m_completedCallback;
                 }
                 public void Dispose()

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1724,7 +1724,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                         }
                     }
 
-                    // Now that we have closed the enumeration handle, we can delete all the enties we have accumulated.  
+                    // Now that we have closed the enumeration handle, we can delete all the entries we have accumulated.  
                     foreach (var providerToClearData in providersToClearData)
                     {
                         SetFilterDataForEtwSession(providerToClearData.Key, null, providerToClearData.Value);
@@ -1760,7 +1760,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// is removed.
         /// 
         /// If 'allSesions' is true it means that you want 'old style' data filtering that affects all ETW sessions
-        /// This is present only used for compatibilty 
+        /// This is present only used for compatibility 
         /// </summary>
         /// <returns>the session index that will be used for this session.  Returns -1 if an entry could not be found </returns>
         private void SetFilterDataForEtwSession(string providerGuid, byte[] data, bool V4_5EventSource = false)
@@ -3093,8 +3093,8 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// <summary>
         /// Sets a single Profile Source (CPU machine counters) that will be used if PMC (Precise Machine Counters)
         /// are turned on.   The profileSourceID is the ID field from the ProfileSourceInfo returned from 'GetInfo()'.
-        /// and the profileSourceInterval is the interval between sampples (the number of events before a stack
-        /// is recoreded.    If you need more that one (the OS allows up to 4 I think), use the variation of this
+        /// and the profileSourceInterval is the interval between samples (the number of events before a stack
+        /// is recorded.    If you need more that one (the OS allows up to 4 I think), use the variation of this
         /// routine that takes two int[].   Calling this will clear all Profiler sources previously set (it is NOT
         /// additive).  
         /// </summary>

--- a/src/TraceEvent/TraceEventStacks.cs
+++ b/src/TraceEvent/TraceEventStacks.cs
@@ -449,7 +449,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         #region private
         /// <summary>
         /// Returns a list of modules for the stack 'stackIdx'.  It also updates the interning table stackModuleLists, so 
-        /// that the entry cooresponding to stackIdx remembers the answer.  This can speed up processing a lot since many
+        /// that the entry corresponding to stackIdx remembers the answer.  This can speed up processing a lot since many
         /// stacks have the same prefixes to root.  
         /// </summary>
         private ModuleList GetModulesForStack(ModuleList[] stackModuleLists, StackSourceCallStackIndex stackIdx)
@@ -613,7 +613,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                 {
                     // Encode the code address for the given thread.  
                     int pseudoStackIndex = GetPseudoStack(thread.ThreadIndex, codeAddrIdx);
-                    // Psuedostacks happen after all the others.  
+                    // PseudoStacks happen after all the others.  
                     if (0 <= pseudoStackIndex)
                     {
                         ret = m_log.CallStacks.Count + 2 * m_log.Threads.Count + m_log.Processes.Count + pseudoStackIndex;
@@ -709,8 +709,8 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
             m_Interner.FrameNameLookup = GetFrameName;
         }
         /// <summary>
-        /// After creating a MultableTraceEventStackSource, you add the samples you want using this AddSample API (you can reuse 'sample' 
-        /// used as an argument to this routine.   It makes a copy.  The samples do NOT need to be added in time order (the MultableTraceEventStackSource
+        /// After creating a MutableTraceEventStackSource, you add the samples you want using this AddSample API (you can reuse 'sample' 
+        /// used as an argument to this routine.   It makes a copy.  The samples do NOT need to be added in time order (the MutableTraceEventStackSource
         /// will sort them).   When you done DoneAddingSamples must be called before using the
         /// the MutableTraceEventStackSource as a stack source.  
         /// </summary>

--- a/src/TraceEvent/TraceLoggingEventId.cs
+++ b/src/TraceEvent/TraceLoggingEventId.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Tracing
 {
     /// <summary>
-    /// TraceLoggingEvnetId is a class that manages assigning event IDs (small 64k numbers)
+    /// TraceLoggingEventId is a class that manages assigning event IDs (small 64k numbers)
     /// to TraceLogging Style events (which don't have them).  Because TraceEvent uses EventIDs
     /// so fundamentally this deficiency is very problematic.   
     /// 
@@ -181,7 +181,7 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
-        // Given partciular provider, opcode and tracelogging meta-data blob, look up the assigned ID
+        // Given particular provider, opcode and tracelogging meta-data blob, look up the assigned ID
         private Dictionary<ProviderMetaDataKey, ushort> m_traceLoggingEventMap;
 
         // For each provider look up the next unassigned eventID that can be used. 

--- a/src/TraceEvent/Utilities/Cache.cs
+++ b/src/TraceEvent/Utilities/Cache.cs
@@ -133,7 +133,7 @@ namespace Utilities
         }
 
         /// <summary>
-        /// Sets the maxiumum number of key-value pairs the cache will keep.  (after that old ones are remvoed). 
+        /// Sets the maximum number of key-value pairs the cache will keep.  (after that old ones are removed). 
         /// </summary>
         public int MaxEntries
         {

--- a/src/TraceEvent/Utilities/StringBuilderCache.cs
+++ b/src/TraceEvent/Utilities/StringBuilderCache.cs
@@ -7,29 +7,29 @@
 **
 ** Class:  StringBuilderCache
 **
-** Purpose: provide a cached reusable instance of stringbuilder
+** Purpose: provide a cached reusable instance of StringBuilder
 **          per thread  it's an optimisation that reduces the 
 **          number of instances constructed and collected.
 **
 **  Acquire - is used to get a string builder to use of a 
 **            particular size.  It can be called any number of 
-**            times, if a stringbuilder is in the cache then
+**            times, if a StringBuilder is in the cache then
 **            it will be returned and the cache emptied.
-**            subsequent calls will return a new stringbuilder.
+**            subsequent calls will return a new StringBuilder.
 **
 **            A StringBuilder instance is cached in 
 **            Thread Local Storage and so there is one per thread
 **
 **  Release - Place the specified builder in the cache if it is 
 **            not too big.
-**            The stringbuilder should not be used after it has 
+**            The StringBuilder should not be used after it has 
 **            been released.
 **            Unbalanced Releases are perfectly acceptable.  It
 **            will merely cause the runtime to create a new 
-**            stringbuilder next time Acquire is called.
+**            StringBuilder next time Acquire is called.
 **
 **  GetStringAndRelease
-**          - ToString() the stringbuilder, Release it to the 
+**          - ToString() the StringBuilder, Release it to the 
 **            cache and return the resulting string
 **
 ===========================================================*/
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Tracing.Utilities
     internal static class StringBuilderCache
     {
         // The value 360 was chosen in discussion with performance experts as a compromise between using
-        // as litle memory (per thread) as possible and still covering a large part of short-lived
+        // as little memory (per thread) as possible and still covering a large part of short-lived
         // StringBuilder creations on the startup path of VS designers.
         private const int MAX_BUILDER_SIZE = 360;
 
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Tracing.Utilities
                 StringBuilder sb = StringBuilderCache.CachedInstance;
                 if (sb != null)
                 {
-                    // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                    // Avoid StringBuilder block fragmentation by getting a new StringBuilder
                     // when the requested size is larger than the current capacity
                     if (capacity <= sb.Capacity)
                     {

--- a/src/TraceEvent/Utilities/command.cs
+++ b/src/TraceEvent/Utilities/command.cs
@@ -38,7 +38,7 @@ namespace Utilities
         public const int Infinite = System.Threading.Timeout.Infinite;
 
         /// <summary>
-        /// CommanOptions holds a set of options that can be passed to the constructor
+        /// CommandOptions holds a set of options that can be passed to the constructor
         /// to the Command Class as well as Command.Run*
         /// </summary>
         public CommandOptions()
@@ -62,7 +62,7 @@ namespace Utilities
         public bool NoThrow { get { return noThrow; } set { noThrow = value; } }
 
         /// <summary>
-        /// Updates the NoThrow propery and returns the updated commandOptions.
+        /// Updates the NoThrow property and returns the updated commandOptions.
         /// <returns>Updated command options</returns>
         /// </summary>
         public CommandOptions AddNoThrow()
@@ -77,7 +77,7 @@ namespace Utilities
         public bool Start { get { return useShellExecute; } set { useShellExecute = value; noWait = value; } }
 
         /// <summary>
-        /// Updates the Start propery and returns the updated commandOptions.
+        /// Updates the Start property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddStart()
         {
@@ -93,7 +93,7 @@ namespace Utilities
         public bool UseShellExecute { get { return useShellExecute; } set { useShellExecute = value; } }
 
         /// <summary>
-        /// Updates the Start propery and returns the updated commandOptions.
+        /// Updates the Start property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddUseShellExecute()
         {
@@ -107,7 +107,7 @@ namespace Utilities
         public bool NoWindow { get { return noWindow; } set { noWindow = value; } }
 
         /// <summary>
-        /// Updates the NoWindow propery and returns the updated commandOptions.
+        /// Updates the NoWindow property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddNoWindow()
         {
@@ -121,7 +121,7 @@ namespace Utilities
         public bool NoWait { get { return noWait; } set { noWait = value; } }
 
         /// <summary>
-        /// Updates the NoWait propery and returns the updated commandOptions.
+        /// Updates the NoWait property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddNoWait()
         {
@@ -130,12 +130,12 @@ namespace Utilities
         }
 
         /// <summary>
-        /// Indicates that the command must run at elevated Windows privledges (causes a new command window)
+        /// Indicates that the command must run at elevated Windows privileges (causes a new command window)
         /// </summary>
         public bool Elevate { get { return elevate; } set { elevate = value; } }
 
         /// <summary>
-        /// Updates the Elevate propery and returns the updated commandOptions.
+        /// Updates the Elevate property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddElevate()
         {
@@ -145,13 +145,13 @@ namespace Utilities
         /// <summary>
         /// By default commands have a 10 minute timeout (600,000 msec), If this
         /// is inappropriate, the Timeout property can change this.  Like all
-        /// timouts in .NET, it is in units of milliseconds, and you can use
+        /// timeouts in .NET, it is in units of milliseconds, and you can use
         /// CommandOptions.Infinite to indicate no timeout. 
         /// </summary>
         public int Timeout { get { return timeoutMSec; } set { timeoutMSec = value; } }
 
         /// <summary>
-        /// Updates the Timeout propery and returns the updated commandOptions.
+        /// Updates the Timeout property and returns the updated commandOptions.
         /// CommandOptions.Infinite can be used for infinite
         /// </summary>
         public CommandOptions AddTimeout(int milliseconds)
@@ -165,7 +165,7 @@ namespace Utilities
         /// </summary>
         public string Input { get { return input; } set { input = value; } }
         /// <summary>
-        /// Updates the Input propery and returns the updated commandOptions.
+        /// Updates the Input property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddInput(string input)
         {
@@ -178,7 +178,7 @@ namespace Utilities
         /// </summary>
         public string CurrentDirectory { get { return currentDirectory; } set { currentDirectory = value; } }
         /// <summary>
-        /// Updates the CurrentDirectory propery and returns the updated commandOptions.
+        /// Updates the CurrentDirectory property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddCurrentDirectory(string directoryPath)
         {
@@ -208,7 +208,7 @@ namespace Utilities
         }
 
         /// <summary>
-        /// Updates the OutputFile propery and returns the updated commandOptions.
+        /// Updates the OutputFile property and returns the updated commandOptions.
         /// </summary>
         public CommandOptions AddOutputFile(string outputFile)
         {
@@ -267,7 +267,7 @@ namespace Utilities
 
         /// <summary>
         /// Adds the environment variable with the give value to the set of 
-        /// environmetn variables to be passed to the sub-process and returns the 
+        /// environment variables to be passed to the sub-process and returns the 
         /// updated commandOptions.   Any time a string
         /// of the form %VAR% is found in a value of a environment variable it is
         /// replaced with the value of the environment variable at the time the
@@ -300,7 +300,7 @@ namespace Utilities
 
     /// <summary>
     /// Command represents a running of a command lineNumber process.  It is basically
-    /// a wrapper over System.Diagnostics.Process, which hides the complexitity
+    /// a wrapper over System.Diagnostics.Process, which hides the complexity
     /// of System.Diagnostics.Process, and knows how to capture output and otherwise
     /// makes calling commands very easy.
     /// </summary>
@@ -372,7 +372,7 @@ namespace Utilities
 
         /// <summary>
         /// Run 'commandLine', sending the output to the console, and wait for the command to complete.
-        /// This simulates what batch filedo when executing their commands.  It is a bit more verbose
+        /// This simulates what batch files do when executing their commands.  It is a bit more verbose
         /// by default, however 
         /// </summary>
         /// <param variable="commandLine">The command lineNumber to run as a subprocess</param>
@@ -420,7 +420,7 @@ namespace Utilities
 
         /// <summary>
         /// Launch a new command and returns the Command object that can be used to monitor
-        /// the restult.  It does not wait for the command to complete, however you 
+        /// the result.  It does not wait for the command to complete, however you 
         /// can call 'Wait' to do that, or use the 'Run' or 'RunToConsole' methods. */
         /// </summary>
         /// <param variable="commandLine">The command lineNumber to run as a subprocess</param>
@@ -494,7 +494,7 @@ namespace Utilities
                 foreach (string key in options.environmentVariables.Keys)
                 {
 
-                    // look for %VAR% strings in the value and subtitute the appropriate environment variable. 
+                    // look for %VAR% strings in the value and substitute the appropriate environment variable. 
                     string value = options.environmentVariables[key];
                     if (value != null)
                     {
@@ -567,7 +567,7 @@ namespace Utilities
 
             if (!startInfo.UseShellExecute)
             {
-                // startInfo asyncronously collecting output
+                // startInfo asynchronously collecting output
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
             }
@@ -694,7 +694,7 @@ namespace Utilities
         public System.Diagnostics.Process Process { get { return process; } }
 
         /// <summary>
-        /// Kill the process (and any child processses (recursively) associated with the 
+        /// Kill the process (and any child processes (recursively) associated with the 
         /// running command).   Note that it may not be able to kill everything it should
         /// if the child-parent' chain is broken by a child that creates a subprocess and
         /// then dies itself.   This is reasonably uncommon, however. 

--- a/src/TraceEvent/ZippedETL.cs
+++ b/src/TraceEvent/ZippedETL.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Tracing
 
         /// <summary>
         /// By default ZippedETL file will zip the ETL file itself and the NGEN pdbs associated with it.
-        /// You can add additional files to the archive by calling AddFile.   In specififed 'archivePath' 
+        /// You can add additional files to the archive by calling AddFile.   In specified 'archivePath' 
         /// is the path in the archive and defaults to just the file name of the original file path.  
         /// </summary>
         public void AddFile(string filePath, string archivePath = null)
@@ -158,7 +158,7 @@ namespace Microsoft.Diagnostics.Tracing
                     {
                         foreach (Tuple<string, string> additionalFile in m_additionalFiles)
                         {
-                            // We dont use CreatEntryFromFile because it will not open files thar are open for writting.  
+                            // We dont use CreatEntryFromFile because it will not open files thar are open for writing.  
                             // Since a typical use of this is to write the log file, which will be open for writing, we 
                             // use File.Open and allow this case explicitly. 
                             using (Stream fs = File.Open(additionalFile.Item1, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -197,7 +197,7 @@ namespace Microsoft.Diagnostics.Tracing
         // Overriding the normal defaults.  
         /// <summary>
         /// This is the symbol reader that is used to generate the NGEN Pdbs as needed
-        /// If it is not specififed one is created on the fly.  
+        /// If it is not specified one is created on the fly.  
         /// </summary>
         public SymbolReader SymbolReader { get; set; }
 


### PR DESCRIPTION
(Hopefully) an easy PR for the team to review and merge. **No logic changes.**

Only 00_AllSamples.cs contains a fix inside code (a typo in a string).
Everything else is safe and just typos inside comments or XML documentation.

Happy Friday 