### PR TITLE
Properly setting the process.Log to be used by the GC to discern whether the process is running with SVR GC Threads.

### DIFF
--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -537,24 +537,13 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
                             return;
                     }
                     mang.GC.m_stats.lastSuspendReason = data.Reason;
+
                     mang.GC.m_stats.suspendTimeRelativeMSec = data.TimeStampRelativeMSec;
 
-                    // Check to see if the traceLogEventSource can get us to the Etlx.TraceLog.
-                    // And if so, we'll have the details of the GC SVR threads to discern 
-                    // if we are truly running a SVR process.
-                    TraceLogEventSource traceLogEventSource = source as TraceLogEventSource;
-                    Etlx.TraceLog traceLog = traceLogEventSource?.TraceLog;
-
-                    // Check to see if we have access to the Etlx.TraceLog in any form and if we haven't 
-                    // got the Thread Info in a previous iteration.
-                    if (((process.Log != null) || (traceLog != null)) && !mang.GC.m_stats.gotThreadInfo)
+                    if ((process.Log != null) && !mang.GC.m_stats.gotThreadInfo)
                     {
                         mang.GC.m_stats.gotThreadInfo = true;
-
-                        // If the process.Log is null, obtain the traceProc from the traceLog.
-                        Etlx.TraceLog validTraceLog = process.Log ?? traceLog;
-                        Etlx.TraceProcess traceProc = validTraceLog.Processes.GetProcess(process.ProcessID, data.TimeStampRelativeMSec);
-
+                        Microsoft.Diagnostics.Tracing.Etlx.TraceProcess traceProc = process.Log.Processes.GetProcess(process.ProcessID, data.TimeStampRelativeMSec);
                         if (traceProc != null)
                         {
                             foreach (var procThread in traceProc.Threads)

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -10,7 +10,6 @@ using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 using Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate;
-using Microsoft.Diagnostics.Tracing.Parsers.FrameworkEventSource;
 using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using Microsoft.Diagnostics.Tracing.Parsers.Symbol;
 using Microsoft.Diagnostics.Tracing.Stacks;

--- a/src/TraceEvent/Computers/TraceProcess.cs
+++ b/src/TraceEvent/Computers/TraceProcess.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             if (processes == null || m_weakCurrentSource.Target != source)
             {
                 TraceLogEventSource traceLogEventSource = source as TraceLogEventSource;
-                Etlx.TraceLog etlxTraceLog = traceLogEventSource?.TraceLog;
+                Etlx.TraceLog etlxTraceLog = null;
+                if (traceLogEventSource != null)
+                {
+                    etlxTraceLog = traceLogEventSource;
+                }
+
                 processes = new TraceProcesses(etlxTraceLog, source);
                 // establish listeners
                 if (m_weakCurrentSource.Target != source)

--- a/src/TraceEvent/Computers/TraceProcess.cs
+++ b/src/TraceEvent/Computers/TraceProcess.cs
@@ -4,6 +4,7 @@
 // This program uses code hyperlinks available as part of the HyperAddin Visual Studio plug-in.
 // It is available from http://www.codeplex.com/hyperAddin 
 // using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using Microsoft.Diagnostics.Utilities;
 using System;
@@ -23,7 +24,9 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             TraceProcesses processes = source.Processes();
             if (processes == null || m_weakCurrentSource.Target != source)
             {
-                processes = new TraceProcesses(null /* TraceLog */, source);
+                TraceLogEventSource traceLogEventSource = source as TraceLogEventSource;
+                Etlx.TraceLog etlxTraceLog = traceLogEventSource?.TraceLog;
+                processes = new TraceProcesses(etlxTraceLog, source);
                 // establish listeners
                 if (m_weakCurrentSource.Target != source)
                 {
@@ -204,7 +207,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
         /// <summary>
         /// The log associated with this collection of processes. 
         /// </summary> 
-        public TraceLog Log { get { return log; } }
+        public Etlx.TraceLog Log { get { return log; } }
         /// <summary>
         /// The count of the number of TraceProcess instances in the TraceProcesses list. 
         /// </summary>
@@ -356,7 +359,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
         /// process, as well as the process lookup tables and a cache that remembers the last calls to
         /// GetNameForAddress(). 
         /// </summary>
-        internal TraceProcesses(TraceLog log, TraceEventDispatcher source)
+        internal TraceProcesses(Etlx.TraceLog log, TraceEventDispatcher source)
         {
             this.log = log;
             this.source = source;
@@ -496,7 +499,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
         // State variables.  
         private GrowableArray<TraceProcess> processes;          // The threads ordered in time. 
         private GrowableArray<TraceProcess> processesByPID;     // The threads ordered by processID.  
-        private TraceLog log;
+        private Etlx.TraceLog log;
         private TraceEventDispatcher source;
         internal event Action<TraceProcess> OnProcessStart;
         internal event Action<TraceProcess> OnProcessStop;
@@ -755,15 +758,15 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
 
         internal TraceProcess(int processID, ProcessIndex processIndex)
         {
-            Initialize(processID, processIndex, null /* TraceEventDispatcher */);
+            Initialize(processID, processIndex, null /* TraceEventDispatcher */, null /* TraceLog */);
         }
 
-        internal TraceProcess(int processID, TraceLog log, ProcessIndex processIndex, TraceEventDispatcher source)
+        internal TraceProcess(int processID, Etlx.TraceLog log, ProcessIndex processIndex, TraceEventDispatcher source)
         {
-            Initialize(processID, processIndex, source);
+            Initialize(processID, processIndex, source, log);
         }
 
-        private void Initialize(int processID, ProcessIndex processIndex, TraceEventDispatcher source)
+        private void Initialize(int processID, ProcessIndex processIndex, TraceEventDispatcher source, Etlx.TraceLog log)
         {
             ProcessID = processID;
             ParentID = -1;
@@ -774,7 +777,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
             Source = source;
             Is64Bit = false;
             LoadedModules = null;
-            Log = null;
+            Log = log;
             Parent = null;
             Threads = null;
             EventsInProcess = null;

--- a/src/TraceEvent/Computers/TraceProcess.cs
+++ b/src/TraceEvent/Computers/TraceProcess.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis
                 Etlx.TraceLog etlxTraceLog = null;
                 if (traceLogEventSource != null)
                 {
-                    etlxTraceLog = traceLogEventSource;
+                    etlxTraceLog = traceLogEventSource.TraceLog;
                 }
 
                 processes = new TraceProcesses(etlxTraceLog, source);


### PR DESCRIPTION
By correctly getting the Etlx.TraceLog, we have the information necessary to discern whether the process has SVR GC threads. This is important as in DATAS, we start off with 1 heap and then change the heap count and the previous logic was failing to get us the BGC based GlobalHeapHistory event as it is fired after GC/Stop. 

## Solution 

We appropriately set process.Log to point to the pertinent Etlx.TraceLog (if available) by ensuring that the TraceProcess allows an Etlx.TraceLog in its constructor rather than the Analysis.TraceLog; the initial concern was that we'll be coupling the Etlx.TraceLog to the Analysis but this has already been done by setting the type of process.Log to Etlx.TraceLog vs. Analysis.TraceLog.

## Further Details on the Problem

The order of events for BGC based GlobalHeapHistory events were:

-> GC/Start
-> GC/Stop
-> GC/GlobalHeapHistory 

And since we previously didn't have details about the SVR GC threads, we were missing this event as the check to do this is:

```csharp
// This is the last GC in progress. We need this for server Background GC.
// See comments for lastCompletedGC.
private static TraceGC GetLastGC(TraceLoadedDotNetRuntime proc)
{
    TraceGC _event = TraceGarbageCollector.GetCurrentGC(proc);
    if ((proc.GC.m_stats.IsServerGCUsed == 1) &&
        (_event == null))
    {
        if (proc.GC.m_stats.lastCompletedGC != null)
        {
            Debug.Assert(proc.GC.m_stats.lastCompletedGC.Type == GCType.BackgroundGC);
            _event = proc.GC.m_stats.lastCompletedGC;
        }
    }

    return _event;
}
```