### PR TITLE
Artifacts are not currently captured properly in CI jobs

### DIFF
--- a/.pipelines/perfview-job.yml
+++ b/.pipelines/perfview-job.yml
@@ -42,6 +42,6 @@ steps:
   displayName: 'Copy Files to Artifacts Staging'
   inputs:
     SourceFolder: '$(system.defaultworkingdirectory)'
-    Contents: '**\bin\$(BuildConfiguration)\**'
+    Contents: '**\bin\${{ parameters.flavor }}\**'
     TargetFolder: '$(build.artifactstagingdirectory)'
   condition: succeededOrFailed()


### PR DESCRIPTION
Fix this by adjusting the path to contents to be captured.