### PR TITLE
Explicitly Reference Microsoft.Win32.Registry as a NuGet Dependency

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -31,6 +31,7 @@
     <dependencies>
       <group targetFramework=".NETStandard2.0">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
+        <dependency id="Microsoft.Win32.Registry" version="4.4.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
TraceEvent depends on Microsoft.Win32.Registry but does not specify the dependency in the nuspec file.  .NET Core shared framework applications are unaffected because Microsoft.Win32.Registry is part of the shared framework, however self-contained and .NET Framework applications are affected.  Many users don't see this issue because Microsoft.Win32.Registry is often on the machine.  This change will guarantee that Microsoft.Win32.Registry is present.