### PR TITLE
Update to ClrMD version 4.0.0-beta.24314.3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -69,7 +69,7 @@
 
   <!-- ClrMD -->
   <PropertyGroup>
-    <MicrosoftDiagnosticsRuntimeVersion>2.3.405304</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.24314.3</MicrosoftDiagnosticsRuntimeVersion>
     <!-- If we set MicrosoftDiagnosticsRuntimeVersion to 'local' instead of the version below, it will build PerfView with a locally built ClrMD. -->
     <!-- This particular path assume clrmd is cloned side-by-side with PerfView, feel free to change as needed. -->
     <!--

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -20,6 +20,9 @@ using System.Threading;
 using Address = System.UInt64;
 using Microsoft.Diagnostics.Utilities;
 using Microsoft.Diagnostics.HeapDump;
+using Azure.Core;
+
+
 #if CROSS_GENERATION_LIVENESS
 using Microsoft.Diagnostics.CrossGenerationLiveness;
 #endif
@@ -35,9 +38,10 @@ public class GCHeapDumper
     /// to dump a heap.  
     /// </summary>
     /// <param name="log"></param>
-    public GCHeapDumper(TextWriter log)
+    public GCHeapDumper(TextWriter log, TokenCredential symbolServerAuthCredential = null)
     {
         m_origLog = log;
+        m_symbolServerAuthCredential = symbolServerAuthCredential;
         m_copyOfLog = new StringWriter();
         m_log = new TeeTextWriter(m_copyOfLog, m_origLog);
 
@@ -274,11 +278,11 @@ public class GCHeapDumper
         {
             try
             {
-                dataTarget = DataTarget.CreateSnapshotAndAttach(processID);
+                dataTarget = DataTarget.CreateSnapshotAndAttach(processID, m_symbolServerAuthCredential);
             }
             catch
             {
-                dataTarget = DataTarget.AttachToProcess(processID, Freeze);
+                dataTarget = DataTarget.AttachToProcess(processID, Freeze, m_symbolServerAuthCredential);
             }
         }
         else
@@ -288,7 +292,7 @@ public class GCHeapDumper
                 UseOSMemoryFeatures = false // disable AWE
             };
 
-            dataTarget = DataTarget.LoadDump(processDumpFile, cacheOptions);
+            dataTarget = DataTarget.LoadDump(processDumpFile, cacheOptions, m_symbolServerAuthCredential);
         }
 
         if (dataTarget.DataReader.PointerSize != IntPtr.Size)
@@ -928,7 +932,7 @@ public class GCHeapDumper
             // ClrMD returns UOH segments with seg.Generation2.Start == seg.Start and seg.Generation2.End == seg.End
             // To make it easy to determine the real generation of the object, augmenting the object with Gen3End and
             // Gen4End as follows such that DotNetHeapInfo.GenerationFor works.
-            if (seg.IsPinnedObjectSegment)
+            if (seg.Kind == GCSegmentKind.Pinned)
             {
                 gcHeapDumpSegment.Gen0End = seg.End;
                 gcHeapDumpSegment.Gen1End = seg.End;
@@ -936,7 +940,7 @@ public class GCHeapDumper
                 gcHeapDumpSegment.Gen3End = seg.End;
                 gcHeapDumpSegment.Gen4End = seg.End;
             }
-            else if (seg.IsLargeObjectSegment)
+            else if (seg.Kind == GCSegmentKind.Large)
             {
                 gcHeapDumpSegment.Gen0End = seg.End;
                 gcHeapDumpSegment.Gen1End = seg.End;
@@ -956,7 +960,7 @@ public class GCHeapDumper
             gcHeapDumpSegments.Add(gcHeapDumpSegment);
 
             total += seg.Length;
-            m_log.WriteLine("Segment: Start {0,16:x} Length: {1,16:x} {2,11:n3}M LOH:{3}", seg.Start, seg.Length, seg.Length / 1000000.0, seg.IsLargeObjectSegment);
+            m_log.WriteLine("Segment: Start {0,16:x} Length: {1,16:x} {2,11:n3}M LOH:{3}", seg.Start, seg.Length, seg.Length / 1000000.0, seg.Kind == GCSegmentKind.Large);
         }
 
         m_log.WriteLine("Segment: Total {0,16} Length: {1,16:x} {2,11:n3}M", "", total, total / 1000000.0);
@@ -1042,7 +1046,7 @@ public class GCHeapDumper
 
             m_log.WriteLine("{0,5:f1}s: Scanning Actual GC roots", m_sw.Elapsed.TotalSeconds);
             var rootsStartTimeMSec = m_sw.Elapsed.TotalMilliseconds;
-            foreach (IClrRoot root in runtimes.SelectMany(r => r.Heap.EnumerateRoots()))
+            foreach (ClrRoot root in runtimes.SelectMany(r => r.Heap.EnumerateRoots()))
             {
                 if (!root.Object.IsValid)
                     continue;
@@ -1578,6 +1582,8 @@ public class GCHeapDumper
     private TextWriter m_log;               // Where we send messages
     private StringWriter m_copyOfLog;       // We keep a copy of all logged messages here to append to output file. 
     private Stopwatch m_sw;                 // We keep track of how long it takes.  
+
+    private TokenCredential m_symbolServerAuthCredential;
 
     private GCHeapDump m_gcHeapDump;        // The image of what we are putting in the file
     private NodeIndex m_JSRoot = NodeIndex.Invalid;     // The root of the JS heap

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -960,7 +960,7 @@ public class GCHeapDumper
             gcHeapDumpSegments.Add(gcHeapDumpSegment);
 
             total += seg.Length;
-            m_log.WriteLine("Segment: Start {0,16:x} Length: {1,16:x} {2,11:n3}M LOH:{3}", seg.Start, seg.Length, seg.Length / 1000000.0, seg.Kind == GCSegmentKind.Large);
+            m_log.WriteLine("Segment: Start {0,16:x} Length: {1,16:x} {2,11:n3}M Kind:{3}", seg.Start, seg.Length, seg.Length / 1000000.0, seg.Kind);
         }
 
         m_log.WriteLine("Segment: Total {0,16} Length: {1,16:x} {2,11:n3}M", "", total, total / 1000000.0);

--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Diagnostics.Runtime;
+﻿using Azure.Core;
+using Azure.Identity;
+using Microsoft.Diagnostics.Runtime;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -57,7 +59,15 @@ internal class Program
             bool processDump = false;
             string inputSpec = null;
             int minSecForTrigger = -1;
-            var dumper = new GCHeapDumper(Console.Out);
+
+            DefaultAzureCredential symbolsTokenCredential = new DefaultAzureCredential(
+                new DefaultAzureCredentialOptions()
+                {
+                    ExcludeInteractiveBrowserCredential = false,
+                    ExcludeManagedIdentityCredential = true,
+                });
+
+            var dumper = new GCHeapDumper(Console.Out, symbolsTokenCredential);
 
             for (int curArgIdx = 0; curArgIdx < args.Length; curArgIdx++)
             {


### PR DESCRIPTION
 - Enable ClrMD to authenticate to a symbol server if required.
 - Update ClrMD API calls.