### PR TITLE
TraceEvent - don't use undocumented APIs

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -512,7 +512,7 @@
       <Link>System.Memory.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(_NugetFallbackFolder)\System.Numerics.Vectors\4.5.0\lib\net46\System.Numerics.Vectors.dll">
+    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Numerics.Vectors\4.5.0\lib\net46\System.Numerics.Vectors.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Numerics.Vectors.dll</LogicalName>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -512,7 +512,7 @@
       <Link>System.Memory.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Numerics.Vectors\4.5.0\lib\net46\System.Numerics.Vectors.dll">
+    <EmbeddedResource Include="$(_NugetFallbackFolder)\System.Numerics.Vectors\4.5.0\lib\net46\System.Numerics.Vectors.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Numerics.Vectors.dll</LogicalName>

--- a/src/TraceEvent/RegisteredTraceEventParser.cs
+++ b/src/TraceEvent/RegisteredTraceEventParser.cs
@@ -1,7 +1,6 @@
 ﻿//     Copyright (c) Microsoft Corporation.  All rights reserved.
 using FastSerialization;
 using Microsoft.Diagnostics.Tracing.Compatibility;
-using Microsoft.Diagnostics.Tracing.Extensions;
 using Microsoft.Diagnostics.Tracing.Session;
 using System;
 using System.Collections.Generic;
@@ -88,7 +87,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         public static string GetManifestForRegisteredProvider(Guid providerGuid)
         {
             int buffSize = 84000;       // Still in the small object heap.  
-            byte* buffer = (byte*)System.Runtime.InteropServices.Marshal.AllocHGlobal(buffSize);
+            var buffer = new byte[buffSize]; // Still in the small object heap.
             byte* enumBuffer = null;
 
             TraceEventNativeMethods.EVENT_RECORD eventRecord = new TraceEventNativeMethods.EVENT_RECORD();
@@ -129,32 +128,55 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 }
             }
 
-            for (int ver = 0; ver <= 255; ver++)
-            {
-                eventRecord.EventHeader.Version = (byte) ver;
-                int count;
-                int status;
-                for (; ; )
-                {
-                    int dummy;
-                    status = ETWParsing.TdhGetAllEventsInformation(&eventRecord, IntPtr.Zero, out dummy, out count, buffer, ref buffSize);
-                    if (status != 122 || 20000000 < buffSize) // 122 == Insufficient buffer keep it under 2Meg
-                    {
-                        break;
-                    }
+            int status;
 
-                    Marshal.FreeHGlobal((IntPtr)buffer);
-                    buffer = (byte*)Marshal.AllocHGlobal(buffSize);
+            for (; ; )
+            {
+                int size = buffer.Length;
+                status = TdhEnumerateManifestProviderEvents(ref eventRecord.EventHeader.ProviderId, buffer, ref size);
+                if (status != 122 || 20000000 < size) // 122 == Insufficient buffer keep it under 2Meg
+                {
+                    break;
                 }
 
-                // TODO FIX NOW deal with too small of a buffer.  
-                if (status == 0)
+                buffer = new byte[size];
+            }
+
+            if (status == 0)
+            {
+                const int NumberOfEventsOffset = 0;
+                const int FirstDescriptorOffset = 8;
+                int eventCount = BitConverter.ToInt32(buffer, NumberOfEventsOffset);
+                var descriptors = new EVENT_DESCRIPTOR[eventCount];
+                fixed (EVENT_DESCRIPTOR* pDescriptors = descriptors)
                 {
-                    TRACE_EVENT_INFO** eventInfos = (TRACE_EVENT_INFO**)buffer;
-                    for (int i = 0; i < count; i++)
+                    Marshal.Copy(buffer, FirstDescriptorOffset, (IntPtr)pDescriptors, descriptors.Length * sizeof(EVENT_DESCRIPTOR));
+                }
+
+                foreach (var descriptor in descriptors)
+                {
+                    var descriptorCopy = descriptor;
+
+                    for (; ; )
                     {
-                        TRACE_EVENT_INFO* eventInfo = eventInfos[i];
-                        byte* eventInfoBuff = (byte*)eventInfo;
+                        int size = buffer.Length;
+                        status = TdhGetManifestEventInformation(ref eventRecord.EventHeader.ProviderId, ref descriptorCopy, buffer, ref size);
+                        if (status != 122 || 20000000 < size) // 122 == Insufficient buffer keep it under 2Meg
+                        {
+                            break;
+                        }
+
+                        buffer = new byte[size];
+                    }
+
+                    if (status != 0)
+                    {
+                        continue;
+                    }
+
+                    fixed (byte* eventInfoBuff = buffer)
+                    {
+                        var eventInfo = (TRACE_EVENT_INFO*)eventInfoBuff;
                         EVENT_PROPERTY_INFO* propertyInfos = &eventInfo->EventPropertyInfoArray;
 
                         if (providerName == null)
@@ -406,17 +428,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                         eventWriter.WriteLine("/>");
                     }
                 }
-                else if (status == 1168 && ver != 0)        // Not Found give up
-                {
-                    break;
-                }
             }
             if (enumBuffer != null)
             {
                 System.Runtime.InteropServices.Marshal.FreeHGlobal((IntPtr)enumBuffer);
             }
 
-            System.Runtime.InteropServices.Marshal.FreeHGlobal((IntPtr)buffer);
             if (providerName == null)
             {
                 throw new ApplicationException("Could not find provider with at GUID of " + providerGuid.ToString());
@@ -978,6 +995,21 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             EVENT_MAP_INFO* info,
             ref int infoSize
         );
+
+        [DllImport("tdh.dll")]
+        internal static extern int TdhEnumerateManifestProviderEvents(
+            [In] ref Guid Guid,
+            [Out] byte[] pBuffer, // Actually PROVIDER_EVENT_INFO*
+            ref int pBufferSize
+        );
+
+        [DllImport("tdh.dll")]
+        internal static extern int TdhGetManifestEventInformation(
+            [In] ref Guid Guid,
+            [In] ref EVENT_DESCRIPTOR eventDesc,
+            [Out] byte[] pBuffer,
+            [In, Out] ref int pBufferSize // size in bytes
+            );
 
         [Flags]
         internal enum MAP_FLAGS

--- a/src/TraceEvent/RegisteredTraceEventParser.cs
+++ b/src/TraceEvent/RegisteredTraceEventParser.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             for (; ; )
             {
                 int size = buffer.Length;
-                status = TdhEnumerateManifestProviderEvents(ref eventRecord.EventHeader.ProviderId, buffer, ref size);
+                status = TdhEnumerateManifestProviderEvents(eventRecord.EventHeader.ProviderId, buffer, ref size);
                 if (status != 122 || 20000000 < size) // 122 == Insufficient buffer keep it under 2Meg
                 {
                     break;
@@ -155,12 +155,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
                 foreach (var descriptor in descriptors)
                 {
-                    var descriptorCopy = descriptor;
-
                     for (; ; )
                     {
                         int size = buffer.Length;
-                        status = TdhGetManifestEventInformation(ref eventRecord.EventHeader.ProviderId, ref descriptorCopy, buffer, ref size);
+                        status = TdhGetManifestEventInformation(eventRecord.EventHeader.ProviderId, descriptor, buffer, ref size);
                         if (status != 122 || 20000000 < size) // 122 == Insufficient buffer keep it under 2Meg
                         {
                             break;
@@ -998,18 +996,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
         [DllImport("tdh.dll")]
         internal static extern int TdhEnumerateManifestProviderEvents(
-            [In] ref Guid Guid,
-            [Out] byte[] pBuffer, // Actually PROVIDER_EVENT_INFO*
+            in Guid Guid,
+            [Out] byte[] pBuffer, // PROVIDER_EVENT_INFO*
             ref int pBufferSize
         );
 
         [DllImport("tdh.dll")]
         internal static extern int TdhGetManifestEventInformation(
-            [In] ref Guid Guid,
-            [In] ref EVENT_DESCRIPTOR eventDesc,
-            [Out] byte[] pBuffer,
-            [In, Out] ref int pBufferSize // size in bytes
-            );
+            in Guid Guid,
+            in EVENT_DESCRIPTOR eventDesc,
+            [Out] byte[] pBuffer, // TRACE_EVENT_INFORMATION*
+            ref int pBufferSize
+        );
 
         [Flags]
         internal enum MAP_FLAGS

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/DispatchTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/DispatchTests.cs
@@ -591,13 +591,18 @@ namespace TraceEventTests
     /// Test code to ensure that the TraceEventDispatcher works properly in the face of lots of
     /// adds and deletes.   
     /// </summary>
-    public class DispatcherTester
+    public class DispatcherTester : IDisposable
     {
         public DispatcherTester(ITestOutputHelper output)
         {
             // Create a real time session, however we 
             m_dispatcher = new ETWTraceEventSource("TestDispatcher", TraceEventSourceType.Session);
             Output = output;
+        }
+
+        public void Dispose()
+        {
+            this.m_dispatcher.Dispose();
         }
 
         private ITestOutputHelper Output

--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -275,6 +275,9 @@ namespace Microsoft.Diagnostics.Tracing
 
             TraceLbrConfigurationInfo = 20,             // Filter flags
             TraceLbrEventListInfo = 21,                 // int array
+
+            // Win 10 build 19582+
+            TraceStackCachingInfo = 24,                 // TRACE_STACK_CACHING_INFO
         };
 
         internal struct CLASSIC_EVENT_ID
@@ -289,6 +292,16 @@ namespace Microsoft.Diagnostics.Tracing
             public int Source;
             public int Interval;
         };
+
+        internal struct TRACE_STACK_CACHING_INFO
+        {
+            public byte Enabled;
+            public byte Padding1;
+            public byte Padding2;
+            public byte Padding3;
+            public int CacheSize;
+            public int BucketCount;
+        }
 
         internal struct PROFILE_SOURCE_INFO
         {

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -744,7 +744,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                 {
                     var info = new TraceEventNativeMethods.TRACE_STACK_CACHING_INFO{ Enabled = 1 };
                     TraceEventNativeMethods.TraceSetInformation(
-                        m_SessionHandle.DangerousGetHandle(),
+                        m_SessionHandle,
                         TraceEventNativeMethods.TRACE_INFO_CLASS.TraceStackCachingInfo,
                         &info,
                         sizeof(TraceEventNativeMethods.TRACE_STACK_CACHING_INFO));


### PR DESCRIPTION
Stop using ETWControl and ETWParsing from OSExtensions.dll. Replace them with implementations that use Microsoft-supported APIs.

- Use TraceSetInformation for configuring profile interval (no change from existing behavior other than using supported API).
- Use TraceSetInformation for configuring stack caching (same behavior, except that the new API is only supported on Windows 10 19582+).
- Use TdhEnumerateManifestProviderEvents for reading manifest data (works perfectly for manifests, but doesn't work for MOF).

Still using OSExtensions.dll for KernelTraceControl stuff, but that's supported by Microsoft. So perhaps the KernelTraceControl stuff could move into TraceEvent and then OSExtensions.dll would no longer be needed at all.