### PR TITLE
Set Codeql.BuildIdentifier

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -18,6 +18,7 @@ jobs:
       - vstest
     variables:
       Codeql.Enabled: true
+      Codeql.BuildIdentifier: PerfView
 
     steps:
     - task: UseDotNet@2


### PR DESCRIPTION
Disambiguates the build of code in this repo vs. code that is only present in the internal repo.