### PR TITLE
Revert "Don't refresh UI if filter combo boxes are unchanged"

### DIFF
--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -247,12 +247,6 @@ namespace PerfView
                 return;
             }
 
-            // if no filters have changed, quick out
-            if (m_lastSetStackSourceFilter != null && Filter.Equals(m_lastSetStackSourceFilter))
-            {
-                return;
-            }
-
             // Synchronize the sample rate if the source supports it.  
             // TODO - Currently nothing uses sampling.  USE OR REMOVE 
             if (newSource.SamplingRate == null)
@@ -469,9 +463,6 @@ namespace PerfView
                     onComplete?.Invoke();
                 });
             });
-
-            // record to throttle calls if no UI changes
-            m_lastSetStackSourceFilter = new FilterParams(Filter);
         }
 
         // The 'Just My App' pattern depends on the directory of the EXE and thus has to be fixed up to be the
@@ -4223,7 +4214,6 @@ namespace PerfView
 
         // Keep track of the parameters we have already seeen. 
         private List<FilterParams> m_history;
-        private FilterParams m_lastSetStackSourceFilter;
         private int m_historyPos;
         private bool m_settingFromHistory;      // true if the filter parameters are being udpated from the history list
         private bool m_fixedUpJustMyCode;

--- a/src/TraceEvent/Stacks/FilterStacks.cs
+++ b/src/TraceEvent/Stacks/FilterStacks.cs
@@ -148,13 +148,8 @@ namespace Diagnostics.Tracing.StackSources
                 return false;
             }
 
-            return
-                Double.TryParse(StartTimeRelativeMSec, out double dblStartTimeRelativeMSec) &&
-                Double.TryParse(asFilterParams.StartTimeRelativeMSec, out double dblFilterParamsStartTimeRelativeMSec) &&
-                dblStartTimeRelativeMSec == dblFilterParamsStartTimeRelativeMSec &&
-                Double.TryParse(EndTimeRelativeMSec, out double dblEndTimeRelativeMSec) &&
-                Double.TryParse(asFilterParams.EndTimeRelativeMSec, out double dblFilterParamsEndTimeRelativeMSec) &&
-                dblEndTimeRelativeMSec == dblFilterParamsEndTimeRelativeMSec &&
+            return StartTimeRelativeMSec == asFilterParams.StartTimeRelativeMSec &&
+                EndTimeRelativeMSec == asFilterParams.EndTimeRelativeMSec &&
                 MinInclusiveTimePercent == asFilterParams.MinInclusiveTimePercent &&
                 FoldRegExs == asFilterParams.FoldRegExs &&
                 IncludeRegExs == asFilterParams.IncludeRegExs &&
@@ -162,7 +157,6 @@ namespace Diagnostics.Tracing.StackSources
                 GroupRegExs == asFilterParams.GroupRegExs &&
                 Scenarios == asFilterParams.Scenarios;
         }
-
         /// <summary>
         ///  override
         /// </summary>


### PR DESCRIPTION
This reverts commit 56d152818ac155c647ce0acdfbc751611665a3b2.

Reverting this commit because it breaks symbol resolution.  When symbols are resolved, the UI does not refresh because nothing in the filter has changed.  I looked briefly at what it would take to fix this, but it was not immediately obvious to me.  I'm happy to re-consider a PR with this functionality that fixes symbol resolution.  We should also see if there are other operations that require a refresh.

cc: kkostrzewa