### PR TITLE
Change source view to include both the inclusive samples data as well as the exclusive samples data

### DIFF
--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -63,7 +63,8 @@
 
             <CommandBinding Command="{x:Static src:StackWindow.LookupSymbolsCommand}" Executed="DoLookupSymbols" />
             <CommandBinding Command="{x:Static src:StackWindow.LookupWarmSymbolsCommand}" Executed="DoLookupWarmSymbols" />
-            <CommandBinding Command="{x:Static src:StackWindow.GotoSourceCommand}" Executed="DoGotoSource"/>
+            <CommandBinding Command="{x:Static src:StackWindow.GotoSourceInclusiveCommand}" Executed="DoGotoSourceInclusive"/>
+            <CommandBinding Command="{x:Static src:StackWindow.GotoSourceExclusiveCommand}" Executed="DoGotoSourceExclusive"/>
             <CommandBinding Command="{x:Static src:StackWindow.OpenEventsCommand}" Executed="DoOpenEvents" CanExecute="CanDoOpenEvents"/>
 
             <CommandBinding Command="{x:Static src:StackWindow.SetTimeRangeCommand}" Executed="DoSetTimeRange"/>
@@ -141,7 +142,8 @@
                 </MenuItem>
                 <MenuItem Command="{x:Static src:StackWindow.LookupSymbolsCommand}" />
                 <MenuItem Command="{x:Static src:StackWindow.LookupWarmSymbolsCommand}" />
-                <MenuItem Command="{x:Static src:StackWindow.GotoSourceCommand}" />
+                <MenuItem Command="{x:Static src:StackWindow.GotoSourceInclusiveCommand}" />
+                <MenuItem Command="{x:Static src:StackWindow.GotoSourceExclusiveCommand}" />
                 <Separator/>
                 <MenuItem Command="{x:Static src:StackWindow.SetTimeRangeCommand}" />
                 <MenuItem Command="{x:Static src:StackWindow.CopyTimeRangeCommand}" />

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -63,8 +63,7 @@
 
             <CommandBinding Command="{x:Static src:StackWindow.LookupSymbolsCommand}" Executed="DoLookupSymbols" />
             <CommandBinding Command="{x:Static src:StackWindow.LookupWarmSymbolsCommand}" Executed="DoLookupWarmSymbols" />
-            <CommandBinding Command="{x:Static src:StackWindow.GotoSourceInclusiveCommand}" Executed="DoGotoSourceInclusive"/>
-            <CommandBinding Command="{x:Static src:StackWindow.GotoSourceExclusiveCommand}" Executed="DoGotoSourceExclusive"/>
+            <CommandBinding Command="{x:Static src:StackWindow.GotoSourceCommand}" Executed="DoGotoSource"/>
             <CommandBinding Command="{x:Static src:StackWindow.OpenEventsCommand}" Executed="DoOpenEvents" CanExecute="CanDoOpenEvents"/>
 
             <CommandBinding Command="{x:Static src:StackWindow.SetTimeRangeCommand}" Executed="DoSetTimeRange"/>
@@ -142,8 +141,7 @@
                 </MenuItem>
                 <MenuItem Command="{x:Static src:StackWindow.LookupSymbolsCommand}" />
                 <MenuItem Command="{x:Static src:StackWindow.LookupWarmSymbolsCommand}" />
-                <MenuItem Command="{x:Static src:StackWindow.GotoSourceInclusiveCommand}" />
-                <MenuItem Command="{x:Static src:StackWindow.GotoSourceExclusiveCommand}" />
+                <MenuItem Command="{x:Static src:StackWindow.GotoSourceCommand}" />
                 <Separator/>
                 <MenuItem Command="{x:Static src:StackWindow.SetTimeRangeCommand}" />
                 <MenuItem Command="{x:Static src:StackWindow.CopyTimeRangeCommand}" />

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2242,7 +2242,15 @@ namespace PerfView
                 });
             });
         }
-        private void DoGotoSource(object sender, ExecutedRoutedEventArgs e)
+        private void DoGotoSourceInclusive(object sender, ExecutedRoutedEventArgs e)
+        {
+            DoGotoSource(sender, e, false);
+        }
+        private void DoGotoSourceExclusive(object sender, ExecutedRoutedEventArgs e)
+        {
+            DoGotoSource(sender, e, true);
+        }
+        private void DoGotoSource(object sender, ExecutedRoutedEventArgs e, bool exclusiveSamplesOnly)
         {
             var cells = SelectedCells();
             if (cells == null || cells.Count == 0)
@@ -2297,7 +2305,7 @@ namespace PerfView
                 }
 
                 SortedDictionary<int, float> metricOnLine;
-                var sourceLocation = GetSourceLocation(asCallTreeNodeBase, cellText, out metricOnLine);
+                var sourceLocation = GetSourceLocation(asCallTreeNodeBase, cellText, exclusiveSamplesOnly, out metricOnLine);
 
                 string sourcePathToOpen = null;
                 string logicalSourcePath = null;
@@ -2359,7 +2367,7 @@ namespace PerfView
         }
 
         // TODO FIX NOW review 
-        private SourceLocation GetSourceLocation(CallTreeNodeBase asCallTreeNodeBase, string cellText,
+        private SourceLocation GetSourceLocation(CallTreeNodeBase asCallTreeNodeBase, string cellText, bool exclusiveSamplesOnly,
             out SortedDictionary<int, float> metricOnLine)
         {
             metricOnLine = null;
@@ -2387,7 +2395,10 @@ namespace PerfView
                         matchingFrameIndex = frameIndex;        // We keep overwriting it, so we get the entry closest to the root.  
                     }
 
-                    callStackIdx = m_stackSource.GetCallerIndex(callStackIdx);
+                    if (exclusiveSamplesOnly)
+                        callStackIdx = StackSourceCallStackIndex.Invalid;
+                    else
+                        callStackIdx = m_stackSource.GetCallerIndex(callStackIdx);
                 }
                 if (matchingFrameIndex != StackSourceFrameIndex.Invalid)
                 {
@@ -3233,8 +3244,9 @@ namespace PerfView
             new InputGestureCollection() { new KeyGesture(Key.S, ModifierKeys.Alt) });
         public static RoutedUICommand LookupWarmSymbolsCommand = new RoutedUICommand("Lookup Warm Symbols", "LookupWarmSymbols", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.S, ModifierKeys.Alt | ModifierKeys.Control) });
-        public static RoutedUICommand GotoSourceCommand = new RoutedUICommand("Goto Source (Def)", "GotoSource", typeof(StackWindow),
+        public static RoutedUICommand GotoSourceInclusiveCommand = new RoutedUICommand("Goto Source (Def)", "GotoSourceInclusive", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.D, ModifierKeys.Alt) });
+        public static RoutedUICommand GotoSourceExclusiveCommand = new RoutedUICommand("Goto Source (Def)(Exclusive Samples Only)", "GotoSourceExclusive", typeof(StackWindow));
 
         // Filtering
         public static RoutedUICommand SetTimeRangeCommand = new RoutedUICommand("Set Time Range", "SetTimeRange", typeof(StackWindow),

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -2242,15 +2242,7 @@ namespace PerfView
                 });
             });
         }
-        private void DoGotoSourceInclusive(object sender, ExecutedRoutedEventArgs e)
-        {
-            DoGotoSource(sender, e, false);
-        }
-        private void DoGotoSourceExclusive(object sender, ExecutedRoutedEventArgs e)
-        {
-            DoGotoSource(sender, e, true);
-        }
-        private void DoGotoSource(object sender, ExecutedRoutedEventArgs e, bool exclusiveSamplesOnly)
+        private void DoGotoSource(object sender, ExecutedRoutedEventArgs e)
         {
             var cells = SelectedCells();
             if (cells == null || cells.Count == 0)
@@ -2305,7 +2297,8 @@ namespace PerfView
                 }
 
                 SortedDictionary<int, float> metricOnLine;
-                var sourceLocation = GetSourceLocation(asCallTreeNodeBase, cellText, exclusiveSamplesOnly, out metricOnLine);
+                SortedDictionary<int, float> exclusiveMetricOnLine;
+                var sourceLocation = GetSourceLocation(asCallTreeNodeBase, cellText, out metricOnLine, out exclusiveMetricOnLine);
 
                 string sourcePathToOpen = null;
                 string logicalSourcePath = null;
@@ -2329,7 +2322,7 @@ namespace PerfView
                         {
                             sourcePathToOpen = CacheFiles.FindFile(sourcePathToOpen, Path.GetExtension(sourcePathToOpen));
                             StatusBar.Log("Annotating source with metric to the file " + sourcePathToOpen);
-                            AnnotateLines(logicalSourcePath, sourcePathToOpen, metricOnLine);
+                            AnnotateLines(logicalSourcePath, sourcePathToOpen, ("Inc", metricOnLine) ,("Exc", exclusiveMetricOnLine));
                         }
                     }
                 }
@@ -2367,10 +2360,11 @@ namespace PerfView
         }
 
         // TODO FIX NOW review 
-        private SourceLocation GetSourceLocation(CallTreeNodeBase asCallTreeNodeBase, string cellText, bool exclusiveSamplesOnly,
-            out SortedDictionary<int, float> metricOnLine)
+        private SourceLocation GetSourceLocation(CallTreeNodeBase asCallTreeNodeBase, string cellText,
+            out SortedDictionary<int, float> metricOnLine, out SortedDictionary<int, float> exclusiveMetricOnLine)
         {
             metricOnLine = null;
+            exclusiveMetricOnLine = null;
             var m = Regex.Match(cellText, "<<(.*!.*)>>");
             if (m.Success)
             {
@@ -2380,12 +2374,14 @@ namespace PerfView
             // Find the most numerous call stack
             // TODO this can be reasonably expensive.   If it is a problem do something about it (e.g. sampling)
             var frameIndexCounts = new Dictionary<StackSourceFrameIndex, float>();
+            var exclusiveFrameIndexCounts = new Dictionary<StackSourceFrameIndex, float>();
             asCallTreeNodeBase.GetSamples(false, delegate (StackSourceSampleIndex sampleIdx)
             {
                 // Find the callStackIdx which corresponds to the name in the cell, and log it to callStackIndexCounts
                 var matchingFrameIndex = StackSourceFrameIndex.Invalid;
                 var sample = m_stackSource.GetSampleByIndex(sampleIdx);
                 var callStackIdx = sample.StackIndex;
+                bool exclusiveSample = true;
                 while (callStackIdx != StackSourceCallStackIndex.Invalid)
                 {
                     var frameIndex = m_stackSource.GetFrameIndex(callStackIdx);
@@ -2395,10 +2391,14 @@ namespace PerfView
                         matchingFrameIndex = frameIndex;        // We keep overwriting it, so we get the entry closest to the root.  
                     }
 
-                    if (exclusiveSamplesOnly)
-                        callStackIdx = StackSourceCallStackIndex.Invalid;
-                    else
-                        callStackIdx = m_stackSource.GetCallerIndex(callStackIdx);
+                    if (exclusiveSample)
+                    {
+                        exclusiveSample = false;
+                        float count = 0;
+                        exclusiveFrameIndexCounts.TryGetValue(matchingFrameIndex, out count);
+                        exclusiveFrameIndexCounts[matchingFrameIndex] = count + sample.Metric;
+                    }
+                    callStackIdx = m_stackSource.GetCallerIndex(callStackIdx);
                 }
                 if (matchingFrameIndex != StackSourceFrameIndex.Invalid)
                 {
@@ -2448,18 +2448,25 @@ namespace PerfView
             if (sourceLocation != null)
             {
                 var filePathForMax = sourceLocation.SourceFile.BuildTimeFilePath;
-                metricOnLine = new SortedDictionary<int, float>();
                 // Accumulate the counts on a line basis
-                foreach (StackSourceFrameIndex frameIdx in frameIndexCounts.Keys)
+                AccumulateCounts(frameIndexCounts, out metricOnLine);
+                AccumulateCounts(exclusiveFrameIndexCounts, out exclusiveMetricOnLine);
+
+                void AccumulateCounts(Dictionary<StackSourceFrameIndex, float> indexCounts, out SortedDictionary<int, float> metricHash)
                 {
-                    var loc = asTraceEventStackSource.GetSourceLine(frameIdx, reader);
-                    if (loc != null && loc.SourceFile.BuildTimeFilePath == filePathForMax)
+                    metricHash = new SortedDictionary<int, float>();
+
+                    foreach (StackSourceFrameIndex frameIdx in indexCounts.Keys)
                     {
-                        frameToLine[frameIdx] = loc.LineNumber;
-                        float metric;
-                        metricOnLine.TryGetValue(loc.LineNumber, out metric);
-                        metric += frameIndexCounts[frameIdx];
-                        metricOnLine[loc.LineNumber] = metric;
+                        var loc = asTraceEventStackSource.GetSourceLine(frameIdx, reader);
+                        if (loc != null && loc.SourceFile.BuildTimeFilePath == filePathForMax)
+                        {
+                            frameToLine[frameIdx] = loc.LineNumber;
+                            float metric;
+                            metricHash.TryGetValue(loc.LineNumber, out metric);
+                            metric += indexCounts[frameIdx];
+                            metricHash[loc.LineNumber] = metric;
+                        }
                     }
                 }
             }
@@ -2520,7 +2527,7 @@ namespace PerfView
             return sourceLocation;
         }
 
-        private void AnnotateLines(string inFileName, string outFileName, SortedDictionary<int, float> lineData)
+        private void AnnotateLines(string inFileName, string outFileName, params ValueTuple<string, SortedDictionary<int, float>>[] lineData)
         {
             using (var inFile = File.OpenText(inFileName))
             using (var outFile = File.CreateText(outFileName))
@@ -2536,18 +2543,21 @@ namespace PerfView
 
                     lineNum++;
 
-                    float value;
-                    if (lineData.TryGetValue(lineNum, out value))
+                    foreach (var data in lineData)
                     {
-                        outFile.Write(ToCompactString(value));
-                    }
-                    else if (lineNum == 1)
-                    {
-                        outFile.Write("Metric|");
-                    }
-                    else
-                    {
-                        outFile.Write("       ");
+                        float value;
+                        if (data.Item2.TryGetValue(lineNum, out value))
+                        {
+                            outFile.Write(ToCompactString(value));
+                        }
+                        else if (lineNum == 1)
+                        {
+                            outFile.Write($"{data.Item1.PadLeft(6)}|");
+                        }
+                        else
+                        {
+                            outFile.Write("       ");
+                        }
                     }
 
                     outFile.WriteLine(line);
@@ -3244,9 +3254,8 @@ namespace PerfView
             new InputGestureCollection() { new KeyGesture(Key.S, ModifierKeys.Alt) });
         public static RoutedUICommand LookupWarmSymbolsCommand = new RoutedUICommand("Lookup Warm Symbols", "LookupWarmSymbols", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.S, ModifierKeys.Alt | ModifierKeys.Control) });
-        public static RoutedUICommand GotoSourceInclusiveCommand = new RoutedUICommand("Goto Source (Def)", "GotoSourceInclusive", typeof(StackWindow),
+        public static RoutedUICommand GotoSourceCommand = new RoutedUICommand("Goto Source (Def)", "GotoSource", typeof(StackWindow),
             new InputGestureCollection() { new KeyGesture(Key.D, ModifierKeys.Alt) });
-        public static RoutedUICommand GotoSourceExclusiveCommand = new RoutedUICommand("Goto Source (Def)(Exclusive Samples Only)", "GotoSourceExclusive", typeof(StackWindow));
 
         // Filtering
         public static RoutedUICommand SetTimeRangeCommand = new RoutedUICommand("Set Time Range", "SetTimeRange", typeof(StackWindow),


### PR DESCRIPTION
I have a scenario where I am attempting to optimize the exlusive cost of a set of methods, and viewing exlusive costs in the source view has been quite helpful.