### PR TITLE
PerfView BuildLayout Command

### DIFF
--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -54,6 +54,25 @@ namespace PerfView
                     (string.Compare(args[0], "/noGui", StringComparison.OrdinalIgnoreCase) == 0 ||
                      string.Compare(args[0], 0, "/logFile", 0, 8, StringComparison.OrdinalIgnoreCase) == 0));
 
+                // Users will need to check the return code for failure because there is no console setup yet and we can't log any status.
+                var buildLayout = args.Length > 1 && string.Compare(args[0], "/buildLayout", StringComparison.OrdinalIgnoreCase) == 0;
+                if (buildLayout)
+                {
+                    string destDirectory = args[1];
+                    if (Directory.Exists(destDirectory))
+                    {
+                        return retCode;
+                    }
+
+                    SupportFiles.SetSupportFilesDir(destDirectory);
+                    App.Unpack();
+                    App.WriteDefaultAppConfigDataFile(destDirectory);
+
+                    retCode = 0;
+                    return retCode;
+                }
+
+
                 // If we need to install, display the splash screen early, otherwise wait
                 if (!Directory.Exists(SupportFiles.SupportFileDir) && !noGui)
                 {
@@ -394,6 +413,11 @@ namespace PerfView
             }
         }
 
+        public static void WriteDefaultAppConfigDataFile(string directoryPath)
+        {
+            string defaultConfig = "<ConfigData>\r\n  <SupportFilesDir>.\\</SupportFilesDir>\r\n</ConfigData>";
+            File.WriteAllText(Path.Combine(directoryPath, "AppConfig.xml"), defaultConfig);
+        }
 
         // Logfile
         /// <summary>

--- a/src/PerfView/Utilities/SupportFiles.cs
+++ b/src/PerfView/Utilities/SupportFiles.cs
@@ -338,6 +338,11 @@ namespace Utilities
             }
         }
 
+        internal static void SetSupportFilesDir(string supportFilesDir)
+        {
+            s_supportFileDir = supportFilesDir;
+        }
+
         private static void Cleanup()
         {
             string cleanupMarkerFile = Path.Combine(SupportFileDirBase, "CleanupNeeded");


### PR DESCRIPTION
Add the `/buildLayout <path>` command to PerfView.

This allows users to build a self-contained fully-extracted version of PerfView that doesn't depend on `%appdata%.  This is useful for certain deployment mechanisms where the deployed PerfView shouldn't impact PerfView in `%appdata%.