### PR TITLE
Overwite the generated PerfView.exe.config with a custom config file

### DIFF
--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -105,6 +105,15 @@
     <Copy SourceFiles="@(AutomatedAnalysisAnalyzers)" DestinationFolder="$(TargetDir)Analyzers" />
   </Target>
 
+  <!--
+    Overwrite the generated app.config with our custom app.config.
+    This is necessary to overwrite the binding redirects that get generated incorrectly.
+    We also don't want to carry the many app-local dependencies, and will instead depend on the in-box .NET Framework versions.
+  -->
+  <Target Name="OverwriteAppConfig" AfterTargets="Build">
+    <Copy SourceFiles="app.config" DestinationFiles="$(TargetDir)\PerfView.exe.config" />
+  </Target>
+
   <ItemGroup>
     <Compile Include="..\heapDump\GCHeapDump.cs">
       <Link>memory\GCHeapDump.cs</Link>


### PR DESCRIPTION
Fixes #1828

MSBuild generates a number of binding redirects that end up loading many app-local versions of dependencies that are available in-box on .NET Framework.  This is unintentional, and furthermore, PerfView doesn't carry most of these dependencies, which means that they aren't present in the released version of PerfView.  This explains why recent executions of PerfView in the bin directory fail with a PlatformNotSupportedException when enabling online certificate revocation checks.  The app-local copy of System.Net.Http.dll is being loaded, which does not contain support for online certificate revocation checks.  The in-box copy of System.Net.Http.dll does contain this capability.

Remove these binding redirects by replacing the generated PerfView.exe.config file with one that only contains the configuration that we want.  By doing this, PerfView will load in-box dependencies instead of app-local versions that are only present in the bin directory after build.

This makes executions of PerfView in the build bin directory closer to executions of PerfView that unpack dependencies into %appdir% and then run PerfView from there.