### PR TITLE
[Auto-Analyzers] Add an issue id to AnalzyerResult

### DIFF
--- a/src/TraceEvent/AutomatedAnalysis/AnalyzerIssue.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AnalyzerIssue.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         /// <param name="url">A URL pointing to further documentation.</param>
         /// <exception cref="InvalidOperationException">Instances of AnalyzerIssue can only be created during Analyzer execution.</exception>
         public AnalyzerIssue(
+            Guid id,
             string title,
             string description,
             string url)
@@ -30,6 +31,7 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
             Title = title;
             Description = description;
             URL = url;
+            Id = id;
         }
 
         /// <summary>
@@ -37,6 +39,12 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         /// </summary>
         public Analyzer Analyzer { get; private set; }
 
+        /// <summary>
+        /// Gets the id of the issue.
+        /// </summary>
+        /// <value></value>
+        public Guid Id { get; protected set; }
+        
         /// <summary>
         /// The title of the issue.
         /// </summary>

--- a/src/TraceEvent/AutomatedAnalysis/AnalyzerIssue.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AnalyzerIssue.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         /// <summary>
         /// Create a new instance of AnalyzerIssue.
         /// </summary>
-        /// <param name="id">A durable id, in form of GUID, to uniquely identify a performance issue.</param>
+        /// <param name="id">A durable id, in form of GUID, to uniquely identify a performance issue. Note: This id is intended to be stable for a given issue.
+        /// Once the analyzer decides the id for a specific issue, it does not change.</param>
         /// <param name="title">A string title.</param>
         /// <param name="description">A string description.</param>
         /// <param name="url">A URL pointing to further documentation.</param>

--- a/src/TraceEvent/AutomatedAnalysis/AnalyzerIssue.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AnalyzerIssue.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         /// <summary>
         /// Create a new instance of AnalyzerIssue.
         /// </summary>
+        /// <param name="id">A durable id, in form of GUID, to uniquely identify a performance issue.</param>
         /// <param name="title">A string title.</param>
         /// <param name="description">A string description.</param>
         /// <param name="url">A URL pointing to further documentation.</param>
@@ -42,7 +43,6 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         /// <summary>
         /// Gets the id of the issue.
         /// </summary>
-        /// <value></value>
         public Guid Id { get; protected set; }
         
         /// <summary>

--- a/src/TraceEvent/TraceEvent.Tests/AutomatedAnalysis/AnalyzerExecutionTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/AutomatedAnalysis/AnalyzerExecutionTests.cs
@@ -48,6 +48,7 @@ namespace TraceEventTests
                 AnalyzerIssue issue = issues[0];
                 Assert.Equal(SingleIssueAnalyzer.Issue, issue);
                 Assert.Equal(SingleIssueAnalyzer.Issue.Analyzer, TestAnalyzerProvider.ExecutionTests_SingleIssueAnalyzer);
+                Assert.Equal(SingleIssueAnalyzer.TestIssueId, issue.Id);
 
                 // Make sure the expected Analyzer was run.
                 IEnumerable<Analyzer> executedAnalyzers = result.ExecutedAnalyzers;
@@ -70,6 +71,7 @@ namespace TraceEventTests
 
     public sealed class SingleIssueAnalyzer : ProcessAnalyzer
     {
+        internal static readonly Guid TestIssueId = Guid.Parse("06e26d5a-14e5-455e-9266-7303857c11c7");
         internal static AnalyzerIssue Issue;
         internal const int PID = 106800;
         internal const string ProcessDescription = "SimpleAllocator.exe";
@@ -79,7 +81,7 @@ namespace TraceEventTests
             if (processContext.Process.DisplayID == PID && ProcessDescription.Equals(processContext.Process.Description))
             {
                 Assert.Null(Issue);
-                Issue = new AnalyzerIssue(Guid.NewGuid(), "Test Title", "Test Description", "http://test-url");
+                Issue = new AnalyzerIssue(TestIssueId, "Test Title", "Test Description", "http://test-url");
                 processContext.AddIssue(Issue);
             }
 

--- a/src/TraceEvent/TraceEvent.Tests/AutomatedAnalysis/AnalyzerExecutionTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/AutomatedAnalysis/AnalyzerExecutionTests.cs
@@ -79,7 +79,7 @@ namespace TraceEventTests
             if (processContext.Process.DisplayID == PID && ProcessDescription.Equals(processContext.Process.Description))
             {
                 Assert.Null(Issue);
-                Issue = new AnalyzerIssue("Test Title", "Test Description", "http://test-url");
+                Issue = new AnalyzerIssue(Guid.NewGuid(), "Test Title", "Test Description", "http://test-url");
                 processContext.AddIssue(Issue);
             }
 


### PR DESCRIPTION
So that the analyzers could decide to put a durable id onto any AnalyzerIssue instance.