### PR TITLE
Only Include Arch-Specific DLLs for RID-Specific Builds That Reference TraceEvent

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -1,77 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.dll') And ('$(ProcessorArchitecture)' == 'x86' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.dll">
       <Link>x86\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.Win61.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.Win61.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.Win61.dll') And ('$(ProcessorArchitecture)' == 'x86' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\KernelTraceControl.Win61.dll">
       <Link>x86\KernelTraceControl.Win61.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\msdia140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\msdia140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\msdia140.dll') And ('$(ProcessorArchitecture)' == 'x86' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\msdia140.dll">
       <Link>x86\msdia140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\msvcp140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\msvcp140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\msvcp140.dll') And ('$(ProcessorArchitecture)' == 'x86' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\msvcp140.dll">
       <Link>x86\msvcp140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\vcruntime140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\vcruntime140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\vcruntime140.dll') And ('$(ProcessorArchitecture)' == 'x86' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\vcruntime140.dll">
       <Link>x86\vcruntime140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\KernelTraceControl.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\KernelTraceControl.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\KernelTraceControl.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\KernelTraceControl.dll">
       <Link>amd64\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\msdia140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\msdia140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\msdia140.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\msdia140.dll">
       <Link>amd64\msdia140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\msvcp140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\msvcp140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\msvcp140.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\msvcp140.dll">
       <Link>amd64\msvcp140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140.dll">
       <Link>amd64\vcruntime140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140_1.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140_1.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140_1.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140_1.dll">
       <Link>amd64\vcruntime140_1.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\KernelTraceControl.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\KernelTraceControl.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\KernelTraceControl.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\KernelTraceControl.dll">
       <Link>arm64\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\msdia140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\msdia140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\msdia140.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\msdia140.dll">
       <Link>arm64\msdia140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\msvcp140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\msvcp140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\msvcp140.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\msvcp140.dll">
       <Link>arm64\msvcp140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140.dll">
       <Link>arm64\vcruntime140.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140_1.dll')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140_1.dll">
+    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140_1.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140_1.dll">
       <Link>arm64\vcruntime140_1.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>


### PR DESCRIPTION
Today when a RID-specific build of TraceEvent is done, all of the native DLLs for all architectures are included in the output.  This means that there are several DLLs that are never needed.  Worse, in the case of single-file builds, those DLLs are included in the final image, which results in a larger binary with no benefit.

Change the behavior so that when a RID-specific build is done, only the needed native DLLs are included.