### PR TITLE
Dynamic events

### DIFF
--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -228,6 +228,7 @@ namespace Stats
             writer.Write("{0}<GCProcess", indent);
             writer.Write(" Process={0}", StringUtilities.QuotePadLeft(stats.Name, 10));
             writer.Write(" ProcessID={0}", StringUtilities.QuotePadLeft(stats.ProcessID.ToString(), 5));
+
             if (runtime.GC.GCSettings != null)
             {
                 writer.Write(" HardLimit=\"{0}\"", runtime.GC.GCSettings.HardLimit);
@@ -454,6 +455,40 @@ namespace Stats
             writer.Write(" AllocedSinceLastGC={0}", StringUtilities.QuotePadLeft(gc.AllocedSinceLastGCMB.ToString("n3"), 5));
             writer.Write(" Type={0}", StringUtilities.QuotePadLeft(gc.Type.ToString(), 18));
             writer.Write(" Reason={0}", StringUtilities.QuotePadLeft(gc.Reason.ToString(), 27));
+            if (gc.committedUsageBefore != null)
+            {
+                writer.Write(" BeforeTotalCommitedInUse={0}", StringUtilities.QuotePadLeft(gc.committedUsageBefore.totalCommittedInUse.ToString("n3"), 10));
+                writer.Write(" BeforeTotalCommitedInGlobalDecommit={0}", StringUtilities.QuotePadLeft(gc.committedUsageBefore.totalCommittedInGlobalDecommit.ToString("n3"), 10));
+                writer.Write(" BeforeTotalCommitedInFree={0}", StringUtilities.QuotePadLeft(gc.committedUsageBefore.totalCommittedInFree.ToString("n3"), 10));
+                writer.Write(" BeforeTotalCommitedInGlobalFree={0}", StringUtilities.QuotePadLeft(gc.committedUsageBefore.totalCommittedInGlobalFree.ToString("n3"), 10));
+                writer.Write(" BeforeTotalBookkeepingCommitted={0}", StringUtilities.QuotePadLeft(gc.committedUsageBefore.totalBookkeepingCommitted.ToString("n3"), 10));
+            }
+            if (gc.committedUsageAfter != null)
+            {
+                writer.Write(" AfterTotalCommittedInUse={0}", StringUtilities.QuotePadLeft(gc.committedUsageAfter.totalCommittedInUse.ToString("n3"), 10));
+                writer.Write(" AfterTotalCommittedInGlobalDecommit={0}", StringUtilities.QuotePadLeft(gc.committedUsageAfter.totalCommittedInGlobalDecommit.ToString("n3"), 10));
+                writer.Write(" AfterTotalCommittedInFree={0}", StringUtilities.QuotePadLeft(gc.committedUsageAfter.totalCommittedInFree.ToString("n3"), 10));
+                writer.Write(" AfterTotalCommittedInGlobalFree={0}", StringUtilities.QuotePadLeft(gc.committedUsageAfter.totalCommittedInGlobalFree.ToString("n3"), 10));
+                writer.Write(" AfterTotalBookkeepingCommitted={0}", StringUtilities.QuotePadLeft(gc.committedUsageAfter.totalBookkeepingCommitted.ToString("n3"), 10));
+            }
+            if (gc.heapCountTuning != null)
+            {
+                writer.Write(" NewHeapCount={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.newHeapCount.ToString("n3"), 10));
+                writer.Write(" GCIndex={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.gcIndex.ToString("n3"), 10));
+                writer.Write(" MedianPercentOverhead={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.medianPercentOverhead.ToString("n3"), 10));
+                writer.Write(" SmoothedMedianPercentOverhead={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.smoothedMedianPercentOverhead.ToString("n3"), 10));
+                writer.Write(" OverheadReductionPerStepUp={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.overheadReductionPerStepUp.ToString("n3"), 10));
+                writer.Write(" OverheadIncreasePerStepDown={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.overheadIncreasePerStepDown.ToString("n3"), 10));
+                writer.Write(" SpaceCostIncreasePerStepUp={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.spaceCostIncreasePerStepUp.ToString("n3"), 10));
+                writer.Write(" SpaceCostDecreasePerStepDown={0}", StringUtilities.QuotePadLeft(gc.heapCountTuning.spaceCostDecreasePerStepDown.ToString("n3"), 10));
+            }
+            if (gc.heapCountSample != null)
+            {
+                writer.Write(" gcElapsedTime={0}", StringUtilities.QuotePadLeft(gc.heapCountSample.gcElapsedTime.ToString("n3"), 10));
+                writer.Write(" sohMslWaitTime={0}", StringUtilities.QuotePadLeft(gc.heapCountSample.sohMslWaitTime.ToString("n3"), 10));
+                writer.Write(" uohMslWaitTime={0}", StringUtilities.QuotePadLeft(gc.heapCountSample.uohMslWaitTime.ToString("n3"), 10));
+                writer.Write(" elapsedBetweenGcs={0}", StringUtilities.QuotePadLeft(gc.heapCountSample.elapsedBetweenGcs.ToString("n3"), 10));
+            }
             writer.WriteLine(">");
             if (gc.HeapStats != null)
             {

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -17,6 +17,37 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
     using Microsoft.Diagnostics.Tracing.Parsers.Clr;
     using System.Collections.Generic;
 
+    // TODO, AndrewAu, property
+    public sealed class CommittedUsageTraceData
+    {
+        public short version;
+        public long totalCommittedInUse;
+        public long totalCommittedInGlobalDecommit;
+        public long totalCommittedInFree;
+        public long totalCommittedInGlobalFree;
+        public long totalBookkeepingCommitted;
+    }
+    public sealed class HeapCountTuningTraceData
+    {
+        public short version;
+        public short newHeapCount;
+        public long gcIndex;
+        public float medianPercentOverhead;
+        public float smoothedMedianPercentOverhead;
+        public float overheadReductionPerStepUp;
+        public float overheadIncreasePerStepDown;
+        public float spaceCostIncreasePerStepUp;
+        public float spaceCostDecreasePerStepDown;
+    }
+    public sealed class HeapCountSampleTraceData
+    {
+        public short version;
+        public long gcElapsedTime;
+        public long sohMslWaitTime;
+        public long uohMslWaitTime;
+        public long elapsedBetweenGcs;
+    }
+
     /* Parsers defined in this file */
     // ClrTraceEventParser, ClrRundownTraceEventParser, ClrStressTraceEventParser
     /* ClrPrivateTraceEventParser  #ClrPrivateProvider */
@@ -842,6 +873,98 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             remove
             {
                 source.UnregisterEventTemplate(value, 38, ProviderGuid);
+            }
+        }
+        public event Action<GCDynamicTraceData> GCDynamic
+        {
+            add
+            {
+                // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+                RegisterTemplate(new GCDynamicTraceData(value, 39, 1, "GC", GCTaskGuid, 40, "GCDynamicData", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 39, ProviderGuid);
+            }
+        }
+        public event Action<TraceEvent, CommittedUsageTraceData> CommittedUsage
+        {
+            add
+            {
+                this.GCDynamic += (GCDynamicTraceData d) =>
+                {
+                    if (string.CompareOrdinal(d.Name, "CommittedUsage") == 0)
+                    {
+                        CommittedUsageTraceData committedUsage = new CommittedUsageTraceData();
+                        committedUsage.version = BitConverter.ToInt16(d.Data, 0);
+                        Debug.Assert(!(committedUsage.version == 1 && d.Data.Length != 42));
+                        Debug.Assert(!(committedUsage.version > 1 && d.Data.Length < 42));
+                        committedUsage.totalCommittedInUse = BitConverter.ToInt64(d.Data, 2);
+                        committedUsage.totalCommittedInGlobalDecommit = BitConverter.ToInt64(d.Data, 10);
+                        committedUsage.totalCommittedInFree = BitConverter.ToInt64(d.Data, 18);
+                        committedUsage.totalCommittedInGlobalFree = BitConverter.ToInt64(d.Data, 26);
+                        committedUsage.totalBookkeepingCommitted = BitConverter.ToInt64(d.Data, 34);
+                        value(d, committedUsage);
+                    }
+                };
+            }
+            remove
+            {
+                // TODO, AndrewAu, implementation
+            }
+        }
+        public event Action<TraceEvent, HeapCountTuningTraceData> HeapCountTuning
+        {
+            add
+            {
+                this.GCDynamic += (GCDynamicTraceData d) =>
+                {
+                    if (string.CompareOrdinal(d.Name, "HeapCountTuning") == 0)
+                    {
+                        HeapCountTuningTraceData heapCountTuning = new HeapCountTuningTraceData();
+                        heapCountTuning.version = BitConverter.ToInt16(d.Data, 0);
+                        Debug.Assert(!(heapCountTuning.version == 1 && d.Data.Length != 36));
+                        Debug.Assert(!(heapCountTuning.version > 1 && d.Data.Length < 36));
+                        heapCountTuning.newHeapCount = BitConverter.ToInt16(d.Data, 2);
+                        heapCountTuning.gcIndex = BitConverter.ToInt64(d.Data, 4);
+                        heapCountTuning.medianPercentOverhead = BitConverter.ToSingle(d.Data, 12);
+                        heapCountTuning.smoothedMedianPercentOverhead = BitConverter.ToSingle(d.Data, 16);
+                        heapCountTuning.overheadReductionPerStepUp = BitConverter.ToSingle(d.Data, 20);
+                        heapCountTuning.overheadIncreasePerStepDown = BitConverter.ToSingle(d.Data, 24);
+                        heapCountTuning.spaceCostIncreasePerStepUp = BitConverter.ToSingle(d.Data, 28);
+                        heapCountTuning.spaceCostDecreasePerStepDown = BitConverter.ToSingle(d.Data, 32);
+                        value(d, heapCountTuning);
+                    }
+                };
+            }
+            remove
+            {
+                // TODO, AndrewAu, implementation
+            }
+        }
+        public event Action<TraceEvent, HeapCountSampleTraceData> HeapCountSample
+        {
+            add
+            {
+                this.GCDynamic += (GCDynamicTraceData d) =>
+                {
+                    if (string.CompareOrdinal(d.Name, "HeapCountSample") == 0)
+                    {
+                        HeapCountSampleTraceData heapCountSample = new HeapCountSampleTraceData();
+                        heapCountSample.version = BitConverter.ToInt16(d.Data, 0);
+                        Debug.Assert(!(heapCountSample.version == 1 && d.Data.Length != 34));
+                        Debug.Assert(!(heapCountSample.version > 1 && d.Data.Length < 34));
+                        heapCountSample.gcElapsedTime = BitConverter.ToInt64(d.Data, 2);
+                        heapCountSample.sohMslWaitTime = BitConverter.ToInt64(d.Data, 10);
+                        heapCountSample.uohMslWaitTime = BitConverter.ToInt64(d.Data, 18);
+                        heapCountSample.elapsedBetweenGcs = BitConverter.ToInt64(d.Data, 26);
+                        value(d, heapCountSample);
+                    }
+                };
+            }
+            remove
+            {
+                // TODO, AndrewAu, implementation
             }
         }
         public event Action<IOThreadTraceData> IOThreadCreationStart
@@ -2178,13 +2301,17 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
             return new ContentionLockCreatedTraceData(action, 90, 8, "Contention", ContentionTaskGuid, 11, "LockCreated", ProviderGuid, ProviderName);
         }
+        static private GCDynamicTraceData GCDynamicTemplate(Action<GCDynamicTraceData> action)
+        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
+            return new GCDynamicTraceData(action, 39, 1, "GC", GCTaskGuid, 41, "Dynamic", ProviderGuid, ProviderName);
+        }
 
         static private volatile TraceEvent[] s_templates;
         protected internal override void EnumerateTemplates(Func<string, string, EventFilterResponse> eventsToObserve, Action<TraceEvent> callback)
         {
             if (s_templates == null)
             {
-                var templates = new TraceEvent[145];
+                var templates = new TraceEvent[146];
                 templates[0] = new GCStartTraceData(null, 1, 1, "GC", GCTaskGuid, 1, "Start", ProviderGuid, ProviderName);
                 templates[1] = new GCEndTraceData(null, 2, 1, "GC", GCTaskGuid, 2, "Stop", ProviderGuid, ProviderName);
                 templates[2] = new GCNoUserDataTraceData(null, 3, 1, "GC", GCTaskGuid, 132, "RestartEEStop", ProviderGuid, ProviderName);
@@ -2339,6 +2466,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 templates[142] = GCLOHCompactTemplate(null);
                 templates[143] = GCFitBucketInfoTemplate(null);
                 templates[144] = ContentionLockCreatedTemplate(null);
+                templates[145] = GCDynamicTemplate(null);
 
                 s_templates = templates;
             }
@@ -7944,6 +8072,75 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         private TraceEvent m_data;
         private int m_baseOffset;
         #endregion
+    }
+
+    public sealed class GCDynamicTraceData : TraceEvent
+    {
+        internal GCDynamicTraceData(Action<GCDynamicTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            Action = action;
+        }
+
+        public string Name { get { return GetUnicodeStringAt(0); } }
+        public Int32 DataSize { get { return GetInt32At(SkipUnicodeString(0)); } }
+        public byte[] Data { get { return GetByteArrayAt(offset: SkipUnicodeString(0) + 4, DataSize); } }
+        public int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(0) + 4 + DataSize); } }
+
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<GCDynamicTraceData>)value; }
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                {
+                    payloadNames = new string[] { "Name", "DataSize", "Data", "ClrInstanceID" };
+                }
+
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return Name;
+                case 1:
+                    return DataSize;
+                case 2:
+                    return Data;
+                case 3:
+                    return ClrInstanceID;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "Name", Name);
+            XmlAttrib(sb, "DataSize", DataSize);
+            XmlAttrib(sb, "Data", string.Join(",", Data));
+            XmlAttrib(sb, "ClrInstanceID", ClrInstanceID);
+            sb.Append("</Event>");
+            return sb;
+        }
+
+        private event Action<GCDynamicTraceData> Action;
     }
 
     public sealed class GCBulkRootStaticVarTraceData : TraceEvent

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -2895,6 +2895,11 @@ namespace Microsoft.Diagnostics.Tracing
                 declaredSet.Add(eventName, eventName);
             }
 
+            // These events are derived from GCDynamic and has no template associated with them
+            declaredSet.Remove("CommittedUsage");
+            declaredSet.Remove("HeapCountTuning");
+            declaredSet.Remove("HeapCountSample");
+
             var enumSet = new SortedDictionary<string, string>();
 
             // Make sure that we have all the event we should have 


### PR DESCRIPTION
This change is the PerfView counterpart of https://github.com/dotnet/runtime/pull/89371

Starting .NET 7, we make `clrgc.dll` compatible with older runtimes, so that you can use a .NET 8 `clrgc.dll` with the .NET 6 app.

However, older runtimes don't know about the new events in the new `clrgc.dll`, which limits our capability to use ETW events to diagnose issues.

To remedy that, we have a `GCDynamic` event that was introduced when `clrgc.dll` was built. The event features a name and an opaque payload. That allows us to serialize any data and fire that instead, and also use the name to disambiguate different events.

Starting .NET 8, we are using it for diagnosing issues related to dynamic heap tuning and memory utilization issues. 

This is the first PR on the PerfView side to handle these dynamic events, and therefore we don't have any prior art on how to expose them. Here I proposed a pattern that works in the sense that we can get the values in the raw XML view as well as on the `TraceGC` objects, but it is not currently available in the Events view and EventStats view.