### PR TITLE
Fix PDBCache Merge From DiagSession to Local SymCache

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -813,20 +813,6 @@ namespace PerfView
                         symPath.Insert("SRV*" + wprSymDir);
                     }
 
-                    // Some diagsession files have a PDBCache directory.
-                    // The file is named something like D1_1<hash>_sc.etl
-                    // The corresponding PDBCache directory is named D1_1_<hash>_PDBCache
-                    string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(etlFilePath);
-                    if (fileNameWithoutExtension.EndsWith("_sc"))
-                    {
-                        fileNameWithoutExtension = fileNameWithoutExtension.Substring(0, fileNameWithoutExtension.Length - 3);
-                        wprSymDir = Path.Combine(filePathDir, $"{fileNameWithoutExtension}_PDBCache");
-                        if (Directory.Exists(wprSymDir))
-                        {
-                            symPath.Insert("SRV*" + wprSymDir);
-                        }
-                    }
-
                     if (!string.IsNullOrWhiteSpace(sourcePath))
                     {
                         sourcePath += ";";

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -10046,22 +10046,20 @@ table {
                     {
                         // The directories contained in the symbol cache resource _are_ in the symbol cache format
                         // which means directories are in the form of /<file.ext>/<hash>/file.ext so in this case
-                        // we use the GetFileName API since it will consider the dictory name a file name.
+                        // we use the GetFileName API since it will consider the directory name a file name.
                         var targetDir = Path.Combine(symbolCachePath, Path.GetFileName(subPath));
 
-                        if (!Directory.Exists(targetDir))
+                        // The directory exists, so we must merge the two cache directories
+                        foreach (var symbolVersionDir in Directory.EnumerateDirectories(subPath))
                         {
-                            Directory.Move(subPath, targetDir);
-                        }
-                        else
-                        {
-                            // The directory exists, so we must merge the two cache directories
-                            foreach (var symbolVersionDir in Directory.EnumerateDirectories(subPath))
+                            var targetVersionDir = Path.Combine(targetDir, Path.GetFileName(symbolVersionDir));
+                            if (!Directory.Exists(targetVersionDir))
                             {
-                                var targetVersionDir = Path.Combine(targetDir, Path.GetFileName(symbolVersionDir));
-                                if (!Directory.Exists(targetVersionDir))
+                                Directory.CreateDirectory(targetVersionDir);
+                                foreach (var symbolFilePath in Directory.EnumerateFiles(symbolVersionDir))
                                 {
-                                    Directory.Move(symbolVersionDir, targetVersionDir);
+                                    string targetFilePath = Path.Combine(targetVersionDir, Path.GetFileName(symbolFilePath));
+                                    File.Move(symbolFilePath, Path.Combine(symbolFilePath, targetFilePath));
                                 }
                             }
                         }


### PR DESCRIPTION
@pharring pointed out that there was already code in PerfView to merge the DiagSession's PDBCache into the local SymCache, such that the SymbolPath shouldn't need to point at the extracted PDBCache.  In looking at this further, the merge was failing because `Directory.Move` cannot move across volumes.  I have updated this code to enumerate the files and move them individually.

This PR also reverts #1846.