### PR TITLE
Reset FocusProcess when checkbox is unselected

### DIFF
--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -587,6 +587,10 @@ namespace PerfView
                     }
                     m_args.FocusProcess = FocusProcessTextBox.Text;
                 }
+                else
+                {
+                    m_args.FocusProcess = null;
+                }
             }
 
             m_args.DataFile = DataFileNameTextBox.Text;


### PR DESCRIPTION
Once set, the "Focus process" option cannot be reset because `PopulateCommandLineArgs` never sets `FocusProcess` to null.

This is a very simple fix without unit tests. I can add tests for `RunCommandDialog` if needed, but it requires to slightly change the constructor to allow skipping the elevation.