### PR TITLE
Address Mirror Merge Conflicts

### DIFF
--- a/.pipelines/mirror.yml
+++ b/.pipelines/mirror.yml
@@ -117,7 +117,7 @@ extends:
             displayName: 'Pull AzDO SourceBranch'
             inputs:
               filename: 'git '
-              arguments: 'pull https://dn-bot:$(dn-bot-devdiv-build-rw-code-rw)@devdiv.visualstudio.com/DevDiv/_git/perfView $(SourceBranch)'
+              arguments: 'pull --strategy=recursive --strategy-option no-renames https://dn-bot:$(dn-bot-devdiv-build-rw-code-rw)@devdiv.visualstudio.com/DevDiv/_git/perfView $(SourceBranch)'
 
           - task: CmdLine@1
             displayName: 'Run git push '


### PR DESCRIPTION
The mirror is currently failing due to rename detection.  The mirror should not be handling renames.