### PR TITLE
Fix Build Warnings

### DIFF
--- a/src/PerfView.TestUtilities/ThrowingTraceListener.cs
+++ b/src/PerfView.TestUtilities/ThrowingTraceListener.cs
@@ -21,7 +21,7 @@ namespace PerfView.TestUtilities
     {
         public override void Fail(string message, string detailMessage)
         {
-            Xunit.Assert.True(false, message + Environment.NewLine + detailMessage);
+            Xunit.Assert.Fail(message + Environment.NewLine + detailMessage);
             throw new DebugAssertFailureException(message + Environment.NewLine + detailMessage);
         }
 

--- a/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
+++ b/src/PerfView.Tests/Utilities/PerfViewTestBase.cs
@@ -43,7 +43,9 @@ namespace PerfViewTests.Utilities
 
         protected static async Task WaitForUIAsync(Dispatcher dispatcher, CancellationToken cancellationToken)
         {
+#pragma warning disable VSTHRD001
             await dispatcher.InvokeAsync(EmptyAction, DispatcherPriority.ContextIdle, cancellationToken);
+#pragma warning restore VSTHRD001
         }
 
         protected async Task RunUITestAsync<T>(

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -4094,40 +4094,5 @@ namespace PerfView
 
             return manifest;
         }
-
-        #region private
-
-        private static void GetStaticReferencedAssemblies(Assembly assembly, Dictionary<Assembly, Assembly> soFar)
-        {
-            soFar[assembly] = assembly;
-            string assemblyDirectory = Path.GetDirectoryName(assembly.ManifestModule.FullyQualifiedName);
-            foreach (AssemblyName childAssemblyName in assembly.GetReferencedAssemblies())
-            {
-                try
-                {
-                    // TODO is this is at best heuristic.  
-                    string childPath = Path.Combine(assemblyDirectory, childAssemblyName.Name + ".dll");
-                    Assembly childAssembly = null;
-                    if (File.Exists(childPath))
-                    {
-                        childAssembly = Assembly.ReflectionOnlyLoadFrom(childPath);
-                    }
-
-                    //TODO do we care about things in the GAC?   it expands the search quite a bit. 
-                    //else
-                    //    childAssembly = Assembly.Load(childAssemblyName);
-
-                    if (childAssembly != null && !soFar.ContainsKey(childAssembly))
-                    {
-                        GetStaticReferencedAssemblies(childAssembly, soFar);
-                    }
-                }
-                catch (Exception)
-                {
-                    Console.WriteLine("Could not load assembly " + childAssemblyName + " skipping.");
-                }
-            }
-        }
-        #endregion
     }
 }

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -2,10 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>PerfView</RootNamespace>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/TraceEvent/Samples/TraceEventSamples.csproj
+++ b/src/TraceEvent/Samples/TraceEventSamples.csproj
@@ -12,8 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" />
     <PackageReference Include="System.Reactive.Linq" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TraceEvent/TraceEvent.Tests/AutomatedAnalysis/AnalyzerResolverTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/AutomatedAnalysis/AnalyzerResolverTests.cs
@@ -67,7 +67,7 @@ namespace TraceEventTests
     {
         protected override void OnAnalyzerLoaded(AnalyzerLoadContext loadContext)
         {
-            Assert.True(false, "No analyzers should be loaded, but OnAnalyzerLoaded was called.");
+            Assert.Fail("No analyzers should be loaded, but OnAnalyzerLoaded was called.");
         }
 
         protected internal override void Resolve()

--- a/src/TraceEvent/TraceEvent.Tests/Memory/ClrMD_Dependencies.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Memory/ClrMD_Dependencies.cs
@@ -27,7 +27,7 @@ namespace TraceEventTests
                     case ClrRootKind.SizedRefHandle:
                         break;
                     default:
-                        Assert.True(false, $"Unexpected ClrRootKind: {kind}");
+                        Assert.Fail($"Unexpected ClrRootKind: {kind}");
                         break;
                 }
             }

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/BPerfTest.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/BPerfTest.cs
@@ -96,7 +96,7 @@ namespace TraceEventTests
                 Output.WriteLine($"Baseline File: {baselineFile}");
                 Output.WriteLine($"Actual File: {eventStatisticsFile}");
                 Output.WriteLine($"To Diff: windiff {baselineFile} {eventStatisticsFile}");
-                Assert.True(false, $"The event statistics doesn't match {Path.GetFullPath(baselineFile)}. It's saved in {Path.GetFullPath(eventStatisticsFile)}.");
+                Assert.Fail($"The event statistics doesn't match {Path.GetFullPath(baselineFile)}. It's saved in {Path.GetFullPath(eventStatisticsFile)}.");
             }
         }
 

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -590,7 +590,7 @@ namespace TraceEventTests
                 Output.WriteLine($"Baseline File: {baselineFile}");
                 Output.WriteLine($"Actual File: {eventStatisticsFile}");
                 Output.WriteLine($"To Diff: windiff {baselineFile} {eventStatisticsFile}");
-                Assert.True(false, $"The event statistics doesn't match {Path.GetFullPath(baselineFile)}. It's saved in {Path.GetFullPath(eventStatisticsFile)}.");
+                Assert.Fail($"The event statistics doesn't match {Path.GetFullPath(baselineFile)}. It's saved in {Path.GetFullPath(eventStatisticsFile)}.");
             }
         }
     }

--- a/src/TraceEvent/TraceEvent.Tests/SegmentedDictionary/ICollection.Generic.Tests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/SegmentedDictionary/ICollection.Generic.Tests.cs
@@ -260,7 +260,7 @@ namespace PerfView.Collections.Tests
                 for (int i = 0; i < count; i++)
                     collection.Remove(collection.ElementAt(0));
                 collection.Add(CreateT(254));
-                Assert.Equal(1, collection.Count);
+                Assert.Single(collection);
             }
         }
 
@@ -310,7 +310,7 @@ namespace PerfView.Collections.Tests
             else
             {
                 collection.Clear();
-                Assert.Equal(0, collection.Count);
+                Assert.Empty(collection);
             }
         }
 
@@ -331,7 +331,7 @@ namespace PerfView.Collections.Tests
                 collection.Clear();
                 collection.Clear();
                 collection.Clear();
-                Assert.Equal(0, collection.Count);
+                Assert.Empty(collection);
             }
         }
 

--- a/src/TraceEvent/TraceEvent.Tests/SegmentedDictionary/SegmentedDictionary.Generic.Tests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/SegmentedDictionary/SegmentedDictionary.Generic.Tests.cs
@@ -64,7 +64,7 @@ namespace PerfView.Collections.Tests
         public void Dictionary_Generic_Constructor_int(int count)
         {
             IDictionary<TKey, TValue> dictionary = new SegmentedDictionary<TKey, TValue>(count);
-            Assert.Equal(0, dictionary.Count);
+            Assert.Empty(dictionary);
         }
 
         [Theory]

--- a/src/TraceEvent/TraceEvent.Tests/Strace/StraceStackSourceTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Strace/StraceStackSourceTests.cs
@@ -32,7 +32,7 @@ namespace TraceEventTests
                 string newBaselineFilePath = Path.ChangeExtension(fileToUnzip, "perfview.xml");
                 StraceStackSource stackSource = new StraceStackSource(unzippedFile);
                 XmlStackSourceWriter.WriteStackViewAsXml(stackSource, newBaselineFilePath);
-                Assert.True(false, $"Baseline file does not exist.  Created new baseline file at {newBaselineFilePath}.  Confirm that this file is correct, and then save it in the inputs\\strace directory of the repo.");
+                Assert.Fail($"Baseline file does not exist.  Created new baseline file at {newBaselineFilePath}.  Confirm that this file is correct, and then save it in the inputs\\strace directory of the repo.");
             }
 
             // Open the baseline.


### PR DESCRIPTION
There are many build warnings which makes it difficult to confirm that a change didn't introduce a build warning.  Address or suppress the warnings appropriately.