### PR TITLE
Limit StructValue resize allocations

### DIFF
--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -603,7 +603,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             PayloadFetchClassInfo classInfo = payloadFetch.Class;
             if (classInfo != null)
             {
-                var ret = new StructValue();
+                var ret = new StructValue(classInfo.FieldFetches.Length);
 
                 for (int i = 0; i < classInfo.FieldFetches.Length; i++)
                 {
@@ -797,6 +797,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         /// </summary>
         internal class StructValue : IDictionary<string, object>
         {
+            internal StructValue(int capacity = 0)
+            {
+                m_values = new List<KeyValuePair<string, object>>(capacity);
+            }
             public IEnumerator<KeyValuePair<string, object>> GetEnumerator() { return m_values.GetEnumerator(); }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return m_values.GetEnumerator(); }
             public bool IsReadOnly { get { return true; } }
@@ -937,7 +941,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) { throw new NotImplementedException(); }
             public bool Remove(KeyValuePair<string, object> item) { throw new NotImplementedException(); }
 
-            private List<KeyValuePair<string, object>> m_values = new List<KeyValuePair<string, object>>();
+            private List<KeyValuePair<string, object>> m_values;
             #endregion
         }
 


### PR DESCRIPTION
We use TraceEvent to gather process-level event counters. I noticed in a recent trace that about 12% of our process memory allocations are due to resizing when we call `DynamicTraceEventData.PayloadValue(int32)`

In particular, the ```system.private.corelib.il!System.Collections.Generic.List`1[System.Collections.Generic.KeyValuePair`2[System.__Canon, System.__Canon]].AddWithResize(System.__Canon)``` and ```system.private.corelib.il!System.Collections.Generic.List`1[System.Collections.Generic.KeyValuePair`2[System.__Canon, System.__Canon]].set_Capacity(int32)``` frames caused by list resizing.

I noticed in the code that when `GetPayloadValueAt(...)` is called a `StructValue` is created and we go through a loop adding `i` `KeyValuePairs` corresponding to `classInfo.FieldFetches.Length`.
https://github.com/microsoft/perfview/blob/4685da655131acb73441f71ec19ea79ffa300ffa/src/TraceEvent/DynamicTraceEventParser.cs#L606C17-L612C18