### PR TITLE
Check whether LTTng is installed and if so, don't attempt to install it.

### DIFF
--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -1249,6 +1249,16 @@ InstallLTTng_Ubuntu()
 
 InstallLTTng()
 {
+    if command -v lttng &> /dev/null
+    then
+        lttngInstalled=1
+
+        BlueText
+        echo "LTTng already installed."
+        ResetText
+        return
+    fi
+
     if [ "$(IsUbuntu)" == "1" ]
     then
         InstallLTTng_Ubuntu


### PR DESCRIPTION
The explicit check is to support scenario when somebody installed LTTng from non-package (i.e. compiling from sources).
That in turn is used in perf lab to use LTTng from 2.12 branch to ensure compatibility (at the moment) with runtime.