### PR TITLE
Fix Surfacing of RelatedActivityID in Real-Time Session Dispatch

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -645,6 +645,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             TraceEvent eventInRealTimeSource = realTimeSource.Lookup(toSend.eventRecord);
             eventInRealTimeSource.userData = toSend.userData;
             eventInRealTimeSource.eventIndex = toSend.eventIndex;           // Lookup assigns the EventIndex, but we want to keep the original.
+            eventInRealTimeSource.myBuffer = toSend.myBuffer;
             realTimeSource.Dispatch(eventInRealTimeSource);
 
             // Optimization, remove 'toSend' from the finalization queue.
@@ -653,6 +654,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             // Do the cleanup, but also keep toSend alive during the dispatch and until finalization was suppressed.
             System.Runtime.InteropServices.Marshal.FreeHGlobal(toSend.myBuffer);
             toSend.instanceContainerID = null;
+            eventInRealTimeSource.myBuffer = IntPtr.Zero;
         }
 
         /// <summary>


### PR DESCRIPTION
`RelatedActivityID` is stored in a `GrowableArray` as part of the `TraceLog`. When the event is pushed in to the `realTimeQueue` in order to dispatch it, the event is cloned.  Cloning creates a new instance of `TraceEvent`, and allocates buffers that are owned by the new clone.  When the event is dispatched, we are missing an assignment of `myBuffer`, which contains the `RelatedActivityID`. Assign `myBuffer` prior to dispatch so that the `RelatedActivityID` is correct.