### PR TITLE
Don't Require CtfStream to Come Before CtfEvents in Metadata Document

### DIFF
--- a/src/TraceEvent/Ctf/CtfMetadata.cs
+++ b/src/TraceEvent/Ctf/CtfMetadata.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Tracing.Ctf
         {
             Dictionary<string, CtfMetadataType> typeAlias = new Dictionary<string, CtfMetadataType>();
             List<CtfStream> streams = new List<CtfStream>();
+            List<CtfEvent> events = new List<CtfEvent>();
 
             foreach (CtfMetadataDeclaration entry in parser.Parse())
             {
@@ -64,13 +65,21 @@ namespace Microsoft.Diagnostics.Tracing.Ctf
 
                     case CtfDeclarationTypes.Event:
                         CtfEvent evt = new CtfEvent(entry.Properties);
-                        streams[evt.Stream].AddEvent(evt);
+                        events.Add(evt);
                         break;
 
                     default:
                         Debug.Fail("Unknown metadata entry type.");
                         break;
                 }
+            }
+
+            // Add events to the corresponding streams after parsing the entire metadata document.
+            // This handles the case where a stream element gets written out after one or more
+            // event elements that reference it.
+            foreach (CtfEvent evt in events)
+            {
+                streams[evt.Stream].AddEvent(evt);
             }
 
             Streams = streams.ToArray();


### PR DESCRIPTION
The current implementation of CtfParser requires that a CtfStream element must be written to the metadata document before any CtfEvent elements that reference it.  Newer versions of LTTng are creating metadata documents where the referenced stream element is written to the document after one or more events reference it.

Relax this ordering requirement in CtfParser.