### PR TITLE
New version for Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,7 +33,7 @@
   <!-- Support files and analyzers -->
   <PropertyGroup>
     <PerfViewSupportFilesVersion>1.0.7</PerfViewSupportFilesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.25</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>1.0.26</MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion>
     <MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>0.1.2</MicrosoftDiagnosticsTracingTraceEventAutomatedAnalysisAnalyzersVersion>
   </PropertyGroup>
 

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -220,20 +220,6 @@
       <Link>x86\msdia140.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\x86\msvcp140.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\x86\msvcp140.dll</LogicalName>
-      <Link>x86\msvcp140.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\x86\vcruntime140.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\x86\vcruntime140.dll</LogicalName>
-      <Link>x86\vcruntime140.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
     <EmbeddedResource Include="$(PerfViewSupportFilesBase)native\x86\sd.exe">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
@@ -290,27 +276,6 @@
       <WithCulture>false</WithCulture>
       <LogicalName>.\amd64\msdia140.dll</LogicalName>
       <Link>amd64\msdia140.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\msvcp140.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\amd64\msvcp140.dll</LogicalName>
-      <Link>amd64\msvcp140.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\amd64\vcruntime140.dll</LogicalName>
-      <Link>amd64\vcruntime140.dll</Link>
-      <Visible>False</Visible>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140_1.dll">
-      <Type>Non-Resx</Type>
-      <WithCulture>false</WithCulture>
-      <LogicalName>.\amd64\vcruntime140_1.dll</LogicalName>
-      <Link>amd64\vcruntime140_1.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
     <EmbeddedResource Include="..\HeapDump\bin\x64\$(Configuration)\net462\HeapDump.exe">

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -44,21 +44,13 @@
     <!-- Native binaries -->
     <file src="$OutDir$netstandard2.0\amd64\KernelTraceControl.dll" target="build\native\amd64\KernelTraceControl.dll" />
     <file src="$OutDir$netstandard2.0\amd64\msdia140.dll" target="build\native\amd64\msdia140.dll" />
-    <file src="$OutDir$netstandard2.0\amd64\msvcp140.dll" target="build\native\amd64\msvcp140.dll" />
-    <file src="$OutDir$netstandard2.0\amd64\vcruntime140.dll" target="build\native\amd64\vcruntime140.dll" />
-    <file src="$OutDir$netstandard2.0\amd64\vcruntime140_1.dll" target="build\native\amd64\vcruntime140_1.dll" />
 
     <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.dll" target="build\native\x86\KernelTraceControl.dll" />
     <file src="$OutDir$netstandard2.0\x86\KernelTraceControl.Win61.dll" target="build\native\x86\KernelTraceControl.Win61.dll" />
     <file src="$OutDir$netstandard2.0\x86\msdia140.dll" target="build\native\x86\msdia140.dll" />
-    <file src="$OutDir$netstandard2.0\x86\msvcp140.dll" target="build\native\x86\msvcp140.dll" />
-    <file src="$OutDir$netstandard2.0\x86\vcruntime140.dll" target="build\native\x86\vcruntime140.dll" />
 
     <file src="$OutDir$netstandard2.0\arm64\KernelTraceControl.dll" target="build\native\arm64\KernelTraceControl.dll" />
     <file src="$OutDir$netstandard2.0\arm64\msdia140.dll" target="build\native\arm64\msdia140.dll" />
-    <file src="$OutDir$netstandard2.0\arm64\msvcp140.dll" target="build\native\arm64\msvcp140.dll" />
-    <file src="$OutDir$netstandard2.0\arm64\vcruntime140.dll" target="build\native\arm64\vcruntime140.dll" />
-    <file src="$OutDir$netstandard2.0\arm64\vcruntime140_1.dll" target="build\native\arm64\vcruntime140_1.dll" />
 
     <!-- NetStandard 2.0 Framework -->
 	

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props
@@ -16,16 +16,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\msvcp140.dll') And ('$(ProcessorArchitecture)' == 'x86' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\msvcp140.dll">
-      <Link>x86\msvcp140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\x86\vcruntime140.dll') And ('$(ProcessorArchitecture)' == 'x86' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\x86\vcruntime140.dll">
-      <Link>x86\vcruntime140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
     <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\KernelTraceControl.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\KernelTraceControl.dll">
       <Link>amd64\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -36,21 +26,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\msvcp140.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\msvcp140.dll">
-      <Link>amd64\msvcp140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140.dll">
-      <Link>amd64\vcruntime140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140_1.dll') And ('$(ProcessorArchitecture)' == 'amd64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\amd64\vcruntime140_1.dll">
-      <Link>amd64\vcruntime140_1.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
     <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\KernelTraceControl.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\KernelTraceControl.dll">
       <Link>arm64\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -58,21 +33,6 @@
     </None>
     <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\msdia140.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\msdia140.dll">
       <Link>arm64\msdia140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\msvcp140.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\msvcp140.dll">
-      <Link>arm64\msvcp140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140.dll">
-      <Link>arm64\vcruntime140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Condition="Exists('$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140_1.dll') And ('$(ProcessorArchitecture)' == 'arm64' Or '$(ProcessorArchitecture)' == 'msil')" Include="$(MSBuildThisFileDirectory)..\build\native\arm64\vcruntime140_1.dll">
-      <Link>arm64\vcruntime140_1.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -107,21 +107,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Include="$(TraceEventSupportFilesBase)native\amd64\msvcp140.dll">
-      <Link>amd64\msvcp140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140.dll">
-      <Link>amd64\vcruntime140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(TraceEventSupportFilesBase)native\amd64\vcruntime140_1.dll">
-      <Link>amd64\vcruntime140_1.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
     <None Include="$(TraceEventSupportFilesBase)native\x86\KernelTraceControl.dll">
       <Link>x86\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -137,16 +122,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Include="$(TraceEventSupportFilesBase)native\x86\msvcp140.dll">
-      <Link>x86\msvcp140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(TraceEventSupportFilesBase)native\x86\vcruntime140.dll">
-      <Link>x86\vcruntime140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
     <None Include="$(TraceEventSupportFilesBase)native\arm64\KernelTraceControl.dll">
       <Link>arm64\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -154,21 +129,6 @@
     </None>
     <None Include="$(TraceEventSupportFilesBase)native\arm64\msdia140.dll">
       <Link>arm64\msdia140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(TraceEventSupportFilesBase)native\arm64\msvcp140.dll">
-      <Link>arm64\msvcp140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(TraceEventSupportFilesBase)native\arm64\vcruntime140.dll">
-      <Link>arm64\vcruntime140.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(TraceEventSupportFilesBase)native\arm64\vcruntime140_1.dll">
-      <Link>arm64\vcruntime140_1.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
Fixes #1659.

Replaces msdia140.dll with a new version that fixes CVE-2018-25032.  Removes dependencies that the new version of msdia140.dll doesn't require.