### PR TITLE
Fix malformed XML documentation in TraceEventSession.cs

### DIFF
--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -581,11 +581,11 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// <summary>
         /// Enable the kernel provider for the session. Before windows 8 this session must be called 'NT Kernel Session'.   
         /// This API is OK to call from one thread while Process() is being run on another
+        /// </summary>
         /// <param name="flags">Specifies the particular kernel events of interest</param>
         /// <param name="stackCapture">
         /// Specifies which events should have their stack traces captured when an event is logged</param>
         /// <returns>Returns true if the session existed before and was restarted (see TraceEventSession)</returns>
-        /// </summary>
         public unsafe bool EnableKernelProvider(KernelTraceEventParser.Keywords flags, KernelTraceEventParser.Keywords stackCapture = KernelTraceEventParser.Keywords.None)
         {
             // Setting stack capture implies that it is on.  
@@ -1386,7 +1386,6 @@ namespace Microsoft.Diagnostics.Tracing.Session
         /// Creating a TraceEventSession does not actually interact with the operating system until a
         /// provider is enabled. At that point the session is considered active (OS state that survives a
         /// process exit has been modified). IsActive returns true if the session is active. 
-        /// 
         /// </summary>
         public bool IsActive
         {
@@ -3121,7 +3120,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
     /// cause any session with the kernel PMCProfile keyword active to start emitting
     /// PMCCounterProf events for each ProfileSouce that is enabled.  
     /// </para>
-    /// /// </summary>
+    /// </summary>
     public static class TraceEventProfileSources
     {
         /// <summary>


### PR DESCRIPTION
While working with a `TraceEventSession` session, I pressed F12 on the `EnableKernelProvider()` method to see what exactly it did.  The documentation that was displayed to me above the decompiled method was a bunch of sentences without periods that had been mushed together into a giant paragraph that didn't make a lot of sense.  Inspection of the source code here revealed that the closing `</summary>` tag accidentally got placed after the parameter documentation (instead of before it).

This change fixes the malformed XML documentation, and fixes a couple other spots in the file as well while we're at it.