### PR TITLE
Don't refresh UI if filter combo boxes are unchanged

### DIFF
--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -247,6 +247,12 @@ namespace PerfView
                 return;
             }
 
+            // if no filters have changed, quick out
+            if (m_lastSetStackSourceFilter != null && Filter.Equals(m_lastSetStackSourceFilter))
+            {
+                return;
+            }
+
             // Synchronize the sample rate if the source supports it.  
             // TODO - Currently nothing uses sampling.  USE OR REMOVE 
             if (newSource.SamplingRate == null)
@@ -463,6 +469,9 @@ namespace PerfView
                     onComplete?.Invoke();
                 });
             });
+
+            // record to throttle calls if no UI changes
+            m_lastSetStackSourceFilter = new FilterParams(Filter);
         }
 
         // The 'Just My App' pattern depends on the directory of the EXE and thus has to be fixed up to be the
@@ -4214,6 +4223,7 @@ namespace PerfView
 
         // Keep track of the parameters we have already seeen. 
         private List<FilterParams> m_history;
+        private FilterParams m_lastSetStackSourceFilter;
         private int m_historyPos;
         private bool m_settingFromHistory;      // true if the filter parameters are being udpated from the history list
         private bool m_fixedUpJustMyCode;

--- a/src/TraceEvent/Stacks/FilterStacks.cs
+++ b/src/TraceEvent/Stacks/FilterStacks.cs
@@ -148,8 +148,13 @@ namespace Diagnostics.Tracing.StackSources
                 return false;
             }
 
-            return StartTimeRelativeMSec == asFilterParams.StartTimeRelativeMSec &&
-                EndTimeRelativeMSec == asFilterParams.EndTimeRelativeMSec &&
+            return
+                Double.TryParse(StartTimeRelativeMSec, out double dblStartTimeRelativeMSec) &&
+                Double.TryParse(asFilterParams.StartTimeRelativeMSec, out double dblFilterParamsStartTimeRelativeMSec) &&
+                dblStartTimeRelativeMSec == dblFilterParamsStartTimeRelativeMSec &&
+                Double.TryParse(EndTimeRelativeMSec, out double dblEndTimeRelativeMSec) &&
+                Double.TryParse(asFilterParams.EndTimeRelativeMSec, out double dblFilterParamsEndTimeRelativeMSec) &&
+                dblEndTimeRelativeMSec == dblFilterParamsEndTimeRelativeMSec &&
                 MinInclusiveTimePercent == asFilterParams.MinInclusiveTimePercent &&
                 FoldRegExs == asFilterParams.FoldRegExs &&
                 IncludeRegExs == asFilterParams.IncludeRegExs &&
@@ -157,6 +162,7 @@ namespace Diagnostics.Tracing.StackSources
                 GroupRegExs == asFilterParams.GroupRegExs &&
                 Scenarios == asFilterParams.Scenarios;
         }
+
         /// <summary>
         ///  override
         /// </summary>


### PR DESCRIPTION
https://github.com/microsoft/perfview/issues/783
- Record last used Filter in field
- Account for start/end time switching 0 based precision (e.g. 0 -> 0.000 are string != but double ==)

No automated tests created, only manual tests executed