### PR TITLE
Remove dependency on Microsoft.NETCore.Portable.Compatibility

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,7 +43,6 @@
     <AzureCoreVersion>1.36.0</AzureCoreVersion>
     <AzureIdentityVersion>1.10.4</AzureIdentityVersion>
     <MicroBuildCoreVersion>0.3.1</MicroBuildCoreVersion>
-    <MicrosoftNETCorePortableCompatibilityVersion>1.0.2</MicrosoftNETCorePortableCompatibilityVersion>
     <MicrosoftIdentityClientVersion>4.58.1</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityClientExtensionsMsalVersion>4.58.1</MicrosoftIdentityClientExtensionsMsalVersion>
     <MicrosoftIdentityModelTokensVersion>7.1.2</MicrosoftIdentityModelTokensVersion>

--- a/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+++ b/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
@@ -30,7 +30,6 @@
 
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Microsoft.NETCore.Portable.Compatibility" version="$MicrosoftNETCorePortableCompatibilityVersion$" />
         <dependency id="Microsoft.Win32.Registry" version="$MicrosoftWin32RegistryVersion$" />
         <dependency id="System.Collections.Immutable" version="$SystemCollectionsImmutableVersion$" />
         <dependency id="System.Diagnostics.Process" version="$SystemDiagnosticsProcessVersion$" />

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -36,7 +36,6 @@
       <NuspecProperties>$(NuspecProperties);Configuration=$(Configuration)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);version=$(InformationalVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);OutDir=$(OutputPath)</NuspecProperties>
-      <NuspecProperties>$(NuspecProperties);MicrosoftNETCorePortableCompatibilityVersion=$(MicrosoftNETCorePortableCompatibilityVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);MicrosoftWin32RegistryVersion=$(MicrosoftWin32RegistryVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);SystemCollectionsImmutableVersion=$(SystemCollectionsImmutableVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);SystemDiagnosticsProcessVersion=$(SystemDiagnosticsProcessVersion)</NuspecProperties>
@@ -62,7 +61,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="$(MicrosoftNETCorePortableCompatibilityVersion)" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="$(MicrosoftDiagnosticsTracingTraceEventSupportFilesVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />


### PR DESCRIPTION
This dependency was added when adding support for `netstandard1.6` and appears to no longer be necessary.

Fixes #2016.