### PR TITLE
Only Run CodeQL on PerfView_Debug Build Jobs

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -8,9 +8,6 @@ trigger:
 pr:
   - main
 
-variables:
-  Codeql.Enabled: true
-
 jobs:
   - job: PerfView_Debug
     pool:
@@ -19,6 +16,8 @@ jobs:
       demands:
       - msbuild
       - vstest
+    variables:
+      Codeql.Enabled: true
 
     steps:
     - task: UseDotNet@2


### PR DESCRIPTION
CodeQL currently runs on all jobs, which means that if the `PerfCollect` job wins, no code will be built, and no updates will be made to the CodeQL results for the repository.  Forcing the run to occur during `PerfView_Debug` ensures that PerfView and its dependencies get built during the CodeQL run.