### PR TITLE
Address CVE-2024-30105 by directly consuming System.Text.Json 8.0.4

### DIFF
--- a/src/EtwHeapDump/EtwHeapDump.csproj
+++ b/src/EtwHeapDump/EtwHeapDump.csproj
@@ -44,6 +44,11 @@
     </Reference>
   </ItemGroup>
 
+  <!-- Override the version of System.Text.Json that is transitively included to address security issues. -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\FastSerialization\FastSerialization.csproj" />
     <ProjectReference Include="..\MemoryGraph\MemoryGraph.csproj" />

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -43,6 +43,11 @@
     </Reference>
   </ItemGroup>
 
+  <!-- Override the version of System.Text.Json that is transitively included to address security issues. -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\FastSerialization\FastSerialization.csproj" />
     <ProjectReference Include="..\TraceEvent\TraceEvent.csproj" />

--- a/src/HeapDumpDLL/HeapDumpDLL.csproj
+++ b/src/HeapDumpDLL/HeapDumpDLL.csproj
@@ -37,6 +37,11 @@
     </Reference>
   </ItemGroup>
 
+  <!-- Override the version of System.Text.Json that is transitively included to address security issues. -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\FastSerialization\FastSerialization.csproj" />
     <ProjectReference Include="..\MemoryGraph\MemoryGraph.csproj" />

--- a/src/SymbolsAuth/SymbolsAuth.csproj
+++ b/src/SymbolsAuth/SymbolsAuth.csproj
@@ -49,6 +49,11 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
   </ItemGroup>
 
+  <!-- Override the version of System.Text.Json that is transitively included to address security issues. -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <!-- *** SourceLink Support *** -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -29,6 +29,11 @@
     </Reference>
   </ItemGroup>
 
+  <!-- Override the version of System.Text.Json that is transitively included to address security issues. -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\PerfView.TestUtilities\PerfView.TestUtilities.csproj" />
     <ProjectReference Include="..\TraceEvent.csproj" />


### PR DESCRIPTION
Address additional projects that transitively pull in vulnerable versions of System.Text.Json.