### PR TITLE
Add option to toggle raw event data truncation

### DIFF
--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -27,6 +27,8 @@ namespace PerfView
     /// </summary>
     public partial class EventWindow : WindowBase
     {
+        public static bool TruncateRawEventData = true;
+
         public EventWindow(Window parent, EventSource source) : base(parent)
         {
             throw new NotImplementedException();
@@ -966,7 +968,7 @@ namespace PerfView
             var eventData = traceLog.GetEvent(elem.Index);
             if (eventData != null)
             {
-                string eventDataAsString = eventData.Dump(true, true);
+                string eventDataAsString = eventData.Dump(true, TruncateRawEventData);
                 StatusBar.LogWriter.WriteLine(eventDataAsString);
                 StatusBar.OpenLog();
                 StatusBar.Status = "Event Dumped to log.";

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -124,6 +124,7 @@
                         <MenuItem Header="Show experimental GC features." x:Name="Option_ExperimentalGCFeatures" IsCheckable="true" Click="ToggleExperimentalGCFeatures" ToolTip="Enable or disable experimental GC features."/>
                     </MenuItem>
                     <MenuItem Header="Navigate to last used directory on launch." x:Name="Option_OpenToLastUsedDirectory" IsCheckable="true" Click="ToggleOpenToLastUsedDirectory" ToolTip="When launching PerfView, navigate to the last opened directory instead of the current working directory."/>
+                    <MenuItem Header="Truncate raw data when dumping an event" x:Name="Option_TruncateRawEventData" IsCheckable="True" Click="ToggleTruncateRawEventData" ToolTip="Controls whether or not a raw event dumped from the events view is truncated." />
                     <MenuItem Header="Theme">
                         <MenuItem Header="Light" x:Name="Theme_Light" IsChecked="{Binding Path=ThemeViewModel.IsLightTheme}" Command="{x:Static src:ThemeViewModel.SetLightThemeCommand}"/>
                         <MenuItem Header="Dark" x:Name="Theme_Dark" IsChecked="{Binding Path=ThemeViewModel.IsDarkTheme}" Command="{x:Static src:ThemeViewModel.SetDarkThemeCommand}"/>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1144,6 +1144,7 @@ namespace PerfView
             // Initialize configuration options.
             InitializeOpenToLastUsedDirectory();
             InitializeDoNotCompressStackFramesOnCopy();
+            InitializeTruncateRawEventData();
 
             InitializeFeedback();
         }
@@ -1206,6 +1207,35 @@ namespace PerfView
             App.UserConfigData["ExperimentalGCFeatures"] = newValue.ToString();
             Option_ExperimentalGCFeatures.IsChecked = newValue;
             Stats.GcStats.EnableExperimentalFeatures = newValue;
+        }
+
+        /// <summary>
+        /// Initial read-in of the user settings to check if they had previously opted-in for the DoNotTruncateRawEventData option
+        /// </summary>
+        public void InitializeTruncateRawEventData()
+        {
+            bool willTruncate;
+            if (!bool.TryParse(App.UserConfigData["TruncateRawEventData"], out willTruncate))
+            {
+                // the default behavior of PerfView has always been to truncate the event data
+                // so if the TryParse fails for any reason, then opt for the original behavior
+                willTruncate = true;
+            }
+            Option_TruncateRawEventData.IsChecked = willTruncate;
+            EventWindow.TruncateRawEventData = willTruncate;
+        }
+
+        /// <summary>
+        /// Toggles the option to truncate or not the raw event data when an event is dumped from the Events view
+        /// </summary>
+        public void ToggleTruncateRawEventData(object sender, RoutedEventArgs e)
+        {
+            bool currentValue;
+            bool.TryParse(App.UserConfigData["TruncateRawEventData"], out currentValue);
+            bool newValue = !currentValue;
+            App.UserConfigData["TruncateRawEventData"] = newValue.ToString();
+            Option_TruncateRawEventData.IsChecked = newValue;
+            EventWindow.TruncateRawEventData = newValue;
         }
 
         /// <summary>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1210,7 +1210,7 @@ namespace PerfView
         }
 
         /// <summary>
-        /// Initial read-in of the user settings to check if they had previously opted-in for the DoNotTruncateRawEventData option
+        /// Initial read-in of the user settings to check if they had previously opted-in for the TruncateRawEventData option
         /// </summary>
         public void InitializeTruncateRawEventData()
         {


### PR DESCRIPTION
Implement the option to allow a user to toggle whether or not the entire contents of a raw event are dumped to the log from the Events view. The original behavior was and the default still is to truncate the middle portion of the event unless the user disables the option.