### PR TITLE
Maintain stable root names for heap snapshots

### DIFF
--- a/src/EtwHeapDump/EtwHeapDump.csproj
+++ b/src/EtwHeapDump/EtwHeapDump.csproj
@@ -53,6 +53,7 @@
 
   <ItemGroup>
     <Compile Include="..\HeapDumpCommon\DotNetHeapInfo.cs" />
+    <Compile Include="..\HeapDumpCommon\GCHeapDumpNames.cs" />
   </ItemGroup>
 
   <!-- .NET Strong Name Signing -->

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1052,6 +1052,7 @@ public class GCHeapDumper
                 bool pinned = root.IsPinned;
                 ComCallableWrapper ccwInfo = obj.HasComCallableWrapper ? obj.GetComCallableWrapper() : null;
 
+                // NOTE: If changing these names, need to document as a breaking change in release notes.
                 string name;
                 switch (kind)
                 {

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1003,7 +1003,7 @@ public class GCHeapDumper
     private MemoryNodeBuilder DumpRoots(DataTarget dataTarget, ClrRuntime[] runtimes)
     {
         int numRoots = 0;
-        var dotNetRoot = new MemoryNodeBuilder(m_gcHeapDump.MemoryGraph, "[.NET Roots]");
+        var dotNetRoot = new MemoryNodeBuilder(m_gcHeapDump.MemoryGraph, GCHeapDumpNames.Bracket(GCHeapDumpNames.DotNetRootsTitle));
         try
         {
             m_log.WriteLine("{0,5:f1}s: Scanning Static Variables", m_sw.Elapsed.TotalSeconds);
@@ -1057,15 +1057,15 @@ public class GCHeapDumper
                 switch (kind)
                 {
                     case ClrRootKind.Stack:
-                        name = "local vars";
+                        name = GCHeapDumpNames.LocalVarsRootTitle;
                         break;
 
                     case ClrRootKind.RefCountedHandle:
-                        name = "COM/WinRT Objects";
+                        name = GCHeapDumpNames.COMWinRTRootTitle;
                         break;
 
                     default:
-                        name = kind.ToString();
+                        name = GetRootTitle(kind);
                         break;
                 };
 
@@ -1083,6 +1083,31 @@ public class GCHeapDumper
         m_log.Flush();
 
         return dotNetRoot;
+    }
+
+    private static string GetRootTitle(ClrRootKind rootKind)
+    {
+        switch (rootKind)
+        {
+            case ClrRootKind.FinalizerQueue:
+                return GCHeapDumpNames.FinalizerQueueRootTitle;
+            case ClrRootKind.StrongHandle:
+                return GCHeapDumpNames.StrongHandleRootTitle;
+            case ClrRootKind.PinnedHandle:
+                return GCHeapDumpNames.PinnedHandleRootTitle;
+            case ClrRootKind.Stack:
+                return GCHeapDumpNames.StackRootTitle;
+            case ClrRootKind.RefCountedHandle:
+                return GCHeapDumpNames.RefCountedHandleRootTitle;
+            case ClrRootKind.AsyncPinnedHandle:
+                return GCHeapDumpNames.AsyncPinnedHandleRootTitle;
+            case ClrRootKind.SizedRefHandle:
+                return GCHeapDumpNames.SizedRefHandleRootTitle;
+            case ClrRootKind.None:
+                return "None";
+            default:
+                throw new ArgumentOutOfRangeException("rootKind");
+        };
     }
 
     private void WriteRoot(IDataReader reader, MemoryNodeBuilder dotNetRoot, ClrObject obj, ClrRootKind kind, bool pinned, ComCallableWrapper ccwInfo, string name, ref int numRoots)
@@ -1117,19 +1142,19 @@ public class GCHeapDumper
             if (comPtr != 0)
                 m_gcHeapDump.MemoryGraph.SetNode(ccwNode, ccwTypeIndex, 200, ccwChildren);
 
-            nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild("[COM/WinRT Objects]");
+            nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild(GCHeapDumpNames.Bracket(GCHeapDumpNames.COMWinRTRootTitle));
             nodeToAddRootTo.AddChild(ccwNode);
         }
         else
         {
             if (kind == (ClrRootKind)(-1))
-                nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild("[static vars]");
+                nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild(GCHeapDumpNames.Bracket(GCHeapDumpNames.StaticVarsRootTitle));
 
             // Add pinned local vars to their own node
             if (pinned && kind == ClrRootKind.Stack)
-                nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild("[Pinned local vars]");
+                nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild(GCHeapDumpNames.Bracket(GCHeapDumpNames.PinnedLocalVarsRootTitle));
             else
-                nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild("[" + name + "]");
+                nodeToAddRootTo = nodeToAddRootTo.FindOrCreateChild(GCHeapDumpNames.Bracket(name));
 
             NodeIndex child = m_gcHeapDump.MemoryGraph.GetNodeIndex(obj);
             nodeToAddRootTo.AddChild(child);
@@ -1148,7 +1173,7 @@ public class GCHeapDumper
 
         if (m_dotNetRoot != NodeIndex.Invalid && m_JSRoot != NodeIndex.Invalid)
         {
-            var rootNode = new MemoryNodeBuilder(m_gcHeapDump.MemoryGraph, "[GC Heaps]");
+            var rootNode = new MemoryNodeBuilder(m_gcHeapDump.MemoryGraph, GCHeapDumpNames.Bracket(GCHeapDumpNames.GCHeapsTitle));
             rootNode.AddChild(m_JSRoot);
             rootNode.AddChild(m_dotNetRoot);
             m_gcHeapDump.MemoryGraph.RootIndex = rootNode.Build();
@@ -1402,7 +1427,7 @@ public class GCHeapDumper
                     if (moduleName != null)
                         fullTypeName = Path.GetFileNameWithoutExtension(moduleName) + "!" + fullTypeName;
 
-                    var typeName = $"[RCW {fullTypeName} RefCnt: {rcwData.RefCount:n0}]";
+                    var typeName = $"[{GCHeapDumpNames.RCWPrefix} {fullTypeName} RefCnt: {rcwData.RefCount:n0}]";
 
                     // We add 1000 to account for the overhead of the RCW that is NOT on the GC heap.
                     if (objSizeAsInt < int.MaxValue - 1000)

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -64,6 +64,7 @@
       <Link>Utilities\StringUtilities.cs</Link>
     </Compile>
     <Compile Include="..\HeapDumpCommon\DotNetHeapInfo.cs" />
+    <Compile Include="..\HeapDumpCommon\GCHeapDumpNames.cs" />
     <Compile Include="..\PerfView\memory\ETWClrProfilerTraceEventParser.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptDumpGraph.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptHeapDumper.cs" />

--- a/src/HeapDumpCommon/GCHeapDumpNames.cs
+++ b/src/HeapDumpCommon/GCHeapDumpNames.cs
@@ -1,0 +1,31 @@
+internal static class GCHeapDumpNames
+{
+    internal const string GCHeapsTitle = "GC Heaps";
+    internal const string DotNetRootsTitle = ".NET Roots";
+    
+    internal const string StaticVarsRootTitle = "static vars";
+    internal const string ThreadStaticVarsRootTitle = "thread static vars";
+    internal const string OtherHandlesRootTitle = "other Handles";
+    internal const string DependentHandlesRootTitle = "Dependent Handles";
+    internal const string LocalVarsRootTitle = "local vars";
+    internal const string PinnedLocalVarsRootTitle= "Pinned local vars";
+    internal const string COMWinRTRootTitle = "COM/WinRT Objects";
+    internal const string OtherRootsTitle = "other roots";
+
+    internal const string FinalizerQueueRootTitle = "FinalizerQueue";
+    internal const string StrongHandleRootTitle = "StrongHandle";
+    internal const string PinnedHandleRootTitle = "PinnedHandle";
+    internal const string StackRootTitle = "Stack";
+    internal const string RefCountedHandleRootTitle = "RefCountedHandle";
+    internal const string AsyncPinnedHandleRootTitle = "AsyncPinnedHandle";
+    internal const string SizedRefHandleRootTitle = "SizedRefHandle";
+
+    internal const string StaticVarPrefix = "static var";
+    internal const string CCWPrefix = "CCW";
+    internal const string RCWPrefix = "RCW";
+
+    internal static string Bracket(string s)
+    {
+        return $"[{s}]";
+    }
+}

--- a/src/HeapDumpCommon/GCHeapDumpNames.cs
+++ b/src/HeapDumpCommon/GCHeapDumpNames.cs
@@ -8,7 +8,7 @@ internal static class GCHeapDumpNames
     internal const string OtherHandlesRootTitle = "other Handles";
     internal const string DependentHandlesRootTitle = "Dependent Handles";
     internal const string LocalVarsRootTitle = "local vars";
-    internal const string PinnedLocalVarsRootTitle= "Pinned local vars";
+    internal const string PinnedLocalVarsRootTitle = "Pinned local vars";
     internal const string COMWinRTRootTitle = "COM/WinRT Objects";
     internal const string OtherRootsTitle = "other roots";
 

--- a/src/HeapDumpDLL/HeapDumpDLL.csproj
+++ b/src/HeapDumpDLL/HeapDumpDLL.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\HeapDump\GCHeapDump.cs" />
     <Compile Include="..\HeapDump\Utilities\*.cs" />
     <Compile Include="..\HeapDumpCommon\DotNetHeapInfo.cs" />
+    <Compile Include="..\HeapDumpCommon\GCHeapDumpNames.cs" />
     <Compile Include="..\PerfView\memory\ETWClrProfilerTraceEventParser.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptDumpGraph.cs" />
     <Compile Include="..\PerfView\memory\JavaScriptHeapDumper.cs" />

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -141,6 +141,9 @@
   </Target>
 
   <ItemGroup>
+    <Compile Include="..\HeapDumpCommon\GCHeapDumpNames.cs">
+      <Link>memory\GCHeapDumpNames.cs</Link>
+    </Compile>
     <Compile Include="..\heapDump\GCHeapDump.cs">
       <Link>memory\GCHeapDump.cs</Link>
     </Compile>

--- a/src/TraceEvent/TraceEvent.Tests/Memory/ClrMD_Dependencies.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Memory/ClrMD_Dependencies.cs
@@ -1,0 +1,36 @@
+using Microsoft.Diagnostics.Runtime;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class ClrMD_Dependencies
+    {
+        /// <summary>
+        /// If this test fails, it means that the ClrRootKind enum has changed.
+        /// We should document this change in release notes, and possibly update
+        /// GCHeapDumper.DumpRoots to keep the set of root names the same (unless a new root type is being added).
+        /// </summary>
+        [Fact]
+        public void DetectClrRootKindChanges()
+        {
+            foreach (var kind in (ClrRootKind[])System.Enum.GetValues(typeof(ClrRootKind)))
+            {
+                switch(kind)
+                {
+                    case ClrRootKind.None:
+                    case ClrRootKind.FinalizerQueue:
+                    case ClrRootKind.StrongHandle:
+                    case ClrRootKind.PinnedHandle:
+                    case ClrRootKind.Stack:
+                    case ClrRootKind.RefCountedHandle:
+                    case ClrRootKind.AsyncPinnedHandle:
+                    case ClrRootKind.SizedRefHandle:
+                        break;
+                    default:
+                        Assert.True(false, $"Unexpected ClrRootKind: {kind}");
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -19,6 +19,16 @@
     <PackageReference Include="System.IO.Compression" Version="$(SystemIOCompressionVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(MicrosoftDiagnosticsRuntimeVersion)' != 'local'">
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(MicrosoftDiagnosticsRuntimeVersion)' == 'local'">
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <Reference Include="Microsoft.Diagnostics.Runtime">
+      <HintPath>$(MicrosoftDiagnosticsRuntimePath)</HintPath>
+    </Reference>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\PerfView.TestUtilities\PerfView.TestUtilities.csproj" />
     <ProjectReference Include="..\TraceEvent.csproj" />


### PR DESCRIPTION
The goal of this change is to ensure that we don't unexpectedly change root names.

 - Detect if the set of roots changes via a test.
 - Add code comments to document these changes via release notes.