### PR TITLE
Add Additional Configuration Events to Minimal Rundown

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3526,7 +3526,8 @@ namespace PerfView
                         // - Runtime/Start event
                         // - TieredCompilation
                         var rundownKeywords = ClrRundownTraceEventParser.Keywords.ForceEndRundown |
-                            ClrRundownTraceEventParser.Keywords.Compilation;
+                            ClrRundownTraceEventParser.Keywords.Compilation |
+                            ClrRundownTraceEventParser.Keywords.GC;
 
                         // Only consider forcing suppression of these keywords if full rundown is enabled.
                         if (!parsedArgs.NoRundown && !parsedArgs.NoClrRundown)

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3521,7 +3521,12 @@ namespace PerfView
                         // to get the runtime start event.  For minimal rundown, just enabling ForceEndRundown
                         // should be enough to get the rundown event for both .NET Framework and .NET Core
                         // without going down any expensive rundown codepaths.
-                        var rundownKeywords = ClrRundownTraceEventParser.Keywords.ForceEndRundown;
+
+                        // Minimal rundown includes:
+                        // - Runtime/Start event
+                        // - TieredCompilation
+                        var rundownKeywords = ClrRundownTraceEventParser.Keywords.ForceEndRundown |
+                            ClrRundownTraceEventParser.Keywords.Compilation;
 
                         // Only consider forcing suppression of these keywords if full rundown is enabled.
                         if (!parsedArgs.NoRundown && !parsedArgs.NoClrRundown)


### PR DESCRIPTION
Allow minimal rundown to collect the following events:
 - Microsoft-Windows-DotNETRuntimeRundown/TieredCompilationRundown/SettingsDCStart
 - Microsoft-Windows-DotNETRuntimeRundown/GC/SettingsRundown

Both of these events are emitted once per process and provide useful configuration information for the runtime.

Fixes #1831.
cc: @Maoni0, @brandonh-msft 