### PR TITLE
Fixed calculation of Alloc MB / Pause Time in GC

### DIFF
--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -168,7 +168,7 @@ namespace Stats
                                 gen.MaxAllocRateMBSec,
                                 gen.TotalPauseTimeMSec,
                                 gen.TotalAllocatedMB,
-                                gen.TotalPauseTimeMSec / runtime.GC.Stats().TotalAllocatedMB,
+                                runtime.GC.Stats().TotalAllocatedMB / gen.TotalPauseTimeMSec,
                                 gen.TotalPromotedMB / gen.TotalCpuMSec,
                                 gen.MeanPauseDurationMSec,
                                 gen.NumInduced,


### PR DESCRIPTION
The numerator and denominator for the Alloc MB / Total Pause Time calculation was reversed. This PR fixes this.

CC: @Maoni0 

![image](https://github.com/microsoft/perfview/assets/68247673/da81f4ce-aeb2-4b95-8e82-c25e5e1b568e)
