### PR TITLE
WIP: fix PerfView to look up Crossgen2 PDBs next to the DLLs

### DIFF
--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -768,6 +768,12 @@ namespace Microsoft.Diagnostics.Symbols
             }
 
             var ngenImageDir = Path.GetDirectoryName(ngenImageFullPath);
+            var ngenPdbPath = Path.Combine(ngenImageDir, Path.GetFileName(pdbPath));
+            if (File.Exists(ngenPdbPath))
+            {
+                return ngenPdbPath;
+            }
+
             var pdbDir = Path.GetDirectoryName(pdbPath);
 
             // We need Crossgen, and there are several options, see what we can do. 


### PR DESCRIPTION
Based on David Wrighton's suggestion I have investigated why PerfView doesn't seem to find the .ni.pdb files next do the appropriate dlls in manual build mode. According to my reading of the code this logic is simply not implemented in HandleNetCorePdbs, this simple change fixes that and lets me locally see that PerfView is now capable of finding the .ni.pdb file.

The purpose of the PR is to discuss whether this is the logic we want for finding Crossgen2 PDBs or what is the right thing to do here. I vaguely recall that PE executables have a way of storing the "original PDB path" referring to the path where the PDB was put at the time of building the executable but AFAIK Crossgen2 currently doesn't support emitting this information.

If the "original PDB path" was the right way to go, we'd need to make a Crossgen2 fix that would store the name of the .ni.pdb file somewhere in the file plus the appropriate PerfView fix for looking up the record but I'm not sure if I'm the right person to do that as we agreed with Manish last summer that for .NET 9 I should switch over from Crossgen2 ownership to other work assignments.

Thanks

Tomas

/cc @brianrob @davidwrighton @mangod9 
(David said I should also tag Ashok Kamath from the VS to comment on this but I cannot find him on GitHub, I'll ping him about this PR on our VS/.NET sync thread.)