### PR TITLE
Remove Internal-Only Code

### DIFF
--- a/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
+++ b/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
@@ -24,7 +24,6 @@ namespace PerfViewTests.Utilities
         {
             _testOutputHelper = testOutputHelper;
 
-            AppLog.s_IsUnderTest = true;
             App.CommandLineArgs = new CommandLineArgs();
             App.CommandProcessor = new CommandProcessor();
 

--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -645,12 +645,6 @@ namespace PerfView
                 return false;
             }
 
-            // Internal users implicitly accept the EULA
-            if (AppLog.InternalUser)
-            {
-                return false;
-            }
-
             return true;
         }
         public static void AcceptEula()
@@ -693,16 +687,7 @@ namespace PerfView
                     }
 
                     bool persistSymPath = true;
-
-                    // If we still don't have anything, add a default one
-                    // Since the default goes off machine, if we are outside of Microsoft, we have to ask
-                    // the user for permission. 
-                    if (AppLog.InternalUser)
-                    {
-                        symPath.Add("SRV*http://symweb.corp.microsoft.com");
-                        symPath.Add(Microsoft.Diagnostics.Symbols.SymbolPath.MicrosoftSymbolServerPath);
-                    }
-                    else if (symPath.Elements.Count == 0)
+                    if (symPath.Elements.Count == 0)
                     {
                         if (SupportFiles.ProcessArch == ProcessorArchitecture.Arm || App.CommandLineArgs.NoGui)
                         {
@@ -879,7 +864,7 @@ namespace PerfView
             ret.Options = symbolFlags;
 
 #if !PERFVIEW_COLLECT
-            if (!AppLog.InternalUser && !App.CommandLineArgs.TrustPdbs)
+            if (!App.CommandLineArgs.TrustPdbs)
             {
                 ret.SecurityCheck = delegate (string pdbFile)
                 {
@@ -1225,21 +1210,6 @@ namespace PerfView
             }
         }
         /// <summary>
-        /// Are we internal to Microsoft (and thus can have experimental features. 
-        /// </summary>
-        public static bool InternalUser
-        {
-            get
-            {
-                if (!s_InternalUser.HasValue)
-                {
-                    s_InternalUser = s_IsUnderTest || SymbolPath.ComputerNameExists(FeedbackServer, 400);
-                }
-
-                return s_InternalUser.Value;
-            }
-        }
-        /// <summary>
         /// Log that the event 'eventName' with an optional string arg happened.  Will
         /// get stamped with the time, user, and session ID.  
         /// </summary>
@@ -1364,7 +1334,6 @@ namespace PerfView
 
         private static DateTime s_startTime;    // used as a unique ID for the launch of the program (for SQM style logging)    
         internal static bool s_IsUnderTest; // set from tests: indicates we're in a test
-        private static bool? s_InternalUser;
 #if !PUBLIC_BUILD
         private static DateTime s_ProbedForFeedbackAt;
         private static bool? s_CanSendFeedback;

--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -1151,154 +1151,8 @@ namespace PerfView
 #endregion
     }
 
-    /// <summary>
-    /// APIs for logging usage data and feedback.
-    /// </summary>
-    public static class AppLog
+    public static class AppInfo
     {
-        /// <summary>
-        /// Returns true if you have access to the file share where we log feedback
-        /// </summary>
-        public static bool CanSendFeedback
-        {
-            get
-            {
-#if PUBLIC_BUILD
-                return false;
-#else
-                if (!s_CanSendFeedback.HasValue)
-                {
-                    if (s_IsUnderTest)
-                    {
-                        s_CanSendFeedback = false;          // Don't send feedback about test runs.  
-                    }
-                    else
-                    {
-                        // Have we tried to probe for the existence of \\clrmain?
-                        if (s_ProbedForFeedbackAt.Ticks == 0)
-                        {
-                            s_ProbedForFeedbackAt = DateTime.Now;
-                            // Only collect data in the REDMOND domain EUROPE has rules about telemetry.  
-                            var userDomain = Environment.GetEnvironmentVariable("USERDOMAIN");
-                            if (userDomain != "REDMOND")
-                            {
-                                s_CanSendFeedback = false;
-                            }
-                            else
-                            {
-                                s_CanSendFeedback = SymbolPath.ComputerNameExists(FeedbackServer) && WriteFeedbackToLog(FeedbackFilePath, "");
-                            }
-                        }
-                        else
-                        {
-                            // Yes, see what has become of it.   
-                            int msecSinceProbe = (int)(DateTime.Now - s_ProbedForFeedbackAt).TotalMilliseconds;
-                            if (msecSinceProbe < 800)
-                            {
-                                Thread.Sleep(msecSinceProbe);       // We probed not to long ago, give it some time
-                            }
-
-                            if (!s_CanSendFeedback.HasValue)
-                            {
-                                s_CanSendFeedback = false;          //Give up if we don't have an answer by now. 
-                            }
-                        }
-                    }
-                }
-                return s_CanSendFeedback.Value;
-#endif
-            }
-        }
-        /// <summary>
-        /// Log that the event 'eventName' with an optional string arg happened.  Will
-        /// get stamped with the time, user, and session ID.  
-        /// </summary>
-        public static void LogUsage(string eventName, string arg1 = "", string arg2 = "")
-        {
-#if !PUBLIC_BUILD
-            if (!CanSendFeedback)
-            {
-                return;
-            }
-
-            try
-            {
-                var usagePath = UsageFilePath;
-                var userName = Environment.GetEnvironmentVariable("USERNAME");
-
-                using (var writer = File.AppendText(usagePath))
-                {
-                    var now = DateTime.Now;
-                    if (s_startTime.Ticks == 0)
-                    {
-                        s_startTime = now;
-                    }
-
-                    var secFromStart = (now - s_startTime).TotalSeconds;
-
-                    var sessionID = (uint)(s_startTime.Ticks / 100000);
-                    // SessionID, user, secondFromStart messageKind, arg 
-                    writer.WriteLine("{0},{1},{2:f1},{3},\"{4}\",\"{5}\"", sessionID, userName, secFromStart, eventName, arg1, arg2);
-                }
-
-                // Keep the file to 10 meg;
-                // Note that the move might fail, but that is OK.  
-                if (new FileInfo(usagePath).Length > 10000000)
-                {
-                    File.Move(usagePath, Path.ChangeExtension(usagePath, ".prev.csv"));
-                }
-            }
-            catch (Exception) { }
-#endif
-        }
-        /// <summary>
-        /// Called if you wish to send feedback to the developer.  Returns true if successful
-        /// We segregate feedback into crashes and suggestions.  
-        /// </summary>
-        public static bool SendFeedback(string message, bool crash)
-        {
-#if PUBLIC_BUILD
-            return false;
-#else
-            if (!CanSendFeedback)
-            {
-                return false;
-            }
-
-            StringWriter sw = new StringWriter();
-            var userName = Environment.GetEnvironmentVariable("USERNAME");
-            var userDomain = Environment.GetEnvironmentVariable("USERDOMAIN");
-
-            var issueID = userName.Replace(" ", "") + "-" + DateTime.Now.ToString("yyyy'-'MM'-'dd'.'HH'.'mm'.'ss");
-            string feedbackFile = FeedbackFilePath;
-            var logPath = Path.Combine(FeedbackDirectory, "UserLog." + issueID + ".txt");
-
-            sw.WriteLine("**********************************************************************");
-            sw.WriteLine("OpenIssueID: {0}", issueID);
-            sw.WriteLine("Date: {0}", DateTime.Now);
-            sw.WriteLine("UserName: {0}", userName);
-            sw.WriteLine("UserDomain: {0}", userDomain);
-            sw.WriteLine("PerfView Version Number: {0}", VersionNumber);
-            sw.WriteLine("PerfView Build Date: {0}", BuildDate);
-
-            try
-            {
-                // Capture the user log, to see how we got here.  if it is less than 20 Meg.  
-                if (File.Exists(App.LogFileName) && (new FileInfo(App.LogFileName)).Length < 20000000)
-                {
-                    File.Copy(App.LogFileName, logPath, true);
-                }
-
-                sw.WriteLine("UserLog: {0}", logPath);
-            }
-            catch { };
-
-            sw.WriteLine("Message:");
-            sw.Write("    ");
-            sw.WriteLine(message.Replace("\n", "\n    "));
-            return WriteFeedbackToLog(feedbackFile, sw.ToString());
-#endif
-        }
         public static string VersionNumber
         {
             get
@@ -1312,65 +1166,15 @@ namespace PerfView
         {
             get
             {
-                var buildDateAttribute = typeof(AppLog).Assembly.GetCustomAttributes<BuildDateAttribute>().FirstOrDefault();
+                var buildDateAttribute = typeof(AppInfo).Assembly.GetCustomAttributes<BuildDateAttribute>().FirstOrDefault();
                 return buildDateAttribute?.BuildDate ?? "Unknown";
             }
         }
-
-#region private
-
-
-        private static string FeedbackServer { get { return "clrMain"; } }
-        private static string UsageFilePath { get { return Path.Combine(FeedbackDirectory, "PerfViewUsage.csv"); } }
-        internal static string FeedbackFilePath { get { return Path.Combine(FeedbackDirectory, "PerfViewFeedback.txt"); } }
-        private static string CrashLogFilePath { get { return Path.Combine(FeedbackDirectory, "PerfViewCrashes.txt"); } }
-        private static string FeedbackDirectory
-        {
-            get
-            {
-                return @"\\" + FeedbackServer + @"\public\writable\perfView";
-            }
-        }
-
-        private static DateTime s_startTime;    // used as a unique ID for the launch of the program (for SQM style logging)    
-        internal static bool s_IsUnderTest; // set from tests: indicates we're in a test
-#if !PUBLIC_BUILD
-        private static DateTime s_ProbedForFeedbackAt;
-        private static bool? s_CanSendFeedback;
-#endif
-        private static bool WriteFeedbackToLog(string filePath, string message)
-        {
-            // Try 5 times (50 msec) to write the file.
-            DateTime start = DateTime.UtcNow;
-            for (int i = 0; i < 5; i++)
-            {
-                try
-                {
-                    System.IO.Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-                    using (var writer = new StreamWriter(filePath, true))   // open for appending. 
-                    {
-                        writer.Write(message);
-                    }
-
-                    return true;
-                }
-                catch (Exception) { }
-
-                if ((DateTime.UtcNow - start).TotalMilliseconds > 50)
-                {
-                    break;
-                }
-
-                System.Threading.Thread.Sleep(10);
-            }
-            return false;
-        }
-#endregion
     }
 
     /// <summary>
     /// VerboseLogWriter is a textWriter that forwards everything to 'verboseLog' but
-    /// also sends any lines in [] to the 'terseLog'. 
+    /// also sends any lines in [] to the 'terseLog'.
     /// </summary>
     internal class VerboseLogWriter : TextWriter
     {

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1011,7 +1011,7 @@ namespace PerfView
                         heapSession.StopOnDispose = false;
                     }
 
-                    PerfViewLogger.Log.CommandLineParameters(ParsedArgsAsString(null, parsedArgs), Environment.CurrentDirectory, AppLog.VersionNumber);
+                    PerfViewLogger.Log.CommandLineParameters(ParsedArgsAsString(null, parsedArgs), Environment.CurrentDirectory, AppInfo.VersionNumber);
                 }
             }
         }
@@ -1198,7 +1198,7 @@ namespace PerfView
                 LogFile.WriteLine("Stopping tracing for sessions '" + s_KernelessionName +
                     "' and '" + s_UserModeSessionName + "'.");
 
-                PerfViewLogger.Log.CommandLineParameters(ParsedArgsAsString(null, parsedArgs), Environment.CurrentDirectory, AppLog.VersionNumber);
+                PerfViewLogger.Log.CommandLineParameters(ParsedArgsAsString(null, parsedArgs), Environment.CurrentDirectory, AppInfo.VersionNumber);
                 PerfViewLogger.Log.StopTracing();
                 PerfViewLogger.StopTime = DateTime.UtcNow;
                 PerfViewLogger.Log.StartAndStopTimes();
@@ -3576,7 +3576,7 @@ namespace PerfView
                     WaitForRundownIdle(parsedArgs.MinRundownTime, parsedArgs.RundownTimeout, rundownFile);
 
                     // Complete perfview rundown.
-                    PerfViewLogger.Log.CommandLineParameters(ParsedArgsAsString(null, parsedArgs), Environment.CurrentDirectory, AppLog.VersionNumber);
+                    PerfViewLogger.Log.CommandLineParameters(ParsedArgsAsString(null, parsedArgs), Environment.CurrentDirectory, AppInfo.VersionNumber);
                     PerfViewLogger.Log.StartAndStopTimes();
                     PerfViewLogger.Log.StopRundown();
                 }

--- a/src/PerfView/Dialogs/UnhandledExceptionDialog.xaml.cs
+++ b/src/PerfView/Dialogs/UnhandledExceptionDialog.xaml.cs
@@ -8,22 +8,13 @@ namespace PerfView.Dialogs
     /// </summary>
     public partial class UnhandledExceptionDialog : WindowBase
     {
-        public UnhandledExceptionDialog(Window parentWindow, object exception, bool feedbackSent) : base(parentWindow)
+        public UnhandledExceptionDialog(Window parentWindow, object exception) : base(parentWindow)
         {
             InitializeComponent();
 
-            string reporting;
-            if (feedbackSent)
-            {
-                reporting = "The fact that this exception went unhanded is a programmer error.   The fact that this failure "
-                          + "occured has been logged so it can be fixed.  You don't need to take any action.\r\n";
-            }
-            else
-            {
-                reporting = "The fact that this exception went unhanded is a programmer error.   It should be reported "
+            string reporting = "The fact that this exception went unhanded is a programmer error.   It should be reported "
                           + "so it can be fixed.  Please set along the following stack trace information which will be "
                           + "useful in diagnosing the problem.\r\n";
-            }
 
             Body.Text = "An unhanded exception occured.\r\n"
                       + "\r\n"

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -16,6 +16,8 @@ namespace Stats
 {
     internal static class GcStats
     {
+        internal static bool EnableExperimentalFeatures;
+
         public static void ToHtml(TextWriter writer, TraceProcess stats, TraceLoadedDotNetRuntime runtime, string fileName, bool doServerGCReport = false)
         {
             writer.WriteLine("<H3><A Name=\"Stats_{0}\"><font color=\"blue\">GC Stats for Process {1,5}: {2}</font><A></H3>", stats.ProcessID, stats.ProcessID, stats.Name);
@@ -191,7 +193,11 @@ namespace Stats
             writer.WriteLine("<H4><A Name=\"Events_{0}\">All GC Events for Process {1,5}: {2}<A></H4>", stats.ProcessID, stats.ProcessID, stats.Name);
             PrintEventTable(writer, stats, runtime, Math.Max(0, runtime.GC.GCs.Count - 1000));
             PrintEventCondemnedReasonsTable(writer, stats, runtime, Math.Max(0, runtime.GC.GCs.Count - 1000));
-            RenderServerGcConcurrencyGraphs(writer, stats, runtime, doServerGCReport);
+
+            if (EnableExperimentalFeatures)
+            {
+                RenderServerGcConcurrencyGraphs(writer, stats, runtime, doServerGCReport);
+            }
 
             if (runtime.GC.Stats().FinalizedObjects.Count > 0)
             {

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -191,11 +191,7 @@ namespace Stats
             writer.WriteLine("<H4><A Name=\"Events_{0}\">All GC Events for Process {1,5}: {2}<A></H4>", stats.ProcessID, stats.ProcessID, stats.Name);
             PrintEventTable(writer, stats, runtime, Math.Max(0, runtime.GC.GCs.Count - 1000));
             PrintEventCondemnedReasonsTable(writer, stats, runtime, Math.Max(0, runtime.GC.GCs.Count - 1000));
-
-            if (PerfView.AppLog.InternalUser)
-            {
-                RenderServerGcConcurrencyGraphs(writer, stats, runtime, doServerGCReport);
-            }
+            RenderServerGcConcurrencyGraphs(writer, stats, runtime, doServerGCReport);
 
             if (runtime.GC.Stats().FinalizedObjects.Count > 0)
             {
@@ -563,7 +559,7 @@ namespace Stats
 
         private static bool ShowPinnedInformation(GCStats stats)
         {
-            if ((PerfView.AppLog.InternalUser) && (stats.NumWithPinEvents > 0))
+            if (stats.NumWithPinEvents > 0)
             {
                 return true;
             }

--- a/src/PerfView/GuiApp.cs
+++ b/src/PerfView/GuiApp.cs
@@ -66,7 +66,7 @@ namespace PerfView
             }
 
             MainWindow.StatusBar.LogWriter.WriteLine("Started with command line: {0}", Environment.CommandLine);
-            MainWindow.StatusBar.LogWriter.WriteLine("PerfView Version: {0}  BuildDate: {1}", AppLog.VersionNumber, AppLog.BuildDate);
+            MainWindow.StatusBar.LogWriter.WriteLine("PerfView Version: {0}  BuildDate: {1}", AppInfo.VersionNumber, AppInfo.BuildDate);
             MainWindow.StatusBar.LogWriter.WriteLine("PerfView Start Time {0}", DateTime.Now);
 
             if (App.NeedsEulaConfirmation(App.CommandLineArgs))
@@ -144,8 +144,7 @@ namespace PerfView
             }
             else
             {
-                var feedbackSent = AppLog.SendFeedback("Unhandled Exception in GUI\r\n" + e.Exception.ToString(), true);
-                var dialog = new PerfView.Dialogs.UnhandledExceptionDialog(MainWindow, e.Exception, feedbackSent);
+                var dialog = new PerfView.Dialogs.UnhandledExceptionDialog(MainWindow, e.Exception);
                 var ret = dialog.ShowDialog();
                 // If it returns, it means that the user has opted to continue.
                 e.Handled = true;
@@ -158,10 +157,9 @@ namespace PerfView
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             // TODO discriminate between the GUI and Non_GUI case.
-            var feedbackSent = AppLog.SendFeedback("Unhandled Exception\r\n" + e.ExceptionObject.ToString(), true);
             MainWindow.Dispatcher.BeginInvoke((Action)delegate ()
             {
-                var dialog = new PerfView.Dialogs.UnhandledExceptionDialog(MainWindow, e.ExceptionObject, feedbackSent);
+                var dialog = new PerfView.Dialogs.UnhandledExceptionDialog(MainWindow, e.ExceptionObject);
                 var ret = dialog.ShowDialog();
             });
         }

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -118,6 +118,9 @@
                         <MenuItem Header="Use Device _Code for GitHub" x:Name="Authentication_UseGitHubDeviceFlow" IsChecked="{Binding Path=AuthenticationViewModel.IsGitHubDeviceFlowEnabled}" Command="{x:Static src:AuthenticationCommands.UseGitHubDeviceFlow}" ToolTip="Use a device code to authenticate with GitHub."/>
                     </MenuItem>
                     <MenuItem Header="Do not shorten frames copied from stack windows" x:Name="Option_DoNotCompressStackFramesOnCopy" IsCheckable="True" Click="ToggleDoNotCompressStackFramesOnCopy" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
+                    <MenuItem Header="_Experimental">
+                        <MenuItem Header="Show experimental GC features." x:Name="Option_ExperimentalGCFeatures" IsCheckable="true" Click="ToggleExperimentalGCFeatures" ToolTip="Enable or disable experimental GC features."/>
+                    </MenuItem>
                     <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
                     <MenuItem Header="Theme">
                         <MenuItem Header="Light" x:Name="Theme_Light" IsChecked="{Binding Path=ThemeViewModel.IsLightTheme}" Command="{x:Static src:ThemeViewModel.SetLightThemeCommand}"/>

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -130,7 +130,6 @@
                     <MenuItem Header="_Users Guide" Command="{x:Static src:MainWindow.UsersGuideCommand}" CommandParameter="UsersGuide"/>
                     <MenuItem Name ="VideoMenuEntry" Header="Getting started _Videos" Click="DoVideoClick"/>
                     <MenuItem Header="Get the _Latest Version" Command="{x:Static src:MainWindow.UsersGuideCommand}" CommandParameter="LatestVersion"/>
-                    <MenuItem Header="Give _Feedback or Ask a question" Click="DoFeedbackClick"/>
                     <MenuItem Header="_Reference Guide" Click="DoReferenceGuide"/>
                     <MenuItem Header="_Command Line Help" Click="DoCommandLineHelp"/>
                     <MenuItem Header="User Command Help" Click="DoUserCommandHelp"/>
@@ -165,8 +164,6 @@
             </TextBlock>
             <Button Name="WikiButton" Grid.Column="7" Margin="5,1,10,1" Content="Wiki" FontSize="9"
                     ToolTip="Goto the PerfView Wiki." Click="DoWikiClick"/>
-            <Button Name="FeedbackButton" Grid.Column="8" Margin="5,1,10,1" Content="Feedback" FontSize="9"
-                    ToolTip="Send feedback to the maintainers of PerfView." Click="DoFeedbackClick"/>
         </Grid>
         <src:StatusBar x:Name="StatusBar" DockPanel.Dock="Bottom"/>
         <Grid>

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -112,13 +112,13 @@
                     </MenuItem>
                 </MenuItem>
                 <MenuItem Header="_Options">
-                    <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
-                    <MenuItem Header="Do not shorten frames copied from stack windows" x:Name="Option_DoNotCompressStackFramesOnCopy" IsCheckable="True" Click="ToggleDoNotCompressStackFramesOnCopy" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
                     <MenuItem Header="_Authentication">
                         <MenuItem Header="Use _Git Credential Manager" x:Name="Authentication_UseGitCredentialManager" IsChecked="{Binding Path=AuthenticationViewModel.IsGitCredentialManagerEnabled}" Command="{x:Static src:AuthenticationCommands.UseGitCredentialManager}" ToolTip="Use the Git Credential Manager to authenticate to GitHub and Azure DevOps."/>
                         <MenuItem Header="Use _Developer Identity for Azure DevOps"  x:Name="Authentication_UseManagedIdentityForAzureDevOps" IsChecked="{Binding Path=AuthenticationViewModel.IsDeveloperIdentityEnabled}" Command="{x:Static src:AuthenticationCommands.UseDeveloperIdentity}" ToolTip="Use Visual Studio or VS Code sign-in information to authenticate to Azure DevOps instances."/>
                         <MenuItem Header="Use Device _Code for GitHub" x:Name="Authentication_UseGitHubDeviceFlow" IsChecked="{Binding Path=AuthenticationViewModel.IsGitHubDeviceFlowEnabled}" Command="{x:Static src:AuthenticationCommands.UseGitHubDeviceFlow}" ToolTip="Use a device code to authenticate with GitHub."/>
                     </MenuItem>
+                    <MenuItem Header="Do not shorten frames copied from stack windows" x:Name="Option_DoNotCompressStackFramesOnCopy" IsCheckable="True" Click="ToggleDoNotCompressStackFramesOnCopy" ToolTip="When pasting stack frame lines copied from the Stack Viewer window, paste the full contents of each line instead of a minimized version." />
+                    <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
                     <MenuItem Header="Theme">
                         <MenuItem Header="Light" x:Name="Theme_Light" IsChecked="{Binding Path=ThemeViewModel.IsLightTheme}" Command="{x:Static src:ThemeViewModel.SetLightThemeCommand}"/>
                         <MenuItem Header="Dark" x:Name="Theme_Dark" IsChecked="{Binding Path=ThemeViewModel.IsDarkTheme}" Command="{x:Static src:ThemeViewModel.SetDarkThemeCommand}"/>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1194,6 +1194,16 @@ namespace PerfView
             PerfDataGrid.DoNotCompressStackFrames = newValue;
         }
 
+        public void ToggleExperimentalGCFeatures(object sender, RoutedEventArgs e)
+        {
+            bool currentValue;
+            bool.TryParse(App.UserConfigData["ExperimentalGCFeatures"], out currentValue);
+            bool newValue = !currentValue;
+            App.UserConfigData["ExperimentalGCFeatures"] = newValue.ToString();
+            Option_ExperimentalGCFeatures.IsChecked = newValue;
+            Stats.GcStats.EnableExperimentalFeatures = newValue;
+        }
+
         /// <summary>
         /// Set the left pane to the specified directory.  If it is a file name, then that file name is opened
         /// </summary>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1135,8 +1135,6 @@ namespace PerfView
                     App.UserConfigData["MainWindowTop"] = Top.ToString("f0", CultureInfo.InvariantCulture);
                     App.UserConfigData["MainWindowLeft"] = Left.ToString("f0", CultureInfo.InvariantCulture);
                 }
-
-                AppLog.LogUsage("Exiting");
             };
 
             // Initialize configuration options.
@@ -1580,14 +1578,6 @@ namespace PerfView
 
             System.Threading.ThreadPool.QueueUserWorkItem(delegate
             {
-                if (AppLog.s_IsUnderTest)
-                {
-                    return;
-                }
-
-                bool canSendFeedback = AppLog.CanSendFeedback;
-                AppLog.LogUsage("Start", DateTime.Now.ToString(), AppLog.BuildDate);
-
                 // If we have the PdbScope.exe file then we can enable the ImageFile capability
                 string pdbScopeFile = Path.Combine(PerfViewExtensibility.Extensions.ExtensionsDirectory, "PdbScope.exe");
                 bool pdbScopeExists = File.Exists(pdbScopeFile);
@@ -1597,14 +1587,6 @@ namespace PerfView
 
                 Dispatcher.BeginInvoke((Action)delegate ()
                 {
-                    if (canSendFeedback)
-                    {
-                        // FeedbackButton.Visibility = System.Windows.Visibility.Visible;
-
-                        // TODO Currently even the internal Wiki is now a broken link, so simply give up for now.
-                        // When we go open source we can use GitHub for this.
-                        // WikiButton.Visibility = System.Windows.Visibility.Visible;
-                    }
                     if (pdbScopeExists)
                     {
                         ImageSizeMenuItem.Visibility = System.Windows.Visibility.Visible;
@@ -1647,34 +1629,7 @@ namespace PerfView
             StatusBar.Log("Opening " + videoUrl);
             Command.Run(Command.Quote(videoUrl), new CommandOptions().AddStart().AddTimeout(CommandOptions.Infinite));
         }
-        private void DoFeedbackClick(object sender, RoutedEventArgs e)
-        {
-            if (AppLog.CanSendFeedback)
-            {
-                var feedbackDialog = new PerfView.Dialogs.FeedbackDialog(this, delegate (string message)
-                {
-                    if (string.IsNullOrWhiteSpace(message))
-                    {
-                        StatusBar.Log("No feedback provided, cancelling.");
-                        return;
-                    }
-                    if (AppLog.SendFeedback(message, false))
-                    {
-                        StatusBar.Log("Successfully appended to " + AppLog.FeedbackFilePath);
-                        StatusBar.Log("Feedback sent.");
-                    }
-                    else
-                    {
-                        StatusBar.LogError("Sorry, there was a problem sending feedback.");
-                    }
-                });
-                feedbackDialog.Show();
-            }
-            else
-            {
-                DisplayUsersGuide("Feedback");
-            }
-        }
+
         private void DoTakeHeapSnapshot(object sender, RoutedEventArgs e)
         {
             App.CommandLineArgs.ProcessDumpFile = null;
@@ -1733,7 +1688,7 @@ namespace PerfView
 
         private void DoAbout(object sender, RoutedEventArgs e)
         {
-            string versionString = "PerfView Version " + AppLog.VersionNumber + " \r\nBuildDate: " + AppLog.BuildDate;
+            string versionString = "PerfView Version " + AppInfo.VersionNumber + " \r\nBuildDate: " + AppInfo.BuildDate;
             MessageBox.Show(versionString, versionString);
         }
 
@@ -2085,11 +2040,6 @@ namespace PerfView
 
         private void Window_Closed(object sender, EventArgs e)
         {
-            if (AppLog.s_IsUnderTest)
-            {
-                return;
-            }
-
             if (App.CommandProcessor.CollectingData)
             {
                 DoAbort(null, null);

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -7393,7 +7393,7 @@ table {
                 advanced.Children.Add(new PerfViewStackSource(this, "Pinning At GC Time"));
             }
 
-            if (hasGCEvents && hasCPUStacks && AppLog.InternalUser)
+            if (hasGCEvents && hasCPUStacks)
             {
                 memory.Children.Add(new PerfViewStackSource(this, "Server GC"));
             }
@@ -7491,7 +7491,7 @@ table {
                 advanced.Children.Add(new PerfViewIisStats(this));
             }
 
-            if (hasProjectNExecutionTracingEvents && AppLog.InternalUser)
+            if (hasProjectNExecutionTracingEvents)
             {
                 advanced.Children.Add(new PerfViewStackSource(this, "Execution Tracing"));
             }
@@ -7542,7 +7542,7 @@ table {
                 m_Children.Add(ui);
             }
 
-            if (AppLog.InternalUser && 0 < experimental.Children.Count)
+            if (0 < experimental.Children.Count)
             {
                 m_Children.Add(experimental);
             }
@@ -8720,7 +8720,7 @@ table {
                 m_Children.Add(advanced);
             }
 
-            if(AppLog.InternalUser && experimental.Children.Count > 0)
+            if(experimental.Children.Count > 0)
             {
                 m_Children.Add(experimental);
             }


### PR DESCRIPTION
 - Remove InternalUser checks that gate functionality.
 - Remove old and unused internal feedback mechanism.
 - Alphabetize the `Options` menu.
 - Create a menu option for experimental GC features.

Note: There is no telemetry that PerfView or TraceEvent send back.  This is an old mechanism that hasn't been used for a long time.