### PR TITLE
Disable CodeQL Scanning for Code-Mirror Jobs

### DIFF
--- a/.pipelines/mirror.yml
+++ b/.pipelines/mirror.yml
@@ -14,6 +14,11 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
+    sdl:
+    codeql:
+      compiled:
+        enabled: false
+        justificationForDisabling: 'This is a mirror pipeline that does not build any code.'
     pool:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2022


### PR DESCRIPTION
This is necessary to remove errors that appear in internal systems due to the fact that the mirror pipeline does not build any code.