### PR TITLE
Dispose cached PDBs properly

### DIFF
--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Symbols
     /// simply implement Windows PDBS here.   This can be factored out of this class when we 
     /// support other formats (e.g. Dwarf).
     /// 
-    /// To implmente support for Windows PDBs we use the Debug Interface Access (DIA).  See 
+    /// To implement support for Windows PDBs we use the Debug Interface Access (DIA).  See 
     /// http://msdn.microsoft.com/library/x93ctkx8.aspx for more.   I have only exposed what
     /// I need, and the interface is quite large (and not super pretty).  
     /// </summary>
@@ -158,6 +158,7 @@ namespace Microsoft.Diagnostics.Symbols
                     ret = GetAssemblyNameFromModuleIndex(mergedAssembliesMap, int.MaxValue, String.Empty) + ret;
                 }
             }
+
             return ret;
         }
 
@@ -173,6 +174,7 @@ namespace Microsoft.Diagnostics.Symbols
                 }
                 catch (Exception) { } // Catch all AssemblyName fails with ' in the name.   
             }
+
             return defaultValue;
         }
 
@@ -192,7 +194,7 @@ namespace Microsoft.Diagnostics.Symbols
         /// This overload of SourceLocationForRva like the one that takes only an RVA will return a source location
         /// if it can.   However this version has additional support for NGEN images.   In the case of NGEN images 
         /// for .NET V4.6.1 or later), the NGEN images can't convert all the way back to a source location, but they 
-        /// can convert the RVA back to IL artifacts (ilAssemblyName, methodMetadataToken, iloffset).  THese can then
+        /// can convert the RVA back to IL artifacts (ilAssemblyName, methodMetadataToken, iloffset).  These can then
         /// be used to look up the source line using the IL PDB.  
         /// 
         /// Thus if the return value from this is null, check to see if the ilAssemblyName is non-null, and if not 
@@ -766,14 +768,14 @@ namespace Microsoft.Diagnostics.Symbols
 
             /// <summary>
             /// Parse the 'srcsrv' stream in a PDB file and return the target for SourceFile
-            /// represented by the 'this' pointer.   This target is iether a ULR or a local file
+            /// represented by the 'this' pointer.   This target is either a ULR or a local file
             /// path.  
             /// 
             /// You can dump the srcsrv stream using a tool called pdbstr 
             ///     pdbstr -r -s:srcsrv -p:PDBPATH
             /// 
             /// The target in this stream is called SRCSRVTRG and there is another variable SRCSRVCMD
-            /// which represents the command to run to fetch the soruce into SRCSRVTRG
+            /// which represents the command to run to fetch the source into SRCSRVTRG
             /// 
             /// To form the target, the stream expect you to private a %targ% variable which is a directory
             /// prefix to tell where to put the source file being fetched.   If the source file is
@@ -810,7 +812,7 @@ namespace Microsoft.Diagnostics.Symbols
             ///  SRCSRVCMD=
             ///  SRCSRVVERCTRL=http
             ///  SRCSRV: source files ---------------------------------------
-            ///  c:\Users\rafalkrynski\Documents\Visual Studio 2012\Projects\DavidSymbolSourceTest\DavidSymbolSourceTest\Demo.cs*SQPvxWBMtvANyCp8Pd3OjoZEUgpKvjDVIY1WbaiFPMw=
+            ///  c:\Users\dev\Documents\Visual Studio 2012\Projects\DavidSymbolSourceTest\DavidSymbolSourceTest\Demo.cs*SQPvxWBMtvANyCp8Pd3OjoZEUgpKvjDVIY1WbaiFPMw=
             ///  SRCSRV: end ------------------------------------------------
             ///  
             /// </summary>
@@ -818,7 +820,7 @@ namespace Microsoft.Diagnostics.Symbols
             /// <param name="command">returns the command to fetch the target source file</param>
             /// <param name="localDirectoryToPlaceSourceFiles">Specify the value for %targ% variable. This is the
             /// directory where source files can be fetched to.  Typically the returned file is under this directory
-            /// If the value is null, %targ% variable be emtpy.  This assumes that the resulting file is something
+            /// If the value is null, %targ% variable be empty.  This assumes that the resulting file is something
             /// that does not need to be copied to the machine (either a URL or a file that already exists)</param>
             private void GetSourceServerTargetAndCommand(out string target, out string command, string localDirectoryToPlaceSourceFiles = null)
             {
@@ -1098,7 +1100,7 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
         {
             ThrowIfDisposed();
 
-            // In order to get the IDiaDataSource3 which includes'getStreamSize' API, you need to use the 
+            // In order to get the IDiaDataSource3 which includes 'getStreamSize' API, you need to use the 
             // dia2_internal.idl file from devdiv to produce the Interop.Dia2Lib.dll 
             // see class DiaLoader for more
             var log = m_reader.m_log;
@@ -1329,7 +1331,18 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
             return buf;
         }
 
+        ~NativeSymbolModule()
+        {
+            Dispose(disposing: false);
+        }
+
         public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
         {
             if (!m_isDisposed)
             {
@@ -1782,7 +1795,7 @@ namespace Dia2Lib
     /// It has one public method 'GetDiaSourceObject' which knows how to create a IDiaDataSource object. 
     /// From there you can do anything you need.  
     /// 
-    /// In order to get IDiaDataSource3 which includes'getStreamSize' API, you need to use the 
+    /// In order to get IDiaDataSource3 which includes 'getStreamSize' API, you need to use the 
     /// vctools\langapi\idl\dia2_internal.idl file from devdiv to produce Dia2Lib.dll
     /// 
     /// roughly what you need to do is 

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -369,25 +369,36 @@ namespace Microsoft.Diagnostics.Symbols
         {
             if (!m_symbolModuleCache.TryGet(pdbFilePath, out ManagedSymbolModule ret))
             {
-                Stream stream = File.Open(pdbFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-                byte[] firstBytes = new byte[4];
-                if (stream.Read(firstBytes, 0, firstBytes.Length) != 4)
+                FileStream stream = File.Open(pdbFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                try
                 {
-                    throw new InvalidOperationException("PDB corrupted (too small) " + pdbFilePath);
+                    byte[] firstBytes = new byte[4];
+                    if (stream.Read(firstBytes, 0, firstBytes.Length) != 4)
+                    {
+                        throw new InvalidOperationException("PDB corrupted (too small) " + pdbFilePath);
+                    }
+
+                    if (firstBytes[0] == 'B' && firstBytes[1] == 'S' && firstBytes[2] == 'J' && firstBytes[3] == 'B')
+                    {
+                        stream.Seek(0, SeekOrigin.Begin);   // Start over
+                        ret = new PortableSymbolModule(this, stream, pdbFilePath);
+                    }
+                    else
+                    {
+                        stream.Dispose();
+                        stream = null;
+                        ret = new NativeSymbolModule(this, pdbFilePath);
+                    }
+                }
+                catch
+                {
+                    stream?.Dispose();
+                    throw;
                 }
 
-                if (firstBytes[0] == 'B' && firstBytes[1] == 'S' && firstBytes[2] == 'J' && firstBytes[3] == 'B')
-                {
-                    stream.Seek(0, SeekOrigin.Begin);   // Start over
-                    ret = new PortableSymbolModule(this, stream, pdbFilePath);
-                }
-                else
-                {
-                    stream.Dispose();
-                    ret = new NativeSymbolModule(this, pdbFilePath);
-                }
                 m_symbolModuleCache.Add(pdbFilePath, ret);
             }
+
             return ret;
         }
 
@@ -485,7 +496,7 @@ namespace Microsoft.Diagnostics.Symbols
             {
                 _Options = value;
                 m_pdbPathCache.Clear();
-                m_log.WriteLine("Setting SYmbolReaderOptions forces clearing Pdb lookup cache");
+                m_log.WriteLine("Setting SymbolReaderOptions forces clearing Pdb lookup cache");
             }
         }
         private SymbolReaderOptions _Options;
@@ -734,7 +745,7 @@ namespace Microsoft.Diagnostics.Symbols
         }
 
         /// <summary>
-        /// Given a NGEN (or ReadyToRun) imge 'ngenImageFullPath' and the PDB path
+        /// Given a NGEN (or ReadyToRun) image 'ngenImageFullPath' and the PDB path
         /// that we WANT it to generate generate the PDB.  Returns either pdbPath 
         /// on success or null on failure.  
         /// 
@@ -1003,7 +1014,7 @@ namespace Microsoft.Diagnostics.Symbols
         }
 
         /// <summary>
-        /// Fetches a file from the server 'serverPath' with pdb signature path 'pdbSigPath' (concatinate them with a / or \ separator
+        /// Fetches a file from the server 'serverPath' with pdb signature path 'pdbSigPath' (concatenate them with a / or \ separator
         /// to form a complete URL or path name).   It will place the file in 'fullDestPath'   It will return true if successful
         /// If 'contentTypeFilter is present, this predicate is called with the URL content type (e.g. application/octet-stream)
         /// and if it returns false, it fails.   This ensures that things that are the wrong content type (e.g. redirects to 
@@ -1014,7 +1025,7 @@ namespace Microsoft.Diagnostics.Symbols
         /// <param name="serverPath">path to server (e.g. \\symbols\symbols or http://symweb) </param>
         /// <param name="pdbIndexPath">pdb path with signature (e.g clr.pdb/1E18F3E494DC464B943EA90F23E256432/clr.pdb)</param>
         /// <param name="fullDestPath">the full path of where to put the file locally </param>
-        /// <param name="contentTypeFilter">if present this allows you to filter out urls that dont match this ContentType.</param>
+        /// <param name="contentTypeFilter">if present this allows you to filter out URLs that don't match this ContentType.</param>
         internal bool GetPhysicalFileFromServer(string serverPath, string pdbIndexPath, string fullDestPath, Predicate<string> contentTypeFilter = null)
         {
             if (File.Exists(fullDestPath))
@@ -1343,12 +1354,12 @@ namespace Microsoft.Diagnostics.Symbols
             {
                 // Decompress it
                 m_log.WriteLine("FindSymbolFilePath: Expanding {0} to {1}", compressedFilePath, targetPath);
-                var commandline = "Expand " + Command.Quote(compressedFilePath) + " " + Command.Quote(targetPath);
+                var commandLine = "Expand " + Command.Quote(compressedFilePath) + " " + Command.Quote(targetPath);
                 var options = new CommandOptions().AddNoThrow();
-                var command = Command.Run(commandline, options);
+                var command = Command.Run(commandLine, options);
                 if (command.ExitCode != 0)
                 {
-                    m_log.WriteLine("FindSymbolFilePath: Failure executing: {0}", commandline);
+                    m_log.WriteLine("FindSymbolFilePath: Failure executing: {0}", commandLine);
                     return null;
                 }
                 File.Delete(compressedFilePath);
@@ -1606,7 +1617,7 @@ namespace Microsoft.Diagnostics.Symbols
     /// <summary>
     /// A SymbolModule represents a file that contains symbolic information 
     /// (a Windows PDB or Portable PDB).  This is the interface that is independent 
-    /// of what kind of symbolic file format you use.  Becase portable PDBs only
+    /// of what kind of symbolic file format you use.  Because portable PDBs only
     /// support managed code, this shared interface is by necessity the interface
     /// for managed code only (currently only Windows PDBs support native code).  
     /// </summary>
@@ -1643,7 +1654,7 @@ namespace Microsoft.Diagnostics.Symbols
         public abstract SourceLocation SourceLocationForManagedCode(uint methodMetadataToken, int ilOffset);
 
         /// <summary>
-        /// If the symbol file format supports SourceLink JSON this routine should be overriden
+        /// If the symbol file format supports SourceLink JSON this routine should be overridden
         /// to return it.  
         /// </summary>
         protected virtual IEnumerable<string> GetSourceLinkJson() { return Enumerable.Empty<string>(); }
@@ -2074,7 +2085,7 @@ namespace Microsoft.Diagnostics.Symbols
                 return true;
             }
 
-            // If we don't match but we have nothinging better, remember it.   Otherwise do nothing as first hit is better.  
+            // If we don't match but we have nothing better, remember it.   Otherwise do nothing as first hit is better.  
             if (_filePath == null)
             {
                 _filePath = filePath;
@@ -2090,7 +2101,7 @@ namespace Microsoft.Diagnostics.Symbols
         }
 
         /// <summary>
-        /// Returns true if 'filePath' matches the checksum OR we don't have a checkdum
+        /// Returns true if 'filePath' matches the checksum OR we don't have a checksum
         /// (thus if we pass what validity check we have).    
         /// </summary>
         private bool ComputeChecksumMatch(string filePath)
@@ -2242,7 +2253,7 @@ namespace Microsoft.Diagnostics.Symbols
                     }
                     catch (EndOfStreamException)
                     {
-                        // We succesfully normalized the entire file.
+                        // We successfully normalized the entire file.
                         // Grab remaining bytes in the case that the file does not end
                         // with a line ending character.
                         AppendLine();


### PR DESCRIPTION
The main fix here is in Utlities\Cache.cs to call Dispose when evicting an entry from the cache (see the new call to ClearEntry from within GetFreeEntry)

In addition, add a finalizer to NativeSymbolModule so that we don't leak native IDiaSource COM objects which hold PDB files open on disk.