### PR TITLE
Fix Broken Test Runs in CI

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -56,6 +56,7 @@ jobs:
          !**\*TestAdapter.dll
          !**\obj\**
         testRunTitle: 'PerfView - Debug'
+        resultsFolder: '$(Agent.TempDirectory)\TestResults'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'
@@ -116,6 +117,7 @@ jobs:
          !**\*TestAdapter.dll
          !**\obj\**
         testRunTitle: 'PerfView - Release'
+        resultsFolder: '$(Agent.TempDirectory)\TestResults'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'


### PR DESCRIPTION
Specify the results directory for test runs to match where AzDO looks for results.