### PR TITLE
Fix the Contention Stacks View for .NET Framework and Older .NET Core Processes

### DIFF
--- a/src/TraceEvent/Computers/StartStopLatencyComputer.cs
+++ b/src/TraceEvent/Computers/StartStopLatencyComputer.cs
@@ -38,7 +38,10 @@ namespace Microsoft.Diagnostics.Tracing.Computers
         protected override void RecordAdditionalStopData(StackSourceSample sample, TraceEvent data)
         {
             var stopData = (ContentionStopTraceData) data;
-            sample.Metric = (float) (stopData.DurationNs / NanosInMillisecond);
+            if (stopData.DurationNs > 0)
+            {
+                sample.Metric = (float)(stopData.DurationNs / NanosInMillisecond);
+            }
             sample.StackIndex = _interner.CallStackIntern(_interner.FrameIntern($"EventData DurationNs {stopData.DurationNs:N0}"), sample.StackIndex);
         }
     }


### PR DESCRIPTION
This change will use the time difference between the Contention/Start and Contention/Stop event unless the process is running on a newer version of .NET Core that specifies the time difference in the Contention/Stop event.  This is the ensure that this view works for all .NET processes and not just newer .NET Core processes.