### PR TITLE
Fix perfview handling of events reporting dynamic helpers

### DIFF
--- a/src/TraceEvent/Parsers/ClrEtwAll.cs.base
+++ b/src/TraceEvent/Parsers/ClrEtwAll.cs.base
@@ -6884,6 +6884,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsDotNETRuntime
         Generic = 0x2,
         HasSharedGenericCode = 0x4,
         Jitted = 0x8,
+        JitHelperMethod = 0x10,
     }
     [Flags]
     public enum ModuleFlags

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -11440,6 +11440,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         public bool IsDynamic { get { return (MethodFlags & MethodFlags.Dynamic) != 0; } }
         public bool IsGeneric { get { return (MethodFlags & MethodFlags.Generic) != 0; } }
         public bool IsJitted { get { return (MethodFlags & MethodFlags.Jitted) != 0; } }
+        public bool IsJitHelper { get { return (MethodFlags & MethodFlags.JitHelper) != 0; } }
 
         public OptimizationTier OptimizationTier
         {

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -1424,6 +1424,10 @@ sd.exe -p minkerneldepot.sys-ntgroup.ntdev.microsoft.com:2020 print -o "C:\Users
                                         break;
                                 }
                                 return sb.ToString();
+                            case BasicType.btChar16:
+                                return "char16_t";
+                            case BasicType.btChar32:
+                                return "char32_t";
                             case BasicType.btFloat:
                                 return symbol.length == 4 ? "float" : "double";
                             default:

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1077,6 +1077,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             // FIX NOW HACK, because Method and Module unload methods are missing.
             jittedMethods = new List<MethodLoadUnloadVerboseTraceData>();
+            jitHelpers = new List<MethodLoadUnloadVerboseTraceData>();
             jsJittedMethods = new List<MethodLoadUnloadJSTraceData>();
             sourceFilesByID = new Dictionary<JavaScriptSourceKey, string>();
 
@@ -1374,7 +1375,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             Action<MethodLoadUnloadVerboseTraceData> onMethodStart = delegate (MethodLoadUnloadVerboseTraceData data)
                 {
                     // We only capture data on unload, because we collect the addresses first.
-                    if (!data.IsDynamic && !data.IsJitted)
+                    if (!data.IsDynamic && !data.IsJitted && !data.IsJitHelper)
                     {
                         bookKeepingEvent = true;
                     }
@@ -1395,6 +1396,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         });
 
                         jittedMethods.Add((MethodLoadUnloadVerboseTraceData)data.Clone());
+                    }
+
+                    if (data.IsJitHelper)
+                    {
+                        jitHelpers.Add((MethodLoadUnloadVerboseTraceData)data.Clone());
                     }
                 };
             rawEvents.Clr.MethodLoadVerbose += onMethodStart;
@@ -2115,6 +2121,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             foreach (var jittedMethod in jittedMethods)
             {
                 codeAddresses.AddMethod(jittedMethod);
+            }
+
+            foreach (var jitHelper in jitHelpers)
+            {
+                codeAddresses.AddMethod(jitHelper);
             }
 
             foreach (var jsJittedMethod in jsJittedMethods)
@@ -3882,6 +3893,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         // TODO FIX NOW remove the jittedMethods ones.
         private List<MethodLoadUnloadVerboseTraceData> jittedMethods;
+        private List<MethodLoadUnloadVerboseTraceData> jitHelpers;
         private List<MethodLoadUnloadJSTraceData> jsJittedMethods;
         private Dictionary<JavaScriptSourceKey, string> sourceFilesByID;
 


### PR DESCRIPTION
The dynamic helpers are reported with `MethodFlags.JitHelper`. Events with this flag were ignored by `PerfView` before this change.

This fixes at least part of https://github.com/dotnet/runtime/issues/88938.