### PR TITLE
Automated Analysis Improvements

### DIFF
--- a/src/TraceEvent/AutomatedAnalysis/AutomatedAnalysisTraceLog.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AutomatedAnalysisTraceLog.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
 
         internal SymbolReader SymbolReader { get; }
 
+        internal HashSet<ModuleFileIndex> ResolvedModules { get; set; } = new HashSet<ModuleFileIndex>();
+
         IEnumerable<Process> ITrace.Processes
         {
             get
@@ -63,7 +65,7 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
             if (traceProcess != null)
             {
                 StackSource stackSource = UnderlyingSource.CPUStacks(traceProcess);
-                stackView = new StackView(traceProcess.Log, stackSource, traceProcess.ProcessIndex, SymbolReader);
+                stackView = new StackView(this, stackSource, traceProcess.ProcessIndex, SymbolReader);
             }
             return stackView;
         }
@@ -79,7 +81,7 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
                     _blockedTimeStacks = UnderlyingSource.BlockedTimeStacks(SymbolReader);
                 }
 
-                stackView = new StackView(traceProcess.Log, _blockedTimeStacks, traceProcess.ProcessIndex, SymbolReader,
+                stackView = new StackView(this, _blockedTimeStacks, traceProcess.ProcessIndex, SymbolReader,
                     (stackSource, processIndex) =>
                     {
                         return new FilterStackSource(

--- a/src/TraceEvent/AutomatedAnalysis/AutomatedAnalysisTraceLog.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AutomatedAnalysisTraceLog.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Diagnostics.Tracing.StackSources;
 using Microsoft.Diagnostics.Symbols;
 using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.Stacks;
@@ -10,6 +11,8 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
     /// </summary>
     public sealed class AutomatedAnalysisTraceLog : ITrace
     {
+        private MutableTraceEventStackSource _blockedTimeStacks;
+
         /// <summary>
         /// Create a new instance for the specified TraceLog and SymbolReader.
         /// </summary>
@@ -41,9 +44,13 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
 
         StackView ITrace.GetStacks(Process process, string stackType)
         {
-            if(StackTypes.CPU.Equals(stackType))
+            if (StackTypes.CPU.Equals(stackType))
             {
                 return GetCPUStacks(process);
+            }
+            else if (StackTypes.Blocked.Equals(stackType))
+            {
+                return GetBlockedTimeStacks(process);
             }
 
             return null;
@@ -56,7 +63,33 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
             if (traceProcess != null)
             {
                 StackSource stackSource = UnderlyingSource.CPUStacks(traceProcess);
-                stackView = new StackView(traceProcess.Log, stackSource, SymbolReader);
+                stackView = new StackView(traceProcess.Log, stackSource, traceProcess.ProcessIndex, SymbolReader);
+            }
+            return stackView;
+        }
+
+        private StackView GetBlockedTimeStacks(Process process)
+        {
+            StackView stackView = null;
+            TraceProcess traceProcess = UnderlyingSource.Processes[(ProcessIndex)process.UniqueID];
+            if (traceProcess != null)
+            {
+                if (_blockedTimeStacks == null)
+                {
+                    _blockedTimeStacks = UnderlyingSource.BlockedTimeStacks(SymbolReader);
+                }
+
+                stackView = new StackView(traceProcess.Log, _blockedTimeStacks, traceProcess.ProcessIndex, SymbolReader,
+                    (stackSource, processIndex) =>
+                    {
+                        return new FilterStackSource(
+                            new FilterParams()
+                            {
+                                IncludeRegExs = $"Process% {traceProcess.Name} ({traceProcess.ProcessID})"
+                            },
+                            stackSource,
+                            ScalingPolicyKind.ScaleToData);
+                    });
             }
             return stackView;
         }

--- a/src/TraceEvent/AutomatedAnalysis/ITrace.cs
+++ b/src/TraceEvent/AutomatedAnalysis/ITrace.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         /// Stacks representing execution on one or more CPUs.
         /// </summary>
         public static string CPU { get; } = "CPU";
+
+        /// <summary>
+        /// Stacks representing time spent on threads but not executing on CPUs.
+        /// </summary>
+        public static string Blocked { get; } = "Blocked";
     }
 
     /// <summary>

--- a/src/TraceEvent/AutomatedAnalysis/ProcessContext.cs
+++ b/src/TraceEvent/AutomatedAnalysis/ProcessContext.cs
@@ -6,6 +6,7 @@
     public sealed class ProcessContext
     {
         private StackView _cpuStacks;
+        private StackView _blockedTimeStacks;
         private AnalyzerExecutionContext _executionContext;
 
         internal ProcessContext(AnalyzerExecutionContext executionContext, Process process)
@@ -31,6 +32,21 @@
                     _cpuStacks = _executionContext.Trace.GetStacks(Process, StackTypes.CPU);
                 }
                 return _cpuStacks;
+            }
+        }
+
+        /// <summary>
+        /// The blocked time stacks for the process being analyzed.
+        /// </summary>
+        public StackView BlockedTimeStacks
+        {
+            get
+            {
+                if (_blockedTimeStacks == null)
+                {
+                    _blockedTimeStacks = _executionContext.Trace.GetStacks(Process, StackTypes.Blocked);
+                }
+                return _blockedTimeStacks;
             }
         }
 


### PR DESCRIPTION
 - Change `StackView.FindNodeByName` behavior to do exact name matches instead of `Regex` name matches.
 - Add support to automated analysis and `AutomatedAnalysisTraceLog` for accessing blocked time stacks.
 - Fix symbol resolution to account for the process being examined.
 - Ensure that all images matching the requested name get resolved, rather than just the first in the trace file.
 - Limit accessible methods on `StackView` to avoid cases where symbols don't get properly resolved.
 - Add caching for symbol resolution in `StackView` to avoid calling into symbol resolution code more often than necessary.