### PR TITLE
Configure SourceLink to Embed Source Files in PDBs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -109,4 +109,9 @@
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishRepositoryUrl>false</PublishRepositoryUrl>
+    <EmbedAllSources>true</EmbedAllSources>
+  </PropertyGroup>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,14 +10,11 @@
     <Features>strict</Features>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DebugType>full</DebugType>
+  <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugType>pdbonly</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <PublishRepositoryUrl>false</PublishRepositoryUrl>
+    <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -107,11 +104,6 @@
   -->
   <PropertyGroup>
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PublishRepositoryUrl>false</PublishRepositoryUrl>
-    <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
 </Project>

--- a/src/FastSerialization/FastSerialization.csproj
+++ b/src/FastSerialization/FastSerialization.csproj
@@ -18,7 +18,6 @@
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);GROWABLEARRAY_PUBLIC;STREAMREADER_PUBLIC;FASTSERIALIZATION_PUBLIC</DefineConstants>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SymbolsAuth/SymbolsAuth.csproj
+++ b/src/SymbolsAuth/SymbolsAuth.csproj
@@ -40,10 +40,6 @@
     </PropertyGroup>
   </Target>
 
-  <PropertyGroup>
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />


### PR DESCRIPTION
Prior to this change, SourceLink attempted to point to the internal repo where we build the Microsoft distribution of PerfView and TraceEvent.

With this change, sources will be embedded in the PDBs so that all users can debug and profile shipped releases.