### PR TITLE
TraceEvent: produce a portable pdb during build

### DIFF
--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -37,6 +37,7 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);COMMAND_PUBLIC;PEFILE_PUBLIC;PERFVIEW;SUPPORT_V1_V2;CONTAINER_WORKAROUND_NOT_NEEDED</DefineConstants>
     <NoWarn>$(NoWarn),0649,0618</NoWarn>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since TraceEvent is a netstandard2.0 library that could also be used on Linux, it would be nice if debugging with symbols also works so I'm proposing changing the pdb format to portable.