### PR TITLE
Address accessibility issues

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,6 +52,7 @@
     <MicrosoftIdentityModelJsonWebTokensVersion>7.1.2</MicrosoftIdentityModelJsonWebTokensVersion>
     <MicrosoftSourceLinkGitHubVersion>8.0.0</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
+    <MicrosoftWebWebView2Version>1.0.2792.45</MicrosoftWebWebView2Version>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>8.0.0</SystemDiagnosticsDiagnosticSourceVersion>

--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -41,6 +41,7 @@ namespace PerfView
         public static int Main(string[] args)
         {
             CommandProcessor = new CommandProcessor();
+            App.SetAccessibilitySwitchOverrides();
 
             StreamWriter writerToCleanup = null;   // If we create a log file, we need to clean it up.  
             int retCode = -1;
@@ -1078,6 +1079,20 @@ namespace PerfView
         }
         private static string m_SymbolPath;
         private static string m_SourcePath;
+
+        /// <summary>
+        /// This enables using new accessibility features that were implemented on .NET Framework 4.7.1 or later 
+        /// despite the application targeting an earlier framework version. This resolves a few accessibility issues
+        /// that were fixed in later versions of .NET Framework. For more information, see below: 
+        ///   https://learn.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches
+        /// </summary>
+        private static void SetAccessibilitySwitchOverrides()
+        {
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures", false);
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.2", false);
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.3", false);
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.4", false);
+        }
 
 #region CreateConsole
         [System.Runtime.InteropServices.DllImport("kernel32", SetLastError = true)]

--- a/src/PerfView/Dialogs/FileInputAndOutput.xaml
+++ b/src/PerfView/Dialogs/FileInputAndOutput.xaml
@@ -27,7 +27,7 @@
                 <Hyperlink Command="Help" CommandParameter="ProcessDumpTextBox">Help</Hyperlink>
         </TextBlock>
 
-        <RichTextBox Grid.Row="0" Grid.Column="1" Margin="0,5,5,0" IsReadOnly="True" IsDocumentEnabled="True">
+        <RichTextBox Grid.Row="0" Grid.Column="1" Margin="0,5,5,0" IsReadOnly="True" IsDocumentEnabled="True" AutomationProperties.Name="Disk Size Analysis Help">
             <RichTextBox.Document>
                 <FlowDocument>
                     <Paragraph Name="InstructionParagraph">
@@ -43,15 +43,16 @@
 
         <TextBlock Grid.Row="2" Grid.Column="0"  VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False"
                    Text="Input File:" ToolTip="The file/directory to open for analysis"/>
-        <TextBox  Grid.Row="2" Grid.Column="1" Margin="0,0,5,0" Name="InputFileName" VerticalAlignment="Center" PreviewKeyDown="InputFileKeyDown" TextChanged="InputFileTextChanged" />
+        <TextBox  Grid.Row="2" Grid.Column="1" Margin="0,0,5,0" Name="InputFileName" VerticalAlignment="Center" PreviewKeyDown="InputFileKeyDown" TextChanged="InputFileTextChanged" AutomationProperties.Name="Input File" />
 
         <ListBox Grid.Row="3" Grid.Column="2" KeyboardNavigation.TabIndex="1" Margin="0,5,5,15" MinHeight="80" Name="Files"
                  PreviewKeyDown="ListBoxKeyDown" MouseDoubleClick="FilesDoubleClick" FontFamily="Courier New"
-                 ToolTip="This shows all the files/directories that match the prefix in the InputFile text box."/>
+                 ToolTip="This shows all the files/directories that match the prefix in the InputFile text box."
+                 AutomationProperties.Name="Files"/>
 
         <TextBlock Grid.Row="4" Grid.Column="0"  VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False"
             Text="Output File:" ToolTip="The file name to put the resulting analysis."/>
-        <TextBox  Grid.Row="4"  Grid.Column="1" Margin="0,0,5,0" Name="OutputFileName" VerticalAlignment="Center"  />
+        <TextBox  Grid.Row="4"  Grid.Column="1" Margin="0,0,5,0" Name="OutputFileName" VerticalAlignment="Center" AutomationProperties.Name="Output File"  />
 
         <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" FlowDirection="RightToLeft">
             <Button Margin="10,5,10,5" Width="80" Content="OK" Click="OKClicked"/>

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml
@@ -21,7 +21,7 @@
         </Grid.RowDefinitions>
 
         <!-- Help message at top -->
-        <RichTextBox Grid.Row="0" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True">
+        <RichTextBox Grid.Row="0" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True" AutomationProperties.Name="Memory data collection help">
             <RichTextBox.Document>
                 <FlowDocument>
                     <Paragraph>
@@ -44,7 +44,7 @@
             <TextBlock  Grid.Column="0"  Margin="5,0" Width="100" VerticalAlignment="Center" ToolTip="The file name of the process dump file from which to extract the GC heap.">
                 <Hyperlink Command="Help" CommandParameter="ProcessDumpTextBox">Process Dump File:</Hyperlink>
             </TextBlock>
-            <TextBox  Margin="0,5,5,0" Grid.Column="1" Name="ProcessDumpTextBox" VerticalAlignment="Center" KeyDown="ProcessDumpKeyDown"  />
+            <TextBox  Margin="0,5,5,0" Grid.Column="1" Name="ProcessDumpTextBox" VerticalAlignment="Center" KeyDown="ProcessDumpKeyDown" AutomationProperties.Name="Process Dump File"  />
         </Grid>
 
         <!-- Option 2 capturing memory from active processes -->
@@ -65,20 +65,24 @@
                 <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Only processes that match this RegEx filter pattern are displayed.">
                     <Hyperlink Command="Help" CommandParameter="ProcessFilterTextBox">Filter:</Hyperlink>
                 </TextBlock>
-                <TextBox KeyboardNavigation.TabIndex="0" VerticalAlignment="Center" Grid.Column="1" Width="100" Margin="5,0,0,0"  Name="FilterTextBox" TextChanged="FilterTextChanged" PreviewKeyDown="FilterTextKeyDown"/>
+                <TextBox KeyboardNavigation.TabIndex="0" VerticalAlignment="Center" Grid.Column="1" Width="100" Margin="5,0,0,0"  Name="FilterTextBox" TextChanged="FilterTextChanged" PreviewKeyDown="FilterTextKeyDown" AutomationProperties.Name="Process Filter"/>
 
                 <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Normally only processed with GC heaps are displayed.  Checking this shows all processes.">
                     <Hyperlink Command="Help" CommandParameter="AllProcsCheckBox">All Procs:</Hyperlink>
                 </TextBlock>
-                <CheckBox Grid.Column="3" Name="AllProcsCheckBox" VerticalAlignment="Center"  IsChecked="true" Click="AllProcsClick" />
+                <CheckBox Grid.Column="3" Name="AllProcsCheckBox" VerticalAlignment="Center"  IsChecked="true" Click="AllProcsClick" AutomationProperties.Name="All Processes" />
 
                 <TextBlock Grid.Column="4" Margin="15,0,0,0" VerticalAlignment="Center" Name="ElevateWarning">
                     Only Processes you have perission to inspect to are shown.
                     <Hyperlink Click="ElevateToAdminClick">Elevate to Admin</Hyperlink> to see all processes.
                 </TextBlock>
             </Grid>
-            <ListBox KeyboardNavigation.TabIndex="1" Margin="5,28,5,12" MinHeight="80" Name="Processes" MouseDoubleClick="ProcessesMouseDoubleClick" SelectionChanged="Processes_SelectionChanged" FontFamily="Courier New" Grid.RowSpan="2">
-
+            <ListBox KeyboardNavigation.TabIndex="1" Margin="5,28,5,12" MinHeight="80" Name="Processes" MouseDoubleClick="ProcessesMouseDoubleClick" SelectionChanged="Processes_SelectionChanged" FontFamily="Courier New" Grid.RowSpan="2" AutomationProperties.Name="Processes">
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding ShortDescription}" />
+                    </Style>
+                </ListBox.ItemContainerStyle>
             </ListBox>
         </Grid>
 
@@ -93,7 +97,7 @@
             <TextBlock  Grid.Column="0" Width="100" Margin="5,0" VerticalAlignment="Center" ToolTip="The name of the data file to create." >
                 <Hyperlink Command="Help" CommandParameter="GCHeapDataFileNameTextBox">Output Data File:</Hyperlink>
             </TextBlock>
-            <TextBox Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" />
+            <TextBox Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" AutomationProperties.Name="Output Data Filename" />
             <Button Grid.Column="2" Content="..."  Width="25" Margin="5,5"
                 VerticalAlignment="Center" Click="DataFileButtonClick" ToolTip="Click to select the file name in a file chooser dialog." />
         </Grid>
@@ -123,12 +127,12 @@
             <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="5,0,5,0" ToolTip="If the heap has more object than this (in Kilo objects) than this, only a sample is taken." >
                         <Hyperlink Command="Help" CommandParameter="MaxDumpTextBox">Max Dump<LineBreak/>K Objs:</Hyperlink>
             </TextBlock>
-            <TextBox Grid.Column="2" Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0"/>
+            <TextBox Grid.Column="2" Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0" AutomationProperties.Name="Maximum dump size in kilo objects"/>
 
             <TextBlock Grid.Column="3" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked the process will be frozen during the dump.">
                     <Hyperlink Command="Help" CommandParameter="FreezeCheckBox">Freeze:</Hyperlink>
             </TextBlock>
-            <CheckBox Grid.Column="4" Name="FreezeCheckBox" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <CheckBox Grid.Column="4" Name="FreezeCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" AutomationProperties.Name="Freeze"/>
 
             <!-- TODO FIX NOW Add DumpData back in.
             <TextBlock Grid.Column="5" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked the data in objects as well as the connectivity information is dumped.">
@@ -140,7 +144,7 @@
             <TextBlock Grid.Column="7" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked Dump will be in Clr Profiler format.">
                 <Hyperlink Command="Help" CommandParameter="SaveETLCheckBox">Save<LineBreak/>ETL:</Hyperlink>
             </TextBlock>
-            <CheckBox Grid.Column="8" Name="SaveETLCheckBox" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <CheckBox Grid.Column="8" Name="SaveETLCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" AutomationProperties.Name="Save ETL"/>
 
             <Button Name="GCButton" Grid.Column="12" Margin="5,0,20,5" Width="60" VerticalAlignment="Center"  Click="GCButtonClick"
                     ToolTip="Causes a GC to happen in the selected process">Force GC</Button>

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -114,7 +114,7 @@
             <TextBlock Grid.Column="8" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed." >
                 <Hyperlink Command="Help" CommandParameter="MarkTextBox">Mark Text:</Hyperlink>
             </TextBlock>
-            <TextBox Grid.Column="9" Name="MarkTextBox" VerticalAlignment="Center" Width="auto" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
+            <TextBox Grid.Column="9" Name="MarkTextBox" VerticalAlignment="Center" Width="150" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
             <Button Name="MarkButton" Grid.Column="10" Margin="5,0" Padding="5,1" Width="auto" VerticalAlignment="Center"
                     ToolTip="Click this button to enter a mark event into the data collected."
                     Click="MarkButtonClick">Mark</Button>

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -26,7 +26,7 @@
             <ColumnDefinition Width="auto"/>
         </Grid.ColumnDefinitions>
         <!-- Help message at top -->
-        <RichTextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True">
+        <RichTextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True" AutomationProperties.Name="Run collection help">
             <RichTextBox.Document>
                 <FlowDocument>
                     <Paragraph Margin="0,0,0,0">
@@ -45,14 +45,14 @@
         <TextBlock Grid.Row="1" Grid.Column="0" x:Name="CommandToRunLabel" Margin="5,0" VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False" ToolTip="The command line of the process to run while collecting data.">
                 <Hyperlink Command="Help" CommandParameter="CommandToRunTextBox">Command:</Hyperlink>
         </TextBlock>
-        <controls:HistoryComboBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="CommandToRunTextBox" VerticalAlignment="Center" KeyDown="CommandToRunKeyDown"  />
+        <controls:HistoryComboBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="CommandToRunTextBox" VerticalAlignment="Center" KeyDown="CommandToRunKeyDown" AutomationProperties.Name="Command to run" />
 
         <!-- FocusProcess section for Collect command-->
         <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
             <TextBlock Name="FocusProcessLabel" Margin="5,0" VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False" ToolTip="Name or PID of the process to collect user-mode events for.">
                 <Hyperlink Command="Help" CommandParameter="FocusProcessTextBox">Focus process:</Hyperlink>
             </TextBlock>
-            <CheckBox Name="FocusProcessCheckBox" VerticalAlignment="Center" Margin="1,2,2,0" Click="FocusProcessCheckBoxClicked" IsChecked="false" />
+            <CheckBox Name="FocusProcessCheckBox" VerticalAlignment="Center" Margin="1,2,2,0" Click="FocusProcessCheckBoxClicked" IsChecked="false" AutomationProperties.Name="Focus process" />
         </StackPanel>
         <TextBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="FocusProcessTextBox" VerticalAlignment="Center" />
 
@@ -60,14 +60,14 @@
         <TextBlock Grid.Row="2" Grid.Column="0" Margin="5,0" VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False" ToolTip="The name of the data file to create." >
             <Hyperlink Command="Help" CommandParameter="DataFileNameTextBox">Data File:</Hyperlink>
         </TextBlock>
-        <TextBox  Grid.Row="2" Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" />
+        <TextBox  Grid.Row="2" Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" AutomationProperties.Name="Data File" />
         <Button Grid.Row="2" Grid.Column="2" Content="..."  Width="25" Margin="5,5"
                 VerticalAlignment="Center" Click="DataFileButtonClick" ToolTip="Click to select the file name in a file chooser dialog." />
 
         <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0" KeyboardNavigation.IsTabStop="False" ToolTip="The directory in which the command is run.">
                 <Hyperlink Command="Help" CommandParameter="CurrentDirTextBox">Current Dir:</Hyperlink>
         </TextBlock>
-        <TextBox  Grid.Row="3" Grid.Column="1"  Name="CurrentDirTextBox" VerticalAlignment="Center"  />
+        <TextBox  Grid.Row="3" Grid.Column="1"  Name="CurrentDirTextBox" VerticalAlignment="Center" AutomationProperties.Name="Current Directory" />
 
         <!-- Row with Merge, run button cancel ... -->
         <Grid Grid.Row="4" Grid.ColumnSpan="3" Margin="0,2,0,-1">
@@ -92,29 +92,29 @@
             <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="Use this option if you wish to analyze on another machine.">
                 <Hyperlink Command="Help" CommandParameter="ZipCheckBox">Zip:</Hyperlink>
             </TextBlock>
-            <CheckBox Grid.Column="1" Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" />
+            <CheckBox Grid.Column="1" Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" AutomationProperties.Name="Zip" />
 
             <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="After this size (in megabytes) old events are thown away to keep file size under control" >
                         <Hyperlink Command="Help" CommandParameter="CircularTextBox">Circular<LineBreak/>MB:</Hyperlink>
             </TextBlock>
 
-            <TextBox Grid.Column="3" Name="CircularTextBox" VerticalAlignment="Center" Width="35" Margin="5,0"/>
+            <TextBox Grid.Column="3" Name="CircularTextBox" VerticalAlignment="Center" Width="35" Margin="5,0" AutomationProperties.Name="Circular Buffer Size in Megabytes"/>
 
             <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="If checked will merge data into a single file, implied by Zip.">
                 <Hyperlink Command="Help" CommandParameter="MergeCheckBox">Merge:</Hyperlink>
             </TextBlock>
-            <CheckBox Grid.Column="5" Name="MergeCheckBox" VerticalAlignment="Center" Click="MergeCheckBoxClicked" Margin="0,0,10,0"/>
+            <CheckBox Grid.Column="5" Name="MergeCheckBox" VerticalAlignment="Center" Click="MergeCheckBoxClicked" Margin="0,0,10,0" AutomationProperties.Name="Merge"/>
 
             <TextBlock  Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2" KeyboardNavigation.IsTabStop="False"
                                ToolTip="Needed for Thread Time views.  Fire an event (and stack trace) every time the processor switch from one thread to another." >
                     <Hyperlink Command="Help" CommandParameter="ThreadTimeCheckbox">Thread<LineBreak/>Time:</Hyperlink>
             </TextBlock>
-            <CheckBox Grid.Column="7" Name="ThreadTimeCheckbox" VerticalAlignment="Center" />
+            <CheckBox Grid.Column="7" Name="ThreadTimeCheckbox" VerticalAlignment="Center" AutomationProperties.Name="Thread Time" />
 
             <TextBlock Grid.Column="8" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed." >
                 <Hyperlink Command="Help" CommandParameter="MarkTextBox">Mark Text:</Hyperlink>
             </TextBlock>
-            <TextBox Grid.Column="9" Name="MarkTextBox" VerticalAlignment="Center" Width="150" Margin="5,0" KeyDown="MarkTextKeyDown" />
+            <TextBox Grid.Column="9" Name="MarkTextBox" VerticalAlignment="Center" Width="auto" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
             <Button Name="MarkButton" Grid.Column="10" Margin="5,0" Padding="5,1" Width="auto" VerticalAlignment="Center"
                     ToolTip="Click this button to enter a mark event into the data collected."
                     Click="MarkButtonClick">Mark</Button>
@@ -167,43 +167,43 @@
                                ToolTip="Fire an event (and stack trace) every time the processor switch from one thread to another." >
                         <Hyperlink Command="Help" CommandParameter="KernelBaseCheckBox">Kernel Base:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="KernelBaseCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" Name="KernelBaseCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Kernel Base"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Fire an event after every time a small amount (typicaly 1MSec) of CPU is consumed." >
                         <Hyperlink Command="Help" CommandParameter="CpuSamplesCheckBox">Cpu Samples:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="CpuSamplesCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="3" Name="CpuSamplesCheckBox" VerticalAlignment="Center" AutomationProperties.Name="CPU Samples"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Fire an event (and stack trace) on page faults and other virtual memory transitions." >
                     <Hyperlink Command="Help" CommandParameter="MemoryCheckBox">Page Faults:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="5" Name="MemoryCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="5" Name="MemoryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Page Faults" />
 
                     <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Fire an event (and a stack trace) when various file operations occur (even if the disk is not accessed)." >
                     <Hyperlink Command="Help" CommandParameter="FileIOCheckBox">File I/O:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="7" Name="FileIOCheckBox" VerticalAlignment="Center"  />
+                    <CheckBox Grid.Row="0" Grid.Column="7" Name="FileIOCheckBox" VerticalAlignment="Center" AutomationProperties.Name="File I/O" />
 
                     <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Fire an event (and a stack trace) when various registry operations occur." >
                     <Hyperlink Command="Help" CommandParameter="RegistryCheckBox">Registry:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="9" Name="RegistryCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="9" Name="RegistryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Registry"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Fire an event (and a stack trace) when low level VirtualAlloc VirtualFree calls are made." >
                     <Hyperlink Command="Help" CommandParameter="VirtualAllocCheckBox">VirtAlloc:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="11" Name="VirtualAllocCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="11" Name="VirtualAllocCheckBox" VerticalAlignment="Center" AutomationProperties.Name="VirtualAlloc"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Fire an event every half second to monitor memory stats for each process on the system.." >
                     <Hyperlink Command="Help" CommandParameter="MemInfoCheckBox">MemInfo:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="13" Name="MemInfoCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="13" Name="MemInfoCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Memory Info"/>
                 </Grid>
 
                 <!-- Check boxes for more kernel events -->
@@ -231,37 +231,37 @@
                                ToolTip="Collect information about creation and closing of Windows OS handles." >
                     <Hyperlink Command="Help" CommandParameter="HandleCheckBox">Handle:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="HandleCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" Name="HandleCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Handle"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Collect detailed information on memory usage of all processes." >
                     <Hyperlink Command="Help" CommandParameter="RefSetCheckBox">RefSet:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="RefSetCheckBox" VerticalAlignment="Center"/>
+                    <CheckBox Grid.Row="0" Grid.Column="3" Name="RefSetCheckBox" VerticalAlignment="Center" AutomationProperties.Name="RefSet"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Collect detailed information Internet Information Services (IIS)" >
                     <Hyperlink Command="Help" CommandParameter="IISCheckBox">IIS:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="5" Name="IISCheckBox" VerticalAlignment="Center"/>
+                    <CheckBox Grid.Row="0" Grid.Column="5" Name="IISCheckBox" VerticalAlignment="Center" AutomationProperties.Name="IIS"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                                ToolTip="Collect a _Netmon.etl file that can be used with NetMon.  Also implies NetCap." >
                     <Hyperlink Command="Help" CommandParameter="NetMonCheckBox">NetMon:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Column="7" Name="NetMonCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Column="7" Name="NetMonCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="NetMon"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                                ToolTip="Capture the full payload of all network packets that enter or leave the machine." Grid.ColumnSpan="2">
                     <Hyperlink Command="Help" CommandParameter="NetCaptureCheckBox">Net Capture:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Column="10" Name="NetCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Column="10" Name="NetCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Net Capture" />
 
                     <TextBlock Grid.Row="0" Grid.Column="11" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                                ToolTip="Capture events from the Task Parallel Library." >
                     <Hyperlink Command="Help" CommandParameter="TplCaptureCheckBox">Tasks (TPL):</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Column="12" Name="TplCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Column="12" Name="TplCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Tasks (TPL)" />
 
                     <CheckBox Grid.Row="0" Grid.Column="14" Name="Box7" VerticalAlignment="Center" Visibility="Hidden" Margin="0,2" />
                 </Grid>
@@ -290,43 +290,43 @@
                                ToolTip="These are the default .NET runtime events.  They should usually be left on." >
                     <Hyperlink Command="Help" CommandParameter="ClrCheckBox">.NET :</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="ClrCheckBox" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" Name="ClrCheckBox" AutomationProperties.Name=".NET" />
 
                     <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Turn on logging of the .NET STress log, which logs unusual events that help track down random failure." >
                     <Hyperlink Command="Help" CommandParameter="StressCheckBox">.NET Stress:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="StressCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="3" Name="StressCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Stress" />
 
                     <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Turn on events associated with background JIT compilation." >
                     <Hyperlink Command="Help" CommandParameter="BackgroundJITCheckBox">Background JIT:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="5" Name="BackgroundJITCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="5" Name="BackgroundJITCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Background JIT" />
 
                     <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Log an event every time a method is called (expensive!)." >
                     <Hyperlink Command="Help" CommandParameter="DotNetCallsCheckBox">.NET Calls:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetCallsCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetCallsCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Calls"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Log information about successful and failed inlining attempts." >
                     <Hyperlink Command="Help" CommandParameter="JITInliningCheckBox">JIT Inlining:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="9" Name="JITInliningCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="9" Name="JITInliningCheckBox" VerticalAlignment="Center" AutomationProperties.Name="JIT Inlining"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                 ToolTip="Log information about .NET Native CCW Ref Counting.">
                      <Hyperlink Command="Help" CommandParameter="CCWRefCountCheckBox"> .NET Native CCW:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="11" Name="CCWRefCountCheckBox" VerticalAlignment="Center"/>
+                    <CheckBox Grid.Row="0" Grid.Column="11" Name="CCWRefCountCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Native CCW"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Log extended information about .NET Runtime loading including R2R and type load events." >
                     <Hyperlink Command="Help" CommandParameter="RuntimeLoadingCheckBox">.NET Loader:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="13" Name="RuntimeLoadingCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="13" Name="RuntimeLoadingCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Loader" />
                 </Grid>
 
                 <!-- Check boxes for more clr events (GC Heap related) -->
@@ -354,37 +354,37 @@
                                ToolTip="Turn off everything except events which happen when .NET Garbage Collections happen." >
                     <Hyperlink Command="Help" CommandParameter="GCCollectOnlyCheckBox">GC Collect Only:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="GCCollectOnlyCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" Name="GCCollectOnlyCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="GC Collect Only" />
 
                     <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,4,2"
                                ToolTip="Turn off everything except events needed to trace .NET GC heap allocations." >
                     <Hyperlink Command="Help" CommandParameter="GCOnlyCheckBox">GC Only:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="GCOnlyCheckBox" VerticalAlignment="Center" Margin="0,2"/>
+                    <CheckBox Grid.Row="0" Grid.Column="3" Name="GCOnlyCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="GC Only"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                                ToolTip="Fire an event whenever a .NET object is allocated capturing its stack." >
                     <Hyperlink Command="Help" CommandParameter="DotNetAllocCheckBox">.NET Alloc:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Column="5" Name="DotNetAllocCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Column="5" Name="DotNetAllocCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name=".NET Alloc" />
 
                     <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                                ToolTip="Do smart sampling which aggressive trims commonly allocated types, and rare time not at all." >
                     <Hyperlink Command="Help" CommandParameter="DotNetAllocSampledCheckBox">.NET SampAlloc:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name=".NET Sample Alloc" />
 
                     <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="16.2,2,0,2"
                                ToolTip="Do smart sampling which aggressive trims commonly allocated types, and rare time not at all." Grid.ColumnSpan="2" >
                     <Hyperlink Command="Help" CommandParameter="ETWDotNetAllocSampledCheckBox">ETW .NET Alloc:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="10" Name="ETWDotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" />
+                    <CheckBox Grid.Row="0" Grid.Column="10" Name="ETWDotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="ETW .NET Alloc"/>
 
                     <TextBlock Grid.Row="0" Grid.Column="11" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Collect a heap snapshot prior to stopping collection." >
                     <Hyperlink Command="Help" CommandParameter="HeapSnapshotCheckBox">Dump Heap:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="12" Name="HeapSnapshotCheckBox" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="0" Grid.Column="12" Name="HeapSnapshotCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Dump Heap"/>
 
                     <CheckBox Grid.Row="0" Grid.Column="14" VerticalAlignment="Center" Visibility="Hidden" Margin="0,2" />
                 </Grid>
@@ -402,7 +402,7 @@
                                ToolTip="A comma separated list of additional providers to turn on during data collection." >
                     <Hyperlink Command="Help" CommandParameter="AdditionalProvidersTextBox">Additional Providers:</Hyperlink>
                     </TextBlock>
-                    <controls:HistoryComboBox  x:Name="AdditionalProvidersTextBox" Grid.Column="1" Margin="2,2,5,2" />
+                    <controls:HistoryComboBox  x:Name="AdditionalProvidersTextBox" Grid.Column="1" Margin="2,2,5,2" AutomationProperties.Name="Additional Providers" />
                     <Button Grid.Column="2" Margin="0,2,5,2" Content=" Provider Browser " Click="ProviderBrowserButtonClick"
                             ToolTip="Click to browse the available ETW providers."/>
                     <TextBlock  Grid.Column="3" Margin="2,0,10,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12
@@ -431,17 +431,17 @@
                                ToolTip="The number of MSec between CPU samples when sample profiling.   Can be less than 1MSec but needs to be > .125MSec.">
                         <Hyperlink Command="Help" CommandParameter="SampleIntervalTextBox">CPU Sample<LineBreak/>Interval Msec</Hyperlink>
                     </TextBlock>
-                    <TextBox Grid.Column="1" Name="SampleIntervalTextBox" VerticalAlignment="Center" Width="30" Margin="0,0,10,0"/>
+                    <TextBox Grid.Column="1" Name="SampleIntervalTextBox" VerticalAlignment="Center" Width="30" Margin="0,0,10,0" AutomationProperties.Name="CPU Sample Interval in milliseconds"/>
 
                     <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0">
-                        <Hyperlink Command="Help" CommandParameter="CpuCountersTextBox" KeyboardNavigation.IsTabStop="False">Cpu<LineBreak/>Ctrs</Hyperlink>
+                        <Hyperlink Command="Help" CommandParameter="CpuCountersTextBox">Cpu<LineBreak/>Ctrs</Hyperlink>
                     </TextBlock>
                     <Button Grid.Column="3" Name="CpuCountersListButton" Margin="2,0,0,2" Content="Ctrs" Height="20" Click="DoCpuCountersListClick"
                     ToolTip="Displays a list you can shift click and ctrl-click to select columns to display." />
                     <Popup Name="CpuCountersPopup" StaysOpen="false" PopupAnimation="Fade" PlacementTarget="{Binding ElementName=CpuCountersListButton}" Placement="Bottom" Margin="2,0,0,0" >
                         <ListBox Name="CpuCountersListBox" SelectionMode="Extended" KeyDown="DoCpuCountersListBoxKey" MouseDoubleClick="DoCpuCountersListBoxDoubleClick" MaxHeight="300"/>
                     </Popup>
-                    <controls:HistoryComboBox Grid.Column="4" Margin="2,0,0,0" Width="180" Height="20" x:Name="CpuCountersTextBox">
+                    <controls:HistoryComboBox Grid.Column="4" Margin="2,0,0,0" Width="180" Height="20" x:Name="CpuCountersTextBox" AutomationProperties.Name="CPU Counters">
                         <controls:HistoryComboBox.ToolTip>
                             <TextBlock>A comma separated list of column #-# ranges to show in the 'data' field.</TextBlock>
                         </controls:HistoryComboBox.ToolTip>
@@ -451,13 +451,13 @@
                                ToolTip="Collect OS (unmanaged) heap allocation stacks for processes running this EXE fileName.">
                         <Hyperlink Command="Help" CommandParameter="OSHeapExeTextBox">OS Heap<LineBreak/>Exe</Hyperlink>
                     </TextBlock>
-                    <TextBox Grid.Column="6" Name="OSHeapExeTextBox" VerticalAlignment="Center" Width="100" Margin="1,0,0,0"/>
+                    <TextBox Grid.Column="6" Name="OSHeapExeTextBox" VerticalAlignment="Center" Width="100" Margin="1,0,0,0" AutomationProperties.Name="OS Heap Executable"/>
 
                     <TextBlock Grid.Column="7" VerticalAlignment="Center" Margin="15,0,0,0"
                                ToolTip="Collect OS (unmanaged) heap allocation stacks for processes with this process ID.">
                         <Hyperlink Command="Help" CommandParameter="OSHeapProcessTextBox">OS Heap<LineBreak/>Process</Hyperlink>
                     </TextBlock>
-                    <TextBox Grid.Column="8" Name="OSHeapProcessTextBox" VerticalAlignment="Center" Width="40" Margin="2,0,0,0"/>
+                    <TextBox Grid.Column="8" Name="OSHeapProcessTextBox" VerticalAlignment="Center" Width="40" Margin="2,0,0,0" AutomationProperties.Name="OS Heap Process"/>
                 </Grid>
 
                 <!-- Net Symbol collection, rundown, ... -->
@@ -474,17 +474,17 @@
                     <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="If checked will force all .NET processes to send symbolic info to running processes at data collection end.">
                         <Hyperlink Command="Help" CommandParameter="RundownCheckBox">.NET Symbol<LineBreak/>Collection</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Column="1" Name="RundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" Click="RundownCheckboxClick"/>
+                    <CheckBox Grid.Column="1" Name="RundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" Click="RundownCheckboxClick" AutomationProperties.Name=".NET Symbol Collection"/>
 
                     <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Version of the runtime before V4.0 requires an expensive rundown.  You can save time by skipping this if you only care about V4.0+ processes.">
                         <Hyperlink Command="Help" CommandParameter="NoNGenRundownCheckBox">No V3.X NGEN<LineBreak/>Symbols</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Column="3" Name="NoNGenRundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" />
+                    <CheckBox Grid.Column="3" Name="NoNGenRundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" AutomationProperties.Name="No V3.X NGEN Symbols" />
 
                     <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Maximum time (in seconds) to wait for .NET symbolic events." >
                         <Hyperlink Command="Help" CommandParameter="RundownTimeoutTextBox">Symbol<LineBreak/>TimeOut</Hyperlink>
                     </TextBlock>
-                    <TextBox Grid.Column="5" Name="RundownTimeoutTextBox" VerticalAlignment="Center" Width="30" IsEnabled="false" Margin="2,0,0,0"/>
+                    <TextBox Grid.Column="5" Name="RundownTimeoutTextBox" VerticalAlignment="Center" Width="30" IsEnabled="false" Margin="2,0,0,0" AutomationProperties.Name="Symbol Timeout"/>
                 </Grid>
 
                 <!-- Max Collect Sec, Stop Trigger ... -->
@@ -499,12 +499,12 @@
                     <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Maximum time (in seconds) to collect data." >
                         <Hyperlink Command="Help" CommandParameter="MaxCollectTextBox">Max Collect<LineBreak/>Sec</Hyperlink>
                     </TextBlock>
-                    <TextBox Grid.Column="1" Name="MaxCollectTextBox" VerticalAlignment="Center" Margin="2,0,0,0" Width="30" />
+                    <TextBox Grid.Column="1" Name="MaxCollectTextBox" VerticalAlignment="Center" Margin="2,0,0,0" Width="30" AutomationProperties.Name="Maximum collection time in seconds" />
 
                     <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Specifies a performance counter that will trigger the end of colletion." >
                         <Hyperlink Command="Help" CommandParameter="StopTriggerTextBox">Stop<LineBreak/>Trigger</Hyperlink>
                     </TextBlock>
-                    <TextBox Grid.Column="3" Name="StopTriggerTextBox" VerticalAlignment="Center" Margin="2,0,5,0" />
+                    <TextBox Grid.Column="3" Name="StopTriggerTextBox" VerticalAlignment="Center" Margin="2,0,5,0" AutomationProperties.Name="Stop Trigger"/>
                 </Grid>
             </Grid>
         </Expander>

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -310,6 +310,7 @@ namespace PerfView
                 Title = "Collecting data over a user specified interval";
                 CommandToRunTextBox.IsEnabled = false;
                 CommandToRunTextBox.Visibility = Visibility.Hidden;
+                CommandToRunLabel.IsEnabled = false;
                 CommandToRunLabel.Visibility = Visibility.Hidden;
                 FocusProcessCheckBox.Visibility = Visibility.Visible;
                 FocusProcessTextBox.Visibility = Visibility.Visible;
@@ -345,6 +346,7 @@ namespace PerfView
                 FocusProcessCheckBox.Visibility = Visibility.Hidden;
                 FocusProcessTextBox.Visibility = Visibility.Hidden;
                 FocusProcessLabel.Visibility = Visibility.Hidden;
+                FocusProcessLabel.IsEnabled = false;
 
                 CommandToRunTextBox.Focus();
             }

--- a/src/PerfView/Dialogs/SymbolPathDialog.xaml
+++ b/src/PerfView/Dialogs/SymbolPathDialog.xaml
@@ -18,11 +18,11 @@
 
         <TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="center" Margin="8,2,5,2" >
             <Hyperlink Name="TitleHyperLink" Command="Help" CommandParameter="SymbolPathTextBox">
-                <TextBlock Name="TitleHyperLinkText" Text="Symbol Path"/>
+                <Run Name="TitleHyperLinkText" Text="Symbol Path"/>
             </Hyperlink>
         </TextBlock>
-        <TextBox Grid.Row="1" Name="SymbolPathTextBox"  Margin="10,2,10,2" KeyDown="DoKeyDown" AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" TextChanged="DoTextChanged" />
-        <TextBox Grid.Row="2" Name="EnvVarTextBox"  Margin="10,2,10,10" IsReadOnly="True" />
+        <TextBox Grid.Row="1" Name="SymbolPathTextBox"  Margin="10,2,10,2" KeyDown="DoKeyDown" AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" TextChanged="DoTextChanged" AutomationProperties.Name="Symbol Path"/>
+        <TextBox Grid.Row="2" Name="EnvVarTextBox"  Margin="10,2,10,10" IsReadOnly="True" AutomationProperties.Name="Environment Variables" />
         <StackPanel Grid.Row="3" Orientation="Horizontal" FlowDirection="RightToLeft">
 
         <Button Margin="10,2,10,5" Width="80" Content="OK" Click="OKClicked"/>

--- a/src/PerfView/Dialogs/UserCommandDialog.xaml
+++ b/src/PerfView/Dialogs/UserCommandDialog.xaml
@@ -4,7 +4,7 @@
         xmlns:src="clr-namespace:PerfView"
         xmlns:controls="clr-namespace:Controls"
         Style="{DynamicResource CustomWindowStyle}"
-        Background="{StaticResource ControlDarkerBackground}"
+        Background="{StaticResource ControlDefaultBackground}"
         Title="Executing User Defined Command" Height="116" Width="669">
     <Window.CommandBindings>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp" />
@@ -18,16 +18,17 @@
 
         <TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="center" Margin="8,2,5,2" >
             <Hyperlink Name="TitleHyperLink" Command="Help" CommandParameter="InvokingUserCommands">
-                <TextBlock Name="TitleHyperLinkText" Text="Help on Invoking User Defined Commands"/>
+                <Run Name="TitleHyperLinkText" Text="Help on Invoking User Defined Commands"/>
             </Hyperlink>
         </TextBlock>
         <controls:HistoryComboBox x:Name="CommandTextBox" Grid.Row="1"  Margin="10,2,10,2"
-                         ToolTip="Enter User define command. Tab will commit completion." Enter="OKClicked" />
+                         ToolTip="Enter user-defined command. Tab will commit completion." AutomationProperties.HelpText="{Binding Path=ToolTip, RelativeSource={RelativeSource Self}}" Enter="OKClicked" 
+                         AutomationProperties.Name="Command"/>
 
         <StackPanel Grid.Row="3" Orientation="Horizontal" FlowDirection="RightToLeft">
-            <Button Margin="10,5,10,5" Width="80" Content="OK" Click="OKClicked"/>
-            <Button Margin="10,5,10,5" KeyboardNavigation.IsTabStop="False" Width="80" Content="Cancel" Click="CancelClicked"/>
-            <Button Margin="10,5,10,5" KeyboardNavigation.IsTabStop="False" Width="120" Content="Command Help" Click="HelpClicked"/>
+            <Button Margin="10,5,10,5" Width="80" Content="OK" Click="OKClicked" TabIndex="2"/>
+            <Button Margin="10,5,10,5" Width="80" Content="Cancel" Click="CancelClicked" TabIndex="1"/>
+            <Button Margin="10,5,10,5" Width="120" Content="Command Help" Click="HelpClicked" TabIndex="0"/>
         </StackPanel>
     </Grid>
 </src:WindowBase>

--- a/src/PerfView/Dialogs/UserCommandDialog.xaml
+++ b/src/PerfView/Dialogs/UserCommandDialog.xaml
@@ -4,7 +4,7 @@
         xmlns:src="clr-namespace:PerfView"
         xmlns:controls="clr-namespace:Controls"
         Style="{DynamicResource CustomWindowStyle}"
-        Background="{StaticResource ControlDefaultBackground}"
+        Background="{StaticResource ControlDarkerBackground}"
         Title="Executing User Defined Command" Height="116" Width="669">
     <Window.CommandBindings>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp" />

--- a/src/PerfView/EventViewer/EventWindow.xaml
+++ b/src/PerfView/EventViewer/EventWindow.xaml
@@ -76,7 +76,7 @@
                 <ColumnDefinition/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
-            <Menu DockPanel.Dock="Top" Background="{DynamicResource ControlDefaultBackground}">
+            <Menu DockPanel.Dock="Top" Background="{DynamicResource ControlDefaultBackground}" AutomationProperties.Name="Navigation">
                 <MenuItem Header="_File">
                     <MenuItem Header="_Parent Window" Click="DoOpenParent"/>
                     <MenuItem Header="_Close" Click="DoClose"/>
@@ -111,7 +111,7 @@
                 <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="StartTextBox" KeyboardNavigation.IsTabStop="False">Start:</Hyperlink>
                 </TextBlock>
-                <controls:HistoryComboBox  x:Name="StartTextBox" Width="90" Enter="DoUpdate">
+                <controls:HistoryComboBox  x:Name="StartTextBox" Width="90" Enter="DoUpdate" AutomationProperties.Name="Start Time">
                     <controls:HistoryComboBox.ToolTip>
                         <TextBlock>Exclude any samples that happened before this time (MSec from start).\r\nCan paste ranges into this box.</TextBlock>
                     </controls:HistoryComboBox.ToolTip>
@@ -119,7 +119,7 @@
                 <TextBlock VerticalAlignment="Center" Margin="10,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="EndTextBox" KeyboardNavigation.IsTabStop="False">End:</Hyperlink>
                 </TextBlock>
-                <controls:HistoryComboBox x:Name="EndTextBox" Width="90" Enter="DoUpdate">
+                <controls:HistoryComboBox x:Name="EndTextBox" Width="90" Enter="DoUpdate" AutomationProperties.Name="End Time">
                     <controls:HistoryComboBox.ToolTip>
                         <TextBlock>Exclude any samples that happened after this time (MSec from start).</TextBlock>
                     </controls:HistoryComboBox.ToolTip>
@@ -127,7 +127,7 @@
                 <TextBlock VerticalAlignment="Center" Margin="10,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="MaxRetTextBox" KeyboardNavigation.IsTabStop="False">MaxRet:</Hyperlink>
                 </TextBlock>
-                <controls:HistoryComboBox x:Name="MaxRetTextBox" Width="80" Enter="DoUpdate">
+                <controls:HistoryComboBox x:Name="MaxRetTextBox" Width="80" Enter="DoUpdate"  AutomationProperties.Name="Max Records Returned">
                     <controls:HistoryComboBox.ToolTip>
                         <TextBlock>At most this number of records are returned (speeds things up).</TextBlock>
                     </controls:HistoryComboBox.ToolTip>
@@ -136,7 +136,7 @@
             <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="20,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="FindTextBox" KeyboardNavigation.IsTabStop="False">Find:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox x:Name="FindTextBox" Grid.Column="2" MinWidth="100" Enter="DoFindEnter">
+            <controls:HistoryComboBox x:Name="FindTextBox" Grid.Column="2" MinWidth="100" Enter="DoFindEnter" AutomationProperties.Name="Find">
                 <controls:HistoryComboBox.ToolTip>
                     <TextBlock>Find a name in the display below (Standard .NET Regular Explressions apply, case insensitive).</TextBlock>
                 </controls:HistoryComboBox.ToolTip>
@@ -155,7 +155,7 @@
             <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="20,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="ProcessFilterTextBox" KeyboardNavigation.IsTabStop="False">Process Filter:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox Grid.Column="1" Margin="0,3,0,3" x:Name="ProcessFilterTextBox" Enter="DoUpdate" >
+            <controls:HistoryComboBox Grid.Column="1" Margin="0,3,0,3" x:Name="ProcessFilterTextBox" Enter="DoUpdate" AutomationProperties.Name="Process Filter" >
                 <controls:HistoryComboBox.ToolTip>
                     <TextBlock>A .NET Regular expression that must match the process name field.</TextBlock>
                 </controls:HistoryComboBox.ToolTip>
@@ -163,7 +163,7 @@
             <TextBlock Grid.Column="2"  VerticalAlignment="Center" Margin="10,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="TextFilterTextBox" KeyboardNavigation.IsTabStop="False">Text Filter:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox Grid.Column="3" Margin="0,3,0,3" x:Name="TextFilterTextBox" Enter="DoUpdate">
+            <controls:HistoryComboBox Grid.Column="3" Margin="0,3,0,3" x:Name="TextFilterTextBox" Enter="DoUpdate" AutomationProperties.Name="Text Filter">
                 <controls:HistoryComboBox.ToolTip>
                     <TextBlock>A .NET Regular expression that must match the data field.</TextBlock>
                 </controls:HistoryComboBox.ToolTip>
@@ -176,7 +176,7 @@
             <Popup Name="ColumnsToDisplayPopup" StaysOpen="false" PopupAnimation="Fade" PlacementTarget="{Binding ElementName=ListButton}" Placement="Bottom" >
                 <ListBox Name="ColumnsToDisplayListBox" SelectionMode="Extended" KeyDown="DoColumnsToDisplayListBoxKey" MouseDoubleClick="DoColumnsToDisplayListBoxDoubleClick" MaxHeight="300"/>
             </Popup>
-            <controls:HistoryComboBox Grid.Column="6" Margin="0,3,0,3" x:Name="ColumnsToDisplayTextBox" Enter="DoUpdate">
+            <controls:HistoryComboBox Grid.Column="6" Margin="0,3,0,3" x:Name="ColumnsToDisplayTextBox" Enter="DoUpdate" AutomationProperties.Name="Columns to Display">
                 <controls:HistoryComboBox.ToolTip>
                     <TextBlock>A space separated list of column names to show in the 'data' field.</TextBlock>
                 </controls:HistoryComboBox.ToolTip>
@@ -207,10 +207,12 @@
                     </TextBlock>
 
                     <TextBox Name="EventTypeFilterTextBox" Grid.Column="2" TextChanged="DoEventTypeFilterTextBoxChanged"
-                             ToolTip="Restrict the event types shown to those containing text typed here."/>
+                             ToolTip="Restrict the event types shown to those containing text typed here."
+                             AutomationProperties.Name="Event Type Filter"/>
                 </Grid>
                 <ListBox Name="EventTypes" SelectionMode="Extended" KeyDown="DoEventTypesKey" MouseDoubleClick="DoUpdate"
-                         ToolTip="Double click, ctrl-Click and shift-Click to select the events you wish to see."/>
+                         ToolTip="Double click, ctrl-Click and shift-Click to select the events you wish to see."
+                         AutomationProperties.Name="Event Types"/>
             </DockPanel>
             <GridSplitter Grid.Column="0" Width="3" />
             <Grid Grid.Column="1">
@@ -229,14 +231,16 @@
                     <TextBox Grid.Column="1" Name="Histogram" Height="20" Margin="3,0,0,0"  Background="Transparent"
                              SelectionChanged="DoHistogramSelectionChanged"  Grid.Row="0" IsReadOnly="True"
                              FontFamily="Courier New" FontSize="10"
-                             ToolTip="Shows how the frequency of the selected events vary over time."/>
+                             ToolTip="Shows how the frequency of the selected events vary over time."
+                             AutomationProperties.Name="Histogram"/>
                 </Grid>
                 <WPFToolKit:DataGrid Grid.Row="1" Name="Grid"
                     AutoGenerateColumns="False"
                     ToolTip="Click on Update button to update."
                     SelectionMode="Extended" SelectionUnit="CellOrRowHeader"
                     SelectedCellsChanged="SelectedCellsChanged"
-                    AlternatingRowBackground="{DynamicResource AlternateRowBackground}" >
+                    AlternatingRowBackground="{DynamicResource AlternateRowBackground}" 
+                    AutomationProperties.Name="Events Table">
                     <WPFToolKit:DataGrid.Columns>
                         <WPFToolKit:DataGridTextColumn
                         x:Name="EventNameColumn"

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -1863,15 +1863,15 @@ namespace PerfView
         {
             foreach (var i in Grid.Columns)
             {
-                    if (i == OriginTimeStampColumn)
-                    {
-                        i.Visibility = Visibility.Visible;
-                    }
-                    else if (i == LocalTimeStampColumn)
-                    {
-                        i.Visibility = Visibility.Hidden;
-                    }
+                if (i == OriginTimeStampColumn)
+                {
+                    i.Visibility = Visibility.Visible;
+                }
+                else if (i == LocalTimeStampColumn)
+                {
+                    i.Visibility = Visibility.Hidden;
                 }
             }
         }
+    }
 }

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -309,11 +309,11 @@ namespace PerfViewExtensibility
             GuiApp.MainWindow.Dispatcher.BeginInvoke((Action)delegate ()
             {
                 var viewer = new WebBrowserWindow(GuiApp.MainWindow);
-                viewer.Browser.Navigating += delegate (object sender, System.Windows.Navigation.NavigatingCancelEventArgs e)
+                viewer.Browser.NavigationStarting += delegate (object sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs e)
                 {
-                    if (e.Uri != null)
+                    if (e.Uri != null && Uri.TryCreate(e.Uri, UriKind.Absolute, out Uri uri))
                     {
-                        if (e.Uri.Scheme == "command")
+                        if (uri.Scheme == "command")
                         {
                             e.Cancel = true;
                             if (viewer.StatusBar.Visibility != System.Windows.Visibility.Visible)
@@ -321,7 +321,7 @@ namespace PerfViewExtensibility
                             viewer.StatusBar.StartWork("Following Hyperlink", delegate ()
                             {
                                 if (DoCommand != null)
-                                    DoCommand(e.Uri.LocalPath, viewer.StatusBar.LogWriter, viewer);
+                                    DoCommand(uri.LocalPath, viewer.StatusBar.LogWriter, viewer);
                                 else
                                     viewer.StatusBar.Log("This view does not support command URLs.");
                                 viewer.StatusBar.EndWork(null);

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -332,7 +332,7 @@ namespace PerfViewExtensibility
                 viewer.Width = 1000;
                 viewer.Height = 600;
                 viewer.Title = title;
-                WebBrowserWindow.Navigate(viewer.Browser, Path.GetFullPath(htmlFilePath));
+                viewer.Source = new Uri(Path.GetFullPath(htmlFilePath));
                 viewer.Show();
                 if (OnOpened != null)
                     viewer.Loaded += delegate { OnOpened(viewer); };

--- a/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
+++ b/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
@@ -13,7 +13,7 @@
             <ColumnDefinition Width="auto"/>
             <ColumnDefinition Width="auto"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" Name="m_StatusMessage" ContextMenu="{x:Null}" IsReadOnly="True" VerticalScrollBarVisibility="Auto">
+        <TextBox Grid.Column="0" Name="m_StatusMessage" ContextMenu="{x:Null}" IsReadOnly="True" VerticalScrollBarVisibility="Auto" AutomationProperties.Name="Status Message">
             <TextBox.Triggers>
                 <EventTrigger RoutedEvent="perfview:StatusBar.HighlightMessage">
                     <EventTrigger.Actions>

--- a/src/PerfView/GuiUtilities/TextEditor/TextEditorControl.xaml
+++ b/src/PerfView/GuiUtilities/TextEditor/TextEditorControl.xaml
@@ -27,7 +27,7 @@
                 <ColumnDefinition Width="auto"/>
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
-            <Menu Grid.Column="0" Background="Transparent" VerticalAlignment="Center">
+            <Menu Grid.Column="0" Background="Transparent" VerticalAlignment="Center" AutomationProperties.Name="Navigation">
                 <MenuItem Header="_File" >
                     <MenuItem Command="Open" Header="_Open"/>
                     <MenuItem Command="Save" Header="_Save"/>
@@ -39,7 +39,7 @@
             <Button Grid.Column="2" Margin="0,2,5,2" FontSize="8" FontWeight="Bold" Content="A" Click="DecreaseFont_Click"  ToolTip="Decrease the default Font size."/>
             <TextBlock Grid.Column="3" Text="Find:" VerticalAlignment="Center"/>
             <src:HistoryComboBox Grid.Column="4" x:Name="FindTextBox" Width="200" KeyDown="FindTextBoxKeyDown" Margin="5,2,0,2"
-                     ToolTip="A .NET regular expression to find. (Ctrl-F)" IsEditable="True" />
+                     ToolTip="A .NET regular expression to find. (Ctrl-F)" IsEditable="True" AutomationProperties.Name="Find"/>
             <Button Grid.Column="5" Content="Next" Margin="3,2,5,2"
                     Command="{x:Static src:TextEditorControl.FindNextCommand}"
                     CommandTarget="{Binding ElementName=Body}"
@@ -47,7 +47,8 @@
                     />
         </Grid>
         <RichTextBox Name="Body" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
-                     AcceptsReturn="True" IsDocumentEnabled="True" FontFamily="Courier New">
+                     AcceptsReturn="True" IsDocumentEnabled="True" FontFamily="Courier New"
+                     AutomationProperties.Name="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=(AutomationProperties.Name)}">
             <RichTextBox.ContextMenu>
                 <ContextMenu>
                     <MenuItem Command="Find" />

--- a/src/PerfView/GuiUtilities/TextEditor/TextEditorWindow.xaml
+++ b/src/PerfView/GuiUtilities/TextEditor/TextEditorWindow.xaml
@@ -6,5 +6,5 @@
         Style="{DynamicResource CustomWindowStyle}"
         Closing="Window_Closing"
         Title="TextEditorWindow" Height="900" Width="1300">
-    <controls:TextEditorControl x:Name="m_TextEditor"/>
+    <controls:TextEditorControl x:Name="m_TextEditor" AutomationProperties.Name="{Binding Path=Title, RelativeSource={RelativeSource AncestorType={x:Type src:WindowBase}}}"/>
 </src:WindowBase>

--- a/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
+++ b/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
@@ -21,6 +21,6 @@
              <TextBlock Grid.Column="3" Margin="5,2,40,3" VerticalAlignment="Center">Click in Window, Ctrl-F for find</TextBlock>
         </Grid>
         <src:StatusBar x:Name="StatusBar" DockPanel.Dock="Bottom" Visibility="Collapsed"/>
-        <wv2:WebView2 Name="_Browser" />
+        <wv2:WebView2 Name="_Browser" Loaded="Browser_Loaded"/>
     </DockPanel>
 </src:WindowBase>

--- a/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
+++ b/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:src="clr-namespace:PerfView"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
         Style="{DynamicResource CustomWindowStyle}"
         Closing="Window_Closing"
         Title="Web Browser" Height="700" Width="1100">
@@ -20,6 +21,6 @@
              <TextBlock Grid.Column="3" Margin="5,2,40,3" VerticalAlignment="Center">Click in Window, Ctrl-F for find</TextBlock>
         </Grid>
         <src:StatusBar x:Name="StatusBar" DockPanel.Dock="Bottom" Visibility="Collapsed"/>
-        <WebBrowser Name="_Browser" SizeChanged="Browser_SizeChanged"></WebBrowser>
+        <wv2:WebView2 Name="_Browser" />
     </DockPanel>
 </src:WindowBase>

--- a/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml.cs
+++ b/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Security.Policy;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using Microsoft.Web.WebView2.Wpf;
 
 
 namespace PerfView.GuiUtilities
@@ -23,9 +26,10 @@ namespace PerfView.GuiUtilities
 
         public bool CanGoForward { get { return Browser.CanGoForward; } }
         public bool CanGoBack { get { return Browser.CanGoBack; } }
-        public WebBrowser Browser { get { return _Browser; } }
+        public WebView2 Browser { get { return _Browser; } }
+
         /// <summary>
-        /// LIke Broswer.Navigate, but you don't have to be on the GUI thread to use it.  
+        /// LIke Browser.Navigate, but you don't have to be on the GUI thread to use it.  
         /// </summary>
         public void Navigate(string uri)
         {
@@ -39,17 +43,9 @@ namespace PerfView.GuiUtilities
         /// <summary>
         /// A simple helper wrapper that translates some exceptions nicely.  
         /// </summary>
-        public static void Navigate(WebBrowser browser, string url)
+        public static void Navigate(WebView2 browser, string url)
         {
-            try
-            {
-                browser.Navigate(url);
-            }
-            catch (COMException)
-            {
-                // This can happen on Win10 systems without IE installed.  
-                throw new ApplicationException("Error Trying to open a Web Browser.   Is Internet Explorer Installed?");
-            }
+            browser.Source = new Uri(url);
         }
 
         #region private
@@ -60,6 +56,7 @@ namespace PerfView.GuiUtilities
                 Browser.GoBack();
             }
         }
+
         private void ForwardClick(object sender, RoutedEventArgs e)
         {
             if (Browser.CanGoForward)
@@ -67,6 +64,7 @@ namespace PerfView.GuiUtilities
                 Browser.GoForward();
             }
         }
+
         /// <summary>
         /// We hide rather than close the editor.  
         /// </summary>
@@ -78,21 +76,6 @@ namespace PerfView.GuiUtilities
                 e.Cancel = true;
             }
         }
-        /// <summary>
-        /// The browser looses where it is when it resizes, which is very confusing to people
-        /// Thus force a resync when the window resizes.  
-        /// </summary>
-        private void Browser_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            if (m_notFirst)
-            {
-                Browser.Navigate(Browser.Source);
-            }
-
-            m_notFirst = true;
-        }
-
-        private bool m_notFirst;
         #endregion 
     }
 }

--- a/src/PerfView/HeapView/GcInfoView.cs
+++ b/src/PerfView/HeapView/GcInfoView.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
@@ -347,7 +348,8 @@ namespace PerfView
             StackPanel reason = new StackPanel();
             {
                 reason.AddTextBlock("GC Reason ", "GCReason", OnHelp, 3, 2);
-                reason.AddButton("Select All", 60, ReasonSelectAll, 3, 2);
+                var selectAllReasonButton = reason.AddButton("Select All", 60, ReasonSelectAll, 3, 2);
+                AutomationProperties.SetName(selectAllReasonButton, "Select all GC reasons");
 
                 m_inducedBlocking = reason.AddCheckBox(true, "Induced Blocking", 3, 2, UpdateEvents);
                 m_inducedNonblocking = reason.AddCheckBox(true, "Induced Nonblocking", 3, 0, UpdateEvents);
@@ -359,7 +361,8 @@ namespace PerfView
             StackPanel gen = new StackPanel();
             {
                 gen.AddTextBlock("Generation ", "Generation", OnHelp, 3, 2);
-                gen.AddButton("Select All", 60, GenerationSelectAll, 3, 2);
+                var selectAllGenerationsButton = gen.AddButton("Select All", 60, GenerationSelectAll, 3, 2);
+                AutomationProperties.SetName(selectAllGenerationsButton, "Select all generations");
 
                 m_g0 = gen.AddCheckBox(true, "0", 3, 0, UpdateEvents);
                 m_g1 = gen.AddCheckBox(true, "1", 3, 0, UpdateEvents);

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -72,7 +72,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Menu Grid.Column="0" Background="{DynamicResource ControlDefaultBackground}">
+            <Menu Grid.Column="0" Background="{DynamicResource ControlDefaultBackground}" AutomationProperties.Name="Navigation">
                 <MenuItem Header="_File">
                     <MenuItem Header="_Clear Temp Files" Click="DoClearTempFiles" ToolTip="Some operations create temporary files.  This command clears all of these."/>
                     <MenuItem Header="Clear User Config" Click="DoClearUserConfig" ToolTip="Reset all user preferences back to their defaults when PerfView was first installed."/>
@@ -179,7 +179,7 @@
                 <ColumnDefinition Width="619*"/>
             </Grid.ColumnDefinitions>
             <DockPanel Background="Gray" Grid.Column="0">
-                <controls:HistoryComboBox x:Name="Directory" DockPanel.Dock="Top"
+                <controls:HistoryComboBox x:Name="Directory" DockPanel.Dock="Top" AutomationProperties.Name="Directory Search Bar"
                          ToolTip="This is the directory to search for performance data files." TextEntered="DoTextEnteredInDirectoryTextBox" />
                 <Grid DockPanel.Dock="Top" >
                     <Grid.ColumnDefinitions>
@@ -190,11 +190,16 @@
                     <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Only files that match this RegEx filter pattern are displayed.">
                     <Hyperlink Command="Help" CommandParameter="FileFilterTextBox">Filter:</Hyperlink>
                     </TextBlock>
-                    <TextBox Name="FileFilterTextBox" TextChanged="FilterTextChanged" KeyDown="FilterKeyDown" Grid.Column="1" Margin="5,2,0,2" />
+                    <TextBox Name="FileFilterTextBox" TextChanged="FilterTextChanged" KeyDown="FilterKeyDown" Grid.Column="1" Margin="5,2,0,2" AutomationProperties.Name="File Filter"/>
                 </Grid>
-                <TreeView x:Name="TreeView" Grid.Column="0" MouseDoubleClick="DoMouseDoubleClickInTreeView" KeyDown="KeyDownInTreeView" SelectedItemChanged="SelectedItemChangedInTreeView" PreviewMouseRightButtonDown="TreeView_PreviewMouseRightButtonDown"
+                <TreeView x:Name="TreeView" AutomationProperties.Name="File Explorer" Grid.Column="0" MouseDoubleClick="DoMouseDoubleClickInTreeView" KeyDown="KeyDownInTreeView" SelectedItemChanged="SelectedItemChangedInTreeView" PreviewMouseRightButtonDown="TreeView_PreviewMouseRightButtonDown"
                           ToolTip="Double Click to open.  Right click contains additional help and additional options."
                           IsEnabled="{Binding ElementName=StatusBar, Path=IsNotWorking}" AllowDrop="True" Drop="DoDrop">
+                    <TreeView.ItemContainerStyle>
+                        <Style TargetType="TreeViewItem">
+                            <Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
+                        </Style>
+                    </TreeView.ItemContainerStyle>
                     <TreeView.ItemTemplate>
                         <HierarchicalDataTemplate ItemsSource="{Binding Children}">
                             <StackPanel Orientation="Horizontal">
@@ -225,7 +230,7 @@
             <GridSplitter Grid.Column="1" Width="3"  HorizontalAlignment="Center" VerticalAlignment="Stretch"/>
             <RichTextBox Name="Body" Grid.Column="2" IsReadOnly="True" IsDocumentEnabled="True"
                          IsEnabled="{Binding ElementName=StatusBar, Path=IsNotWorking}"
-                         VerticalScrollBarVisibility="auto" >
+                         VerticalScrollBarVisibility="auto" AutomationProperties.Name="Usage Information">
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0"/>

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -2276,9 +2277,9 @@ namespace PerfView
                     s_Browser = null;
                 };
 
-                s_Browser.Browser.Navigating += delegate (object sender, NavigatingCancelEventArgs e)
+                s_Browser.Browser.NavigationStarting += delegate (object sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs e)
                 {
-                    if (e.Uri != null && !string.IsNullOrEmpty(e.Uri.Host))
+                    if (e.Uri != null && Uri.TryCreate(e.Uri, UriKind.Absolute, out Uri uri) && !string.IsNullOrEmpty(uri.Host))
                     {
                         if (!GuiApp.MainWindow.AllowNavigateToWeb)
                         {
@@ -2287,7 +2288,7 @@ namespace PerfView
                         }
                         else
                         {
-                            OpenExternalBrowser(e.Uri);
+                            OpenExternalBrowser(uri);
                             e.Cancel = true;
                         }
                     }

--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -2303,7 +2303,7 @@ namespace PerfView
                 url = url + "#" + anchor;
             }
 
-            WebBrowserWindow.Navigate(s_Browser.Browser, url);
+            s_Browser.Source = new Uri(url);
             if (s_Browser.WindowState == WindowState.Minimized)
             {
                 s_Browser.WindowState = WindowState.Normal;

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -14,6 +14,9 @@
     <Company>Microsoft</Company>
     <Copyright>Copyright © Microsoft 2010</Copyright>
     <FileVersion>$(PerfViewVersion)</FileVersion>
+    
+    <!-- WebView2 downloads the wrong drivers unless this is set -->
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
@@ -89,6 +92,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="$(MicrosoftIdentityModelAbstractionsVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelTokensVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="$(MicrosoftWebWebView2Version)" GeneratePathProperty="true" />
     <PackageReference Include="PerfView.SupportFiles" Version="$(PerfViewSupportFilesVersion)" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" GeneratePathProperty="true" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" GeneratePathProperty="true" />

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -524,6 +524,48 @@
       <Link>Microsoft.IdentityModel.JsonWebTokens.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgMicrosoft_Web_WebView2)\lib\net462\Microsoft.Web.WebView2.Core.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\Microsoft.Web.WebView2.Core.dll</LogicalName>
+      <Link>Microsoft.Web.WebView2.Core.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgMicrosoft_Web_WebView2)\lib\net462\Microsoft.Web.WebView2.WinForms.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\Microsoft.Web.WebView2.WinForms.dll</LogicalName>
+      <Link>Microsoft.Web.WebView2.WinForms.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgMicrosoft_Web_WebView2)\lib\net462\Microsoft.Web.WebView2.Wpf.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\Microsoft.Web.WebView2.Wpf.dll</LogicalName>
+      <Link>Microsoft.Web.WebView2.Wpf.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgMicrosoft_Web_WebView2)\runtimes\win-x86\native\WebView2Loader.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\runtimes\win-x86\native\WebView2Loader.dll</LogicalName>
+      <Link>runtimes\win-x86\native\WebView2Loader.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgMicrosoft_Web_WebView2)\runtimes\win-x64\native\WebView2Loader.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\runtimes\win-x64\native\WebView2Loader.dll</LogicalName>
+      <Link>runtimes\win-x64\native\WebView2Loader.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgMicrosoft_Web_WebView2)\runtimes\win-arm64\native\WebView2Loader.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\runtimes\win-arm64\native\WebView2Loader.dll</LogicalName>
+      <Link>runtimes\win-arm64\native\WebView2Loader.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_Tokens)\lib\net461\Microsoft.IdentityModel.Tokens.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -1117,15 +1117,15 @@ namespace PerfView
                         {
                             Viewer = null;
                         };
-                        Viewer.Browser.Navigating += delegate (object sender, System.Windows.Navigation.NavigatingCancelEventArgs e)
+                        Viewer.Browser.NavigationStarting += delegate (object sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs e)
                         {
-                            if (e.Uri.Scheme == "command")
+                            if (Uri.TryCreate(e.Uri, UriKind.Absolute, out Uri uri) && uri.Scheme == "command")
                             {
                                 e.Cancel = true;
                                 Viewer.StatusBar.StartWork("Following Hyperlink", delegate ()
                                 {
                                     Action continuation;
-                                    var message = DoCommand(e.Uri, Viewer.StatusBar, out continuation);
+                                    var message = DoCommand(uri.LocalPath, Viewer.StatusBar, out continuation);
                                     Viewer.StatusBar.EndWork(delegate ()
                                     {
                                         if (message != null)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -1142,7 +1142,7 @@ namespace PerfView
                         Viewer.Width = 1000;
                         Viewer.Height = 600;
                         Viewer.Title = Title;
-                        WebBrowserWindow.Navigate(Viewer.Browser, reportFileName);
+                        Viewer.Source = new Uri(reportFileName);
                         Viewer.Show();
 
                         doAfter?.Invoke();

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml
@@ -31,7 +31,8 @@
         AlternatingRowBackground="{DynamicResource AlternateRowBackground}"
         CanUserSortColumns="False"
         ClipboardCopyMode="IncludeHeader"
-        Margin="0,0,-23,0" PreparingCellForEdit="Grid_PreparingCellForEdit" >
+        Margin="0,0,-23,0" PreparingCellForEdit="Grid_PreparingCellForEdit"
+        AutomationProperties.Name="Data Grid">
         <WPFToolKit:DataGrid.Columns>
             <WPFToolKit:DataGridTemplateColumn
                 x:Name="DisplayNameColumn"

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -13,7 +13,7 @@
         <DataTemplate x:Key="TreeControlCell">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="{Binding IndentString}" FontFamily="Courier New"/>
-                <CheckBox IsChecked="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding HasChildren}"/>
+                <CheckBox IsChecked="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding HasChildren}" AutomationProperties.Name="Expand"/>
                 <TextBlock Name="Name" Text="{Binding Name}" FontWeight="{Binding FontWeight}"/>
                 <TextBlock Margin="5,0,0,0" Visibility="{Binding VisibleIfDisplayingSecondary}">
                     <Hyperlink Command="Help" CommandParameter="PrimaryAndSecondaryNodes">?</Hyperlink>
@@ -194,7 +194,7 @@
                 <ColumnDefinition/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
-            <Menu Grid.Column="0" Background="{DynamicResource ControlDefaultBackground}">
+            <Menu Grid.Column="0" Background="{DynamicResource ControlDefaultBackground}" AutomationProperties.Name="Navigation">
                 <MenuItem Header="_File">
                     <MenuItem Header="Parent _Window" Click="DoOpenParent"/>
                     <MenuItem Header="Set Symbol _Path" Click="DoSetSymbolPath" ToolTip="Sets the locations to look for symbolic information (PDB files)."/>
@@ -250,7 +250,7 @@
                     ToolTipService.ShowOnDisabled="True"
                     ToolTip="Set to forward filter parameters (Alt-right arrow)">
                 Forward</Button>
-            <TextBox Name="TopStats" Grid.Column="3" Background="Transparent" Margin="0,1" />
+            <TextBox Name="TopStats" Grid.Column="3" Background="Transparent" Margin="0,1" AutomationProperties.Name="Top Stats"/>
         </Grid>
         <!-- This is the Start, End, Find line-->
         <Grid DockPanel.Dock="Top" Margin="0,1">
@@ -263,7 +263,7 @@
                 <TextBlock VerticalAlignment="Center" Margin="5,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="StartTextBox">Start:</Hyperlink>
                 </TextBlock>
-                <controls:HistoryComboBox  x:Name="StartTextBox" Width="90" Enter="DoUpdate" >
+                <controls:HistoryComboBox  x:Name="StartTextBox" Width="90" Enter="DoUpdate" AutomationProperties.Name="Start Time">
                     <controls:HistoryComboBox.ToolTip>
                         <TextBlock>Exclude any samples that happened before this time (MSec from start).</TextBlock>
                     </controls:HistoryComboBox.ToolTip>
@@ -271,7 +271,7 @@
                 <TextBlock VerticalAlignment="Center" Margin="10,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="EndTextBox" KeyboardNavigation.IsTabStop="False">End:</Hyperlink>
                 </TextBlock>
-                <controls:HistoryComboBox x:Name="EndTextBox" Width="90" Enter="DoUpdate">
+                <controls:HistoryComboBox x:Name="EndTextBox" Width="90" Enter="DoUpdate" AutomationProperties.Name="End Time">
                     <controls:HistoryComboBox.ToolTip>
                         <TextBlock>Exclude any samples that happened after this time (MSec from start).</TextBlock>
                     </controls:HistoryComboBox.ToolTip>
@@ -314,7 +314,7 @@
             <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="20,0,1,0">
                         <Hyperlink Command="Help" CommandParameter="FindTextBox" KeyboardNavigation.IsTabStop="False">Find:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox x:Name="FindTextBox" Grid.Column="2" MinWidth="100" Enter="DoFindEnter">
+            <controls:HistoryComboBox x:Name="FindTextBox" Grid.Column="2" MinWidth="100" Enter="DoFindEnter" AutomationProperties.Name="Find">
                 <controls:HistoryComboBox.ToolTip>
                     <TextBlock>Find a name in the display below (Standard .NET Regular Expressions apply, case insensitive).</TextBlock>
                 </controls:HistoryComboBox.ToolTip>
@@ -338,7 +338,7 @@
             <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
                     <Hyperlink Command="Help" CommandParameter="GroupPatsTextBox" KeyboardNavigation.IsTabStop="False">GroupPats:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox x:Name="GroupRegExTextBox" Grid.Column="1" MinWidth="80" Enter="DoUpdate">
+            <controls:HistoryComboBox x:Name="GroupRegExTextBox" Grid.Column="1" MinWidth="80" Enter="DoUpdate" AutomationProperties.Name="Group Patterns">
                 <controls:HistoryComboBox.ToolTip>
                     <ToolTip StaysOpen="True">
                         <TextBlock>
@@ -355,7 +355,7 @@
             <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,1,0">
                 <Hyperlink Command="Help" CommandParameter="FoldPercentTextBox" KeyboardNavigation.IsTabStop="False">Fold%:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox x:Name="FoldPercentTextBox" Grid.Column="3" MinWidth="42" Enter="DoUpdate" Margin="0,0,5,0">
+            <controls:HistoryComboBox x:Name="FoldPercentTextBox" Grid.Column="3" MinWidth="42" Enter="DoUpdate" Margin="0,0,5,0" AutomationProperties.Name="Fold Percent">
                 <controls:HistoryComboBox.ToolTip>
                     <ToolTip StaysOpen="True">
                         <TextBlock> Nodes that have less than this % Inclusive metric will be removed and their
@@ -366,7 +366,7 @@
             <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="5,0,1,0">
                 <Hyperlink Command="Help" CommandParameter="FoldPatsTextBox" KeyboardNavigation.IsTabStop="False">FoldPats:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox x:Name="FoldRegExTextBox" Grid.Column="5" MinWidth="80" Enter="DoUpdate">
+            <controls:HistoryComboBox x:Name="FoldRegExTextBox" Grid.Column="5" MinWidth="80" Enter="DoUpdate" AutomationProperties.Name="Fold Patterns">
                 <controls:HistoryComboBox.ToolTip>
                     <ToolTip StaysOpen="True">
                         <TextBlock>
@@ -379,7 +379,7 @@
             <TextBlock Grid.Column="6" VerticalAlignment="Center" Margin="10,0,1,0">
                 <Hyperlink Command="Help" CommandParameter="IncPatsTextBox" KeyboardNavigation.IsTabStop="False">IncPats:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox x:Name="IncludeRegExTextBox" Grid.Column="7"  MinWidth="80" Margin="0,0,5,0" Enter="DoUpdate">
+            <controls:HistoryComboBox x:Name="IncludeRegExTextBox" Grid.Column="7"  MinWidth="80" Margin="0,0,5,0" Enter="DoUpdate" AutomationProperties.Name="Include Patterns">
                 <controls:HistoryComboBox.ToolTip>
                     <ToolTip StaysOpen="True">
                         <TextBlock>
@@ -393,7 +393,7 @@
             <TextBlock Grid.Column="8" VerticalAlignment="Center" Margin="10,0,1,0">
                 <Hyperlink Command="Help" CommandParameter="ExcPatsTextBox" KeyboardNavigation.IsTabStop="False">ExcPats:</Hyperlink>
             </TextBlock>
-            <controls:HistoryComboBox x:Name="ExcludeRegExTextBox" Grid.Column="9" MinWidth="80" Enter="DoUpdate">
+            <controls:HistoryComboBox x:Name="ExcludeRegExTextBox" Grid.Column="9" MinWidth="80" Enter="DoUpdate" AutomationProperties.Name="Exclude Patterns">
                 <controls:HistoryComboBox.ToolTip>
                     <ToolTip StaysOpen="True">
                         <TextBlock>
@@ -431,7 +431,7 @@
                         </TextBlock>
                     </TabItem.Header>
                     <!-- TODO FIX NOW The margin is a hack.  I don't know why I need it... -->
-                    <src:CallerCalleeView x:Name="CallerCalleeView" Margin="0,0,20,0" />
+                    <src:CallerCalleeView x:Name="CallerCalleeView" Margin="0,0,20,0"/>
                 </TabItem>
                 <!-- CallerTreeTab -->
                 <TabItem Name="CallTreeTab">
@@ -496,14 +496,15 @@
                         Notes <Hyperlink Command="Help" CommandParameter="NotesView">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
-                    <TextBox Name="NotesTabBody" AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" FontFamily="Courier New" FontSize="11" TextChanged="Notes_TextChanged"/>
+                    <TextBox Name="NotesTabBody" AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" FontFamily="Courier New" FontSize="11" TextChanged="Notes_TextChanged" AutomationProperties.Name="Notes"/>
                 </TabItem>
             </TabControl>
             <GridSplitter Grid.Row="1" Height="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
             <ContentControl Name="NodePane"/>
             <TextBox Name="Notes" Grid.Row="2"  GotFocus="Notes_GotFocus"
                      ContextMenu="{Binding ContextMenu, ElementName=DockPanel}"
-                     AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" FontFamily="Courier New" FontSize="11" TextChanged="Notes_TextChanged" VerticalAlignment="Stretch">
+                     AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" FontFamily="Courier New" FontSize="11" TextChanged="Notes_TextChanged" VerticalAlignment="Stretch"
+                     AutomationProperties.Name="Notes">
                 Notes typed here will be saved when the view is saved.  F2 will hide/unhide.
             </TextBox>
             <TextBlock Name="HelpMessage" Grid.Row="2" TextAlignment="Center" VerticalAlignment="Center" FontSize="35" Opacity="0.5">

--- a/src/PerfView/StackViewer/StackWindow.xaml.cs
+++ b/src/PerfView/StackViewer/StackWindow.xaml.cs
@@ -690,28 +690,20 @@ namespace PerfView
                 name = node.Name;
             }
 
-            CallerCalleeView.SetFocus(name, m_callTree);
-
-            m_calleesView.SetRoot(AggregateCallTreeNode.CalleeTree(node));
             if (IsMemoryWindow)
             {
                 CalleesTitle.Text = "Objects that are referred to by " + node.Name;
-            }
-            else
-            {
-                CalleesTitle.Text = "Methods that are called by " + node.Name;
-            }
-
-            m_callersView.SetRoot(AggregateCallTreeNode.CallerTree(node));
-
-            if (IsMemoryWindow)
-            {
                 CallersTitle.Text = "Objects that refer to " + node.Name;
             }
             else
             {
+                CalleesTitle.Text = "Methods that are called by " + node.Name;
                 CallersTitle.Text = "Methods that call " + node.Name;
             }
+
+            CallerCalleeView.SetFocus(name, m_callTree);
+            m_calleesView.SetRoot(AggregateCallTreeNode.CalleeTree(node));
+            m_callersView.SetRoot(AggregateCallTreeNode.CallerTree(node));
 
             DataContext = node;
             return true;

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -7302,9 +7302,7 @@
         and the other is JSON based, and neither of them will be surprising, they are simply the 'obvious' encoding of the
         data that the stack viewer needs in those formats.   For example here is a sample of the .perfView.xml format
     </p>
-    <dl>
-        <dd>
-            <pre>
+    <pre>
         &lt;StackSource&gt;
           &lt;Samples&gt;
            &lt;Sample Time="10" Metric="10"&gt; 
@@ -7316,6 +7314,7 @@
            &lt;/Sample&gt;
            &lt;Sample Time="20" Metric="10"&gt; 
                 Func3 
+
                 Func 
                 Main 
            &lt;/Sample&gt;
@@ -7332,9 +7331,7 @@
            &lt;/Sample&gt;
           &lt;/Samples&gt;
          &lt;/StackSource&gt;
-            </pre>
-        </dd>
-    </dl>
+    </pre>
     <p>
         You can see that the format can be very straightforward.   There is a 'StackSource' element that has a member 'Samples'
         which in turn contains a list of Samples, each of which has a time and a metric (both of these are optional, time defaults
@@ -7349,9 +7346,7 @@
         the stack.   Here is an example.   Like the previous example you can cut and paste into a *.perfView.json file and
         open it in PerfView, to see the data in the stack viewer.
     </p>
-    <dl>
-        <dd>
-            <pre>
+    <pre>
     {
       "StackSource" :  {
         "Samples" : [
@@ -7388,9 +7383,7 @@
         ]
       }
     }
-</pre>
-        </dd>
-    </dl>
+    </pre>
     <h3>Advanced .perfView.xml Format</h3>
     <p>
         The simple format is nice because it is so easy to explain, but it is very inefficient.  You can see the each stack

--- a/src/PerfView/Themes/DarkTheme.xaml
+++ b/src/PerfView/Themes/DarkTheme.xaml
@@ -98,8 +98,7 @@ SOFTWARE.
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle StrokeDashArray="1 2"
-                               StrokeThickness="1"
+                    <Rectangle StrokeThickness="1"
                                Stroke="{StaticResource ControlBrightPrimaryColourBorderBrush}"
                                SnapsToDevicePixels="true"
                                Margin="2" />

--- a/src/PerfView/Utilities/ProcessTree.cs
+++ b/src/PerfView/Utilities/ProcessTree.cs
@@ -75,6 +75,21 @@ namespace PerfView
                 return creationDate;
             }
         }
+
+        public string ShortDescription
+        {
+            get
+            {
+                var shortName = Name;
+                if (shortName.Length > 24)
+                {
+                    shortName = shortName.Substring(0, 24);
+                }
+
+                return $"{shortName} ({ProcessID})";
+            }
+        }
+
         public long CpuTime100ns
         {
             get

--- a/src/PerfView/app.config
+++ b/src/PerfView/app.config
@@ -6,7 +6,6 @@
   </system.diagnostics>
   <runtime>
     <gcAllowVeryLargeObjects enabled="true"/>
-    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false;" />
   </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>

--- a/src/PerfView/app.config
+++ b/src/PerfView/app.config
@@ -6,6 +6,7 @@
   </system.diagnostics>
   <runtime>
     <gcAllowVeryLargeObjects enabled="true"/>
+    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false;" />
   </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>

--- a/src/PerfViewExtensions/GlobalSrc/Commands.cs
+++ b/src/PerfViewExtensions/GlobalSrc/Commands.cs
@@ -150,7 +150,7 @@ public class Commands : CommandEnvironment
                 // We are not on the GUI thread, so any time we interact with the GUI thread we must dispatch to it.  
                 window.Dispatcher.BeginInvoke((Action)delegate
                 {
-                    window.Navigate(htmlFileName);
+                    window.Source = new Uri(htmlFileName);
                 });
                 // You can also get the window.Browser DOM object and fiddle with elements directly.   
                 return;


### PR DESCRIPTION
An accessibility review was completed on PerfView which identified a number of accessibility issues with PerfView, this PR addresses as many of the Sev 1 and Sev 2 accessibility issues that were possible without too much work. There are some other issues which were not addressed in this PR because they would require a significant amount of work to fix or it needed some more investigation.

## Replaced ActiveX with WebView2 for all web browser components
The ActiveX-based WebBrowser control has been replaced with WebView2 controls. A large number of accessibility issues that were identified were in places we were using the WebBrowser as it wasn't generating a very accessible UI. WebView2 was a (mostly) drop-in replacement that was able to address every accessibility issue that was reported. The WebView2 package includes inside it the driver/dll, so it is all self-contained and won't require the user to install anything to get it to work. Some of the subscribed event handlers on the browser control had to be updated to support the different event handler argument types as well.

It is worth mentioning that the latest version of WebView2 does not officially support Windows 7/8 ([source](https://blogs.windows.com/msedgedev/2022/12/09/microsoft-edge-and-webview2-ending-support-for-windows-7-and-windows-8-8-1/)), however it will still likely work it is just that they aren't testing that it works (see https://github.com/MicrosoftEdge/WebView2Feedback/issues/3404). If we want to be extra sure, we can roll back the WebView2 SDK version to `1.0.1519.0` though.

## Added AutomationProperties.Name for many elements
This property is used by accessibility software such as Narrator to describe what the currently highlighted element is. If an element is a text block or contains some content, the narrator will use that content by default as this name, but for other elements such as input elements, we need to specify it manually as it isn't able to extract it automatically from any adjacent labels. 

There are also some cases like TreeView or ListBox where the items inside the control use the ToString() method on the object to get the AutomationProperties.Name, which in some cases was undesirable as it was not user-friendly. For these cases we make use of a Setter to override the AutomationProperties.Name binding to a better value. There were also some other places that needed some specific work done to get the UI name to show up when WPF was unable to determine the correct value from the content or if the content was too long and needed to be shortened.

## Other changes
- There were a handful of places where `KeyboardNavigation.IsTabStop="False"` was set where it should have been true as it contained useful information that a user using accessibility tools may need.
- The border around the selected element when using tab navigation in the dark theme was very hard to see. I have changed it so that instead of being a dashed line it is a solid line.
- I disabled legacy accessiblity features in the app.config that were causing some false-positive accessibility issues to be reported. You can read more about this [here](https://learn.microsoft.com/en-us/dotnet/framework/whats-new/whats-new-in-accessibility#accessibility-switches).