### PR TITLE
Don't Enable All CLR Keywords in DotNetVersionLogger 

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2991,7 +2991,7 @@ namespace PerfView
 
             if (parsedArgs.DisableDotNetVersionLogging)
             {
-                cmdLineArgs += " /DisableVersionLogging";
+                cmdLineArgs += " /DisableDotNetVersionLogging";
             }
 
             if (parsedArgs.ContinueOnError)

--- a/src/PerfView/DotNetVersionLogger.cs
+++ b/src/PerfView/DotNetVersionLogger.cs
@@ -44,7 +44,7 @@ namespace PerfView
                     _session.EnableProvider(
                         ClrTraceEventParser.ProviderGuid,
                         TraceEventLevel.Always,
-                        (ulong)TraceEventKeyword.None,
+                        0x8000000000000000UL,
                         new TraceEventProviderOptions() { EventIDsToEnable = new List<int> { 187 } });
 
                     _session.Source.Clr.RuntimeStart += OnRuntimeInformationStartEvent;


### PR DESCRIPTION
The `DotNetVersionLogger` was inadvertently enabling all keywords `(0)` which resulted in very verbose traces.  This is especially true for processes that start during tracing, which will then enable logging of all allocations.