### PR TITLE
Chromium Timestamp is in microseconds

### DIFF
--- a/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
+++ b/src/TraceEvent/Stacks/ChromiumStackSourceWriter.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.Tracing.Stacks.Formats
                     writer.Write($"\"name\": \"{GetEscaped(frameIdToFrameTuple[profileEvent.FrameId].Name, escapedNames)}\", ");
                     writer.Write($"\"cat\": \"sampleEvent\", ");
                     writer.Write($"\"ph\": \"{(profileEvent.Type == ProfileEventType.Open ? "B" : "E")}\", ");
-                    writer.Write($"\"ts\": {profileEvent.RelativeTime.ToString("R", CultureInfo.InvariantCulture)}, ");
+                    writer.Write($"\"ts\": {(profileEvent.RelativeTime * 1000).ToString("R", CultureInfo.InvariantCulture)}, ");
                     writer.Write($"\"pid\": {perThread.Key.ProcessId}, ");
                     writer.Write($"\"tid\": {perThread.Key.Id}, ");
                     writer.Write($"\"sf\": {profileEvent.FrameId}");


### PR DESCRIPTION
I converted a .nettrace file to the chromium format via `dotnet-trace convert` and noticed that my 15s long trace was only displayed as being 15ms long. After some digging and consulting the documentation, it appears that a timestamp expressed in milliseconds is being written into the `ts` field that expects a microsecond timestamp.
![image](https://github.com/microsoft/perfview/assets/7110884/cab7b20a-3a74-4912-8127-6ee9d3df98c7)
This bug has been previously reported here https://github.com/dotnet/diagnostics/issues/1315#issuecomment-653632216 but incorrectly classified as a bug in chromium. I believe this confusion might have been due to setting
```csharp
writer.Write("\"displayTimeUnit\": \"ms\", ");
```
just a few lines below but alas this is only a display concern
![image](https://github.com/microsoft/perfview/assets/7110884/f8417b82-cf8e-40a8-a745-fbd3017b480a)
