### PR TITLE
Improve Rundown and Abort Paths

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -199,6 +199,7 @@ namespace PerfView
         }
 
         public int RundownTimeout = 120;
+        public int RundownMaxMB = -1;
         public int MinRundownTime;
         public bool NoView;
         public float CpuSampleMSec = 1.0F;
@@ -408,6 +409,8 @@ namespace PerfView
                 "Don't do rundown .NET (CLR) rundown information )(for symbolic name lookup).");
             parser.DefineOptionalQualifier("RundownTimeout", ref RundownTimeout,
                 "Maximum number of seconds to wait for CLR rundown to complete.");
+            parser.DefineOptionalQualifier("RundownMaxMB", ref RundownMaxMB,
+                "Approximate maximum size of rundown etl file.");
             parser.DefineOptionalQualifier("MinRundownTime", ref MinRundownTime,
                 "Minimum number of seconds to wait for CLR rundown to complete.");
             parser.DefineOptionalQualifier("KeepAllEvents", ref KeepAllEvents,

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -2844,6 +2844,11 @@ namespace PerfView
                 cmdLineArgs += " /RundownTimeout:" + parsedArgs.RundownTimeout;
             }
 
+            if (parsedArgs.RundownMaxMB != -1)
+            {
+                cmdLineArgs += " /RundownMaxMB:" + parsedArgs.RundownMaxMB;
+            }
+
             if (parsedArgs.CpuCounters != null)
             {
                 cmdLineArgs += " /CpuCounters:" + Command.Quote(string.Join(",", parsedArgs.CpuCounters));
@@ -3595,7 +3600,7 @@ namespace PerfView
                     PerfViewLogger.Log.WaitForIdle();
 
                     // Wait for rundown to complete.
-                    WaitForRundownIdle(parsedArgs.MinRundownTime, parsedArgs.RundownTimeout, rundownFile);
+                    WaitForRundownIdle(parsedArgs.MinRundownTime, parsedArgs.RundownTimeout, parsedArgs.RundownMaxMB, rundownFile);
 
                     // Complete perfview rundown.
                     DotNetVersionLogger.Stop();
@@ -3621,9 +3626,10 @@ namespace PerfView
         /// Currently there is no good way to know when rundown is finished.  We basically wait as long as
         /// the rundown file is growing.  
         /// </summary>
-        private void WaitForRundownIdle(int minSeconds, int maxSeconds, string rundownFilePath)
+        private void WaitForRundownIdle(int minSeconds, int maxSeconds, int maxSizeMB, string rundownFilePath)
         {
             LogFile.WriteLine("Waiting up to {0} sec for rundown events.  Use /RundownTimeout to change.", maxSeconds);
+            LogFile.WriteLine($"Maximum rundown file size is {maxSizeMB}MB.  Use /RundownMaxMB to change.");
             LogFile.WriteLine("If you know your process has exited, use /noRundown qualifer to skip this step.");
 
             long rundownFileLen = 0;
@@ -3639,6 +3645,12 @@ namespace PerfView
                 var delta = newRundownFileLen - rundownFileLen;
                 LogFile.WriteLine("Rundown File Length: {0:n1}MB delta: {1:n1}MB", newRundownFileLen / 1000000.0, delta / 1000000.0);
                 rundownFileLen = newRundownFileLen;
+
+                if ((maxSizeMB > 0) && rundownFileLen >= (maxSizeMB * 1024 * 1024))
+                {
+                    LogFile.WriteLine($"Exceeded maximum rundown file size of {maxSizeMB}MB.");
+                    break;
+                }
 
                 if (i >= minSeconds)
                 {

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1470,6 +1470,9 @@ namespace PerfView
                     DisableNetMonTrace();
                 }
                 catch (Exception) { }
+
+                // Ensure that DotNetVersionLogger is disabled.
+                DotNetVersionLogger.Abort();
             }
         }
 

--- a/src/PerfView/DotNetVersionLogger.cs
+++ b/src/PerfView/DotNetVersionLogger.cs
@@ -21,7 +21,7 @@ namespace PerfView
 
         private sealed class VersionLogger : IDisposable
         {
-            private const string SessionName = "PerfView-DotNetVersionLogger-Session";
+            internal const string SessionName = "PerfView-DotNetVersionLogger-Session";
             private readonly static TextWriter Log = App.CommandProcessor.LogFile;
             private TraceEventSession _session;
             private AutoResetEvent _sessionStopEvent = new AutoResetEvent(false);
@@ -151,6 +151,21 @@ namespace PerfView
                 _loggerInstance.Stop();
                 _loggerInstance.Dispose();
             }
+        }
+
+        public static void Abort()
+        {
+
+            try
+            {
+                using (TraceEventSession session = new TraceEventSession(
+                    VersionLogger.SessionName,
+                    TraceEventSessionOptions.Attach))
+                {
+                    session.Stop(true);
+                }
+            }
+            catch (Exception) { }
         }
     }
 }

--- a/src/PerfView/DotNetVersionLogger.cs
+++ b/src/PerfView/DotNetVersionLogger.cs
@@ -70,7 +70,7 @@ namespace PerfView
                     _session.EnableProvider(
                         ClrRundownTraceEventParser.ProviderGuid,
                         TraceEventLevel.Always,
-                        (ulong)TraceEventKeyword.None,
+                        0x8000000000000000UL,
                         new TraceEventProviderOptions() { EventIDsToEnable = new List<int> { 187 } });
                 }
                 catch (Exception ex)

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1440,27 +1440,33 @@ namespace Microsoft.Diagnostics.Tracing.Session
                                    sizeof(char) * TraceEventSession.MaxNameSize +     // For log moduleFile name 
                                    sizeof(char) * TraceEventSession.MaxNameSize;      // For session name
 
-            byte* sessionsArray = stackalloc byte[MAX_SESSIONS * sizeOfProperties];
-            TraceEventNativeMethods.EVENT_TRACE_PROPERTIES** propetiesArray = stackalloc TraceEventNativeMethods.EVENT_TRACE_PROPERTIES*[MAX_SESSIONS];
+            List<string> activeTraceNames = null;
 
-            for (int i = 0; i < MAX_SESSIONS; i++)
+            // Allocate the sessionsArray on the heap for environments that have a large number of sessions.
+            byte[] sessionsArr = new byte[MAX_SESSIONS * sizeOfProperties];
+            fixed (byte* sessionsArray = sessionsArr)
             {
-                TraceEventNativeMethods.EVENT_TRACE_PROPERTIES* properties = (TraceEventNativeMethods.EVENT_TRACE_PROPERTIES*)&sessionsArray[sizeOfProperties * i];
-                properties->Wnode.BufferSize = (uint)sizeOfProperties;
-                properties->LoggerNameOffset = (uint)sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES);
-                properties->LogFileNameOffset = (uint)sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES) + sizeof(char) * TraceEventSession.MaxNameSize;
-                propetiesArray[i] = properties;
-            }
-            int sessionCount = 0;
-            int hr = TraceEventNativeMethods.QueryAllTraces((IntPtr)propetiesArray, MAX_SESSIONS, ref sessionCount);
-            Marshal.ThrowExceptionForHR(TraceEventNativeMethods.GetHRFromWin32(hr));
+                TraceEventNativeMethods.EVENT_TRACE_PROPERTIES** propetiesArray = stackalloc TraceEventNativeMethods.EVENT_TRACE_PROPERTIES*[MAX_SESSIONS];
 
-            List<string> activeTraceNames = new List<string>(sessionCount);
-            for (int i = 0; i < sessionCount; i++)
-            {
-                byte* propertiesBlob = (byte*)propetiesArray[i];
-                string sessionName = new string((char*)(&propertiesBlob[propetiesArray[i]->LoggerNameOffset]));
-                activeTraceNames.Add(sessionName);
+                for (int i = 0; i < MAX_SESSIONS; i++)
+                {
+                    TraceEventNativeMethods.EVENT_TRACE_PROPERTIES* properties = (TraceEventNativeMethods.EVENT_TRACE_PROPERTIES*)&sessionsArray[sizeOfProperties * i];
+                    properties->Wnode.BufferSize = (uint)sizeOfProperties;
+                    properties->LoggerNameOffset = (uint)sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES);
+                    properties->LogFileNameOffset = (uint)sizeof(TraceEventNativeMethods.EVENT_TRACE_PROPERTIES) + sizeof(char) * TraceEventSession.MaxNameSize;
+                    propetiesArray[i] = properties;
+                }
+                int sessionCount = 0;
+                int hr = TraceEventNativeMethods.QueryAllTraces((IntPtr)propetiesArray, MAX_SESSIONS, ref sessionCount);
+                Marshal.ThrowExceptionForHR(TraceEventNativeMethods.GetHRFromWin32(hr));
+
+                activeTraceNames = new List<string>(sessionCount);
+                for (int i = 0; i < sessionCount; i++)
+                {
+                    byte* propertiesBlob = (byte*)propetiesArray[i];
+                    string sessionName = new string((char*)(&propertiesBlob[propetiesArray[i]->LoggerNameOffset]));
+                    activeTraceNames.Add(sessionName);
+                }
             }
             return activeTraceNames;
         }


### PR DESCRIPTION
1. Allow users to specify `/RundownMaxMB` to limit the size of the rundown ETL file.
2. Update the `DotNetVersionLogger` to enable a non-existent keyword.  This ensures that unrequested rundown events aren't enabled.
3. Update `TraceEventSession.GetActiveSessionNames` to allocate on the heap instead of on the stack to ensure that failures don't occur on machines with a large number of sessions.
4. Add the `DotNetVersionLogger` session to the list of sessions covered by the `abort` command.