### PR TITLE
Drop netstandart1.6

### DIFF
--- a/src/TraceEvent/AutomatedAnalysis/DirectoryAnalyzerResolver.cs
+++ b/src/TraceEvent/AutomatedAnalysis/DirectoryAnalyzerResolver.cs
@@ -1,5 +1,4 @@
-﻿#if NET462 || NETSTANDARD2_0
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 
 namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
@@ -44,4 +43,3 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         }
     }
 }
-#endif

--- a/src/TraceEvent/Compatibility.cs
+++ b/src/TraceEvent/Compatibility.cs
@@ -1,48 +1,11 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.Tracing.Compatibility
 {
-#if NETSTANDARD1_6
-
-    // Design based on Core CLR 2.0.0
-    public class ApplicationException : Exception
-    {
-        internal const int COR_E_APPLICATION = unchecked((int)0x80131600);
-
-        public ApplicationException()
-            : base("Error in the application.")
-        {
-            HResult = COR_E_APPLICATION;
-        }
-
-        public ApplicationException(String message)
-            : base(message)
-        {
-            HResult = COR_E_APPLICATION;
-        }
-
-        public ApplicationException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-            HResult = COR_E_APPLICATION;
-        }
-    }    
-#endif
-
     internal static class Extentions
     {
-        public static IntPtr GetHandle(this Process process)
-        {
-#if NETSTANDARD1_6
-            return process.SafeHandle.DangerousGetHandle();
-#else
-            return process.Handle;
-#endif
-        }
-
 #if NET462
         public static StringDictionary GetEnvironment(this ProcessStartInfo startInfo) => startInfo.EnvironmentVariables;
 #else

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -642,13 +642,8 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 return 8;
             }
-#if !NETSTANDARD1_6
+
             bool is64bitOS = Environment.Is64BitOperatingSystem;
-#else
-            // Sadly this API does not work properly on V4.7.1 of the Desktop framework.   See https://github.com/Microsoft/perfview/issues/478 for more.  
-            // However with this partial fix, (works on everything not NetSTandard, and only in 32 bit processes), that we can wait for the fix.
-            bool is64bitOS = (RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.Arm64);
-#endif
             return is64bitOS ? 8 : 4;
         }
 

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -32,9 +32,6 @@
       <group targetFramework=".NETFramework4.6.2">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
       </group>
-      <group targetFramework=".NETStandard1.6">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
-      </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
       </group>
@@ -81,23 +78,7 @@
     <file src="$OutDir$netstandard2.0\TraceReloggerLib.dll" target="lib\netstandard2.0" />
     <file src="$OutDir$netstandard2.0\OSExtensions.dll" target="lib\netstandard2.0" />
 
-    <!-- NetStandard 1.6 Framework -->
-	
-    <!-- Built libraries -->
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\netstandard1.6" />
-
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.FastSerialization.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.FastSerialization.xml" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\netstandard1.6" />
-
-    <!-- Support Dlls -->
-    <file src="$OutDir$netstandard1.6\Dia2Lib.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\TraceReloggerLib.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\OSExtensions.dll" target="lib\netstandard1.6" />
-
-    <!-- NET 4.5 Framework -->
+    <!-- NET 4.6.2 Framework -->
 
     <!-- Built libraries -->
     <file src="$OutDir$net462\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\net462" />

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -78,23 +78,23 @@
     </None>
 
     <!-- There are no static references to these so I need to copy them explicitly.  
-         The first two COM interop assemblies so they are the same for all targets, I pick netstandard1.6 pretty arbitraily 
+         The first two COM interop assemblies so they are the same for all targets, I pick netstandard2.0 pretty arbitraily 
          OSExtensions is also the same for all targets.  It needs to be copied for the dev-time case since in that case it runs the DLLs from the .nuget cache
          by default, and OSExtensions needs to be in the right relative location with respect to the native DLLs (since it loads them via relative path).   
       -->
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard2.0\TraceReloggerLib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\TraceReloggerLib.dll">
       <Link>TraceReloggerLib.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\Dia2Lib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\Dia2Lib.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Dia2Lib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Dia2Lib.dll">
       <Link>Dia2Lib.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
 
 	<!-- you have to pick the right version of this DLL because it depends on things besides System.Runtime.dll -->
-    <None Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll">
+    <None Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\netstandard2.0\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\OSExtensions.dll">
       <Link>OSExtensions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/src/TraceEvent/Stacks/RecursionGuard.cs
+++ b/src/TraceEvent/Stacks/RecursionGuard.cs
@@ -38,11 +38,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (numResets > RecursionGuardConfiguration.MaxResets)
             {
-#if NETSTANDARD1_6
-                throw new Exception("Stack Overflow");
-#else 
                 throw new StackOverflowException();
-#endif
             }
             _currentThreadRecursionDepth = (ushort)currentThreadRecursionDepth;
             _resetCount = (ushort)numResets;

--- a/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
+++ b/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
@@ -232,16 +232,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (!escapedNames.TryGetValue(name, out string escaped))
             {
-#if NETSTANDARD1_6 || DEBUG // the Debug check allows us to test this code path for other TFMs
-                // System.Web.HttpUtility.JavaScriptStringEncode is not part of the .NET Standard 1.6
-                // but it's part of .NET 4.0+. So we just use reflection to invoke it.
-                escaped = escapedNames[name] = (string)Type
-                    .GetType("System.Web.HttpUtility, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
-                    .GetMethod("JavaScriptStringEncode", new Type[1] { typeof(string) })
-                    .Invoke(null, new object[] { name });
-#elif NETSTANDARD2_0 || NET462
                 escaped = escapedNames[name] = System.Web.HttpUtility.JavaScriptStringEncode(name);
-#endif
             }
 
             return escaped;

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -10,9 +10,7 @@ using Microsoft.Diagnostics.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-#if !NETSTANDARD1_6
 using System.Dynamic;
-#endif
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -594,13 +592,11 @@ namespace Microsoft.Diagnostics.Tracing
     /// </para>
     /// </summary>
     public abstract unsafe class TraceEvent
-#if !NETSTANDARD1_6
         // To support DLR access of dynamic payload data ("((dynamic) myEvent).MyPayloadName"),
         // we derive from DynamicObject and override a couple of methods. If for some reason in
         // the future we wanted to derive from a different base class, we could also accomplish
         // this by implementing the IDynamicMetaObjectProvider interface instead.
         : DynamicObject
-#endif
     {
         /// <summary>
         /// The GUID that uniquely identifies the Provider for this event.  This can return Guid.Empty for classic (Pre-VISTA) ETW providers.  
@@ -999,13 +995,11 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
-#if !NETSTANDARD1_6
         // These overloads allow integration with the DLR (Dynamic Language Runtime). That
         // enables getting at payload data in a more convenient fashion, directly by name.
         // In PowerShell, it "just works" (e.g. "$myEvent.MyPayload" will just work); in
         // C# you can activate it by casting to 'dynamic' (e.g. "var myEvent = (dynamic)
         // GetEventSomehow(); Console.WriteLine(myEvent.MyPayload);").
-
         public override IEnumerable<string> GetDynamicMemberNames()
         {
             return PayloadNames;
@@ -1016,8 +1010,6 @@ namespace Microsoft.Diagnostics.Tracing
             result = PayloadByName(binder.Name);
             return result != null;
         }
-#endif
-
 
         // Getting at payload values.  
         /// <summary>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -35,7 +35,7 @@
   </Target>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);COMMAND_PUBLIC;PEFILE_PUBLIC;PERFVIEW;SUPPORT_V1_V2;CONTAINER_WORKAROUND_NOT_NEEDED</DefineConstants>
+    <DefineConstants>$(DefineConstants);COMMAND_PUBLIC;PEFILE_PUBLIC;PERFVIEW;SUPPORT_V1_V2;CONTAINER_WORKAROUND_NOT_NEEDED;SYNC_SYMBOLREADER_LOG</DefineConstants>
     <NoWarn>$(NoWarn),0649,0618</NoWarn>
   </PropertyGroup>
 
@@ -43,7 +43,7 @@
     Unconditional use of PackageReference would work if we targeted net462, but the reference APIs do not include
     support for net462 targets. Work around the issue by using conditional references.
   -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
@@ -63,10 +63,6 @@
     <Reference Include="System.Web" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
-    <DefineConstants>$(DefineConstants);SYNC_SYMBOLREADER_LOG</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
@@ -105,11 +101,6 @@
     <Compile Remove="Ctf/CtfTracing.Tests/**/*.*" />
     <Compile Remove="TraceEvent.Tests/**/*.*" />
     <Compile Remove="Samples/**/*.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <Compile Remove="Utilities/FastStream.cs" />
-    <Compile Remove="Stacks/Linux/*.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -196,11 +187,11 @@
     <!-- *********************************************************** -->
     <!-- Copying three managed binaries explicitly should not be needed because the 
          dependency logic should just do it for us, but for some reason ths only
-         works for the net462 target framework and not the netstandard1.6.  and netstanard2.0 
+         works for the net462 target framework and not the netstanard2.0 
          We work around it here by copying the files explicitly. 
 	 We don't have version for 2.0 so we use the 1.6 versions.  -->
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <None Include="$(TraceEventSupportFilesBase)\netstandard1.6\Dia2Lib.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk"> 
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -869,7 +869,7 @@ namespace Microsoft.Diagnostics.Tracing
 #if !NOT_WINDOWS
             Process process = Process.GetCurrentProcess();
             IntPtr tokenHandle = IntPtr.Zero;
-            bool success = OpenProcessToken(process.GetHandle(), TOKEN_ADJUST_PRIVILEGES, out tokenHandle);
+            bool success = OpenProcessToken(process.Handle, TOKEN_ADJUST_PRIVILEGES, out tokenHandle);
             if (!success)
             {
                 throw new Win32Exception();
@@ -897,7 +897,7 @@ namespace Microsoft.Diagnostics.Tracing
 #if !NOT_WINDOWS 
             Process process = Process.GetCurrentProcess();
             IntPtr tokenHandle = IntPtr.Zero;
-            if (!OpenProcessToken(process.GetHandle(), TOKEN_QUERY, out tokenHandle))
+            if (!OpenProcessToken(process.Handle, TOKEN_QUERY, out tokenHandle))
             {
                 return null;
             }

--- a/src/TraceEvent/Utilities/command.cs
+++ b/src/TraceEvent/Utilities/command.cs
@@ -445,28 +445,22 @@ namespace Utilities
 
             if (options.elevate)
             {
-#if NETSTANDARD1_6
-                throw new NotImplementedException("Launching elevated processes is not implemented when TraceEvent is built for NetStandard 1.6");
-#else
                 options.useShellExecute = true;
                 startInfo.Verb = "runas";
                 if (options.currentDirectory == null)
                 {
                     options.currentDirectory = Directory.GetCurrentDirectory();
                 }
-#endif
             }
 
             startInfo.CreateNoWindow = options.noWindow;
             if (options.useShellExecute)
             {
                 startInfo.UseShellExecute = true;
-#if ! NETSTANDARD1_6
                 if (options.noWindow)
                 {
                     startInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 }
-#endif
             }
             else
             {
@@ -478,10 +472,8 @@ namespace Utilities
                 startInfo.UseShellExecute = false;
                 startInfo.RedirectStandardError = true;
                 startInfo.RedirectStandardOutput = true;
-#if ! NETSTANDARD1_6
                 startInfo.ErrorDialog = false;
                 startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-#endif
                 startInfo.CreateNoWindow = true;
 
                 process.OutputDataReceived += new DataReceivedEventHandler(OnProcessOutput);

--- a/src/TraceEvent/ZippedETL.cs
+++ b/src/TraceEvent/ZippedETL.cs
@@ -112,12 +112,10 @@ namespace Microsoft.Diagnostics.Tracing
             FileUtilities.ForceDelete(newFileName);
             try
             {
-#if !NETSTANDARD1_6
                 if (LowPriority)
                 {
                     Thread.CurrentThread.Priority = ThreadPriority.Lowest;
                 }
-#endif
                 Log.WriteLine("[Zipping ETL file {0}]", m_etlFilePath);
                 using (var zipArchive = ZipFile.Open(newFileName, ZipArchiveMode.Create))
                 {
@@ -186,9 +184,7 @@ namespace Microsoft.Diagnostics.Tracing
             }
             finally
             {
-#if !NETSTANDARD1_6
                 Thread.CurrentThread.Priority = ThreadPriority.Normal;
-#endif
                 FileUtilities.ForceDelete(newFileName);
             }
             return success;
@@ -282,12 +278,11 @@ namespace Microsoft.Diagnostics.Tracing
                     if (Merge)
                     {
                         var startTime = DateTime.UtcNow;
-#if !NETSTANDARD1_6
                         if (LowPriority)
                         {
                             Thread.CurrentThread.Priority = ThreadPriority.Lowest;
                         }
-#endif
+
                         try
                         {
                             Log.WriteLine("Starting Merging of {0}", m_etlFilePath);
@@ -308,9 +303,7 @@ namespace Microsoft.Diagnostics.Tracing
                         }
                         finally
                         {
-#if !NETSTANDARD1_6
                             Thread.CurrentThread.Priority = ThreadPriority.Normal;
-#endif
                         }
                     }
                     else
@@ -331,12 +324,11 @@ namespace Microsoft.Diagnostics.Tracing
                 {
                     if (NGenSymbolFiles)
                     {
-#if !NETSTANDARD1_6
                         if (LowPriority)
                         {
                             Thread.CurrentThread.Priority = ThreadPriority.Lowest;
                         }
-#endif
+
                         try
                         {
                             var startTime = DateTime.UtcNow;
@@ -352,9 +344,7 @@ namespace Microsoft.Diagnostics.Tracing
                         }
                         finally
                         {
-#if !NETSTANDARD1_6
                             Thread.CurrentThread.Priority = ThreadPriority.Normal;
-#endif
                         }
                     }
                     else


### PR DESCRIPTION
Seems to be only practical reason to support netstandard1.6 is for .NET Core 1.1, Mono 4.6, Xamarin.Android 7.0, Xamarin.iOS 10.0 which probably not needed. If so, that's probably dead code.

The only potential place to look closer is ETWTraceEventSource.GetOSPointerSize()