### PR TITLE
Harden TraceEventSession.ProviderNameToGuid

### DIFF
--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1639,17 +1639,18 @@ namespace Microsoft.Diagnostics.Tracing.Session
                     var providersDesc = (TraceEventNativeMethods.PROVIDER_ENUMERATION_INFO*)buffer;
 
                     hr = TraceEventNativeMethods.TdhEnumerateProviders(providersDesc, ref buffSize);
-                    if (hr != 0)
+                    if ((hr == 0) && (providersDesc != null))
+                    {
+                        var providers = (TraceEventNativeMethods.TRACE_PROVIDER_INFO*)&providersDesc[1];
+                        for (int i = 0; i < providersDesc->NumberOfProviders; i++)
+                        {
+                            var name = new string((char*)&buffer[providers[i].ProviderNameOffset]);
+                            s_providersByName[name] = providers[i].ProviderGuid;
+                        }
+                    }
+                    else
                     {
                         Trace.WriteLine("TdhEnumerateProviders failed HR = " + hr);
-                        providersDesc->NumberOfProviders = 0;
-                    }
-
-                    var providers = (TraceEventNativeMethods.TRACE_PROVIDER_INFO*)&providersDesc[1];
-                    for (int i = 0; i < providersDesc->NumberOfProviders; i++)
-                    {
-                        var name = new string((char*)&buffer[providers[i].ProviderNameOffset]);
-                        s_providersByName[name] = providers[i].ProviderGuid;
                     }
                 }
                 return s_providersByName;


### PR DESCRIPTION
Avoid dereferencing a null pointer if `providersDesc` is `null`.

This code has not changed recently - it appears that something has changed underneath this call.  That said, we can definitely harden this path and do better.