### PR TITLE
Fix for issue #1767

### DIFF
--- a/src/TraceEvent/TraceEvent.Tests/Regression/Issue1767.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Regression/Issue1767.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class Issue1767 : IDisposable
+    {
+        int sessionCount = 65;
+        List<string> sessions = new List<string>();
+
+        public Issue1767()
+        {
+            try
+            {
+                for (int i = 0; i < sessionCount; i++)
+                {
+                    string name = $"Issue1767Test_{i}";
+                    sessions.Add(name);
+                    TraceEventSession session = new TraceEventSession(name);
+                    session.EnableProvider(ClrTraceEventParser.ProviderGuid, TraceEventLevel.Informational, (ulong)ClrTraceEventParser.Keywords.GC);
+                }
+            }
+            catch
+            {
+                // not all systems can create this many sessions
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (string sessionName in sessions)
+            {
+                TraceEventSession session = new TraceEventSession(sessionName);
+                session.Dispose();
+            }
+        }
+
+        [Fact]
+        public void GetActiveSessionNamesWithMoreThan64()
+        {
+            List<string> activeSessionNames = TraceEventSession.GetActiveSessionNames();
+
+            // This assert fails a lot because not all machines will exceed 64 visible sessions
+            // One machine of mine stops at 45
+            Assert.True(activeSessionNames.Count >= 65, $"Expected 65 or more sessions but had {activeSessionNames.Count}");
+        }
+    }
+}

--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -1107,6 +1107,7 @@ namespace Microsoft.Diagnostics.Tracing
           out int FinalUncompressedSize
        );
 
+        internal const uint ERROR_MORE_DATA = 234;
         internal const uint ERROR_WMI_INSTANCE_NOT_FOUND = 4201;
     } // end class
     #endregion


### PR DESCRIPTION
This change updates GetActiveSessionNames to check for ERROR_MORE_DATA and retry once when calling QueryAllTraces.

I chose to implement this by modifying the current function as little as possible. To do that, I wrapped the core logic and made a recursive call to it for the retry, with a depth counter that maxes out at 1.

This change also has a unit test, but I don't think it is ready to be committed. I am including it so a discussion can be had about it.

In general it seems hard to reliably simulate this condition on a broad set of machines that will run this test suite (65+ active etw sessions while EtwMaxLoggers registry key is not set.) Just between my two developer machines I couldn't do it 🤣 

I'm open to ideas here on how the test can be improved to be more reliable, otherwise it probably needs to be removed.