### PR TITLE
Aggregate CPU and ThreadTime by UserCrit acquisition

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -137,6 +137,7 @@ namespace PerfView
         public bool NetMonCapture;          // Capture a NetMon-only trace as well as a standard ETW trace (implies NetworkCapture)  
         public bool CCWRefCount;            // Capture CCW references count increasing and decreasing
         public bool RuntimeLoading;         // Capture information about runtime loading such as R2R and type load events
+        public bool UserCritContention;     // Capture UserCrit contention events
 
         public bool Wpr;                    // Collect like WPR (no zip, puts NGEN pdbs in a .ngenpdbs directory).  
 
@@ -535,6 +536,7 @@ namespace PerfView
             parser.DefineOptionalQualifier("JITInlining", ref JITInlining, "Turns on logging of successful and failed JIT inlining attempts.");
             parser.DefineOptionalQualifier("CCWRefCount", ref CCWRefCount, "Turns on logging of information about .NET Native CCW reference counting.");
             parser.DefineOptionalQualifier("RuntimeLoading", ref RuntimeLoading, "Turn on logging of runtime loading operations.");
+            parser.DefineOptionalQualifier("UserCritContention", ref UserCritContention, "Turn on UserCrit contention events.");
             parser.DefineOptionalQualifier("OSHeapProcess", ref OSHeapProcess, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given process ID.");
             parser.DefineOptionalQualifier("OSHeapExe", ref OSHeapExe, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given EXE (only filename WITH extension).");
 

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -928,6 +928,11 @@ namespace PerfView
                             parsedArgs.ClrEventLevel, (ulong)parsedArgs.ClrEvents, options);
                     }
 
+                    if (parsedArgs.UserCritContention)
+                    {
+                        EnableUserProvider(userModeSession, "Microsoft-Windows-Win32k", new Guid("8C416C79-D49B-4F01-A467-E56D3AA8234C"), TraceEventLevel.Verbose, 0x10000000, options);
+                    }
+
                     // Start network monitoring capture if needed
                     if (parsedArgs.NetMonCapture)
                     {
@@ -3162,6 +3167,11 @@ namespace PerfView
             if (parsedArgs.RuntimeLoading)
             {
                 cmdLineArgs += " /RuntimeLoading";
+            }
+
+            if (parsedArgs.UserCritContention)
+            {
+                cmdLineArgs += " /UserCritContention";
             }
 
             if(parsedArgs.ImageIDsOnly)

--- a/src/PerfView/StateMachineFramework/UserCritComputer.cs
+++ b/src/PerfView/StateMachineFramework/UserCritComputer.cs
@@ -1,0 +1,165 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Stacks;
+
+namespace PerfView
+{
+    /// <summary>
+    /// UserCritScenarioConfiguration is an implementation of the ScenarioConfiguration abstract class that allows
+    /// ComputingResourceStateMachine to track resources according to UserCrit acquisition status.
+    /// </summary>
+    public sealed class UserCritScenarioConfiguration : ScenarioConfiguration
+    {
+        public UserCritScenarioConfiguration(TraceLog traceLog)
+            : base(traceLog)
+        {
+            // The thread state map must be created before the request computer because
+            // a reference to the thread state map is held by the request computer.
+            m_ThreadStateMap = new UserCritThreadStateMap(traceLog);
+            m_UserCritComputer = new UserCritComputer(this);
+        }
+
+        public override ScenarioStateMachine ScenarioStateMachine
+        {
+            get { return m_UserCritComputer; }
+        }
+
+        public override ScenarioThreadState[] ScenarioThreadState
+        {
+            get { return m_ThreadStateMap.ThreadState; }
+        }
+
+        internal UserCritThreadStateMap ThreadStateMap
+        {
+            get { return m_ThreadStateMap; }
+        }
+
+        #region Private
+        private UserCritComputer m_UserCritComputer;
+
+        private UserCritThreadStateMap m_ThreadStateMap;
+        #endregion
+    }
+
+    /// <summary>
+    /// Represents the state machine that tracks the UserCrit.
+    /// </summary>
+    public sealed class UserCritComputer : ScenarioStateMachine
+    {
+        private const string Win32kProviderName = "";
+
+        public UserCritComputer(UserCritScenarioConfiguration configuration)
+            : base(configuration)
+        {
+            m_ThreadStateMap = configuration.ThreadStateMap;
+        }
+
+        /// <summary>
+        /// Execute the UserCrit computer.
+        /// </summary>
+        public override void RegisterEventHandlers(TraceEventDispatcher eventDispatcher)
+        {
+            DynamicTraceEventParser dynamicParser = new DynamicTraceEventParser(eventDispatcher);
+            dynamicParser.AddCallbackForProviderEvent("Microsoft-Windows-Win32k", "ExclusiveUserCrit", (data) =>
+            {
+                TraceThread thread = data.Thread();
+                if (null == thread)
+                {
+                    return;
+                }
+
+                m_ThreadStateMap[thread.ThreadIndex].AcquisitionType = UserCritAcquisitionType.Exclusive;
+            });
+            dynamicParser.AddCallbackForProviderEvent("Microsoft-Windows-Win32k", "SharedUserCrit", (data) =>
+            {
+                TraceThread thread = data.Thread();
+                if (null == thread)
+                {
+                    return;
+                }
+
+                m_ThreadStateMap[thread.ThreadIndex].AcquisitionType = UserCritAcquisitionType.Shared;
+            });
+            dynamicParser.AddCallbackForProviderEvent("Microsoft-Windows-Win32k", "ReleaseUserCrit", (data) =>
+            {
+                TraceThread thread = data.Thread();
+                if (null == thread)
+                {
+                    return;
+                }
+
+                m_ThreadStateMap[thread.ThreadIndex].AcquisitionType = UserCritAcquisitionType.NotHeld;
+            });
+        }
+
+        /// <summary>
+        /// Maps thread Indexes to their status.
+        /// </summary>
+        private UserCritThreadStateMap m_ThreadStateMap;
+        /// <summary>
+    }
+
+    internal enum UserCritAcquisitionType
+    {
+        NotHeld = 0,
+        Exclusive,
+        Shared
+    }
+
+    /// <summary>
+    /// The base class for thread state associated with a thread.
+    /// </summary>
+    internal class UserCritThreadState : ScenarioThreadState
+    {
+        public UserCritAcquisitionType AcquisitionType { get; set; }
+
+        /// <summary>
+        /// Computes that part of the frame from the root of app processes up to (but not including) the thread frame.
+        /// </summary>
+        public override StackSourceCallStackIndex GetCallStackIndex(MutableTraceEventStackSource stackSource, TraceThread thread, TraceEvent data)
+        {
+            // Get the call stack index for the process and root of all processes
+            StackSourceCallStackIndex callStackIndex = stackSource.GetCallStackForProcess(thread.Process);
+
+            // Add the UserCrit acquisition status.
+            string acquisitionType = $"UserCrit Status: {AcquisitionType}";
+            StackSourceFrameIndex requestsFrameIndex = stackSource.Interner.FrameIntern(acquisitionType);
+            callStackIndex = stackSource.Interner.CallStackIntern(requestsFrameIndex, callStackIndex);
+
+            return callStackIndex;
+        }
+    }
+
+    #region private classes
+
+    /// <summary>
+    /// A simple class that implements lookup by Thread index
+    /// </summary>
+    internal sealed class UserCritThreadStateMap
+    {
+        internal UserCritThreadStateMap(TraceLog traceLog)
+        {
+            m_traceLog = traceLog;
+            m_ThreadState = new UserCritThreadState[traceLog.Threads.Count];
+            for (int i = 0; i < m_ThreadState.Length; ++i)
+            {
+                m_ThreadState[i] = new UserCritThreadState();
+            }
+        }
+
+        internal UserCritThreadState this[ThreadIndex index]
+        {
+            get { return m_ThreadState[(int)index]; }
+        }
+
+        internal UserCritThreadState[] ThreadState
+        {
+            get { return m_ThreadState; }
+        }
+
+        private UserCritThreadState[] m_ThreadState;
+        private TraceLog m_traceLog;
+    }
+    #endregion
+}


### PR DESCRIPTION
 - Adds a new `/UserCritContention` command line argument to capture contention on the UserCrit.
 - Adds a new `UI` view group with new views to display CPU and ThreadTime while the UserCrit is held.