### PR TITLE
Remove Pinned Commit Hash for Mariner Docker Image

### DIFF
--- a/src/perfcollect/tests/containers/mariner-2.0.dockerfile
+++ b/src/perfcollect/tests/containers/mariner-2.0.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0@sha256:82314abb594a695fd8817774e8b7f101934902cc1d99b3075e80acbc8b9b23ee
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 # Copy perfcollect sources.
 COPY . /src/


### PR DESCRIPTION
Remove the pinned commit hash for Mariner Docker image since we aren't going to get automatic notifications of updates.

We were previously getting updates, but they were "internal" updates and needed to be ported to GitHub.