### PR TITLE
Fix Bugs in Linux Perf Script Traces

### DIFF
--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptStackSource.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Diagnostics.Tracing.Stacks;
+using Microsoft.Diagnostics.Tracing.Stacks.Linux;
 using Microsoft.Diagnostics.Tracing.Utilities;
 using System;
 using System.Collections.Concurrent;
@@ -230,7 +231,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
 
             for (int i = 0; i < analyzers.Count; i++)
             {
-                var endingStates = analyzers[i].EndingStates;
+                var endingStates = analyzers[i].ThreadStateComputer.EndingStates;
 
                 if (i < analyzers.Count - 1)
                 {
@@ -239,11 +240,11 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                     {
                         for (int j = i + 1; j < analyzers.Count; j++)
                         {
-                            var beginningStates = analyzers[j].BeginningStates;
+                            var beginningStates = analyzers[j].ThreadStateComputer.BeginningStates;
 
                             if (beginningStates.ContainsKey(threadId))
                             {
-                                var afterEvent = beginningStates[threadId].Value;
+                                var afterEvent = beginningStates[threadId].Event;
                                 analyzers[i].UpdateThreadState(afterEvent);
 
                                 break;
@@ -514,8 +515,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
     public class BlockedTimeAnalyzer
     {
         public double TimeStamp { get; private set; }
-        public Dictionary<int, KeyValuePair<LinuxThreadState, LinuxEvent>> BeginningStates { get; }
-        public Dictionary<int, KeyValuePair<LinuxThreadState, LinuxEvent>> EndingStates { get; }
+        internal LinuxPerfScriptThreadStateComputer ThreadStateComputer { get; }
         public Dictionary<LinuxEvent, LinuxPerfScriptStackSourceSample> LinuxEventSamples { get; }
         public Dictionary<int, LinuxEvent> LastCpuUsage { get; }
         public List<ThreadPeriod> BlockedThreadPeriods { get; }
@@ -537,8 +537,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
 
         public BlockedTimeAnalyzer(LinuxPerfScriptStackSource stackSource)
         {
-            BeginningStates = new Dictionary<int, KeyValuePair<LinuxThreadState, LinuxEvent>>();
-            EndingStates = new Dictionary<int, KeyValuePair<LinuxThreadState, LinuxEvent>>();
+            ThreadStateComputer = new LinuxPerfScriptThreadStateComputer();
             LinuxEventSamples = new Dictionary<LinuxEvent, LinuxPerfScriptStackSourceSample>();
             LastCpuUsage = new Dictionary<int, LinuxEvent>();
             BlockedThreadPeriods = new List<ThreadPeriod>();
@@ -552,14 +551,7 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                 TimeStamp = linuxEvent.TimeMSec;
             }
 
-            if (!BeginningStates.ContainsKey(linuxEvent.ThreadID))
-            {
-                BeginningStates.Add(
-                    linuxEvent.ThreadID,
-                    new KeyValuePair<LinuxThreadState, LinuxEvent>(LinuxThreadState.CPU_TIME, linuxEvent));
-
-                EndingStates[linuxEvent.ThreadID] = BeginningStates[linuxEvent.ThreadID];
-            }
+            ThreadStateComputer.PrimeThreadState(linuxEvent);
 
             DoMetrics(linuxEvent);
         }
@@ -571,7 +563,8 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
 
         public bool IsThreadBlocked(int threadId)
         {
-            return EndingStates.ContainsKey(threadId) && EndingStates[threadId].Key == LinuxThreadState.BLOCKED_TIME;
+            LinuxPerfScriptThreadState threadState = ThreadStateComputer.GetEndingStateState(threadId);
+            return threadState != null && threadState.ThreadState == LinuxThreadState.BLOCKED_TIME;
         }
 
         public void FinishAnalyzing(double endTime)
@@ -587,66 +580,69 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
 
         public void FlushBlockedThreadsAt(double endTime)
         {
-            foreach (int threadid in EndingStates.Keys)
+            IReadOnlyDictionary<int, LinuxPerfScriptThreadState> endingStates = ThreadStateComputer.EndingStates;
+
+            foreach (int threadid in endingStates.Keys)
             {
-                if (EndingStates[threadid].Key == LinuxThreadState.BLOCKED_TIME)
+                if (endingStates[threadid].ThreadState == LinuxThreadState.BLOCKED_TIME)
                 {
-                    KeyValuePair<LinuxThreadState, LinuxEvent> sampleInfo = EndingStates[threadid];
-                    sampleInfo.Value.Period = TimeStamp - sampleInfo.Value.TimeMSec;
-                    AddThreadPeriod(threadid, sampleInfo.Value.TimeMSec, TimeStamp);
-                    StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Value, this));
+                    LinuxPerfScriptThreadState sampleInfo = endingStates[threadid];
+                    sampleInfo.Event.Period = TimeStamp - sampleInfo.Event.TimeMSec;
+                    AddThreadPeriod(threadid, sampleInfo.Event.TimeMSec, TimeStamp);
+                    StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Event, this));
                 }
             }
         }
 
         private void DoMetrics(LinuxEvent linuxEvent)
         {
-            KeyValuePair<LinuxThreadState, LinuxEvent> sampleInfo;
-
             // This is check for completed scheduler events, ones that start with prev_comm and have 
             //   corresponding next_comm.
             if (linuxEvent.Kind == EventKind.Scheduler)
             {
                 SchedulerEvent schedEvent = (SchedulerEvent)linuxEvent;
-                if (EndingStates.ContainsKey(schedEvent.Switch.PreviousThreadID) &&
-                    EndingStates[schedEvent.Switch.PreviousThreadID].Key == LinuxThreadState.CPU_TIME) // Blocking
+                LinuxPerfScriptThreadState previousThreadState = ThreadStateComputer.GetEndingStateState(schedEvent.Switch.PreviousThreadID);
+                if (previousThreadState != null &&
+                    previousThreadState.ThreadState == LinuxThreadState.CPU_TIME) // Blocking
                 {
                     // PreviousThreadID is now blocking.  linuxEvent contains its blocking stack, so save it here.
                     // When it unblocks (becomes NextThreadID below, we'll log a sample for it.)
-                    EndingStates[schedEvent.Switch.PreviousThreadID] =
-                        new KeyValuePair<LinuxThreadState, LinuxEvent>(LinuxThreadState.BLOCKED_TIME, linuxEvent);
+                    previousThreadState.ThreadState = LinuxThreadState.BLOCKED_TIME;
+                    previousThreadState.Event = linuxEvent;
                 }
 
-                if (EndingStates.TryGetValue(schedEvent.Switch.NextThreadID, out sampleInfo) &&
-                    sampleInfo.Key == LinuxThreadState.BLOCKED_TIME) // Unblocking
+                LinuxPerfScriptThreadState nextThreadState = ThreadStateComputer.GetEndingStateState(schedEvent.Switch.NextThreadID);
+                if (nextThreadState != null &&
+                    nextThreadState.ThreadState == LinuxThreadState.BLOCKED_TIME) // Unblocking
                 {
-                    sampleInfo.Value.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
-                    AddThreadPeriod(sampleInfo.Value.ThreadID, sampleInfo.Value.TimeMSec, linuxEvent.TimeMSec);
-                    StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Value, this));
+                    nextThreadState.Event.Period = linuxEvent.TimeMSec - nextThreadState.Event.TimeMSec;
+                    AddThreadPeriod(nextThreadState.Event.ThreadID, nextThreadState.Event.TimeMSec, linuxEvent.TimeMSec);
+                    StackSource.AddSample(StackSource.CreateSampleFor(nextThreadState.Event, this));
 
-                    EndingStates[schedEvent.Switch.NextThreadID] =
-                        new KeyValuePair<LinuxThreadState, LinuxEvent>(LinuxThreadState.CPU_TIME, linuxEvent);
+                    nextThreadState.ThreadState = LinuxThreadState.CPU_TIME;
+                    nextThreadState.Event = linuxEvent;
                 }
             }
             else if(linuxEvent.Kind == EventKind.ThreadExit)
             {
                 ThreadExitEvent exitEvent = (ThreadExitEvent)linuxEvent;
-                if (EndingStates.TryGetValue(exitEvent.Exit.ThreadID, out sampleInfo))
+                LinuxPerfScriptThreadState exitThreadState = ThreadStateComputer.GetEndingStateState(exitEvent.Exit.ThreadID);
+                if (exitThreadState != null)
                 {
-                    if (sampleInfo.Key == LinuxThreadState.BLOCKED_TIME) // Blocked on exit
+                    if (exitThreadState.ThreadState == LinuxThreadState.BLOCKED_TIME) // Blocked on exit
                     {
-                        sampleInfo.Value.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
-                        AddThreadPeriod(sampleInfo.Value.ThreadID, sampleInfo.Value.TimeMSec, linuxEvent.TimeMSec);
-                        StackSource.AddSample(StackSource.CreateSampleFor(sampleInfo.Value, this));
+                        exitThreadState.Event.Period = linuxEvent.TimeMSec - exitThreadState.Event.TimeMSec;
+                        AddThreadPeriod(exitThreadState.Event.ThreadID, exitThreadState.Event.TimeMSec, linuxEvent.TimeMSec);
+                        StackSource.AddSample(StackSource.CreateSampleFor(exitThreadState.Event, this));
                     }
                     else // Unblocked on exit
                     {
-                        linuxEvent.Period = linuxEvent.TimeMSec - sampleInfo.Value.TimeMSec;
+                        linuxEvent.Period = linuxEvent.TimeMSec - exitThreadState.Event.TimeMSec;
                         StackSource.AddSample(StackSource.CreateSampleFor(linuxEvent, this));
                     }
 
                     // Remove the thread so that any events that might come after the exit are ignored.
-                    EndingStates.Remove(exitEvent.Exit.ThreadID);
+                    ThreadStateComputer.RemoveThread(exitEvent);
                 }
             }
             else if (linuxEvent.Kind == EventKind.Cpu)

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptThreadStateComputer.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptThreadStateComputer.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.Diagnostics.Tracing.StackSources;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Tracing.Stacks.Linux
+{
+    internal sealed class LinuxPerfScriptThreadStateComputer
+    {
+        private readonly Dictionary<int, LinuxPerfScriptThreadState> _beginningStates = new Dictionary<int, LinuxPerfScriptThreadState>();
+        private readonly Dictionary<int, LinuxPerfScriptThreadState> _endingStates = new Dictionary<int, LinuxPerfScriptThreadState>();
+
+        internal void PrimeThreadState(LinuxEvent linuxEvent)
+        {
+            if (!_beginningStates.ContainsKey(linuxEvent.ThreadID))
+            {
+                _beginningStates.Add(
+                    linuxEvent.ThreadID,
+                    new LinuxPerfScriptThreadState()
+                    {
+                        ThreadState = LinuxThreadState.CPU_TIME,
+                        Event = linuxEvent
+                    });
+
+                _endingStates[linuxEvent.ThreadID] = _beginningStates[linuxEvent.ThreadID];
+            }
+
+            // TODO: If this is a sched_switch event, then connect the two thread ids.
+        }
+
+        internal void RemoveThread(ThreadExitEvent exitEvent)
+        {
+            // TODO: Do we need to also get the in-container thread ID?
+            // TODO: Do we also need to remove from beginning states?
+            _endingStates.Remove(exitEvent.Exit.ThreadID);
+        }
+
+        internal LinuxPerfScriptThreadState GetBeginningState(int threadID)
+        {
+            _beginningStates.TryGetValue(threadID, out LinuxPerfScriptThreadState value);
+            return value;
+        }
+
+        internal LinuxPerfScriptThreadState GetEndingStateState(int threadID)
+        {
+            _endingStates.TryGetValue(threadID, out LinuxPerfScriptThreadState value);
+            return value;
+        }
+
+        internal IReadOnlyDictionary<int, LinuxPerfScriptThreadState> BeginningStates
+        {
+            get { return _beginningStates; }
+        }
+
+        internal IReadOnlyDictionary<int, LinuxPerfScriptThreadState> EndingStates
+        {
+            get { return _endingStates; }
+        }
+    }
+
+    internal sealed class LinuxPerfScriptThreadState
+    {
+        // Only allow the thread state computer to create instances.
+        // This is important because we're going to use the same instance 
+        // across multiple thread IDs.
+        //
+        // This is required to handle cases when the capture took place inside
+        // of a container and the thread ID is from inside the container,
+        // but the prev_pid is from outside the container.
+        internal LinuxPerfScriptThreadState()
+        {
+        }
+
+        public LinuxThreadState ThreadState { get; set; }
+        public LinuxEvent Event { get; set; }
+    }
+}


### PR DESCRIPTION
 - Handle cases where the process name contains spaces.
 - Handle cases where the process name shows up as ":<number>".
 - Handle cases where the trace is captured in a container and the process ID / thread ID don't match what is present in the `sched:*` event payload.  This happens because the kernel doesn't update the PID / TID based on the process namespace.