### PR TITLE
ci: matrix build & separate test runs

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -9,16 +9,21 @@ pr:
   - main
 
 jobs:
-  - job: PerfView_Debug
+  - job: Build
+    strategy:
+      matrix:
+        Debug:
+          configuration: Debug
+          Codeql.Enabled: true
+          Codeql.BuildIdentifier: PerfView
+        Release:
+          configuration: Release
     pool:
       vmImage: 'windows-2022'
       name: Azure Pipelines
       demands:
       - msbuild
       - vstest
-    variables:
-      Codeql.Enabled: true
-      Codeql.BuildIdentifier: PerfView
 
     steps:
     - task: UseDotNet@2
@@ -43,7 +48,7 @@ jobs:
       displayName: 'Build PerfView.sln'
       inputs:
         solution: PerfView.sln
-        configuration: Debug
+        configuration: $(configuration)
 
     - task: VSTest@2
       displayName: 'Run Tests'
@@ -55,7 +60,7 @@ jobs:
          **\PerfViewTests.dll
          !**\*TestAdapter.dll
          !**\obj\**
-        testRunTitle: 'PerfView - Debug'
+        testRunTitle: 'PerfView - $(configuration)'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'
@@ -69,66 +74,8 @@ jobs:
       displayName: 'Publish Artifacts'
       inputs:
         PathtoPublish: '$(build.artifactstagingdirectory)'
-        ArtifactName: 'PerfViewBinaries-Debug'
+        ArtifactName: 'PerfViewBinaries-$(configuration)'
       condition: succeededOrFailed()
-
-  - job: PerfView_Release
-    pool:
-      vmImage: 'windows-2022'
-      name: Azure Pipelines
-      demands:
-      - msbuild
-      - vstest
-
-    steps:
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core SDK 3.1'
-      inputs:
-        version: 3.1.x
-
-    - task: NuGetToolInstaller@1
-      displayName: 'Install NuGet.exe'
-      inputs:
-        versionSpec: 6.3.0
-
-    - task: NuGetCommand@2
-      displayName: 'NuGet Restore PerfView.sln'
-      inputs:
-        restoreSolution: PerfView.sln
-        feedsToUse: config
-        includeNuGetOrg: false
-        nugetConfigPath: '.\NuGet.config'
-
-    - task: MSBuild@1
-      displayName: 'Build PerfView.sln'
-      inputs:
-        solution: PerfView.sln
-        configuration: Release
-
-    - task: VSTest@2
-      displayName: 'Run Tests'
-      inputs:
-        testAssemblyVer2: |
-         **\LinuxTracing.Tests.dll
-         **\Tests.dll
-         **\TraceEventTests.dll
-         **\PerfViewTests.dll
-         !**\*TestAdapter.dll
-         !**\obj\**
-        testRunTitle: 'PerfView - Release'
-
-    - task: CopyFiles@2
-      displayName: 'Copy Files to Artifacts Staging'
-      inputs:
-        SourceFolder: '$(system.defaultworkingdirectory)'
-        Contents: '**\bin\$(BuildConfiguration)\**'
-        TargetFolder: '$(build.artifactstagingdirectory)'
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact'
-      inputs:
-        PathtoPublish: '$(build.artifactstagingdirectory)'
-        ArtifactName: 'PerfViewBinaries-Release'
 
   - job: PerfCollect
     pool:

--- a/.ado.yml
+++ b/.ado.yml
@@ -51,16 +51,32 @@ jobs:
         configuration: $(configuration)
 
     - task: VSTest@2
-      displayName: 'Run Tests'
+      displayName: Test
       inputs:
-        testAssemblyVer2: |
-         **\LinuxTracing.Tests.dll
-         **\Tests.dll
-         **\TraceEventTests.dll
-         **\PerfViewTests.dll
-         !**\*TestAdapter.dll
-         !**\obj\**
-        testRunTitle: 'PerfView - $(configuration)'
+        testRunTitle: 'LinuxTracing ($(configuration))'
+        failOnMinTestsNotRun: true
+        testAssemblyVer2: '**\bin\$(configuration)\**\Tests.dll'
+
+    - task: VSTest@2
+      displayName: Test LinuxTracing
+      inputs:
+        testRunTitle: LinuxTracing ($(configuration))
+        failOnMinTestsNotRun: true
+        testAssemblyVer2: '**\bin\$(configuration)\**\LinuxTracing.Tests.dll'
+
+    - task: VSTest@2
+      displayName: Test TraceEvent
+      inputs:
+        testRunTitle: TraceEvent ($(configuration))
+        failOnMinTestsNotRun: true
+        testAssemblyVer2: '**\bin\$(configuration)\**\TraceEventTests.dll'
+
+    - task: VSTest@2
+      displayName: Test PerfView
+      inputs:
+        testRunTitle: PerfView ($(configuration))
+        failOnMinTestsNotRun: true
+        testAssemblyVer2: '**\bin\$(configuration)\**\PerfViewTests.dll'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/MultiFileMergeAll.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/MultiFileMergeAll.cs
@@ -32,66 +32,68 @@ namespace TraceEventTests
             Output.WriteLine(string.Format("Processing the file {0}, Making ETLX and scanning.", etlFilePath));
             string eltxFilePath = Path.ChangeExtension(etlFilePath, ".etlx");
 
-            TraceEventDispatcher source = new ETWTraceEventSource(fileNames, TraceEventSourceType.MergeAll);
-            TraceLog traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(source, eltxFilePath));
-
-            Assert.Equal(95506, traceLog.EventCount);
-            var stopEvents = traceLog.Events.Filter(e => e.EventName == "Activity2Stop/Stop");
-            Assert.Equal(55, stopEvents.Count());
-            Assert.Equal((uint)13205, (uint)stopEvents.Last().EventIndex);
-
-            using (var file = new StreamReader($"{TestDataDir}\\diaghub-dotnetcore3.1-win-x64-diagsession.baseline.txt"))
+            using (TraceEventDispatcher source = new ETWTraceEventSource(fileNames, TraceEventSourceType.MergeAll))
+            using (TraceLog traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(source, eltxFilePath)))
             {
-                var traceSource = traceLog.Events.GetSource();
-                traceSource.AllEvents += delegate (TraceEvent data)
+
+                Assert.Equal(95506, traceLog.EventCount);
+                var stopEvents = traceLog.Events.Filter(e => e.EventName == "Activity2Stop/Stop");
+                Assert.Equal(55, stopEvents.Count());
+                Assert.Equal((uint)13205, (uint)stopEvents.Last().EventIndex);
+
+                using (var file = new StreamReader($"{TestDataDir}\\diaghub-dotnetcore3.1-win-x64-diagsession.baseline.txt"))
                 {
-                    string eventName = data.ProviderName + "/" + data.EventName;
-
-                    // We are going to skip dynamic events from the CLR provider.
-                    // The issue is that this depends on exactly which manifest is present
-                    // on the machine, and I just don't want to deal with the noise of 
-                    // failures because you have a slightly different one.  
-                    if (data.ProviderName == "DotNet")
+                    var traceSource = traceLog.Events.GetSource();
+                    traceSource.AllEvents += delegate (TraceEvent data)
                     {
-                        return;
-                    }
+                        string eventName = data.ProviderName + "/" + data.EventName;
 
-                    // We don't want to use the manifest for CLR Private events since 
-                    // different machines might have different manifests.  
-                    if (data.ProviderName == "Microsoft-Windows-DotNETRuntimePrivate")
-                    {
-                        if (data.GetType().Name == "DynamicTraceEventData" || data.EventName.StartsWith("EventID"))
+                        // We are going to skip dynamic events from the CLR provider.
+                        // The issue is that this depends on exactly which manifest is present
+                        // on the machine, and I just don't want to deal with the noise of
+                        // failures because you have a slightly different one.
+                        if (data.ProviderName == "DotNet")
                         {
                             return;
                         }
-                    }
-                    // Same problem with classic OS events.   We don't want to rely on the OS to parse since this could vary between baseline and test. 
-                    else if (data.ProviderName == "MSNT_SystemTrace")
-                    {
-                        // However we to allow a couple of 'known good' ones through so we test some aspects of the OS parsing logic in TraceEvent.   
-                        if (data.EventName != "SystemConfig/Platform" && data.EventName != "Image/KernelBase")
+
+                        // We don't want to use the manifest for CLR Private events since
+                        // different machines might have different manifests.
+                        if (data.ProviderName == "Microsoft-Windows-DotNETRuntimePrivate")
+                        {
+                            if (data.GetType().Name == "DynamicTraceEventData" || data.EventName.StartsWith("EventID"))
+                            {
+                                return;
+                            }
+                        }
+                        // Same problem with classic OS events.   We don't want to rely on the OS to parse since this could vary between baseline and test.
+                        else if (data.ProviderName == "MSNT_SystemTrace")
+                        {
+                            // However we to allow a couple of 'known good' ones through so we test some aspects of the OS parsing logic in TraceEvent.
+                            if (data.EventName != "SystemConfig/Platform" && data.EventName != "Image/KernelBase")
+                            {
+                                return;
+                            }
+                        }
+                        // In theory we have the same problem with any event that the OS supplies the parsing.   I dont want to be too aggressive about
+                        // turning them off, however becasuse I want those code paths tested
+
+
+                        // TODO FIX NOW, this is broken and should be fixed.
+                        // We are hacking it here so we don't turn off the test completely.
+                        if (eventName == "DotNet/CLR.SKUOrVersion")
                         {
                             return;
                         }
-                    }
-                    // In theory we have the same problem with any event that the OS supplies the parsing.   I dont want to be too aggressive about 
-                    // turning them off, however becasuse I want those code paths tested
 
+                        var evt = GeneralParsing.Parse(data);
 
-                    // TODO FIX NOW, this is broken and should be fixed.  
-                    // We are hacking it here so we don't turn off the test completely.  
-                    if (eventName == "DotNet/CLR.SKUOrVersion")
-                    {
-                        return;
-                    }
+                        var line = file.ReadLine();
+                        Assert.Equal(evt, line);
+                    };
 
-                    var evt = GeneralParsing.Parse(data);
-
-                    var line = file.ReadLine();
-                    Assert.Equal(evt, line);
-                };
-
-                traceSource.Process();
+                    traceSource.Process();
+                }
             }
         }
     }


### PR DESCRIPTION
Deduplicates the pipeline definition

Bonus: fix the missing dispose: https://dev.azure.com/ms/perfview/_build/results?buildId=487047&view=logs&j=72b59a5c-f9fa-5437-adfc-3f855724a45f&t=5b7ce142-d0b8-54c6-2760-989d7bf6c9fb&l=994