### PR TITLE
Weekly CI Trigger

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -8,6 +8,14 @@ trigger:
 pr:
   - main
 
+schedules:
+  - cron: "0 0 * * 2" # Trigger on Tuesday at Midnight UTC
+    displayName: Weekly Build
+    branches:
+      include:
+        - main
+    always: true
+
 jobs:
   - job: PerfView_Debug
     pool:


### PR DESCRIPTION
Trigger the CI to run weekly at midnight UTC.  This ensures that we maintain fresh component governance data to be used to detect security vulnerabilities.