### PR TITLE
Update Symbol File Check Text for PerfView

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -868,7 +868,7 @@ namespace PerfView
             {
                 ret.SecurityCheck = delegate (string pdbFile)
                 {
-                    var result = System.Windows.MessageBox.Show("Found " + pdbFile + " in a location that may not be trustworthy, do you trust this file?",
+                    var result = System.Windows.MessageBox.Show("Found " + pdbFile + " on your local machine.  Do you want to use it?",
                         "Security Check", System.Windows.MessageBoxButton.YesNo);
                     return result == System.Windows.MessageBoxResult.Yes;
                 };


### PR DESCRIPTION
When attempting to use a locally-detected symbol file, prompt the user with the following text:

"Found <path to pdb> on your local machine.  Do you want to use it?"