### PR TITLE
Removes linux-cloud-tools-5.15.0-79-generic as it's not available for Ubuntu 20.04 on arm64 AND looks like it's not needed anyway (trace works without it).

### DIFF
--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -1102,7 +1102,7 @@ InstallPerf_Ubuntu()
     then
         apt-get install -y linux-tools-azure zip software-properties-common
     else
-        apt-get install -y linux-tools-common linux-tools-`uname -r` linux-cloud-tools-`uname -r` zip software-properties-common
+        apt-get install -y linux-tools-common linux-tools-`uname -r` zip software-properties-common
     fi
 }
 


### PR DESCRIPTION
Fixes #1902.