### PR TITLE
Remove Obsolete Exception Constructor

### DIFF
--- a/src/PerfView.TestUtilities/ThrowingTraceListener.cs
+++ b/src/PerfView.TestUtilities/ThrowingTraceListener.cs
@@ -95,10 +95,6 @@ namespace PerfView.TestUtilities
             public DebugAssertFailureException() { }
             public DebugAssertFailureException(string message) : base(message) { }
             public DebugAssertFailureException(string message, Exception inner) : base(message, inner) { }
-            protected DebugAssertFailureException(
-              System.Runtime.Serialization.SerializationInfo info,
-              System.Runtime.Serialization.StreamingContext context) : base(info, context)
-            { }
         }
     }
 }


### PR DESCRIPTION
Per guidance, `Exception(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)` is now obsolete and should not be extended by application code.