### PR TITLE
Add cgmanifest.json Files to Track Dependencies from SupportFiles Packages

### DIFF
--- a/src/PerfView/cgmanifest.json
+++ b/src/PerfView/cgmanifest.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "version": 1,
+    "registrations": [
+        {
+            "component": {
+                "type": "other",
+                "other": {
+                    "name": "KernelTraceControl.dll",
+                    "version": "10.0.22000.1",
+                    "downloadUrl": "https://learn.microsoft.com/en-us/windows-hardware/get-started/adk-install",
+                    "hash": ""
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "other",
+                "other": {
+                    "name": "msdia140.dll",
+                    "version": "14.36.32543.0",
+                    "downloadUrl": "https://devdiv.visualstudio.com/DevDiv/_artifacts/feed/VS-CoreXtFeeds/NuGet/VS.Redist.Vctools.Amd64/overview/1.0.8605846-17-6-20231027-01",
+                    "hash": ""
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "other",
+                "other": {
+                    "name": "DiagnosticsHub.Packaging*.dll",
+                    "version": "15.9.18158.1",
+                    "downloadUrl": "",
+                    "hash": ""
+                }
+            }
+        }
+    ]
+}

--- a/src/TraceEvent/cgmanifest.json
+++ b/src/TraceEvent/cgmanifest.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "version": 1,
+    "registrations": [
+        {
+            "component": {
+                "type": "other",
+                "other": {
+                    "name": "KernelTraceControl.dll",
+                    "version": "10.0.22000.1",
+                    "downloadUrl": "https://learn.microsoft.com/en-us/windows-hardware/get-started/adk-install",
+                    "hash": ""
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "other",
+                "other": {
+                    "name": "msdia140.dll",
+                    "version": "14.36.32543.0",
+                    "downloadUrl": "https://devdiv.visualstudio.com/DevDiv/_artifacts/feed/VS-CoreXtFeeds/NuGet/VS.Redist.Vctools.Amd64/overview/1.0.8605846-17-6-20231027-01",
+                    "hash": ""
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The `cgmanifest.json` files will surface otherwise undetectable dependencies in component governance in the Microsoft-internal Azure DevOps instance.