### PR TITLE
Provide a StackResolver so that InternStackSource can resolve stacks …

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -1880,11 +1880,11 @@ namespace PerfView
         public void GuiHeapSnapshot(CommandLineArgs parsedArgs, bool waitForCompletion)
         {
 #if !PERFVIEW_COLLECT
-            // We'll wait on this handle until the heap snapshot completes.
-            ManualResetEvent waitHandle = new ManualResetEvent(false);
-
             if (GuiApp.MainWindow != null)
             {
+                // We'll wait on this handle until the heap snapshot completes.
+                ManualResetEvent waitHandle = new ManualResetEvent(false);
+
                 GuiApp.MainWindow.Dispatcher.BeginInvoke((Action)delegate ()
                 {
                     GuiApp.MainWindow.TakeHeapShapshot((Action)delegate ()
@@ -1894,11 +1894,15 @@ namespace PerfView
                         waitHandle.Set();
                     });
                 });
-            }
 
-            if (waitForCompletion)
+                if (waitForCompletion)
+                {
+                    waitHandle.WaitOne();
+                }
+            }
+            else
             {
-                waitHandle.WaitOne();
+                LogFile.WriteLine("[WARNING: Unable to capture the requested heap snapshot via command line.  Please re-run without /NoGui.]");
             }
 #endif
         }

--- a/src/TraceEvent/AutomatedAnalysis/StackView.cs
+++ b/src/TraceEvent/AutomatedAnalysis/StackView.cs
@@ -106,7 +106,8 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         /// Resolve symbols for the specified module.
         /// </summary>
         /// <param name="moduleName">The name of the module (without the dll or exe suffix).</param>
-        public void ResolveSymbols(string moduleName)
+        /// <returns>true if it tries to resolve the module, or false if it already tried</returns>
+        public bool ResolveSymbols(string moduleName)
         {
             if (!_resolvedSymbolModules.Contains(moduleName))
             {
@@ -155,7 +156,10 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
 
                 // Mark the module as resolved so that we don't try again.
                 _resolvedSymbolModules.Add(moduleName);
+                return true;
             }
+
+            return false;
         }
 
         /// <summary>

--- a/src/TraceEvent/Stacks/Stacks.cs
+++ b/src/TraceEvent/Stacks/Stacks.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved
 // This file is best viewed using outline mode (Ctrl-M Ctrl-O)
 
+using Microsoft.Diagnostics.Tracing.AutomatedAnalysis;
 using Microsoft.Diagnostics.Utilities;
 using System;
 using System.Collections.Concurrent;
@@ -853,11 +854,16 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
+        /// OnUnresolvedStackFrame will take an unresolved module 'moduleName', try to resolve it, and return the source with the module resolved (or null if it couldn't be resolved)
+        /// </summary>
+        public delegate StackSourceStacks OnUnresolvedStackFrame(string moduleName);
+        
+        /// <summary>
         /// InternFullStackFromSource will take a call stack 'baseCallStackIndex' from the source 'source' and completely copy it into
         /// the intern stack source (interning along the way of course).   Logically baseCallStackIndex has NOTHING to do with any of the
         /// call stack indexes in the intern stack source.  
         /// </summary>
-        private StackSourceCallStackIndex InternFullStackFromSource(StackSourceCallStackIndex baseCallStackIndex, StackSourceStacks source, int maxDepth = 1000)
+        protected StackSourceCallStackIndex InternFullStackFromSource(StackSourceCallStackIndex baseCallStackIndex, StackSourceStacks source, int maxDepth = 1000, OnUnresolvedStackFrame onUnresolvedStackFrame = null)
         {
             // To avoid stack overflows.  
             if (maxDepth < 0)
@@ -875,6 +881,19 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 
             var baseFullFrameName = source.GetFrameName(baseFrame, true);
             var moduleName = "";
+
+            // Check if this is an unresolved frame
+            if (onUnresolvedStackFrame != null && baseFullFrameName.EndsWith("!?") && !baseFullFrameName.Equals("?!?"))
+            {
+                moduleName = baseFullFrameName.Substring(0, baseFullFrameName.Length - 2);
+                var sourceWithResolvedModule = onUnresolvedStackFrame(moduleName);
+                if (sourceWithResolvedModule != null)
+                {
+                    source = sourceWithResolvedModule;
+                    baseFullFrameName = source.GetFrameName(baseFrame, true);
+                }
+            }
+
             var frameName = baseFullFrameName;
             var index = baseFullFrameName.IndexOf('!');
             if (index >= 0)
@@ -885,7 +904,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
 
             var myModuleIndex = Interner.ModuleIntern(moduleName);
             var myFrameIndex = Interner.FrameIntern(frameName, myModuleIndex);
-            var ret = Interner.CallStackIntern(myFrameIndex, InternFullStackFromSource(baseCaller, source, maxDepth - 1));
+            var ret = Interner.CallStackIntern(myFrameIndex, InternFullStackFromSource(baseCaller, source, maxDepth - 1, onUnresolvedStackFrame));
             return ret;
         }
         #endregion


### PR DESCRIPTION
…along the way

Provide an optional way to resolve the stacks as we are interning them, in case somebody wants a fully resolved stack.

Also, change InternFullStackFromSource from a private method to protected, in case there's a class that extends InternStackSource and wants to call the method directly