### PR TITLE
Enable pdb file name extractions for Windows file names when running on Linux.

### DIFF
--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -182,13 +182,13 @@ namespace Microsoft.Diagnostics.Symbols
             }
 
             string pdbIndexPath = null;
-            string pdbSimpleName = Path.GetFileName(pdbFileName);        // Make sure the simple name is really a simple name
+            string pdbSimpleName = PathUtil.GetPlatformIndependentFileName(pdbFileName);        // Make sure the simple name is really a simple name
 
             // If we have a dllPath, look right beside it, or in a directory symbols.pri\retail\dll
             if (pdbPath == null && dllFilePath != null)        // Check next to the file. 
             {
                 m_log.WriteLine("FindSymbolFilePath: Checking relative to DLL path {0}", dllFilePath);
-                string pdbPathCandidate = Path.Combine(Path.GetDirectoryName(dllFilePath), Path.GetFileName(pdbFileName));
+                string pdbPathCandidate = Path.Combine(Path.GetDirectoryName(dllFilePath), PathUtil.GetPlatformIndependentFileName(pdbFileName));
                 if (PdbMatches(pdbPathCandidate, pdbIndexGuid, pdbIndexAge))
                 {
                     pdbPath = pdbPathCandidate;


### PR DESCRIPTION
If a .NET app is built on Windows, then deployed on Linux, the pdb path will have Windows path separators. On Unix, `Path.GetFileName` will not consider '\\' as a path separator and will fail to extract the file name.
The change adds a new utility method: `PathUtil.GetPlatformIndependentFileName` that, when running on non-Windows platforms, will check to see if the path contains any '\\' separators and return only the string after the last separator. `SymbolReader.FindSymbolFilePath` will use this new method to get the pdb file name.