### PR TITLE
Address Overflow of /MaxSizeMB

### DIFF
--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3653,7 +3653,7 @@ namespace PerfView
                 LogFile.WriteLine("Rundown File Length: {0:n1}MB delta: {1:n1}MB", newRundownFileLen / 1000000.0, delta / 1000000.0);
                 rundownFileLen = newRundownFileLen;
 
-                if ((maxSizeMB > 0) && rundownFileLen >= (maxSizeMB * 1024 * 1024))
+                if ((maxSizeMB > 0) && rundownFileLen >= ((long)maxSizeMB * 1024 * 1024))
                 {
                     LogFile.WriteLine($"Exceeded maximum rundown file size of {maxSizeMB}MB.");
                     break;


### PR DESCRIPTION
When converting from MB to bytes, it is possible to overflow MaxSizeMB because it gets converted from MB to bytes.  Cast `maxSizeMB` to `long` to avoid this.