### PR TITLE
fix: arm64/kerneltracecontrol.dll file name

### DIFF
--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -121,7 +121,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Include="$(TraceEventSupportFilesBase)native\arm64\KernelTraceControl.dll">
+    <None Include="$(TraceEventSupportFilesBase)native\arm64\kerneltracecontrol.dll">
       <Link>arm64\KernelTraceControl.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>


### PR DESCRIPTION
Fixes builds on case-sensitive systems. The actual DLL in the package is lowercase.

<img width="370" alt="image" src="https://github.com/user-attachments/assets/cde3e2b3-f48c-4ee7-a6e7-bd3533865f87">



```
/usr/share/dotnet/sdk/8.0.303/Microsoft.Common.CurrentVersion.targets(5270,5): error MSB3030: Could not copy the file "/home/runner/.nuget/packages/microsoft.diagnostics.tracing.traceevent.supportfiles/1.0.28/lib/native/arm64/KernelTraceControl.dll" because it was not found. [/home/runner/work/sentry-dotnet/sentry-dotnet/modules/perfview/src/TraceEvent/TraceEvent.csproj::TargetFramework=netstandard2.0]
```