### PR TITLE
Fix detection of PerHeapHistories events presence

### DIFF
--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -902,7 +902,7 @@ namespace Stats
             {
                 if (runtime.GC.GCs[i].IsComplete)
                 {
-                    if (runtime.GC.GCs[i].PerHeapHistories == null)
+                    if (!(runtime.GC.GCs[i].PerHeapHistories?.Count > 0))
                     {
                         missingPerHeapHistories++;
 

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -2504,7 +2504,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         /// <summary>
         /// Per heap statistics
         /// </summary>
-        public List<GCPerHeapHistory> PerHeapHistories = new List<GCPerHeapHistory>();
+        public List<GCPerHeapHistory> PerHeapHistories;
         /// <summary>
         /// Sum of the pinned plug sizes
         /// </summary>
@@ -2806,7 +2806,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
                 return gc.AllocedSinceLastGCBasedOnAllocTickMB[(int)gen];
             }
 
-            if (gc.PerHeapHistories?.Count != 0 && gc.Index > 0 && GCs[gc.Index - 1].PerHeapHistories?.Count != 0)
+            if (gc.PerHeapHistories != null && gc.Index > 0 && GCs[gc.Index - 1].PerHeapHistories != null)
             {
                 double TotalAllocated = 0;
                 if (gc.Index > 0)
@@ -4721,6 +4721,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
                     hist.GenData[(int)GenIndex] = data.GenData(GenIndex);
                 }
 
+                if (_event.PerHeapHistories == null) { _event.PerHeapHistories = new List<GCPerHeapHistory>(); }
                 _event.PerHeapHistories.Add(hist);
             }
         }

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -2393,7 +2393,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         {
             get
             {
-                if ((PerHeapHistories != null) && (_PerHeapCondemnedReasons == null))
+                if ((PerHeapHistories?.Count > 0) && (_PerHeapCondemnedReasons == null))
                 {
                     int NumHeaps = PerHeapHistories.Count;
                     _PerHeapCondemnedReasons = new GCCondemnedReasons[NumHeaps];
@@ -2504,7 +2504,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         /// <summary>
         /// Per heap statistics
         /// </summary>
-        public List<GCPerHeapHistory> PerHeapHistories;
+        public List<GCPerHeapHistory> PerHeapHistories = new List<GCPerHeapHistory>();
         /// <summary>
         /// Sum of the pinned plug sizes
         /// </summary>
@@ -2806,7 +2806,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
                 return gc.AllocedSinceLastGCBasedOnAllocTickMB[(int)gen];
             }
 
-            if (gc.PerHeapHistories != null && gc.Index > 0 && GCs[gc.Index - 1].PerHeapHistories != null)
+            if (gc.PerHeapHistories?.Count > 0 && gc.Index > 0 && GCs[gc.Index - 1].PerHeapHistories?.Count > 0)
             {
                 double TotalAllocated = 0;
                 if (gc.Index > 0)
@@ -2930,12 +2930,14 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         /// </summary>
         private static double GetUserAllocatedPerHeap(List<TraceGC> GCs, TraceGC gc, int HeapIndex, Gens gen)
         {
+            Debug.Assert(HeapIndex < gc.PerHeapHistories.Count);
+
             long prevObjSize = 0;
             if (gc.Index > 0)
             {
                 // If the prevous GC has that heap get its size.
                 var perHeapGenData = GCs[gc.Index - 1].PerHeapHistories;
-                if (HeapIndex < perHeapGenData.Count)
+                if (perHeapGenData?.Count > 0 && HeapIndex < perHeapGenData.Count)
                 {
                     prevObjSize = perHeapGenData[HeapIndex].GenData[(int)gen].ObjSizeAfter;
                     // Note that for gen3 we need to do something extra as its after data may not be updated if the last
@@ -2986,7 +2988,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
                 {
                     // If the prevous GC has that heap get its size.
                     var perHeapGenData = GCs[gc.Index - 1].PerHeapHistories;
-                    if (HeapIndex < perHeapGenData.Count)
+                    if (perHeapGenData?.Count > 0 && HeapIndex < perHeapGenData.Count)
                     {
                         return perHeapGenData[HeapIndex].GenData[(int)gen].Budget;
                     }

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -2806,7 +2806,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
                 return gc.AllocedSinceLastGCBasedOnAllocTickMB[(int)gen];
             }
 
-            if (gc.PerHeapHistories != null && gc.Index > 0 && GCs[gc.Index - 1].PerHeapHistories != null)
+            if (gc.PerHeapHistories?.Count != 0 && gc.Index > 0 && GCs[gc.Index - 1].PerHeapHistories?.Count != 0)
             {
                 double TotalAllocated = 0;
                 if (gc.Index > 0)


### PR DESCRIPTION
Trivial fix.

The presence of per heap history events is detected by comparing PerHeapHistories with `null`, but this property is never `null`, since the list is allocated in the constructor. 

https://github.com/microsoft/perfview/blob/dec5b67a215a446863285169d4be09b4f91180d1/src/TraceEvent/Computers/TraceManagedProcess.cs#L2507

As a result, even though we can fallback to allocation ticks, we never fallback and if the history events are missing, the allocation rate is unavailable or incorrect. 

We can check for `Count == 0` instead and then fallback works.