### PR TITLE
Fix clean build of PerfView.sln

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -42,38 +42,38 @@
     <file src="Microsoft.Diagnostics.Tracing.TraceEvent.props" target="buildTransitive\Microsoft.Diagnostics.Tracing.TraceEvent.props" />
 
     <!-- Native binaries -->
-    <file src="$OutDir$netstandard2.0\amd64\KernelTraceControl.dll" target="build\native\amd64\KernelTraceControl.dll" />
-    <file src="$OutDir$netstandard2.0\amd64\msdia140.dll" target="build\native\amd64\msdia140.dll" />
-    <file src="$OutDir$netstandard2.0\amd64\msvcp140.dll" target="build\native\amd64\msvcp140.dll" />
-    <file src="$OutDir$netstandard2.0\amd64\vcruntime140.dll" target="build\native\amd64\vcruntime140.dll" />
-    <file src="$OutDir$netstandard2.0\amd64\vcruntime140_1.dll" target="build\native\amd64\vcruntime140_1.dll" />
+    <file src="$OutDir$amd64\KernelTraceControl.dll" target="build\native\amd64\KernelTraceControl.dll" />
+    <file src="$OutDir$amd64\msdia140.dll" target="build\native\amd64\msdia140.dll" />
+    <file src="$OutDir$amd64\msvcp140.dll" target="build\native\amd64\msvcp140.dll" />
+    <file src="$OutDir$amd64\vcruntime140.dll" target="build\native\amd64\vcruntime140.dll" />
+    <file src="$OutDir$amd64\vcruntime140_1.dll" target="build\native\amd64\vcruntime140_1.dll" />
 
-    <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.dll" target="build\native\x86\KernelTraceControl.dll" />
-    <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.Win61.dll" target="build\native\x86\KernelTraceControl.Win61.dll" />
-    <file src="$OutDir$netstandard2.0\x86\msdia140.dll" target="build\native\x86\msdia140.dll" />
-    <file src="$OutDir$netstandard2.0\x86\msvcp140.dll" target="build\native\x86\msvcp140.dll" />
-    <file src="$OutDir$netstandard2.0\x86\vcruntime140.dll" target="build\native\x86\vcruntime140.dll" />
+    <file src="$OutDir$x86\KernelTraceControl.dll" target="build\native\x86\KernelTraceControl.dll" />
+    <file src="$OutDir$x86\KernelTraceControl.Win61.dll" target="build\native\x86\KernelTraceControl.Win61.dll" />
+    <file src="$OutDir$x86\msdia140.dll" target="build\native\x86\msdia140.dll" />
+    <file src="$OutDir$x86\msvcp140.dll" target="build\native\x86\msvcp140.dll" />
+    <file src="$OutDir$x86\vcruntime140.dll" target="build\native\x86\vcruntime140.dll" />
 
-    <file src="$OutDir$netstandard2.0\arm64\KernelTraceControl.dll" target="build\native\arm64\KernelTraceControl.dll" />
-    <file src="$OutDir$netstandard2.0\arm64\msdia140.dll" target="build\native\arm64\msdia140.dll" />
-    <file src="$OutDir$netstandard2.0\arm64\msvcp140.dll" target="build\native\arm64\msvcp140.dll" />
-    <file src="$OutDir$netstandard2.0\arm64\vcruntime140.dll" target="build\native\arm64\vcruntime140.dll" />
-    <file src="$OutDir$netstandard2.0\arm64\vcruntime140_1.dll" target="build\native\arm64\vcruntime140_1.dll" />
+    <file src="$OutDir$arm64\KernelTraceControl.dll" target="build\native\arm64\KernelTraceControl.dll" />
+    <file src="$OutDir$arm64\msdia140.dll" target="build\native\arm64\msdia140.dll" />
+    <file src="$OutDir$arm64\msvcp140.dll" target="build\native\arm64\msvcp140.dll" />
+    <file src="$OutDir$arm64\vcruntime140.dll" target="build\native\arm64\vcruntime140.dll" />
+    <file src="$OutDir$arm64\vcruntime140_1.dll" target="build\native\arm64\vcruntime140_1.dll" />
 
     <!-- NetStandard 2.0 Framework -->
 	
     <!-- Built libraries -->
-    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard2.0" />
-    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\netstandard2.0" />
-    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\netstandard2.0" />
+    <file src="$OutDir$Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$Microsoft.Diagnostics.Tracing.TraceEvent.xml" target="lib\netstandard2.0" />
+    <file src="$OutDir$Microsoft.Diagnostics.Tracing.TraceEvent.pdb" target="lib\netstandard2.0" />
 
-    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.dll" target="lib\netstandard2.0" />
-    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.xml" target="lib\netstandard2.0" />
-    <file src="$OutDir$netstandard2.0\Microsoft.Diagnostics.FastSerialization.pdb" target="lib\netstandard2.0" />
+    <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.xml" target="lib\netstandard2.0" />
+    <file src="$OutDir$Microsoft.Diagnostics.FastSerialization.pdb" target="lib\netstandard2.0" />
 
     <!-- Support Dlls -->
-    <file src="$OutDir$netstandard2.0\Dia2Lib.dll" target="lib\netstandard2.0" />
-    <file src="$OutDir$netstandard2.0\TraceReloggerLib.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$Dia2Lib.dll" target="lib\netstandard2.0" />
+    <file src="$OutDir$TraceReloggerLib.dll" target="lib\netstandard2.0" />
 
     <!-- Source code (All Frameworks *) -->
     <file exclude="obj\**\*.cs;bin\**\*.cs;TraceEvent.Tests\**\*.cs;Ctf\CtfTracing.Tests\**\*.cs" src="**\*.cs" target="src" />

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk"> 
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
TraceEvent doesn't build cleanly. The $OutDir$ variable used in the .nuspec doesn't expand correctly, so the build tries to reference C:\netstandard2.0 The fix is to switch from TargetFrameworks (plural) to TargetFramework.