### PR TITLE
Use previous stable release of VSTest

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -49,7 +49,7 @@ jobs:
       displayName: Install Latest Stable VSTest
       inputs:
         packageFeedSelector: 'nugetOrg'
-        versionSelector: 'latestStable'
+        versionSelector: 'latestPreRelease'
 
     - task: VSTest@2
       displayName: 'Run Tests'

--- a/.ado.yml
+++ b/.ado.yml
@@ -50,7 +50,7 @@ jobs:
       inputs:
         packageFeedSelector: 'nugetOrg'
         versionSelector: 'specificVersion'
-        testPlatformVersion: '17.5.0'
+        testPlatformVersion: '17.2.0'
 
     - task: VSTest@2
       displayName: 'Run Tests'

--- a/.ado.yml
+++ b/.ado.yml
@@ -50,7 +50,7 @@ jobs:
       inputs:
         packageFeedSelector: 'nugetOrg'
         versionSelector: 'specificVersion'
-        testPlatformVersion: '17.6.2'
+        testPlatformVersion: '17.6.3'
 
     - task: VSTest@2
       displayName: 'Run Tests'

--- a/.ado.yml
+++ b/.ado.yml
@@ -49,7 +49,8 @@ jobs:
       displayName: Install Latest Stable VSTest
       inputs:
         packageFeedSelector: 'nugetOrg'
-        versionSelector: 'latestPreRelease'
+        versionSelector: 'specificVersion'
+        testPlatformVersion: '17.6.3'
 
     - task: VSTest@2
       displayName: 'Run Tests'

--- a/.ado.yml
+++ b/.ado.yml
@@ -50,7 +50,7 @@ jobs:
       inputs:
         packageFeedSelector: 'nugetOrg'
         versionSelector: 'specificVersion'
-        testPlatformVersion: '17.6.3'
+        testPlatformVersion: '17.6.2'
 
     - task: VSTest@2
       displayName: 'Run Tests'

--- a/.ado.yml
+++ b/.ado.yml
@@ -44,6 +44,12 @@ jobs:
       inputs:
         solution: PerfView.sln
         configuration: Debug
+    
+    - task: VisualStudioTestPlatformInstaller@1
+      displayName: Install Latest Stable VSTest
+      inputs:
+        packageFeedSelector: 'nugetOrg'
+        versionSelector: 'latestStable'
 
     - task: VSTest@2
       displayName: 'Run Tests'
@@ -56,6 +62,7 @@ jobs:
          !**\*TestAdapter.dll
          !**\obj\**
         testRunTitle: 'PerfView - Debug'
+        vsTestVersion: 'toolsInstaller'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'

--- a/.ado.yml
+++ b/.ado.yml
@@ -50,7 +50,7 @@ jobs:
       inputs:
         packageFeedSelector: 'nugetOrg'
         versionSelector: 'specificVersion'
-        testPlatformVersion: '17.6.2'
+        testPlatformVersion: '17.5.0'
 
     - task: VSTest@2
       displayName: 'Run Tests'

--- a/.ado.yml
+++ b/.ado.yml
@@ -44,13 +44,13 @@ jobs:
       inputs:
         solution: PerfView.sln
         configuration: Debug
-    
+
     - task: VisualStudioTestPlatformInstaller@1
       displayName: Install Latest Stable VSTest
       inputs:
         packageFeedSelector: 'nugetOrg'
         versionSelector: 'specificVersion'
-        testPlatformVersion: '17.2.0'
+        testPlatformVersion: '17.6.2'
 
     - task: VSTest@2
       displayName: 'Run Tests'
@@ -113,6 +113,13 @@ jobs:
         solution: PerfView.sln
         configuration: Release
 
+    - task: VisualStudioTestPlatformInstaller@1
+      displayName: Install Latest Stable VSTest
+      inputs:
+        packageFeedSelector: 'nugetOrg'
+        versionSelector: 'specificVersion'
+        testPlatformVersion: '17.6.3'
+
     - task: VSTest@2
       displayName: 'Run Tests'
       inputs:
@@ -124,6 +131,7 @@ jobs:
          !**\*TestAdapter.dll
          !**\obj\**
         testRunTitle: 'PerfView - Release'
+        vsTestVersion: 'toolsInstaller'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'


### PR DESCRIPTION
Temporarily pin version of VSTest to 17.6.3 till we figure out why TRX is not produced on newer versions.