### PR TITLE
Enable running in isolation and --blame

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -45,25 +45,17 @@ jobs:
         solution: PerfView.sln
         configuration: Debug
 
-    - task: VisualStudioTestPlatformInstaller@1
-      displayName: Install Latest Stable VSTest
-      inputs:
-        packageFeedSelector: 'nugetOrg'
-        versionSelector: 'specificVersion'
-        testPlatformVersion: '17.6.3'
-
     - task: VSTest@2
       displayName: 'Run Tests'
       inputs:
         testAssemblyVer2: |
-         **\LinuxTracing.Tests.dll
-         **\Tests.dll
-         **\TraceEventTests.dll
-         **\PerfViewTests.dll
-         !**\*TestAdapter.dll
-         !**\obj\**
+         **\bin\**\LinuxTracing.Tests.dll
+         **\bin\**\Tests.dll
+         **\bin\**\TraceEventTests.dll
+         **\bin\**\PerfViewTests.dll
         testRunTitle: 'PerfView - Debug'
-        vsTestVersion: 'toolsInstaller'
+        runTestsInIsolation: true
+        otherConsoleOptions: '--blame'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'
@@ -113,25 +105,17 @@ jobs:
         solution: PerfView.sln
         configuration: Release
 
-    - task: VisualStudioTestPlatformInstaller@1
-      displayName: Install Latest Stable VSTest
-      inputs:
-        packageFeedSelector: 'nugetOrg'
-        versionSelector: 'specificVersion'
-        testPlatformVersion: '17.6.3'
-
     - task: VSTest@2
       displayName: 'Run Tests'
       inputs:
         testAssemblyVer2: |
-         **\LinuxTracing.Tests.dll
-         **\Tests.dll
-         **\TraceEventTests.dll
-         **\PerfViewTests.dll
-         !**\*TestAdapter.dll
-         !**\obj\**
+         **\bin\**\LinuxTracing.Tests.dll
+         **\bin\**\Tests.dll
+         **\bin\**\TraceEventTests.dll
+         **\bin\**\PerfViewTests.dll
         testRunTitle: 'PerfView - Release'
-        vsTestVersion: 'toolsInstaller'
+        runTestsInIsolation: true
+        otherConsoleOptions: '--blame'
 
     - task: CopyFiles@2
       displayName: 'Copy Files to Artifacts Staging'

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -2055,7 +2055,7 @@ namespace PerfView
                 DoAbort(null, null);
             }
 
-            // Environment.Exit(0);        // TODO can we do this another way?
+            // DO NOT call Environment.Exit(0) here, it will kill the test runner, and tests won't complete.
         }
 
         // GUI Command objects.

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -2055,7 +2055,7 @@ namespace PerfView
                 DoAbort(null, null);
             }
 
-            Environment.Exit(0);        // TODO can we do this another way?
+            // Environment.Exit(0);        // TODO can we do this another way?
         }
 
         // GUI Command objects.


### PR DESCRIPTION
PerfView tests are running in process because they are .NET Framework tests, and the WPF code is exiting process with 0, which makes the test runner think all tests passed, but in reality only a small portion of tests run.

Make the tests run in a sub-process, where we can detect that it exited before it should, even when it exits with 0. I am also enabling blame so it shows you which test most likely crashed the process. This adds a little bit of overhead, feel free to remove that if you don't need it. It will still crash, but with less info.
