### PR TITLE
Update TraceEvent Dependencies

### DIFF
--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -30,8 +30,22 @@
 
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
-        <dependency id="Microsoft.Win32.Registry" version="4.4.0" />
+        <dependency id="Microsoft.NETCore.Portable.Compatibility" version="$MicrosoftNETCorePortableCompatibilityVersion$" />
+        <dependency id="Microsoft.Win32.Registry" version="$MicrosoftWin32RegistryVersion$" />
+        <dependency id="System.Collections.Immutable" version="$SystemCollectionsImmutableVersion$" />
+        <dependency id="System.Diagnostics.Process" version="$SystemDiagnosticsProcessVersion$" />
+        <dependency id="System.Diagnostics.TraceSource" version="$SystemDiagnosticsTraceSourceVersion$" />
+        <dependency id="System.IO.Compression" version="$SystemIOCompressionVersion$" />
+        <dependency id="System.IO.UnmanagedMemoryStream" version="$SystemIOUnmanagedMemoryStreamVersion$" />
+        <dependency id="System.Net.Requests" version="$SystemNetRequestsVersion$" />
+        <dependency id="System.Net.NameResolution" version="$SystemNetNameResolutionVersion$" />
+        <dependency id="System.Reflection.Metadata" version="$SystemReflectionMetadataVersion$" />
+        <dependency id="System.Reflection.TypeExtensions" version="$SystemReflectionTypeExtensionsVersion$" />
+        <dependency id="System.Runtime" version="$SystemRuntimeVersion$" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="$SystemRuntimeCompilerServicesUnsafeVersion$" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="$SystemSecurityCryptographyAlgorithmsVersion$" />
+        <dependency id="System.Threading.Tasks.Parallel" version="$SystemThreadingTasksParallelVersion$" />
+        <dependency id="System.Threading.Thread" version="$SystemThreadingThreadVersion$" />
       </group>
     </dependencies>
   </metadata>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -33,7 +33,25 @@
 
   <Target Name="SetNuspecProperties">
     <PropertyGroup>
-      <NuspecProperties>Configuration=$(Configuration);version=$(InformationalVersion);OutDir=$(OutputPath)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);Configuration=$(Configuration)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);version=$(InformationalVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);OutDir=$(OutputPath)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);MicrosoftNETCorePortableCompatibilityVersion=$(MicrosoftNETCorePortableCompatibilityVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);MicrosoftWin32RegistryVersion=$(MicrosoftWin32RegistryVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemCollectionsImmutableVersion=$(SystemCollectionsImmutableVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemDiagnosticsProcessVersion=$(SystemDiagnosticsProcessVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemDiagnosticsTraceSourceVersion=$(SystemDiagnosticsTraceSourceVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemIOCompressionVersion=$(SystemIOCompressionVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemIOUnmanagedMemoryStreamVersion=$(SystemIOUnmanagedMemoryStreamVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemNetRequestsVersion=$(SystemNetRequestsVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemNetNameResolutionVersion=$(SystemNetNameResolutionVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemReflectionMetadataVersion=$(SystemReflectionMetadataVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemReflectionTypeExtensionsVersion=$(SystemReflectionTypeExtensionsVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemRuntimeVersion=$(SystemRuntimeVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemRuntimeCompilerServicesUnsafeVersion=$(SystemRuntimeCompilerServicesUnsafeVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemSecurityCryptographyAlgorithmsVersion=$(SystemSecurityCryptographyAlgorithmsVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemThreadingTasksParallelVersion=$(SystemThreadingTasksParallelVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);SystemThreadingThreadVersion=$(SystemThreadingThreadVersion)</NuspecProperties>
     </PropertyGroup>
   </Target>
 
@@ -47,6 +65,7 @@
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="$(MicrosoftNETCorePortableCompatibilityVersion)" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemDiagnosticsTraceSourceVersion)" />
     <PackageReference Include="System.IO.Compression" Version="$(SystemIOCompressionVersion)" />


### PR DESCRIPTION
This includes the following work:
1. Add the missing System.Collections.Immutable explicit dependency.
2. Update the TraceEvent nuspec file to include all dependencies.

Fixes #1989.