### PR TITLE
Disable V2 Rundown by Default

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -149,7 +149,7 @@ namespace PerfView
         public bool NoNGenPdbs;
         public bool NoNGenRundown = true;
         public bool NoClrRundown;
-        public bool NoV2Rundown;
+        public bool NoV2Rundown = true;
         public bool LowPriority;
 
         public bool? Merge;


### PR DESCRIPTION
The Microsoft-Windows-DotNetRuntimeRundown provider was added as part of CLR 4.0.  In order to handle rundown for CLR 2.0, we must enable the Microsoft-Windows-DotNetRuntime provider, which in CLR 2.0, contains the rundown events.  Unfortunately, this creates a situation where we're also turning on some potentially verbose non-rundown events for CLR 4.0 processes.  This results in unintentionally larger traces, and rundowns that take much longer than expected.

Given that CLR 2.0 is not nearly as common as it once was, we will disable rundown for CLR 2.0 by default.  Users that want to profile CLR 2.0 processes can do so by setting `/NoV2Rundown:false` during collection.