### PR TITLE
3 UI changes to the Events view

### DIFF
--- a/src/CSVReader/EventSource.cs
+++ b/src/CSVReader/EventSource.cs
@@ -173,13 +173,19 @@ namespace EventSources
         /// <summary>
         /// Displays fields as key-value pairs.  
         /// </summary>
-        public virtual string Rest { get { return m_displayFields[5]; } set { m_displayFields[5] = value; } }
+        public virtual string Rest { get { return m_displayFields[11]; } set { m_displayFields[11] = value; } }
         // The properties are for binding in the GUI.   
         // set property is a hack to allow selection in the GUI (which wants two way binding for that case)
         public string DisplayField1 { get { return m_displayFields[0]; } set { } }
         public string DisplayField2 { get { return m_displayFields[1]; } set { } }
         public string DisplayField3 { get { return m_displayFields[2]; } set { } }
         public string DisplayField4 { get { return m_displayFields[3]; } set { } }
+        public string DisplayField5 { get { return m_displayFields[4]; } set { } }
+        public string DisplayField6 { get { return m_displayFields[5]; } set { } }
+        public string DisplayField7 { get { return m_displayFields[6]; } set { } }
+        public string DisplayField8 { get { return m_displayFields[7]; } set { } }
+        public string DisplayField9 { get { return m_displayFields[8]; } set { } }
+        public string DisplayField10 { get { return m_displayFields[9]; } set { } }
 
         // returns true of 'pattern' matches the display fields.  
         public virtual bool Matches(Regex pattern)
@@ -194,10 +200,10 @@ namespace EventSources
         {
             if (m_displayFields == null)
             {
-                m_displayFields = new string[5];
+                m_displayFields = new string[11];
             }
 
-            Debug.Assert(m_displayFields.Length == 5);
+            Debug.Assert(m_displayFields.Length == 11);
             // TODO FIX NOW NOT DONE 
         }
 
@@ -208,7 +214,7 @@ namespace EventSources
         protected internal string[] m_displayFields;
         protected EventRecord(int numNonRestFields)
         {
-            Debug.Assert(numNonRestFields >= 4 || numNonRestFields == 0);
+            Debug.Assert(numNonRestFields >= 10 || numNonRestFields == 0);
             m_displayFields = new string[numNonRestFields];
         }
         protected EventRecord() { }

--- a/src/PerfView/EtwEventSource.cs
+++ b/src/PerfView/EtwEventSource.cs
@@ -23,7 +23,7 @@ namespace PerfView
         public ETWEventSource(TraceLog traceLog)
         {
             m_tracelog = traceLog;
-            NonRestFields = 4;
+            NonRestFields = 10;
             MaxEventTimeRelativeMsec = traceLog.SessionDuration.TotalMilliseconds;
         }
         public override ICollection<string> EventNames
@@ -823,7 +823,7 @@ namespace PerfView
             m_records = records;
             m_records.OnNewRecord += this.EventCallback;
 
-            NonRestFields = 4;
+            NonRestFields = 10;
             MaxEventTimeRelativeMsec = 60000;       // Currently set to 1 min, will expand when we exceed that.  
             m_allEventRecords = new List<GenericEventRecord>();
             m_eventFieldNames = new SortedDictionary<string, string[]>();

--- a/src/PerfView/EventViewer/EventWindow.xaml
+++ b/src/PerfView/EventViewer/EventWindow.xaml
@@ -307,7 +307,7 @@
                         <WPFToolKit:DataGridTextColumn
                         Header="Rest"
                         Binding="{Binding Rest, Mode=TwoWay}"
-                        Width="*" />
+                        Width="Auto" />
                     </WPFToolKit:DataGrid.Columns>
                 </WPFToolKit:DataGrid>
             </Grid>

--- a/src/PerfView/EventViewer/EventWindow.xaml
+++ b/src/PerfView/EventViewer/EventWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:src="clr-namespace:PerfView"
         xmlns:controls="clr-namespace:Controls"
         Style="{DynamicResource CustomWindowStyle}"
-        Title="Events Filtered by Type" Height="493" Width="989">
+        Title="Events Filtered by Type" WindowState="Maximized">
     <Window.Resources>
         <!-- Shared Styles -->
         <Style x:Key="RightAlign">
@@ -275,9 +275,39 @@
                         Binding="{Binding DisplayField4, Mode=TwoWay}"
                         Width="Auto" />
                         <WPFToolKit:DataGridTextColumn
+                        Visibility="Hidden"
+                        Header="Field5"
+                        Binding="{Binding DisplayField5, Mode=TwoWay}"
+                        Width="Auto" />
+                        <WPFToolKit:DataGridTextColumn
+                        Visibility="Hidden"
+                        Header="Field6"
+                        Binding="{Binding DisplayField6, Mode=TwoWay}"
+                        Width="Auto" />
+                        <WPFToolKit:DataGridTextColumn
+                        Visibility="Hidden"
+                        Header="Field7"
+                        Binding="{Binding DisplayField7, Mode=TwoWay}"
+                        Width="Auto" />
+                        <WPFToolKit:DataGridTextColumn
+                        Visibility="Hidden"
+                        Header="Field8"
+                        Binding="{Binding DisplayField8, Mode=TwoWay}"
+                        Width="Auto" />
+                        <WPFToolKit:DataGridTextColumn
+                        Visibility="Hidden"
+                        Header="Field9"
+                        Binding="{Binding DisplayField9, Mode=TwoWay}"
+                        Width="Auto" />
+                        <WPFToolKit:DataGridTextColumn
+                        Visibility="Hidden"
+                        Header="Field10"
+                        Binding="{Binding DisplayField10, Mode=TwoWay}"
+                        Width="Auto" />
+                        <WPFToolKit:DataGridTextColumn
                         Header="Rest"
                         Binding="{Binding Rest, Mode=TwoWay}"
-                        Width="Auto" />
+                        Width="*" />
                     </WPFToolKit:DataGrid.Columns>
                 </WPFToolKit:DataGrid>
             </Grid>


### PR DESCRIPTION
1) increasing the columns displayed in the Events view to 10 before resolving to Rest.for someone who uses the Events view heavily only displaying 4 columns before resolving to Rest seems like a unnecessary limitation (was this because this was written at a time when we had very small monitors? 😄). 

2) displaying the Events view window maximized by default because most likely you will want to do that

3) changed the Rest column to fit the window instead of leaving a huge amount of space which means if you select that column you will mostly see just empty space and just lost most of your valuable columns on the left hand side - 

<img width="1211" alt="image" src="https://github.com/microsoft/perfview/assets/10837357/db027097-e0eb-4304-86d0-c42024081a15">