### PR TITLE
Fixes for Process Dump to GC Dump Conversion

### DIFF
--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml.cs
@@ -36,7 +36,7 @@ namespace PerfView.Dialogs
             if (args.ProcessDumpFile != null)
             {
                 ProcessDumpTextBox.Text = args.ProcessDumpFile;
-                DataFileNameTextBox.Text = System.IO.Path.ChangeExtension(args.ProcessDumpFile, ".gcDump");
+                DataFileNameTextBox.Text = args.ProcessDumpFile + ".gcDump";
                 SizeToContent = SizeToContent.Height;
                 ProcessRow.Visibility = Visibility.Collapsed;
                 StatusBar.Status = "Confirm parameters and hit enter to extract the GC heap from the dump.";
@@ -130,10 +130,10 @@ namespace PerfView.Dialogs
                 m_args.DoCommand = App.CommandProcessor.HeapSnapshotFromProcessDump;
             }
 
-            var dataFile = DataFileNameTextBox.Text;
+            var dataFile = RemoveQuotesFromPath(DataFileNameTextBox.Text);
             if (dataFile.Length == 0)
             {
-                StatusBar.Log("Error: Output data file not specififed.");
+                StatusBar.Log("Error: Output data file not specified.");
                 return;
             }
             m_args.DataFile = dataFile;
@@ -179,6 +179,19 @@ namespace PerfView.Dialogs
                     DataFileNameTextBox.Text = CommandProcessor.GetNewFile(DataFileNameTextBox.Text);
                 }
             });
+        }
+
+        private string RemoveQuotesFromPath(string inputPath)
+        {
+            if (!string.IsNullOrEmpty(inputPath) && inputPath.Length >= 2)
+            {
+                if (inputPath[0] == '\"' && inputPath[inputPath.Length - 1] == '\"')
+                {
+                    inputPath = inputPath.Substring(1, inputPath.Length - 2);
+                }
+            }
+
+            return inputPath;
         }
 
         private void DoHyperlinkHelp(object sender, ExecutedRoutedEventArgs e)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -9672,7 +9672,7 @@ table {
     public class ProcessDumpPerfViewFile : PerfViewFile
     {
         public override string FormatName { get { return "Process Dump"; } }
-        public override string[] FileExtensions { get { return new string[] { ".dmp" }; } }
+        public override string[] FileExtensions { get { return new string[] { ".dmp", ".hdmp", ".mdmp" }; } }
 
         public override void Open(Window parentWindow, StatusBar worker, Action doAfter = null)
         {


### PR DESCRIPTION
 - Recognize .hdmp and .mdmp files as process dumps.  Change the .gcdump file suffix to include the source suffix (e.g. .hdmp.gcdump) to avoid inadvertent overwrites of files with the same name but different suffix.
 - Trim surrounding quotes from the target .gcdump path to avoid failures in platform APIs that do not expect them.

cc: @leculver 