### PR TITLE
TFM and Dependency Clean-Up

### DIFF
--- a/src/CSVReader/CSVReader.csproj
+++ b/src/CSVReader/CSVReader.csproj
@@ -19,7 +19,7 @@
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>StrongName</StrongName>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <!-- .NET Strong Name Signing -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,11 +30,51 @@
     <UtilitiesVersion>3.0.8</UtilitiesVersion>
   </PropertyGroup>
 
-  <!-- versions of dependencies that more than one project use -->
+  <!-- Support files and analyzers -->
   <PropertyGroup>
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.25</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>0.1.1</MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>
+  </PropertyGroup>
+
+  <!-- External dependencies -->
+  <PropertyGroup>
+    <AzureCoreVersion>1.24.0</AzureCoreVersion>
+    <AzureIdentityVersion>1.6.0</AzureIdentityVersion>
+    <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>
+    <MicrosoftNETCorePortableCompatibilityVersion>1.0.1</MicrosoftNETCorePortableCompatibilityVersion>
+    <MicrosoftIdentityClientVersion>4.39.0</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientExtensionsMsalVersion>2.19.3</MicrosoftIdentityClientExtensionsMsalVersion>
+    <MicrosoftIdentityModelTokensVersion>6.22.0</MicrosoftIdentityModelTokensVersion>
+    <MicrosoftIdentityModelJsonWebTokensVersion>6.22.0</MicrosoftIdentityModelJsonWebTokensVersion>
+    <MicrosoftSourceLinkGitHubVersion>1.1.1</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftWin32RegistryVersion>4.4.0</MicrosoftWin32RegistryVersion>
+    <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
+    <SystemCollectionsImmutableVersion>1.7.1</SystemCollectionsImmutableVersion>
+    <SystemDiagnosticsDiagnosticSourceVersion>4.6.0</SystemDiagnosticsDiagnosticSourceVersion>
+    <SystemDiagnosticsProcessVersion>4.3.0</SystemDiagnosticsProcessVersion>
+    <SystemDiagnosticsTraceSourceVersion>4.3.0</SystemDiagnosticsTraceSourceVersion>
+    <SystemIOCompressionVersion>4.3.0</SystemIOCompressionVersion>
+    <SystemIOUnmanagedMemoryStreamVersion>4.3.0</SystemIOUnmanagedMemoryStreamVersion>
+    <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
+    <SystemNetNameResolutionVersion>4.3.0</SystemNetNameResolutionVersion>
+    <SystemNetRequestsVersion>4.3.0</SystemNetRequestsVersion>
+    <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
+    <SystemReflectionMetadataVersion>1.8.1</SystemReflectionMetadataVersion>
+    <SystemReflectionTypeExtensionsVersion>4.3.0</SystemReflectionTypeExtensionsVersion>
+    <SystemRuntimeVersion>4.3.0</SystemRuntimeVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>5.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemRuntimeInteropServicesRuntimeInformationVersion></SystemRuntimeInteropServicesRuntimeInformationVersion>
+    <SystemSecurityCryptographyAlgorithmsVersion>4.3.0</SystemSecurityCryptographyAlgorithmsVersion>
+    <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
+    <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
+    <SystemThreadingTasksParallelVersion>4.3.0</SystemThreadingTasksParallelVersion>
+    <SystemThreadingThreadVersion>4.3.0</SystemThreadingThreadVersion>
+  </PropertyGroup>
+
+  <!-- ClrMD -->
+  <PropertyGroup>
     <MicrosoftDiagnosticsRuntimeVersion>2.3.405304</MicrosoftDiagnosticsRuntimeVersion>
     <!-- If we set MicrosoftDiagnosticsRuntimeVersion to 'local' instead of the version below, it will build PerfView with a locally built ClrMD. -->
     <!-- This particular path assume clrmd is cloned side-by-side with PerfView, feel free to change as needed. -->
@@ -42,9 +82,16 @@
     <MicrosoftDiagnosticsRuntimeVersion>local</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsRuntimePath>$(MSBuildThisFileDirectory)\..\..\clrmd\artifacts\bin\Microsoft.Diagnostics.Runtime\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.Runtime.dll</MicrosoftDiagnosticsRuntimePath>
     -->
-    <MicrosoftSourceLinkGitHubVersion>1.1.1</MicrosoftSourceLinkGitHubVersion>
+  </PropertyGroup>
+
+  <!-- Test dependencies -->
+  <PropertyGroup>
+    <MicrosoftVisualStudioThreadingVersion>15.3.23</MicrosoftVisualStudioThreadingVersion>
     <XunitVersion>2.4.0</XunitVersion>
+    <XunitExtensibilityCoreVersion>2.4.0</XunitExtensibilityCoreVersion>
+    <XunitExtensibilityExecutionVersion>2.4.0</XunitExtensibilityExecutionVersion>
     <XunitRunnerVisualstudioVersion>2.4.0</XunitRunnerVisualstudioVersion>
+    <XunitStaFactVersion>0.3.2</XunitStaFactVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/EtwClrProfilerSigning/EtwClrProfilerSigning.csproj
+++ b/src/EtwClrProfilerSigning/EtwClrProfilerSigning.csproj
@@ -28,7 +28,7 @@
     <FilesToSign Include="$(OutDir)\amd64\EtwClrProfiler.dll">
         <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EtwClrProfiler\ETWClrProfilerX64.vcxproj" />

--- a/src/EtwHeapDump/EtwHeapDump.csproj
+++ b/src/EtwHeapDump/EtwHeapDump.csproj
@@ -27,7 +27,7 @@
         <StrongName>StrongName</StrongName>
     </FilesToSign>
 
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MicrosoftDiagnosticsRuntimeVersion)' != 'local'">

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -16,15 +16,6 @@
     <InformationalVersion>$(FastSerializationVersion)</InformationalVersion>
   </PropertyGroup>
 
-  <Choose>
-    <When Condition="'$(TargetFramework)' == 'netstandard1.3'">
-      <ItemGroup>
-        <PackageReference Include="System.IO.MemoryMappedFiles" Version="4.3.0" />
-        <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-      </ItemGroup>
-    </When>
-  </Choose>
-
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);GROWABLEARRAY_PUBLIC;STREAMREADER_PUBLIC;FASTSERIALIZATION_PUBLIC</DefineConstants>
   </PropertyGroup>

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.FastSerialization</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.FastSerialization</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -31,7 +31,7 @@
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>StrongName</StrongName>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <!-- .NET Strong Name Signing -->

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -28,11 +28,6 @@
 
   <ItemGroup>
     <PackageReference Include="PerfView.SupportFiles" Version="$(PerfViewSupportFilesVersion)" PrivateAssets="all" />
-
-    <!-- These are required for ClrMD and are here so that we can embed the assemblies into PerfView. -->
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MicrosoftDiagnosticsRuntimeVersion)' != 'local'">
@@ -87,7 +82,7 @@
     <FilesToSign Include="$(TargetPath)">
         <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/HeapDumpDLL/HeapDumpDLL.csproj
+++ b/src/HeapDumpDLL/HeapDumpDLL.csproj
@@ -68,7 +68,7 @@
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>StrongName</StrongName>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <!-- .NET Strong Name Signing -->

--- a/src/MemoryGraph/MemoryGraph.csproj
+++ b/src/MemoryGraph/MemoryGraph.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.MemoryGraph</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.MemoryGraph</AssemblyName>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/MemoryGraph/MemoryGraph.csproj
+++ b/src/MemoryGraph/MemoryGraph.csproj
@@ -29,7 +29,7 @@
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>StrongName</StrongName>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <!-- .NET Strong Name Signing -->

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -21,12 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.23" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" PrivateAssets="all" />
-    <PackageReference Include="Xunit.StaFact" Version="0.3.2" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" />
+    <PackageReference Include="Xunit.StaFact" Version="$(XunitStaFactVersion)" />
+    <PackageReference Include="xunit.extensibility.core" Version="$(XunitExtensibilityCoreVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XunitExtensibilityExecutionVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -339,49 +339,56 @@
       <Link>PerfView.xml</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\TraceEvent\$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.dll">
+    <EmbeddedResource Include="$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Diagnostics.Tracing.TraceEvent.dll</LogicalName>
       <Link>Microsoft.Diagnostics.Tracing.TraceEvent.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\FastSerialization\$(OutDir)Microsoft.Diagnostics.FastSerialization.dll">
+    <EmbeddedResource Include="$(OutDir)Microsoft.Diagnostics.FastSerialization.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Diagnostics.FastSerialization.dll</LogicalName>
       <Link>Microsoft.Diagnostics.FastSerialization.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Runtime.InteropServices.RuntimeInformation.dll">
+    <EmbeddedResource Include="$(OutDir)Microsoft.Win32.Registry.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\Microsoft.Win32.Registry.dll</LogicalName>
+      <Link>Microsoft.Win32.Registry.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(OutDir)System.Runtime.InteropServices.RuntimeInformation.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Runtime.InteropServices.RuntimeInformation.dll</LogicalName>
       <Link>System.Runtime.InteropServices.RuntimeInformation.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Collections.Immutable.dll">
+    <EmbeddedResource Include="$(OutDir)System.Collections.Immutable.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Collections.Immutable.dll</LogicalName>
       <Link>System.Collections.Immutable.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Reflection.Metadata.dll">
+    <EmbeddedResource Include="$(OutDir)System.Reflection.Metadata.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Reflection.Metadata.dll</LogicalName>
       <Link>System.Reflection.Metadata.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\TraceEvent\$(OutDir)System.Runtime.CompilerServices.Unsafe.dll">
+    <EmbeddedResource Include="$(OutDir)System.Runtime.CompilerServices.Unsafe.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Runtime.CompilerServices.Unsafe.dll</LogicalName>
       <Link>System.Runtime.CompilerServices.Unsafe.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\TraceEvent\$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.xml">
+    <EmbeddedResource Include="$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.xml">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Diagnostics.Tracing.TraceEvent.xml</LogicalName>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -391,7 +391,7 @@
       <Link>Microsoft.Diagnostics.FastSerialization.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgMicrosoft_Win32_Registry)\lib\netstandard2.0\Microsoft.Win32.Registry.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_Win32_Registry)\lib\net461\Microsoft.Win32.Registry.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Win32.Registry.dll</LogicalName>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -55,12 +55,36 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.22.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" />
-    <PackageReference Include="PerfView.SupportFiles" Version="$(PerfViewSupportFilesVersion)" PrivateAssets="all" />
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.AutomatedAnalysis.Analyzers" Version="$(MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="$(MicrosoftIdentityClientExtensionsMsalVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelTokensVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="PerfView.SupportFiles" Version="$(PerfViewSupportFilesVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Numerics.Vectors" Version="$(SystemNumericsVectorsVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      TraceEvent dependencies that are packaged with PerfView
+
+      NOTE: These can be consumed as package references because PerfView will load TraceEvent directly.
+      HeapDump dependencies are pulled from the HeapDump output directory because HeapDump runs out of process
+      and can have a different set of dependencies.
+    -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" GeneratePathProperty="true" />
 
     <!-- *** SourceLink Support *** -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
@@ -139,6 +163,20 @@
     </None>
     <None Include="SupportFiles\Eula.rtf" />
   </ItemGroup>
+
+  <!-- Embed System.Runtime.InteropServices.RuntimeInformation.dll with a special target because it doesn't come from a package. -->
+  <Target Name="EmbedNetStandardCompatAssemblies" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition=" '%(ReferenceCopyLocalPaths.FileName)' == 'System.Runtime.InteropServices.RuntimeInformation' ">
+        <Type>Non-Resx</Type>
+        <WithCulture>false</WithCulture>
+        <LogicalName>.\System.Runtime.InteropServices.RuntimeInformation.dll</LogicalName>
+        <Link>System.Runtime.InteropServices.RuntimeInformation.dll</Link>
+        <Visible>False</Visible>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\x86\msdia140.dll">
       <Type>Non-Resx</Type>
@@ -254,21 +292,21 @@
       <Link>amd64\HeapDump.exe.config</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Buffers\4.5.1\lib\net461\System.Buffers.dll">
+    <EmbeddedResource Include="..\HeapDump\$(OutDir)\System.Buffers.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\HeapDump\System.Buffers.dll</LogicalName>
       <Link>HeapDump\System.Buffers.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Collections.Immutable\5.0.0\lib\net461\System.Collections.Immutable.dll">
+    <EmbeddedResource Include="..\HeapDump\$(OutDir)\System.Collections.Immutable.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\HeapDump\System.Collections.Immutable.dll</LogicalName>
       <Link>HeapDump\System.Collections.Immutable.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Memory\4.5.4\lib\net461\System.Memory.dll">
+    <EmbeddedResource Include="..\HeapDump\$(OutDir)\System.Memory.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\HeapDump\System.Memory.dll</LogicalName>
@@ -289,14 +327,14 @@
       <Link>HeapDump\System.Numerics.Vectors.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Reflection.Metadata\5.0.0\lib\net461\System.Reflection.Metadata.dll">
+    <EmbeddedResource Include="..\HeapDump\$(OutDir)\System.Reflection.Metadata.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\HeapDump\System.Reflection.Metadata.dll</LogicalName>
       <Link>HeapDump\System.Reflection.Metadata.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.ValueTuple\4.4.0\lib\net461\System.ValueTuple.dll">
+    <EmbeddedResource Include="..\HeapDump\$(OutDir)\System.ValueTuple.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\HeapDump\System.ValueTuple.dll</LogicalName>
@@ -339,56 +377,49 @@
       <Link>PerfView.xml</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.dll">
+    <EmbeddedResource Include="..\TraceEvent\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Diagnostics.Tracing.TraceEvent.dll</LogicalName>
       <Link>Microsoft.Diagnostics.Tracing.TraceEvent.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)Microsoft.Diagnostics.FastSerialization.dll">
+    <EmbeddedResource Include="..\FastSerialization\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.FastSerialization.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Diagnostics.FastSerialization.dll</LogicalName>
       <Link>Microsoft.Diagnostics.FastSerialization.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)Microsoft.Win32.Registry.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_Win32_Registry)\lib\netstandard2.0\Microsoft.Win32.Registry.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Win32.Registry.dll</LogicalName>
       <Link>Microsoft.Win32.Registry.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)System.Runtime.InteropServices.RuntimeInformation.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\System.Runtime.InteropServices.RuntimeInformation.dll</LogicalName>
-      <Link>System.Runtime.InteropServices.RuntimeInformation.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)System.Collections.Immutable.dll">
+    <EmbeddedResource Include="$(PkgSystem_Collections_Immutable)\lib\netstandard2.0\System.Collections.Immutable.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Collections.Immutable.dll</LogicalName>
       <Link>System.Collections.Immutable.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)System.Reflection.Metadata.dll">
+    <EmbeddedResource Include="$(PkgSystem_Reflection_Metadata)\lib\netstandard2.0\System.Reflection.Metadata.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Reflection.Metadata.dll</LogicalName>
       <Link>System.Reflection.Metadata.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)System.Runtime.CompilerServices.Unsafe.dll">
+    <EmbeddedResource Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Runtime.CompilerServices.Unsafe.dll</LogicalName>
       <Link>System.Runtime.CompilerServices.Unsafe.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(OutDir)Microsoft.Diagnostics.Tracing.TraceEvent.xml">
+    <EmbeddedResource Include="..\TraceEvent\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.xml">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Diagnostics.Tracing.TraceEvent.xml</LogicalName>
@@ -448,63 +479,63 @@
       <Link>Dia2Lib.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\Azure.Core\1.24.0\lib\net461\Azure.Core.dll">
+    <EmbeddedResource Include="$(PkgAzure_Core)\lib\net461\Azure.Core.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Azure.Core.dll</LogicalName>
       <Link>Azure.Core.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\Azure.Identity\1.6.0\lib\netstandard2.0\Azure.Identity.dll">
+    <EmbeddedResource Include="$(PkgAzure_Identity)\lib\netstandard2.0\Azure.Identity.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Azure.Identity.dll</LogicalName>
       <Link>Azure.Identity.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\Microsoft.Identity.Client\4.39.0\lib\net461\Microsoft.Identity.Client.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_Identity_Client)\lib\net461\Microsoft.Identity.Client.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Identity.Client.dll</LogicalName>
       <Link>Microsoft.Identity.Client.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\Microsoft.Identity.Client.Extensions.Msal\2.19.3\lib\net45\Microsoft.Identity.Client.Extensions.Msal.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_Identity_Client_Extensions_Msal)\lib\net45\Microsoft.Identity.Client.Extensions.Msal.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.Identity.Client.Extensions.Msal.dll</LogicalName>
       <Link>Microsoft.Identity.Client.Extensions.Msal.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\Microsoft.IdentityModel.JsonWebTokens\6.22.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_JsonWebTokens)\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.IdentityModel.JsonWebTokens.dll</LogicalName>
       <Link>Microsoft.IdentityModel.JsonWebTokens.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\Microsoft.IdentityModel.Tokens\6.22.0\lib\net461\Microsoft.IdentityModel.Tokens.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_Tokens)\lib\net461\Microsoft.IdentityModel.Tokens.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.IdentityModel.Tokens.dll</LogicalName>
       <Link>Microsoft.IdentityModel.Tokens.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Buffers\4.5.1\lib\net461\System.Buffers.dll">
+    <EmbeddedResource Include="$(PkgSystem_Buffers)\lib\net461\System.Buffers.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Buffers.dll</LogicalName>
       <Link>System.Buffers.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Diagnostics.DiagnosticSource\4.6.0\lib\net46\System.Diagnostics.DiagnosticSource.dll">
+    <EmbeddedResource Include="$(PkgSystem_Diagnostics_DiagnosticSource)\lib\net46\System.Diagnostics.DiagnosticSource.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Diagnostics.DiagnosticSource.dll</LogicalName>
       <Link>System.Diagnostics.DiagnosticSource.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Memory\4.5.4\lib\net461\System.Memory.dll">
+    <EmbeddedResource Include="$(PkgSystem_Memory)\lib\net461\System.Memory.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Memory.dll</LogicalName>
@@ -518,21 +549,21 @@
       <Link>System.Numerics.Vectors.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Text.Encodings.Web\4.7.2\lib\net461\System.Text.Encodings.Web.dll">
+    <EmbeddedResource Include="$(PkgSystem_Text_Encodings_Web)\lib\net461\System.Text.Encodings.Web.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Text.Encodings.Web.dll</LogicalName>
       <Link>System.Text.Encodings.Web.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Text.Json\4.7.2\lib\net461\System.Text.Json.dll">
+    <EmbeddedResource Include="$(PkgSystem_Text_Json)\lib\net461\System.Text.Json.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Text.Json.dll</LogicalName>
       <Link>System.Text.Json.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(NuGetPackageRoot)\System.Threading.Tasks.Extensions\4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll">
+    <EmbeddedResource Include="$(PkgSystem_Threading_Tasks_Extensions)\lib\net461\System.Threading.Tasks.Extensions.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Threading.Tasks.Extensions.dll</LogicalName>
@@ -679,7 +710,7 @@
     <FilesToSign Include="$(TargetPath)">
         <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/PerfView/SymbolReaderHttpHandler.cs
+++ b/src/PerfView/SymbolReaderHttpHandler.cs
@@ -40,7 +40,7 @@ namespace PerfView
         /// <summary>
         /// Construct a new <see cref="SymbolReaderHttpHandler"/> instance.
         /// </summary>
-        public SymbolReaderHttpHandler() : base(new HttpClientHandler())
+        public SymbolReaderHttpHandler() : base(new HttpClientHandler() { CheckCertificateRevocationList = true })
         {
         }
 

--- a/src/TraceEvent/AutomatedAnalysis/DirectoryAnalyzerResolver.cs
+++ b/src/TraceEvent/AutomatedAnalysis/DirectoryAnalyzerResolver.cs
@@ -1,5 +1,4 @@
-﻿#if NET462 || NETSTANDARD2_0
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 
 namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
@@ -44,4 +43,3 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         }
     }
 }
-#endif

--- a/src/TraceEvent/BPerf/BPerfEventSource.cs
+++ b/src/TraceEvent/BPerf/BPerfEventSource.cs
@@ -428,11 +428,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 long length = fs.Length;
 
-#if NET462
-                using (var mmapedFile = MemoryMappedFile.CreateFromFile(fs, null, length, MemoryMappedFileAccess.Read, null, HandleInheritability.None, true))
-#else
                 using (var mmapedFile = MemoryMappedFile.CreateFromFile(fs, null, length, MemoryMappedFileAccess.Read, HandleInheritability.None, true))
-#endif
                 {
                     var accessor = mmapedFile.CreateViewAccessor(0, length, MemoryMappedFileAccess.Read);
                     byte* ptr = (byte*)0;

--- a/src/TraceEvent/Compatibility.cs
+++ b/src/TraceEvent/Compatibility.cs
@@ -5,48 +5,13 @@ using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.Tracing.Compatibility
 {
-#if NETSTANDARD1_6
-
-    // Design based on Core CLR 2.0.0
-    public class ApplicationException : Exception
-    {
-        internal const int COR_E_APPLICATION = unchecked((int)0x80131600);
-
-        public ApplicationException()
-            : base("Error in the application.")
-        {
-            HResult = COR_E_APPLICATION;
-        }
-
-        public ApplicationException(String message)
-            : base(message)
-        {
-            HResult = COR_E_APPLICATION;
-        }
-
-        public ApplicationException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-            HResult = COR_E_APPLICATION;
-        }
-    }    
-#endif
-
     internal static class Extentions
     {
         public static IntPtr GetHandle(this Process process)
         {
-#if NETSTANDARD1_6
-            return process.SafeHandle.DangerousGetHandle();
-#else
             return process.Handle;
-#endif
         }
 
-#if NET462
-        public static StringDictionary GetEnvironment(this ProcessStartInfo startInfo) => startInfo.EnvironmentVariables;
-#else
         public static IDictionary<string, string> GetEnvironment(this ProcessStartInfo startInfo) => startInfo.Environment;
-#endif
     }
 }

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -642,13 +642,8 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 return 8;
             }
-#if !NETSTANDARD1_6
+
             bool is64bitOS = Environment.Is64BitOperatingSystem;
-#else
-            // Sadly this API does not work properly on V4.7.1 of the Desktop framework.   See https://github.com/Microsoft/perfview/issues/478 for more.  
-            // However with this partial fix, (works on everything not NetSTandard, and only in 32 bit processes), that we can wait for the fix.
-            bool is64bitOS = (RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.Arm64);
-#endif
             return is64bitOS ? 8 : 4;
         }
 

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -29,12 +29,6 @@
     <tags>TraceEvent EventSource Microsoft ETW Event Tracing for Windows</tags>
 
     <dependencies>
-      <group targetFramework=".NETFramework4.6.2">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
-      </group>
-      <group targetFramework=".NETStandard1.6">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
-      </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
       </group>
@@ -79,36 +73,6 @@
     <!-- Support Dlls -->
     <file src="$OutDir$netstandard2.0\Dia2Lib.dll" target="lib\netstandard2.0" />
     <file src="$OutDir$netstandard2.0\TraceReloggerLib.dll" target="lib\netstandard2.0" />
-
-    <!-- NetStandard 1.6 Framework -->
-	
-    <!-- Built libraries -->
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\netstandard1.6" />
-
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.FastSerialization.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.FastSerialization.xml" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\netstandard1.6" />
-
-    <!-- Support Dlls -->
-    <file src="$OutDir$netstandard1.6\Dia2Lib.dll" target="lib\netstandard1.6" />
-    <file src="$OutDir$netstandard1.6\TraceReloggerLib.dll" target="lib\netstandard1.6" />
-
-    <!-- NET 4.5 Framework -->
-
-    <!-- Built libraries -->
-    <file src="$OutDir$net462\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\net462" />
-    <file src="$OutDir$net462\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\net462" />
-    <file src="$OutDir$net462\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\net462" />
-
-    <file src="$OutDir$net462\Microsoft.Diagnostics.FastSerialization.dll" target="lib\net462" />
-    <file src="$OutDir$net462\Microsoft.Diagnostics.FastSerialization.xml" target="lib\net462" />
-    <file src="$OutDir$net462\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\net462" />
-
-    <!-- Support Dlls -->
-    <file src="$OutDir$net462\Dia2Lib.dll" target="lib\net462" />
-    <file src="$OutDir$net462\TraceReloggerLib.dll" target="lib\net462" />
 
     <!-- Source code (All Frameworks *) -->
     <file exclude="obj\**\*.cs;bin\**\*.cs;TraceEvent.Tests\**\*.cs;Ctf\CtfTracing.Tests\**\*.cs" src="**\*.cs" target="src" />

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -77,30 +77,14 @@
       <Visible>False</Visible>
     </None>
 
-    <!-- There are no static references to these so I need to copy them explicitly.  
-         The first two COM interop assemblies so they are the same for all targets, I pick netstandard1.6 pretty arbitraily 
-         OSExtensions is also the same for all targets.  It needs to be copied for the dev-time case since in that case it runs the DLLs from the .nuget cache
-         by default, and OSExtensions needs to be in the right relative location with respect to the native DLLs (since it loads them via relative path).   
-      -->
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\TraceReloggerLib.dll">
+    <!-- There are no static references to these so they need to be copied explicitly.  They are COM interop assemblies so they are the same for all targets. -->
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard2.0\TraceReloggerLib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\TraceReloggerLib.dll">
       <Link>TraceReloggerLib.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\Dia2Lib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\Dia2Lib.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Dia2Lib.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Dia2Lib.dll">
       <Link>Dia2Lib.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-
-	<!-- you have to pick the right version of this DLL because it depends on things besides System.Runtime.dll -->
-    <None Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\netstandard1.6\OSExtensions.dll">
-      <Link>OSExtensions.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND Exists('$(MSBuildThisFileDirectory)..\lib\net462\OSExtensions.dll')" Include="$(MSBuildThisFileDirectory)..\lib\net462\OSExtensions.dll">
-      <Link>OSExtensions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>

--- a/src/TraceEvent/Stacks/RecursionGuard.cs
+++ b/src/TraceEvent/Stacks/RecursionGuard.cs
@@ -38,11 +38,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (numResets > RecursionGuardConfiguration.MaxResets)
             {
-#if NETSTANDARD1_6
-                throw new Exception("Stack Overflow");
-#else 
                 throw new StackOverflowException();
-#endif
             }
             _currentThreadRecursionDepth = (ushort)currentThreadRecursionDepth;
             _resetCount = (ushort)numResets;

--- a/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
+++ b/src/TraceEvent/Stacks/StackSourceWriterHelper.cs
@@ -232,16 +232,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         {
             if (!escapedNames.TryGetValue(name, out string escaped))
             {
-#if NETSTANDARD1_6 || DEBUG // the Debug check allows us to test this code path for other TFMs
-                // System.Web.HttpUtility.JavaScriptStringEncode is not part of the .NET Standard 1.6
-                // but it's part of .NET 4.0+. So we just use reflection to invoke it.
-                escaped = escapedNames[name] = (string)Type
-                    .GetType("System.Web.HttpUtility, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
-                    .GetMethod("JavaScriptStringEncode", new Type[1] { typeof(string) })
-                    .Invoke(null, new object[] { name });
-#elif NETSTANDARD2_0 || NET462
                 escaped = escapedNames[name] = System.Web.HttpUtility.JavaScriptStringEncode(name);
-#endif
             }
 
             return escaped;

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -28,11 +28,9 @@ namespace Microsoft.Diagnostics.Symbols
         public SymbolReader(TextWriter log, string nt_symbol_path = null, DelegatingHandler httpClientDelegatingHandler = null)
         {
             m_log = log;
-#if SYNC_SYMBOLREADER_LOG
             // Make sure that accesses to the log are synchronized to avoid races due to the fact that System.Diagnostics.Process
             // uses AsyncStreamReader to read from the stdout/stderr and so it's possible to have concurrent writes to this log.
             m_log = TextWriter.Synchronized(log);
-#endif
             m_symbolModuleCache = new Cache<string, ManagedSymbolModule>(10);
             m_pdbPathCache = new Cache<PdbSignature, string>(10);
 

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" PrivateAssets="all" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Include="System.IO.Compression" Version="$(SystemIOCompressionVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -10,9 +10,7 @@ using Microsoft.Diagnostics.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-#if !NETSTANDARD1_6
 using System.Dynamic;
-#endif
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -594,13 +592,11 @@ namespace Microsoft.Diagnostics.Tracing
     /// </para>
     /// </summary>
     public abstract unsafe class TraceEvent
-#if !NETSTANDARD1_6
         // To support DLR access of dynamic payload data ("((dynamic) myEvent).MyPayloadName"),
         // we derive from DynamicObject and override a couple of methods. If for some reason in
         // the future we wanted to derive from a different base class, we could also accomplish
         // this by implementing the IDynamicMetaObjectProvider interface instead.
         : DynamicObject
-#endif
     {
         /// <summary>
         /// The GUID that uniquely identifies the Provider for this event.  This can return Guid.Empty for classic (Pre-VISTA) ETW providers.  
@@ -999,7 +995,6 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
-#if !NETSTANDARD1_6
         // These overloads allow integration with the DLR (Dynamic Language Runtime). That
         // enables getting at payload data in a more convenient fashion, directly by name.
         // In PowerShell, it "just works" (e.g. "$myEvent.MyPayload" will just work); in
@@ -1016,8 +1011,6 @@ namespace Microsoft.Diagnostics.Tracing
             result = PayloadByName(binder.Name);
             return result != null;
         }
-#endif
-
 
         // Getting at payload values.  
         /// <summary>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -40,26 +40,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="$(MicrosoftNETCorePortableCompatibilityVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemDiagnosticsTraceSourceVersion)" />
+    <PackageReference Include="System.IO.Compression" Version="$(SystemIOCompressionVersion)" />
+    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="$(SystemIOUnmanagedMemoryStreamVersion)" />
+    <PackageReference Include="System.Net.Requests" Version="$(SystemNetRequestsVersion)" />
+    <PackageReference Include="System.Net.NameResolution" Version="$(SystemNetNameResolutionVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="$(SystemReflectionTypeExtensionsVersion)" />
+    <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(SystemSecurityCryptographyAlgorithmsVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemThreadingTasksParallelVersion)" />
+    <PackageReference Include="System.Threading.Thread" Version="$(SystemThreadingThreadVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.8.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-
     <!-- *** SourceLink Support *** -->
   <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
   </ItemGroup>
@@ -192,7 +191,7 @@
 
   <!-- ******************* Signing Support *********************** -->
   <ItemGroup>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackageSpec)'==''">

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk"> 
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -43,7 +43,7 @@
     Unconditional use of PackageReference would work if we targeted net462, but the reference APIs do not include
     support for net462 targets. Work around the issue by using conditional references.
   -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
@@ -57,16 +57,6 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
-    <DefineConstants>$(DefineConstants);SYNC_SYMBOLREADER_LOG</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
@@ -200,7 +190,7 @@
          We work around it here by copying the files explicitly. 
 	 We don't have version for 2.0 so we use the 1.6 versions.  -->
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6'">
+  <ItemGroup>
     <None Include="$(TraceEventSupportFilesBase)\netstandard1.6\Dia2Lib.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -39,10 +39,6 @@
     <NoWarn>$(NoWarn),0649,0618</NoWarn>
   </PropertyGroup>
 
-  <!--
-    Unconditional use of PackageReference would work if we targeted net462, but the reference APIs do not include
-    support for net462 targets. Work around the issue by using conditional references.
-  -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
@@ -182,13 +178,6 @@
     <None Include="EventPipe\EventSerialization.md" />
     <None Include="EventPipe\NetPerfFormat.md" />
   </ItemGroup>
-
-    <!-- *********************************************************** -->
-    <!-- Copying three managed binaries explicitly should not be needed because the 
-         dependency logic should just do it for us, but for some reason ths only
-         works for the net462 target framework and not the netstandard1.6.  and netstanard2.0 
-         We work around it here by copying the files explicitly. 
-	 We don't have version for 2.0 so we use the 1.6 versions.  -->
 
   <ItemGroup>
     <None Include="$(TraceEventSupportFilesBase)\netstandard1.6\Dia2Lib.dll">

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -93,11 +93,6 @@
     <Compile Remove="Samples/**/*.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <Compile Remove="Utilities/FastStream.cs" />
-    <Compile Remove="Stacks/Linux/*.cs" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="$(TraceEventSupportFilesBase)native\amd64\KernelTraceControl.dll">
       <Link>amd64\KernelTraceControl.dll</Link>

--- a/src/TraceEvent/Utilities/command.cs
+++ b/src/TraceEvent/Utilities/command.cs
@@ -445,28 +445,22 @@ namespace Microsoft.Diagnostics.Utilities
 
             if (options.elevate)
             {
-#if NETSTANDARD1_6
-                throw new NotImplementedException("Launching elevated processes is not implemented when TraceEvent is built for NetStandard 1.6");
-#else
                 options.useShellExecute = true;
                 startInfo.Verb = "runas";
                 if (options.currentDirectory == null)
                 {
                     options.currentDirectory = Directory.GetCurrentDirectory();
                 }
-#endif
             }
 
             startInfo.CreateNoWindow = options.noWindow;
             if (options.useShellExecute)
             {
                 startInfo.UseShellExecute = true;
-#if ! NETSTANDARD1_6
                 if (options.noWindow)
                 {
                     startInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 }
-#endif
             }
             else
             {
@@ -478,10 +472,8 @@ namespace Microsoft.Diagnostics.Utilities
                 startInfo.UseShellExecute = false;
                 startInfo.RedirectStandardError = true;
                 startInfo.RedirectStandardOutput = true;
-#if ! NETSTANDARD1_6
                 startInfo.ErrorDialog = false;
                 startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-#endif
                 startInfo.CreateNoWindow = true;
 
                 process.OutputDataReceived += new DataReceivedEventHandler(OnProcessOutput);

--- a/src/TraceEvent/ZippedETL.cs
+++ b/src/TraceEvent/ZippedETL.cs
@@ -112,12 +112,10 @@ namespace Microsoft.Diagnostics.Tracing
             FileUtilities.ForceDelete(newFileName);
             try
             {
-#if !NETSTANDARD1_6
                 if (LowPriority)
                 {
                     Thread.CurrentThread.Priority = ThreadPriority.Lowest;
                 }
-#endif
                 Log.WriteLine("[Zipping ETL file {0}]", m_etlFilePath);
                 using (var zipArchive = ZipFile.Open(newFileName, ZipArchiveMode.Create))
                 {
@@ -186,9 +184,7 @@ namespace Microsoft.Diagnostics.Tracing
             }
             finally
             {
-#if !NETSTANDARD1_6
                 Thread.CurrentThread.Priority = ThreadPriority.Normal;
-#endif
                 FileUtilities.ForceDelete(newFileName);
             }
             return success;
@@ -282,12 +278,10 @@ namespace Microsoft.Diagnostics.Tracing
                     if (Merge)
                     {
                         var startTime = DateTime.UtcNow;
-#if !NETSTANDARD1_6
                         if (LowPriority)
                         {
                             Thread.CurrentThread.Priority = ThreadPriority.Lowest;
                         }
-#endif
                         try
                         {
                             Log.WriteLine("Starting Merging of {0}", m_etlFilePath);
@@ -308,9 +302,7 @@ namespace Microsoft.Diagnostics.Tracing
                         }
                         finally
                         {
-#if !NETSTANDARD1_6
                             Thread.CurrentThread.Priority = ThreadPriority.Normal;
-#endif
                         }
                     }
                     else
@@ -331,12 +323,10 @@ namespace Microsoft.Diagnostics.Tracing
                 {
                     if (NGenSymbolFiles)
                     {
-#if !NETSTANDARD1_6
                         if (LowPriority)
                         {
                             Thread.CurrentThread.Priority = ThreadPriority.Lowest;
                         }
-#endif
                         try
                         {
                             var startTime = DateTime.UtcNow;
@@ -352,9 +342,7 @@ namespace Microsoft.Diagnostics.Tracing
                         }
                         finally
                         {
-#if !NETSTANDARD1_6
                             Thread.CurrentThread.Priority = ThreadPriority.Normal;
-#endif
                         }
                     }
                     else

--- a/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
+++ b/src/TraceEventPackageSigning/TraceEventPackageSigning.csproj
@@ -23,7 +23,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/TraceParserGen/TraceParserGen.csproj
+++ b/src/TraceParserGen/TraceParserGen.csproj
@@ -20,7 +20,7 @@
     <FilesToSign Include="$(TargetPath)">
         <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Utilities/Utilities.csproj
+++ b/src/Utilities/Utilities.csproj
@@ -28,7 +28,7 @@
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>StrongName</StrongName>
     </FilesToSign>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
   </ItemGroup>
 
   <!-- .NET Strong Name Signing -->


### PR DESCRIPTION
This work is inspired by and builds off of #1808.  Thanks @kant2002!

 - Standardizes libraries to build only for netstandard2.0.
 - Attempts to rationalize dependency management between PerfView and TraceEvent and to depend to NuGet path properties instead of the manual construction of the path to the NuGet package.
 - Removes unnecessary code for building TraceEvent against netstandard1.6 and net462.
 - Includes a change to enable online certificate revocation checking in `SymbolReaderHttpHandler` which couldn't be implemented on all of the TFMs prior to this change.