### PR TITLE
Add properties for accessing processor time & 

### DIFF
--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -161,6 +161,12 @@ namespace Microsoft.Diagnostics.Tracing
         /// The name of the session that generated the data. 
         /// </summary>
         public string SessionName { get { return logFiles[0].LoggerName; } }
+
+        /// <summary>
+        /// Resolution of the hardware timer, in units of 100 nanoseconds.
+        /// </summary>
+        public ulong TimerResolution { get { return logFiles[0].LogfileHeader.TimerResolution; } }
+
         /// <summary>
         /// The size of the log, will return 0 if it does not know. 
         /// </summary>

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// <summary>
         /// Resolution of the hardware timer, in units of 100 nanoseconds.
         /// </summary>
-        public ulong TimerResolution { get { return logFiles[0].LogfileHeader.TimerResolution; } }
+        public uint TimerResolution { get { return logFiles[0].LogfileHeader.TimerResolution; } }
 
         /// <summary>
         /// The size of the log, will return 0 if it does not know. 

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -995,6 +995,60 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
+        /// <summary>
+        /// The processor time of the event, if available
+        /// </summary>
+        public ulong ProcessorTime
+        {
+            get
+            {
+                if((eventRecord->EventHeader.Flags & TraceEventNativeMethods.EVENT_HEADER_FLAG_NO_CPUTIME) != 0)
+                {
+                    return (eventRecord->EventHeader.KernelTime << sizeof(int)) + eventRecord->EventHeader.UserTime;
+                }
+                else
+                {
+                    return eventRecord->EventHeader.KernelTime + eventRecord->EventHeader.UserTime;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The user time of the event, if available
+        /// </summary>
+        public uint? UserTime
+        {
+            get
+            {
+                if ((eventRecord->EventHeader.Flags & TraceEventNativeMethods.EVENT_HEADER_FLAG_NO_CPUTIME) != 0)
+                {
+                    return null;
+                }
+                else
+                {
+                    return eventRecord->EventHeader.UserTime;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The kernel time of the event, if available
+        /// </summary>
+        public uint? KernelTime
+        {
+            get
+            {
+                if ((eventRecord->EventHeader.Flags & TraceEventNativeMethods.EVENT_HEADER_FLAG_NO_CPUTIME) != 0)
+                {
+                    return null;
+                }
+                else
+                {
+                    return eventRecord->EventHeader.KernelTime;
+                }
+            }
+        }
+
         // These overloads allow integration with the DLR (Dynamic Language Runtime). That
         // enables getting at payload data in a more convenient fashion, directly by name.
         // In PowerShell, it "just works" (e.g. "$myEvent.MyPayload" will just work); in

--- a/src/TraceEvent/TraceEventNativeMethods.cs
+++ b/src/TraceEvent/TraceEventNativeMethods.cs
@@ -171,8 +171,8 @@ namespace Microsoft.Diagnostics.Tracing
             //	no access to GuidPtr, union'd with guid field
             //	no access to ClientContext & MatchAnyKeywords, ProcessorTime, 
             //	union'd with kernelTime,userTime
-            public int KernelTime;         // Offset 0x28
-            public int UserTime;
+            public uint KernelTime;         // Offset 0x28
+            public uint UserTime;
         }
 
         /// <summary>
@@ -399,6 +399,7 @@ namespace Microsoft.Diagnostics.Tracing
         */
 
         internal const ushort EVENT_HEADER_FLAG_STRING_ONLY = 0x0004;
+        internal const ushort EVENT_HEADER_FLAG_NO_CPUTIME = 0x0010;
         internal const ushort EVENT_HEADER_FLAG_32_BIT_HEADER = 0x0020;
         internal const ushort EVENT_HEADER_FLAG_64_BIT_HEADER = 0x0040;
         internal const ushort EVENT_HEADER_FLAG_CLASSIC_HEADER = 0x0100;
@@ -426,8 +427,8 @@ namespace Microsoft.Diagnostics.Tracing
             public byte Opcode;
             public ushort Task;
             public ulong Keyword;
-            public int KernelTime;         // offset: 0x38
-            public int UserTime;           // offset: 0x3C
+            public uint KernelTime;         // offset: 0x38
+            public uint UserTime;           // offset: 0x3C
             public Guid ActivityId;
         }
 


### PR DESCRIPTION
- Add LogfileHeader.[TimerResolution](https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-trace_logfile_header)
- Add UserTime and KernelTime fields for [ProcessorTime](https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header)