### PR TITLE
Trim whitespace when parsing additional providers

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3714,7 +3714,7 @@ namespace PerfView
                 TraceEventLevel level = TraceEventLevel.Verbose;
                 ulong matchAnyKeywords = unchecked((ulong)-1);
 
-                var rest = providerSpec;
+                var rest = providerSpec.Trim();
                 Match m = Regex.Match(rest, @"^([^:]*)(:(.*))?$");
                 Debug.Assert(m.Success);
                 rest = m.Groups[3].Value;


### PR DESCRIPTION
Without this change, a very simple mistake such as an extra space in the comma-separated list of providers will silently cause the provider to not be enabled.  This is a very easy mistake to make if the list of providers you want to enable is large and you are copying and pasting the list from somewhere else and it gets word wrapped, etc.