### PR TITLE
Add ASP.NET Core Stats view

### DIFF
--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3398,6 +3398,7 @@ table {
         private const string _eventRequestStart = "Request/Start";
         private const string _eventRequestStop = "Request/Stop";
         private const string _eventUnhandledException = "UnhandledException";
+        private const string _eventCounters = "EventCounters";
 
         // main storage for tracking requests and associated processes
         private Dictionary<string, ANCHostingRequest> incompleteRequests = new Dictionary<string, ANCHostingRequest>();
@@ -3517,6 +3518,7 @@ table {
                         break;
 
                     case _eventManifestData:
+                    case _eventCounters:
                         // ignore
                         break;
 

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3565,10 +3565,6 @@ table {
             outputWriter.WriteLine($"<li>Inbound Request Rate (total RequestStart events/total log session time): {(inboundRequestCount / dataFile.SessionDuration.TotalSeconds):N2}</li>");
             outputWriter.WriteLine($"</ul>");
 
-            // for commands:
-            // string detailedRequestCommandString = $"detailedrequestevents:{request.ContextId};{request.StartTimeRelativeMSec};{request.EndTimeRelativeMSec}";
-            // <A HREF=\"command:{detailedRequestCommandString}\">{requestPath}</A>
-
             // show info about processes that output these events
             if (processesThatEmittedEvents.Count > 0)
             {
@@ -3638,22 +3634,17 @@ table {
                 outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
                 outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
                 outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
-                //outputWriter.Write("<th align='center' title='ActivityId of the request - click to open Events view for this ID'>ActivityID</th>");
                 outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
                 outputWriter.Write("<th align='center' title='Note'>Note - see below</th>");
                 outputWriter.WriteLine("</tr></thead>");
                 outputWriter.WriteLine("<tbody>");
                 foreach (ANCHostingRequest request in incompleteRequests.Values)
                 {
-                    // used for opening the request in the Events view
-                    //string detailedRequestCommandString = $"detailedrequestevents:{request.ActivityId};{request.StartTimeRelativeMSec};{request.EndTimeRelativeMSec}";
-
                     outputWriter.Write("<tr>");
                     outputWriter.Write($"<td>{request.ProcessID}</td>");
                     outputWriter.Write($"<td>{request.Method}</td>");
                     outputWriter.Write($"<td>{request.Path}</td>");
                     outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
-                    //outputWriter.Write($"<td><a href=\"command:{detailedRequestCommandString}\">{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</a></td>");
                     outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
 
                     string note = String.Empty;
@@ -3689,7 +3680,6 @@ table {
                 outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
                 outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
                 outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
-                //outputWriter.Write("<th align='center' title='ActivityId of the request - click to open Events view for this ID'>ActivityID</th>");
                 outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
                 outputWriter.WriteLine("</tr></thead>");
                 outputWriter.WriteLine("<tbody>");
@@ -3697,15 +3687,11 @@ table {
                 {
                     foreach (ANCHostingRequest request in slowestRequests)
                     {
-                        // used for opening the request in the Events view
-                        //string detailedRequestCommandString = $"detailedrequestevents:{request.ActivityId};{request.StartTimeRelativeMSec};{request.EndTimeRelativeMSec}";
-
                         outputWriter.Write("<tr>");
                         outputWriter.Write($"<td>{request.ProcessID}</td>");
                         outputWriter.Write($"<td>{request.Method}</td>");
                         outputWriter.Write($"<td>{request.Path}</td>");
                         outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
-                        //outputWriter.Write($"<td><a href=\"command:{detailedRequestCommandString}\">{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</a></td>");
                         outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
                         outputWriter.WriteLine("</tr>");
                     }
@@ -3730,21 +3716,16 @@ table {
                 outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
                 outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
                 outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
-                //outputWriter.Write("<th align='center' title='ActivityId of the request - click to open Events view for this ID'>ActivityID</th>");
                 outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
                 outputWriter.WriteLine("</tr></thead>");
                 outputWriter.WriteLine("<tbody>");
                 foreach (ANCHostingRequest request in completeRequests)
                 {
-                    // used for opening the request in the Events view
-                    //string detailedRequestCommandString = $"detailedrequestevents:{request.ActivityId};{request.StartTimeRelativeMSec};{request.EndTimeRelativeMSec}";
-
                     outputWriter.Write("<tr>");
                     outputWriter.Write($"<td>{request.ProcessID}</td>");
                     outputWriter.Write($"<td>{request.Method}</td>");
                     outputWriter.Write($"<td>{request.Path}</td>");
                     outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
-                    //outputWriter.Write($"<td><a href=\"command:{detailedRequestCommandString}\">{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</a></td>");
                     outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
                     outputWriter.WriteLine("</tr>");
                 }

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3401,9 +3401,9 @@ table {
         private const string _eventCounters = "EventCounters";
 
         // main storage for tracking requests and associated processes
-        private Dictionary<string, ANCHostingRequest> incompleteRequests = new Dictionary<string, ANCHostingRequest>();
-        private List<ANCHostingRequest> completeRequests = new List<ANCHostingRequest>();
-        private HashSet<ProcessIndex> processesThatEmittedEvents = new HashSet<ProcessIndex>();
+        private Dictionary<string, ANCHostingRequest> incompleteRequests;
+        private List<ANCHostingRequest> completeRequests;
+        private HashSet<ProcessIndex> processesThatEmittedEvents;
 
         // holds non-request events like host/start and stop, etc.
         private List<OtherHostingEvent> otherEvents = new List<OtherHostingEvent>();
@@ -3426,6 +3426,10 @@ table {
              * UnhandledException
              * ServerReady
              */
+
+            incompleteRequests = new Dictionary<string, ANCHostingRequest>();
+            completeRequests = new List<ANCHostingRequest>();
+            processesThatEmittedEvents = new HashSet<ProcessIndex>();
 
             // using the push/callback model for TraceLog processing
             var dispatcher = dataFile.Events.GetSource();

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3406,7 +3406,7 @@ table {
         private HashSet<ProcessIndex> processesThatEmittedEvents;
 
         // holds non-request events like host/start and stop, etc.
-        private List<OtherHostingEvent> otherEvents = new List<OtherHostingEvent>();
+        private List<OtherHostingEvent> otherEvents;
 
         public PerfViewAspNetCoreStats(PerfViewFile dataFile) : base(dataFile, "ASP.NET Core Stats") { }
 
@@ -3430,6 +3430,7 @@ table {
             incompleteRequests = new Dictionary<string, ANCHostingRequest>();
             completeRequests = new List<ANCHostingRequest>();
             processesThatEmittedEvents = new HashSet<ProcessIndex>();
+            otherEvents = new List<OtherHostingEvent>();
 
             // using the push/callback model for TraceLog processing
             var dispatcher = dataFile.Events.GetSource();

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3414,6 +3414,9 @@ table {
         {
             outputWriter.WriteLine("<H2>ASP.NET Core Request Statistics</H2>");
 
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+
             // request/stop does not contain status code or anything like that
             // maybe add ILogger events, if available, to enhance these logs?
             // possibility: the ActivityStart/Stop events in System.Diagnostics.DiagnosticSource for ANCHosting do contain status code, check for these?
@@ -3473,13 +3476,6 @@ table {
                             request.Path = (string)traceEvent.PayloadByName("path");
                             if (String.IsNullOrEmpty(request.Path))
                                 request.Path = "/";
-
-                            // if the request is complete then move it to the completeRequests List
-                            if(request.IsComplete)
-                            {
-                                incompleteRequests.Remove(request.IndexingKey);
-                                completeRequests.Add(request);
-                            }
                         }
                         else
                         {
@@ -3559,9 +3555,6 @@ table {
                         break;
                 }
             });
-
-            Stopwatch sw = new Stopwatch();
-            sw.Start();
 
             // process the log which invokes the callbacks above
             dispatcher.Process();

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3388,6 +3388,30 @@ table {
         #endregion
     }
 
+    /// <summary>
+    /// Generates an ASP.NET Core Stats HTML page
+    /// </summary>
+    public class PerfViewAspNetCoreStats : PerfViewHtmlReport
+    {
+        public PerfViewAspNetCoreStats(PerfViewFile dataFile) : base(dataFile, "ASP.NET Core Stats") { }
+
+        protected override void WriteHtmlBody(TraceLog dataFile, TextWriter writer, string fileName, TextWriter log)
+        {
+            writer.WriteLine("<H2>ASP.NET Core Request Statistics</H2>");
+
+            var dispatcher = dataFile.Events.GetSource();
+
+
+
+            writer.Flush();
+        }
+
+        protected override string DoCommand(string command, StatusBar worker)
+        {
+            return base.DoCommand(command, worker);
+        }
+    }
+
     public class PerfViewEventStats : PerfViewHtmlReport
     {
         public PerfViewEventStats(PerfViewFile dataFile) : base(dataFile, "EventStats") { }
@@ -7160,6 +7184,7 @@ table {
             bool hasAssemblyLoad = false;
             bool hasJIT = false;
             bool hasUserCrit = false;
+            bool hasAspNetCoreHosting = false;
 
             var stackEvents = new List<TraceEventCounts>();
             foreach (var counts in tracelog.Stats)
@@ -7173,6 +7198,11 @@ table {
                 if (!hasAspNet && name.StartsWith("AspNetReq"))
                 {
                     hasAspNet = true;
+                }
+
+                if(!hasAspNetCoreHosting && counts.ProviderName.Equals("Microsoft.AspNetCore.Hosting", StringComparison.OrdinalIgnoreCase) && name.StartsWith("Request"))
+                {
+                    hasAspNetCoreHosting = true;
                 }
 
                 if (!hasIis && name.StartsWith("IIS"))
@@ -7532,6 +7562,11 @@ table {
             if (hasIis)
             {
                 advanced.Children.Add(new PerfViewIisStats(this));
+            }
+
+            if(hasAspNetCoreHosting)
+            {
+                advanced.Children.Add(new PerfViewAspNetCoreStats(this));
             }
 
             if (hasProjectNExecutionTracingEvents)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3439,7 +3439,7 @@ table {
             /* generally we are focusing on only one process' events; however, it's possible multiple processes
              * were emitting Microsoft.AspNetCore.Hosting events. So we need the ability to track more than one and associate
              * each event with its specific PID.
-             * Thus using a Dictionary where the key is PID, and each value is a SortedList of requests, sorted by StartTimeRelativeMSec
+             * Thus using a Dictionary where the key is the ActivityId of the request, and the value is the ANCHostingRequest class that tracks request details
              */
 
             Stopwatch sw = new Stopwatch();
@@ -3593,18 +3593,18 @@ table {
                 outputWriter.WriteLine("<h3>General Events</h3>");
                 outputWriter.WriteLine("<table border=\"1\">");
                 outputWriter.Write("<thead><tr>");
+                outputWriter.Write("<th align='center' title='The PID that emitted the event'>Process ID</th>");
                 outputWriter.Write("<th align='center' title='Raw time of the event in UTC'>Time (UTC)</th>");
                 outputWriter.Write("<th align='center' title='How many milliseconds after the trace started this event was emitted'>Trace Relative Time (msec)</th>");
-                outputWriter.Write("<th align='center' title='The PID that emitted the event'>Process ID</th>");
                 outputWriter.Write("<th align='center' title='The event that was emitted'>Event</th>");
                 outputWriter.WriteLine("</tr></thead>");
                 outputWriter.WriteLine("<tbody>");
                 foreach (OtherHostingEvent hostingEvent in otherEvents)
                 {
                     outputWriter.Write("<tr>");
+                    outputWriter.Write($"<td>{hostingEvent.ProcessID}</td>");
                     outputWriter.Write($"<td>{hostingEvent.TimeUTC}</td>");
                     outputWriter.Write($"<td>{hostingEvent.TimeRelativeMSec}</td>");
-                    outputWriter.Write($"<td>{hostingEvent.ProcessID}</td>");
                     outputWriter.Write($"<td>{hostingEvent.EventName}</td>");
                     outputWriter.WriteLine("</tr>");
                 }

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3401,8 +3401,8 @@ table {
         private const string _eventHostStop = "Host/Stop";
         private const string _eventUnhandledException = "UnhandledException";
         private const string _eventServerReady = "ServerReady";
-        private const string _iloggerProvider = "Microsoft-Extensions-Logging";
-        private const string _iloggerProviderFormattedMessage = "Microsoft-Extensions-Logging/FormattedMessage";
+        //private const string _iloggerProvider = "Microsoft-Extensions-Logging";
+        //private const string _iloggerProviderFormattedMessage = "Microsoft-Extensions-Logging/FormattedMessage";
 
         // master requests dictionary
         private Dictionary<Guid, ANCHostingRequest> requests = new Dictionary<Guid, ANCHostingRequest>();
@@ -3416,17 +3416,9 @@ table {
         {
             outputWriter.WriteLine("<H2>ASP.NET Core Request Statistics</H2>");
 
-            // example output for request start event:
-            // data.TaskName = "Request"
-            // data.OpcodeName = "Start"
-            // data.EventName = "Request/Start"
-            // data.ProcessID
-            // data.ActivityID ==> use StartStopActivityComputer.ActivityPathString(Guid) for displaying
-            //                 ==> StartStopActivityComputer.IsActivityPath(guid, processID)
-            // data.PayloadNames = {"method", "path"}
-            // data.PayloadByName("method"|"path"|etc.) cast to string if appropriate (since the method returns object)
-
             // request/stop does not contain status code or anything like that
+            // maybe add ILogger events, if available, to enhance these logs?
+            // also down the road if both ILogger and MS-ANC-Hosting events are available, use both and integrate them?
             /* 
              * some possible events (ref: https://source.dot.net/#Microsoft.AspNetCore.Hosting/Internal/HostingEventSource.cs):
              * Request/Start and Request/Stop
@@ -3434,12 +3426,6 @@ table {
              * Host/Start and Host/Stop
              * UnhandledException
              * ServerReady
-             */
-
-            /* generally we are focusing on only one process' events; however, it's possible multiple processes
-             * were emitting Microsoft.AspNetCore.Hosting events. So we need the ability to track more than one and associate
-             * each event with its specific PID.
-             * Thus using a Dictionary where the key is the ActivityId of the request, and the value is the ANCHostingRequest class that tracks request details
              */
 
             Stopwatch sw = new Stopwatch();

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3626,19 +3626,17 @@ table {
                 outputWriter.WriteLine("<table border=\"1\">");
                 outputWriter.WriteLine("<caption>This table shows the top 20 slowest requests in this trace. Requests taking <100 milliseconds are ignored. Hover over column headings for explanation of columns.</caption>");
                 outputWriter.Write("<thead><tr>");
-                if(slowestRequests.Any())
+                outputWriter.Write("<th align='center' title='Process ID'>PID</th>");
+                outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
+                outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
+                outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
+                //outputWriter.Write("<th align='center' title='ActivityId of the request - click to open Events view for this ID'>ActivityID</th>");
+                outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
+                outputWriter.Write("<th align='center' title='Note'>Note - see below</th>");
+                outputWriter.WriteLine("</tr></thead>");
+                outputWriter.WriteLine("<tbody>");
+                if (slowestRequests.Any())
                 {
-                    outputWriter.Write("<th align='center' title='Process ID'>PID</th>");
-                    outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
-                    outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
-                    outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
-                    //outputWriter.Write("<th align='center' title='Start time of request, if available, relative to when the trace started, in milliseconds'>Relative start time (msec)</th>");
-                    //outputWriter.Write("<th align='center' title='End time of request, if available, relative to when the trace started, in milliseconds'>Relative end time (msec)</th>");
-                    //outputWriter.Write("<th align='center' title='ActivityId of the request - click to open Events view for this ID'>ActivityID</th>");
-                    outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
-                    outputWriter.Write("<th align='center' title='Note'>Note - see below</th>");
-                    outputWriter.WriteLine("</tr></thead>");
-                    outputWriter.WriteLine("<tbody>");
                     foreach (ANCHostingRequest request in slowestRequests)
                     {
                         // used for opening the request in the Events view
@@ -3649,8 +3647,6 @@ table {
                         outputWriter.Write($"<td>{request.Method}</td>");
                         outputWriter.Write($"<td>{request.Path}</td>");
                         outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
-                        //outputWriter.Write($"<td>{request.StartTimeRelativeMSec}</td>");
-                        //outputWriter.Write($"<td>{request.EndTimeRelativeMSec}</td>");
                         //outputWriter.Write($"<td><a href=\"command:{detailedRequestCommandString}\">{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</a></td>");
                         outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
 
@@ -3661,20 +3657,17 @@ table {
                         outputWriter.Write($"<td>{note}</td>");
                         outputWriter.WriteLine("</tr>");
                     }
-                    outputWriter.WriteLine("</tbody>");
-                    outputWriter.WriteLine("<tfoot>");
-                    outputWriter.WriteLine("<tr><td colspan=6><sup>1</sup> Request already running when trace started - duration is based on trace start time</td></tr>");
-                    outputWriter.WriteLine("<tr><td colspan=6><sup>2</sup> Request started during the trace but did not stop before the trace ended - duration is based on trace stop time</td></tr>");
-                    outputWriter.WriteLine("</tfoot>");
                 }
                 else
                 {
-                    outputWriter.WriteLine("<th align='center' title='no requests took more than 100 milliseconds'>No requests took >= 100 milliseconds</th>");
-                    outputWriter.WriteLine("</tr></thead>");
+                    outputWriter.WriteLine("<td align='center' title='no requests took more than 100 milliseconds' colspan=6>No requests took >= 100 milliseconds</td>");
                 }
-                
+                outputWriter.WriteLine("</tbody>");
+                outputWriter.WriteLine("<tfoot>");
+                outputWriter.WriteLine("<tr><td colspan=6><sup>1</sup> Request already running when trace started - duration is based on trace start time</td></tr>");
+                outputWriter.WriteLine("<tr><td colspan=6><sup>2</sup> Request started during the trace but did not stop before the trace ended - duration is based on trace stop time</td></tr>");
+                outputWriter.WriteLine("</tfoot>");
                 outputWriter.WriteLine("</table>");
-
             }
 
             // all requests table
@@ -3689,8 +3682,6 @@ table {
                 outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
                 outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
                 outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
-                //outputWriter.Write("<th align='center' title='Start time of request, if available, relative to when the trace started, in milliseconds'>Relative start time (msec)</th>");
-                //outputWriter.Write("<th align='center' title='End time of request, if available, relative to when the trace started, in milliseconds'>Relative end time (msec)</th>");
                 //outputWriter.Write("<th align='center' title='ActivityId of the request - click to open Events view for this ID'>ActivityID</th>");
                 outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
                 outputWriter.Write("<th align='center' title='Note'>Note - see below</th>");
@@ -3706,8 +3697,6 @@ table {
                     outputWriter.Write($"<td>{request.Method}</td>");
                     outputWriter.Write($"<td>{request.Path}</td>");
                     outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
-                    //outputWriter.Write($"<td>{request.StartTimeRelativeMSec}</td>");
-                    //outputWriter.Write($"<td>{request.EndTimeRelativeMSec}</td>");
                     //outputWriter.Write($"<td><a href=\"command:{detailedRequestCommandString}\">{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</a></td>");
                     outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
 

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -3433,6 +3433,9 @@ table {
             // for inbound requests/sec stats, use an int counter
             int inboundRequestCount = 0;
 
+            // for tracking a raw count of unhandled exception events
+            int unhandledExceptionCount = 0;
+
             // this callback is invoked when the dispatcher.Process() call is made later, upon matching ANCHosting provider events (any of them)
             dispatcher.Dynamic.AddCallbackForProviderEvent(_hostingProvider, null, delegate (TraceEvent traceEvent)
             {
@@ -3503,6 +3506,7 @@ table {
                         break;
 
                     case _eventUnhandledException:
+                        unhandledExceptionCount++;
                         if (incompleteRequests.TryGetValue(ANCHostingRequest.GetIndexingKeyFromEvent(traceEvent), out request))
                         {
                             // request exists, update it
@@ -3561,6 +3565,7 @@ table {
             outputWriter.WriteLine($"<li>Total Requests: {incompleteRequests.Count + completeRequests.Count}</li>");
             outputWriter.WriteLine($"<li>Total Complete Requests: {completeRequests.Count}</li>");
             outputWriter.WriteLine($"<li>Total Incomplete Requests: {incompleteRequests.Count}</li>");
+            outputWriter.WriteLine($"<li>Total Unhandled Exception Events: {unhandledExceptionCount}</li>");
             outputWriter.WriteLine($"<li>Trace Duration (Sec): {dataFile.SessionDuration.TotalSeconds:N2}</li>");
             outputWriter.WriteLine($"<li>Inbound Request Rate (total RequestStart events/total log session time): {(inboundRequestCount / dataFile.SessionDuration.TotalSeconds):N2}</li>");
             outputWriter.WriteLine($"</ul>");
@@ -3634,6 +3639,7 @@ table {
                 outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
                 outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
                 outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
+                outputWriter.Write("<th align='center' title='Exception was thrown during the course of request processing and was not handled by the app.'>Unhandled Exception</th>");
                 outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
                 outputWriter.Write("<th align='center' title='Note'>Note - see below</th>");
                 outputWriter.WriteLine("</tr></thead>");
@@ -3645,6 +3651,7 @@ table {
                     outputWriter.Write($"<td>{request.Method}</td>");
                     outputWriter.Write($"<td>{request.Path}</td>");
                     outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
+                    outputWriter.Write($"<td>{(request.HasUnhandledException ? "yes" : "no")}</td>");
                     outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
 
                     string note = String.Empty;
@@ -3680,6 +3687,7 @@ table {
                 outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
                 outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
                 outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
+                outputWriter.Write("<th align='center' title='Exception was thrown during the course of request processing and was not handled by the app.'>Unhandled Exception</th>");
                 outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
                 outputWriter.WriteLine("</tr></thead>");
                 outputWriter.WriteLine("<tbody>");
@@ -3692,6 +3700,7 @@ table {
                         outputWriter.Write($"<td>{request.Method}</td>");
                         outputWriter.Write($"<td>{request.Path}</td>");
                         outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
+                        outputWriter.Write($"<td>{(request.HasUnhandledException ? "yes" : "no")}</td>");
                         outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
                         outputWriter.WriteLine("</tr>");
                     }
@@ -3716,6 +3725,7 @@ table {
                 outputWriter.Write("<th align='center' title='HTTP Method/Verb - may not be available'>Method</th>");
                 outputWriter.Write("<th align='center' title='Request Path - may not be available'>Path</th>");
                 outputWriter.Write("<th align='center' title='Duration of the request in milliseconds'>Duration (msec)</th>");
+                outputWriter.Write("<th align='center' title='Exception was thrown during the course of request processing and was not handled by the app.'>Unhandled Exception</th>");
                 outputWriter.Write("<th align='center' title='ActivityId of the request - this is a good request-specific text filter for the Events view'>ActivityID</th>");
                 outputWriter.WriteLine("</tr></thead>");
                 outputWriter.WriteLine("<tbody>");
@@ -3726,6 +3736,7 @@ table {
                     outputWriter.Write($"<td>{request.Method}</td>");
                     outputWriter.Write($"<td>{request.Path}</td>");
                     outputWriter.Write($"<td>{request.DurationMsec:N2}</td>");
+                    outputWriter.Write($"<td>{(request.HasUnhandledException ? "yes" : "no")}</td>");
                     outputWriter.Write($"<td>{StartStopActivityComputer.ActivityPathString(request.ActivityId)}</td>");
                     outputWriter.WriteLine("</tr>");
                 }


### PR DESCRIPTION
This PR adds the _ASP.NET Core Stats_ view to the "Advanced" folder (placement was based on where the current IIS Stats and ASP.NET Stats views are located, but can definitely be changed). At the moment it relies on the presence of **Microsoft.AspNetCore.Hosting** events, such as _Request/Start_ and _Request/Stop_. 
This view is added for both regular ETL files, as well as EventPipe files - it's only built/generated in one place so it looks the same from either type of dataset.

While right now it only consumes those Hosting events, the goal for future output is to be able to consume Microsoft.Extensions.Logging events as well to supplement output, or even base the calculations on those events instead of Hosting (say, when Hosting events aren't available but ILogger events are). Another possibility is using DiagnosticSource events if available, such as the Activity Start/Stop events that correspond to Hosting events. One benefit to those latter events, if available, is those contain the status code of the response, whereas the regular Hosting's Request/Stop events do not. 

I was using the IIS Stats view as reference output here, although, one feature I have not currently implemented is the ability to open the Events view and feed it specific ActivityIDs like what IIS Stats does in the Slow Requests section. I did try this initially but the opening of the Events window in IIS Stats view seems to have been built specifically for ETL files, and it didn't work for EventPipe files. The PR code does contain some remnants of this testing in the PerfViewAspNetCoreStats.DoCommand method, but right now nothing triggers DoCommand. This is something I hope to fix sometime soon in the near-ish future, as it would be useful to have IMO.

In a PerfView-captured and compressed file, here's how it's surfaced when the Hosting events are present:
![image](https://github.com/microsoft/perfview/assets/38960254/af59330c-5718-457e-b529-2c747d369f13)

And in a dotnet-trace EventPipe file:
![image](https://github.com/microsoft/perfview/assets/38960254/bcfcc448-747d-4129-80d2-da0750de6ddf)

Some example output:
![image](https://github.com/microsoft/perfview/assets/38960254/10da5464-2d25-4bfe-9edd-5eb2e67a55de)
![image](https://github.com/microsoft/perfview/assets/38960254/c2563331-3bff-4a11-8df2-100d42aa2818)

A bit more complex output with multiple processes emitting events:
![image](https://github.com/microsoft/perfview/assets/38960254/813f0628-0fb9-4ac6-afe3-20ca8e7f9fa8)
