### PR TITLE
Breaking Changes for FastSerialization

### DIFF
--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -1694,27 +1694,6 @@ namespace FastSerialization
             });
         }
 
-        /// <summary>
-        /// Registers a type name that can be created by instantiating the parameterless constructor.
-        /// 
-        /// When the <code>Deserializer</code>encounters a serialized type, it will look for a registered factory or type registration
-        /// so that it knows how to construct an empty instance of the type that can be filled.  All non-primitive types
-        /// must either be registered by calling RegisterFactory or RegisterType.
-        /// </summary>
-        public void RegisterType(string typeName)
-        {
-            RegisterFactory(typeName, () =>
-            {
-                IFastSerializable instance = null;
-                Type type = Type.GetType(typeName);
-                if (type != null)
-                {
-                    instance = CreateDefault(type);
-                }
-                return instance;
-            });
-        }
-
         private static IFastSerializable CreateDefault(Type type)
         {
             try

--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -113,14 +113,14 @@ namespace FastSerialization
             StreamLabelWidth.EightBytes,
             StreamReaderAlignment.EightBytes);
 
-        public SerializationSettings SetStreamLabelWidth(StreamLabelWidth width)
+        public SerializationSettings WithStreamLabelWidth(StreamLabelWidth width)
         {
             return new SerializationSettings(
                 width,
                 StreamReaderAlignment);
         }
 
-        public SerializationSettings SetStreamReaderAlignment(StreamReaderAlignment alignment)
+        public SerializationSettings WithStreamReaderAlignment(StreamReaderAlignment alignment)
         {
             return new SerializationSettings(
                 StreamLabelWidth,

--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -186,6 +186,11 @@ namespace FastSerialization
         /// IStreamReader.GotoSuffixLabel for more)
         /// </summary>
         void WriteSuffixLabel(StreamLabel value);
+
+        /// <summary>
+        /// The settings associated with this writer.
+        /// </summary>
+        SerializationSettings Settings { get; }
     }
 
 
@@ -255,6 +260,11 @@ namespace FastSerialization
         /// and then seeking to that position.  
         /// </summary>
         void GotoSuffixLabel();
+
+        /// <summary>
+        /// The settings associated with this reader.
+        /// </summary>
+        SerializationSettings Settings { get; }
     }
 
 #if !DOTNET_V35
@@ -1057,9 +1067,9 @@ namespace FastSerialization
         /// <paramref name="leaveOpen"/> parameter determines whether the deserializer will close the stream when it
         /// closes.
         /// </summary>
-        public Deserializer(Stream inputStream, string streamName, bool leaveOpen, SerializationSettings config = null)
+        public Deserializer(Stream inputStream, string streamName, bool leaveOpen, SerializationSettings settings)
         {
-            IOStreamStreamReader reader = new IOStreamStreamReader(inputStream, leaveOpen: leaveOpen, settings: config);
+            IOStreamStreamReader reader = new IOStreamStreamReader(inputStream, leaveOpen: leaveOpen, settings: settings);
             Initialize(reader, streamName);
         }
 

--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -107,19 +107,31 @@ namespace FastSerialization
     {
         internal StreamLabelWidth StreamLabelWidth { get; }
 
+        internal StreamReaderAlignment StreamReaderAlignment { get; }
+
         public static SerializationSettings Default { get; } = new SerializationSettings(
-            StreamLabelWidth.EightBytes);
+            StreamLabelWidth.EightBytes,
+            StreamReaderAlignment.EightBytes);
 
         public SerializationSettings SetStreamLabelWidth(StreamLabelWidth width)
         {
             return new SerializationSettings(
-                width);
+                width,
+                StreamReaderAlignment);
+        }
+
+        public SerializationSettings SetStreamReaderAlignment(StreamReaderAlignment alignment)
+        {
+            return new SerializationSettings(
+                StreamLabelWidth,
+                alignment);
         }
 
         private SerializationSettings(
-            StreamLabelWidth streamLabelWidth)
+            StreamLabelWidth streamLabelWidth, StreamReaderAlignment streamReaderAlignment)
         {
             StreamLabelWidth = streamLabelWidth;
+            StreamReaderAlignment = streamReaderAlignment;
         }
     }
 

--- a/src/FastSerialization/FastSerialization.cs
+++ b/src/FastSerialization/FastSerialization.cs
@@ -98,14 +98,16 @@ namespace FastSerialization
     };
 
     /// <summary>
-    /// These settings apply to use of Serializer and Deserializer specifically.
+    /// Settings used by <code>Serializer</code> and <code>Deserializer</code>.
     /// </summary>
 #if FASTSERIALIZATION_PUBLIC
     public
 #endif
-    sealed class SerializationConfiguration
+    sealed class SerializationSettings
     {
         public StreamLabelWidth StreamLabelWidth { get; set; } = StreamLabelWidth.EightBytes;
+
+        public string[] AllowedTypeNames { get; set; } = Array.Empty<string>();
     }
 
     /// <summary>
@@ -516,7 +518,7 @@ namespace FastSerialization
         /// <param name="filePath">The destination file.</param>
         /// <param name="entryObject">The object to serialize.</param>
         /// <param name="share">Optional sharing mode for the destination file. Defaults to <see cref="FileShare.Read"/>.</param>
-        public Serializer(string filePath, IFastSerializable entryObject, FileShare share = FileShare.Read) : this(new IOStreamStreamWriter(filePath, share: share), entryObject) { }
+        public Serializer(string filePath, IFastSerializable entryObject, FileShare share = FileShare.Read) : this(new IOStreamStreamWriter(filePath, settings: new SerializationSettings(), share: share), entryObject) { }
 
         /// <summary>
         /// Create a serializer that writes <paramref name="entryObject"/> to a <see cref="Stream"/>. The serializer
@@ -533,7 +535,7 @@ namespace FastSerialization
         /// closes.
         /// </summary>
         public Serializer(Stream outputStream, IFastSerializable entryObject, bool leaveOpen)
-            : this(new IOStreamStreamWriter(outputStream, leaveOpen: leaveOpen), entryObject)
+            : this(new IOStreamStreamWriter(outputStream, new SerializationSettings(), leaveOpen: leaveOpen), entryObject)
         {
         }
 
@@ -1035,18 +1037,18 @@ namespace FastSerialization
         /// <summary>
         /// Create a Deserializer that reads its data from a given file
         /// </summary>
-        public Deserializer(string filePath, SerializationConfiguration config = null)
+        public Deserializer(string filePath, SerializationSettings settings)
         {
-            IOStreamStreamReader reader = new IOStreamStreamReader(filePath, config);
+            IOStreamStreamReader reader = new IOStreamStreamReader(filePath, settings);
             Initialize(reader, filePath);
         }
 
         /// <summary>
         /// Create a Deserializer that reads its data from a given System.IO.Stream.   The stream will be closed when the Deserializer is done with it.  
         /// </summary>
-        public Deserializer(Stream inputStream, string streamName, SerializationConfiguration config = null)
+        public Deserializer(Stream inputStream, string streamName, SerializationSettings settings)
         {
-            IOStreamStreamReader reader = new IOStreamStreamReader(inputStream, config: config);
+            IOStreamStreamReader reader = new IOStreamStreamReader(inputStream, settings: settings);
             Initialize(reader, streamName);
         }
 
@@ -1055,9 +1057,9 @@ namespace FastSerialization
         /// <paramref name="leaveOpen"/> parameter determines whether the deserializer will close the stream when it
         /// closes.
         /// </summary>
-        public Deserializer(Stream inputStream, string streamName, bool leaveOpen, SerializationConfiguration config = null)
+        public Deserializer(Stream inputStream, string streamName, bool leaveOpen, SerializationSettings config = null)
         {
-            IOStreamStreamReader reader = new IOStreamStreamReader(inputStream, leaveOpen: leaveOpen, config: config);
+            IOStreamStreamReader reader = new IOStreamStreamReader(inputStream, leaveOpen: leaveOpen, settings: config);
             Initialize(reader, streamName);
         }
 

--- a/src/FastSerialization/MemoryMappedFileStreamReader.cs
+++ b/src/FastSerialization/MemoryMappedFileStreamReader.cs
@@ -29,16 +29,22 @@ namespace FastSerialization
         private long _capacity;
         private long _offset;
 
-        public MemoryMappedFileStreamReader(string mapName, long length)
-            : this(MemoryMappedFile.OpenExisting(mapName, MemoryMappedFileRights.Read), length, leaveOpen: false)
+        public MemoryMappedFileStreamReader(string mapName, long length, SerializationSettings settings)
+            : this(MemoryMappedFile.OpenExisting(mapName, MemoryMappedFileRights.Read), length, leaveOpen: false, settings)
         {
         }
 
-        public MemoryMappedFileStreamReader(MemoryMappedFile file, long length, bool leaveOpen)
+        public MemoryMappedFileStreamReader(MemoryMappedFile file, long length, bool leaveOpen, SerializationSettings settings)
         {
             _file = file;
             _fileLength = length;
             _leaveOpen = leaveOpen;
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            Settings = settings;
 
             if (IntPtr.Size == 4)
             {
@@ -53,11 +59,17 @@ namespace FastSerialization
             _viewAddress = _view.SafeMemoryMappedViewHandle.DangerousGetHandle();
         }
 
-        public static MemoryMappedFileStreamReader CreateFromFile(string path)
+        public static MemoryMappedFileStreamReader CreateFromFile(string path, SerializationSettings settings)
         {
             long capacity = new FileInfo(path).Length;
             MemoryMappedFile file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, Guid.NewGuid().ToString("N"), capacity, MemoryMappedFileAccess.Read);
-            return new MemoryMappedFileStreamReader(file, capacity, leaveOpen: false);
+            return new MemoryMappedFileStreamReader(file, capacity, leaveOpen: false, settings);
+        }
+
+        public SerializationSettings Settings
+        {
+            get;
+            private set;
         }
 
         public DeferedStreamLabel Current

--- a/src/FastSerialization/MemoryMappedFileStreamReader.cs
+++ b/src/FastSerialization/MemoryMappedFileStreamReader.cs
@@ -40,11 +40,7 @@ namespace FastSerialization
             _fileLength = length;
             _leaveOpen = leaveOpen;
 
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-            Settings = settings;
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
 
             if (IntPtr.Size == 4)
             {

--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -23,8 +23,8 @@ namespace FastSerialization
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            SerializationSettings = settings;
-            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            Settings = settings;
+            if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 readLabel = () =>
                 {
@@ -161,7 +161,7 @@ namespace FastSerialization
         {
             Debug.Assert(label != StreamLabel.Invalid);
 
-            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 Debug.Assert((long)label <= int.MaxValue);
                 position = (uint)label;
@@ -178,7 +178,7 @@ namespace FastSerialization
         {
             get
             {
-                if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
+                if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
                 {
                     return (StreamLabel)(uint)position;
                 }
@@ -212,7 +212,7 @@ namespace FastSerialization
         /// <summary>
         /// Returns the <code>SerializationSettings</code> for this stream reader.
         /// </summary>
-        internal SerializationSettings SerializationSettings { get; private set; }
+        internal SerializationSettings Settings { get; private set; }
         #endregion
 
         #region private 

--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -12,15 +12,19 @@ namespace FastSerialization
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given byte buffer
         /// </summary>
-        public SegmentedMemoryStreamReader(SegmentedList<byte> data, SerializationConfiguration config = null) : this(data, 0, data.Count, config) { }
+        public SegmentedMemoryStreamReader(SegmentedList<byte> data, SerializationSettings settings) : this(data, 0, data.Count, settings) { }
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given subregion of a byte buffer 
         /// </summary>
-        public SegmentedMemoryStreamReader(SegmentedList<byte> data, long start, long length, SerializationConfiguration config = null)
+        public SegmentedMemoryStreamReader(SegmentedList<byte> data, long start, long length, SerializationSettings settings)
         {
-            SerializationConfiguration = config ?? new SerializationConfiguration();
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
 
-            if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            SerializationSettings = settings;
+            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 readLabel = () =>
                 {
@@ -157,7 +161,7 @@ namespace FastSerialization
         {
             Debug.Assert(label != StreamLabel.Invalid);
 
-            if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 Debug.Assert((long)label <= int.MaxValue);
                 position = (uint)label;
@@ -174,7 +178,7 @@ namespace FastSerialization
         {
             get
             {
-                if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+                if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
                 {
                     return (StreamLabel)(uint)position;
                 }
@@ -206,9 +210,9 @@ namespace FastSerialization
         protected virtual void Dispose(bool disposing) { }
 
         /// <summary>
-        /// Returns the SerializationConfiguration for this stream reader.
+        /// Returns the <code>SerializationSettings</code> for this stream reader.
         /// </summary>
-        internal SerializationConfiguration SerializationConfiguration { get; private set; }
+        internal SerializationSettings SerializationSettings { get; private set; }
         #endregion
 
         #region private 

--- a/src/FastSerialization/SegmentedMemoryStreamReader.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamReader.cs
@@ -18,12 +18,8 @@ namespace FastSerialization
         /// </summary>
         public SegmentedMemoryStreamReader(SegmentedList<byte> data, long start, long length, SerializationSettings settings)
         {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
 
-            Settings = settings;
             if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 readLabel = () =>

--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -10,9 +10,13 @@ namespace FastSerialization
         public SegmentedMemoryStreamWriter(SerializationSettings settings) : this(64, settings) { }
         public SegmentedMemoryStreamWriter(long initialSize, SerializationSettings settings)
         {
-            SerializationSettings = settings;
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
 
-            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            Settings = settings;
+            if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 writeLabel = (value) =>
                 {
@@ -100,14 +104,14 @@ namespace FastSerialization
         public SegmentedMemoryStreamReader GetReader()
         {
             var readerBytes = bytes;
-            return new SegmentedMemoryStreamReader(readerBytes, 0, readerBytes.Count, SerializationSettings);
+            return new SegmentedMemoryStreamReader(readerBytes, 0, readerBytes.Count, Settings);
         }
         public void Dispose() { }
 
         /// <summary>
         /// Returns the SerializerSettings for this stream writer.
         /// </summary>
-        internal SerializationSettings SerializationSettings { get; private set; }
+        internal SerializationSettings Settings { get; private set; }
 
         #region private
         protected virtual void MakeSpace()

--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -10,12 +10,8 @@ namespace FastSerialization
         public SegmentedMemoryStreamWriter(SerializationSettings settings) : this(64, settings) { }
         public SegmentedMemoryStreamWriter(long initialSize, SerializationSettings settings)
         {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
 
-            Settings = settings;
             if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 writeLabel = (value) =>

--- a/src/FastSerialization/SegmentedMemoryStreamWriter.cs
+++ b/src/FastSerialization/SegmentedMemoryStreamWriter.cs
@@ -7,12 +7,12 @@ namespace FastSerialization
 {
     public class SegmentedMemoryStreamWriter
     {
-        public SegmentedMemoryStreamWriter(SerializationConfiguration config = null) : this(64, config) { }
-        public SegmentedMemoryStreamWriter(long initialSize, SerializationConfiguration config = null)
+        public SegmentedMemoryStreamWriter(SerializationSettings settings) : this(64, settings) { }
+        public SegmentedMemoryStreamWriter(long initialSize, SerializationSettings settings)
         {
-            SerializationConfiguration = config ?? new SerializationConfiguration();
+            SerializationSettings = settings;
 
-            if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 writeLabel = (value) =>
                 {
@@ -100,14 +100,14 @@ namespace FastSerialization
         public SegmentedMemoryStreamReader GetReader()
         {
             var readerBytes = bytes;
-            return new SegmentedMemoryStreamReader(readerBytes, 0, readerBytes.Count, SerializationConfiguration);
+            return new SegmentedMemoryStreamReader(readerBytes, 0, readerBytes.Count, SerializationSettings);
         }
         public void Dispose() { }
 
         /// <summary>
-        /// Returns the SerializationConfiguration for this stream writer.
+        /// Returns the SerializerSettings for this stream writer.
         /// </summary>
-        internal SerializationConfiguration SerializationConfiguration { get; private set; }
+        internal SerializationSettings SerializationSettings { get; private set; }
 
         #region private
         protected virtual void MakeSpace()

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -22,7 +22,7 @@ namespace FastSerialization
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given byte buffer
         /// </summary>
-        public MemoryStreamReader(byte[] data) : this(data, 0, data.Length, new SerializationSettings()) { }
+        public MemoryStreamReader(byte[] data, SerializationSettings settings) : this(data, 0, data.Length, settings) { }
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given subregion of a byte buffer.
         /// </summary>
@@ -37,8 +37,8 @@ namespace FastSerialization
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            SerializationSettings = settings;
-            if(SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            Settings = settings;
+            if(Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 readLabel = () =>
                 {
@@ -61,9 +61,14 @@ namespace FastSerialization
         /// </summary>
         public virtual long Length { get { return endPosition; } }
         public virtual bool HasLength { get { return true; } }
-        public SerializationSettings SerializationSettings { get; private set; }
 
         #region implemenation of IStreamReader
+
+        /// <summary>
+        /// The settings associated with this reader.
+        /// </summary>
+        public SerializationSettings Settings { get; private set; }
+
         public virtual void Read(byte[] data, int offset, int length)
         {
             if (length > endPosition - position)
@@ -256,8 +261,8 @@ namespace FastSerialization
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            SerializationSettings = settings;
-            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            Settings = settings;
+            if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 writeLabel = (value) =>
                 {
@@ -277,7 +282,10 @@ namespace FastSerialization
             bytes = new byte[initialSize];
         }
 
-        public SerializationSettings SerializationSettings { get; set; }
+        /// <summary>
+        /// The settings associated with this writer.
+        /// </summary>
+        public SerializationSettings Settings { get; private set; }
 
         /// <summary>
         /// Returns a IStreamReader that will read the written bytes. You cannot write additional bytes to the stream after making this call.
@@ -291,7 +299,7 @@ namespace FastSerialization
                 readerBytes = new byte[endPosition];
                 Array.Copy(bytes, readerBytes, endPosition);
             }
-            return new MemoryStreamReader(readerBytes, 0, endPosition, new SerializationSettings());
+            return new MemoryStreamReader(readerBytes, 0, endPosition, Settings);
         }
 
         /// <summary>
@@ -944,7 +952,7 @@ namespace FastSerialization
         /// <returns></returns>
         public PinnedStreamReader Clone()
         {
-            PinnedStreamReader ret = new PinnedStreamReader(inputStream, SerializationSettings, bytes.Length - align);
+            PinnedStreamReader ret = new PinnedStreamReader(inputStream, Settings, bytes.Length - align);
             return ret;
         }
 
@@ -1069,7 +1077,7 @@ namespace FastSerialization
         public override StreamLabel GetLabel()
         {
             long len = Length;
-            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes && len != (uint)len)
+            if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes && len != (uint)len)
             {
                 throw new NotSupportedException("Streams larger than 4 GB.  You need to use /MaxEventCount to limit the size.");
             }

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -32,13 +32,9 @@ namespace FastSerialization
             position = start;
             endPosition = length;
 
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
 
-            Settings = settings;
-            if(Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 readLabel = () =>
                 {
@@ -256,12 +252,8 @@ namespace FastSerialization
         /// </summary>
         public MemoryStreamWriter(SerializationSettings settings, int initialSize = 64)
         {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
 
-            Settings = settings;
             if (Settings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 writeLabel = (value) =>

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -672,10 +672,10 @@ namespace FastSerialization
         /// Create a new IOStreamStreamReader from the given System.IO.Stream.   Optionally you can specify the size of the read buffer
         /// The stream will be closed by the IOStreamStreamReader when it is closed.  
         /// </summary>
-        public IOStreamStreamReader(Stream inputStream, SerializationSettings settings, int bufferSize = defaultBufferSize, bool leaveOpen = false, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
-            : base(new byte[bufferSize + (int)alignment], 0, 0, settings)
+        public IOStreamStreamReader(Stream inputStream, SerializationSettings settings, int bufferSize = defaultBufferSize, bool leaveOpen = false)
+            : base(new byte[bufferSize + (int)settings.StreamReaderAlignment], 0, 0, settings)
         {
-            align = (int)alignment;
+            align = (int)settings.StreamReaderAlignment;
             Debug.Assert(bufferSize % align == 0);
             this.inputStream = inputStream;
             this.leaveOpen = leaveOpen;
@@ -934,8 +934,8 @@ namespace FastSerialization
         /// Create a new PinnedStreamReader that gets its data from a given System.IO.Stream.  You can optionally set the size of the read buffer.  
         /// The stream will be closed by the PinnedStreamReader when it is closed.  
         /// </summary>
-        public PinnedStreamReader(Stream inputStream, SerializationSettings settings, int bufferSize = defaultBufferSize, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
-            : base(inputStream, settings, bufferSize, alignment: alignment)
+        public PinnedStreamReader(Stream inputStream, SerializationSettings settings, int bufferSize = defaultBufferSize)
+            : base(inputStream, settings, bufferSize)
         {
             // Pin the array
             pinningHandle = System.Runtime.InteropServices.GCHandle.Alloc(bytes, System.Runtime.InteropServices.GCHandleType.Pinned);

--- a/src/FastSerialization/StreamReaderWriter.cs
+++ b/src/FastSerialization/StreamReaderWriter.cs
@@ -22,18 +22,23 @@ namespace FastSerialization
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given byte buffer
         /// </summary>
-        public MemoryStreamReader(byte[] data) : this(data, 0, data.Length) { }
+        public MemoryStreamReader(byte[] data) : this(data, 0, data.Length, new SerializationSettings()) { }
         /// <summary>
         /// Create a IStreamReader (reads binary data) from a given subregion of a byte buffer.
         /// </summary>
-        public MemoryStreamReader(byte[] data, int start, int length, SerializationConfiguration config = null)
+        public MemoryStreamReader(byte[] data, int start, int length, SerializationSettings settings)
         {
             bytes = data;
             position = start;
             endPosition = length;
-            SerializationConfiguration = config != null ? config : new SerializationConfiguration();
 
-            if(SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            SerializationSettings = settings;
+            if(SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 readLabel = () =>
                 {
@@ -56,7 +61,7 @@ namespace FastSerialization
         /// </summary>
         public virtual long Length { get { return endPosition; } }
         public virtual bool HasLength { get { return true; } }
-        public SerializationConfiguration SerializationConfiguration { get; private set; }
+        public SerializationSettings SerializationSettings { get; private set; }
 
         #region implemenation of IStreamReader
         public virtual void Read(byte[] data, int offset, int length)
@@ -244,12 +249,15 @@ namespace FastSerialization
         /// 
         /// Call 'GetBytes' call to get the raw array.  Only the first 'Length' bytes are valid
         /// </summary>
-        public MemoryStreamWriter(int initialSize = 64, SerializationConfiguration config = null)
+        public MemoryStreamWriter(SerializationSettings settings, int initialSize = 64)
         {
-            bytes = new byte[initialSize];
-            SerializationConfiguration = config != null ? config : new SerializationConfiguration();
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
 
-            if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes)
+            SerializationSettings = settings;
+            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes)
             {
                 writeLabel = (value) =>
                 {
@@ -265,9 +273,11 @@ namespace FastSerialization
                     Write((long)value);
                 };
             }
+
+            bytes = new byte[initialSize];
         }
 
-        public SerializationConfiguration SerializationConfiguration { get; set; }
+        public SerializationSettings SerializationSettings { get; set; }
 
         /// <summary>
         /// Returns a IStreamReader that will read the written bytes. You cannot write additional bytes to the stream after making this call.
@@ -281,7 +291,7 @@ namespace FastSerialization
                 readerBytes = new byte[endPosition];
                 Array.Copy(bytes, readerBytes, endPosition);
             }
-            return new MemoryStreamReader(readerBytes, 0, endPosition);
+            return new MemoryStreamReader(readerBytes, 0, endPosition, new SerializationSettings());
         }
 
         /// <summary>
@@ -647,15 +657,15 @@ namespace FastSerialization
         /// Create a new IOStreamStreamReader from the given file.  
         /// </summary>
         /// <param name="fileName"></param>
-        public IOStreamStreamReader(string fileName, SerializationConfiguration config = null)
-            : this(new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete), config: config) { }
+        public IOStreamStreamReader(string fileName, SerializationSettings settings)
+            : this(new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete), settings: settings) { }
 
         /// <summary>
         /// Create a new IOStreamStreamReader from the given System.IO.Stream.   Optionally you can specify the size of the read buffer
         /// The stream will be closed by the IOStreamStreamReader when it is closed.  
         /// </summary>
-        public IOStreamStreamReader(Stream inputStream, int bufferSize = defaultBufferSize, bool leaveOpen = false, SerializationConfiguration config = null, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
-            : base(new byte[bufferSize + (int)alignment], 0, 0, config)
+        public IOStreamStreamReader(Stream inputStream, SerializationSettings settings, int bufferSize = defaultBufferSize, bool leaveOpen = false, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
+            : base(new byte[bufferSize + (int)alignment], 0, 0, settings)
         {
             align = (int)alignment;
             Debug.Assert(bufferSize % align == 0);
@@ -907,17 +917,17 @@ namespace FastSerialization
         /// <summary>
         /// Create a new PinnedStreamReader that gets its data from a given file.  You can optionally set the size of the read buffer.  
         /// </summary>
-        public PinnedStreamReader(string fileName, int bufferSize = defaultBufferSize, SerializationConfiguration config = null)
+        public PinnedStreamReader(string fileName, SerializationSettings settings, int bufferSize = defaultBufferSize)
             : this(new FileStream(fileName, FileMode.Open, FileAccess.Read,
-            FileShare.Read | FileShare.Delete), bufferSize, config)
+            FileShare.Read | FileShare.Delete), settings, bufferSize)
         { }
 
         /// <summary>
         /// Create a new PinnedStreamReader that gets its data from a given System.IO.Stream.  You can optionally set the size of the read buffer.  
         /// The stream will be closed by the PinnedStreamReader when it is closed.  
         /// </summary>
-        public PinnedStreamReader(Stream inputStream, int bufferSize = defaultBufferSize, SerializationConfiguration config = null, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
-            : base(inputStream, bufferSize, config: config, alignment: alignment)
+        public PinnedStreamReader(Stream inputStream, SerializationSettings settings, int bufferSize = defaultBufferSize, StreamReaderAlignment alignment = StreamReaderAlignment.EightBytes)
+            : base(inputStream, settings, bufferSize, alignment: alignment)
         {
             // Pin the array
             pinningHandle = System.Runtime.InteropServices.GCHandle.Alloc(bytes, System.Runtime.InteropServices.GCHandleType.Pinned);
@@ -934,7 +944,7 @@ namespace FastSerialization
         /// <returns></returns>
         public PinnedStreamReader Clone()
         {
-            PinnedStreamReader ret = new PinnedStreamReader(inputStream, bytes.Length - align);
+            PinnedStreamReader ret = new PinnedStreamReader(inputStream, SerializationSettings, bytes.Length - align);
             return ret;
         }
 
@@ -1004,13 +1014,13 @@ namespace FastSerialization
         /// Create a IOStreamStreamWriter that writes its data to a given file that it creates
         /// </summary>
         /// <param name="fileName"></param>
-        public IOStreamStreamWriter(string fileName, SerializationConfiguration config = null, FileShare share = FileShare.Read) : this(new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, share), config: config) { }
+        public IOStreamStreamWriter(string fileName, SerializationSettings settings, FileShare share = FileShare.Read) : this(new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, share), settings: settings) { }
 
         /// <summary>
         /// Create a IOStreamStreamWriter that writes its data to a System.IO.Stream
         /// </summary>
-        public IOStreamStreamWriter(Stream outputStream, int bufferSize = defaultBufferSize + sizeof(long), bool leaveOpen = false, SerializationConfiguration config = null)
-            : base(bufferSize, config)
+        public IOStreamStreamWriter(Stream outputStream, SerializationSettings settings, int bufferSize = defaultBufferSize + sizeof(long), bool leaveOpen = false)
+            : base(settings, bufferSize)
         {
             this.outputStream = outputStream;
             this.leaveOpen = leaveOpen;
@@ -1059,7 +1069,7 @@ namespace FastSerialization
         public override StreamLabel GetLabel()
         {
             long len = Length;
-            if (SerializationConfiguration.StreamLabelWidth == StreamLabelWidth.FourBytes && len != (uint)len)
+            if (SerializationSettings.StreamLabelWidth == StreamLabelWidth.FourBytes && len != (uint)len)
             {
                 throw new NotSupportedException("Streams larger than 4 GB.  You need to use /MaxEventCount to limit the size.");
             }

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -17,11 +17,11 @@ using Address = System.UInt64;
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName, new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputFileName, SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName, new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputStream, streamName, SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)))
     { }
 
     /// <summary>
@@ -192,7 +192,7 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
     private void Write(string outputFileName)
     {
         Debug.Assert(MemoryGraph != null);
-        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), this);
+        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), this);
         serializer.Close();
     }
 

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -17,11 +17,11 @@ using Address = System.UInt64;
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName, SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)))
+        this(new Deserializer(inputFileName, SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName, SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)))
+        this(new Deserializer(inputStream, streamName, SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)))
     { }
 
     /// <summary>
@@ -192,7 +192,7 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
     private void Write(string outputFileName)
     {
         Debug.Assert(MemoryGraph != null);
-        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), this);
+        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)), this);
         serializer.Close();
     }
 

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -17,11 +17,11 @@ using Address = System.UInt64;
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName, SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)))
+        this(new Deserializer(inputFileName, SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName, SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)))
+        this(new Deserializer(inputStream, streamName, SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)))
     { }
 
     /// <summary>
@@ -192,7 +192,7 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
     private void Write(string outputFileName)
     {
         Debug.Assert(MemoryGraph != null);
-        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), this);
+        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), this);
         serializer.Close();
     }
 

--- a/src/HeapDump/GCHeapDump.cs
+++ b/src/HeapDump/GCHeapDump.cs
@@ -17,11 +17,11 @@ using Address = System.UInt64;
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputFileName, new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputStream, streamName, new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
     { }
 
     /// <summary>
@@ -192,7 +192,7 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
     private void Write(string outputFileName)
     {
         Debug.Assert(MemoryGraph != null);
-        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), this);
+        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), this);
         serializer.Close();
     }
 

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1256,7 +1256,7 @@ public class GCHeapDumper
         if (m_outputFileName != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to file.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), m_gcHeapDump);
             serializer.Close();
 
             m_log.WriteLine("Actual file size = {0:f3}MB", new FileInfo(m_outputFileName).Length / 1000000.0);
@@ -1265,7 +1265,7 @@ public class GCHeapDumper
         if (m_outputStream != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to stream.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), m_gcHeapDump);
             serializer.Close();
         }
 

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1256,7 +1256,7 @@ public class GCHeapDumper
         if (m_outputFileName != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to file.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), m_gcHeapDump);
             serializer.Close();
 
             m_log.WriteLine("Actual file size = {0:f3}MB", new FileInfo(m_outputFileName).Length / 1000000.0);
@@ -1265,7 +1265,7 @@ public class GCHeapDumper
         if (m_outputStream != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to stream.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), m_gcHeapDump);
             serializer.Close();
         }
 

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1256,7 +1256,7 @@ public class GCHeapDumper
         if (m_outputFileName != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to file.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), m_gcHeapDump);
             serializer.Close();
 
             m_log.WriteLine("Actual file size = {0:f3}MB", new FileInfo(m_outputFileName).Length / 1000000.0);
@@ -1265,7 +1265,7 @@ public class GCHeapDumper
         if (m_outputStream != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to stream.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), m_gcHeapDump);
             serializer.Close();
         }
 

--- a/src/HeapDump/GCHeapDumper.cs
+++ b/src/HeapDump/GCHeapDumper.cs
@@ -1256,7 +1256,7 @@ public class GCHeapDumper
         if (m_outputFileName != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to file.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputFileName, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)), m_gcHeapDump);
             serializer.Close();
 
             m_log.WriteLine("Actual file size = {0:f3}MB", new FileInfo(m_outputFileName).Length / 1000000.0);
@@ -1265,7 +1265,7 @@ public class GCHeapDumper
         if (m_outputStream != null)
         {
             m_log.WriteLine("{0,5:f1}s:   Started Writing to stream.", m_sw.Elapsed.TotalSeconds);
-            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), m_gcHeapDump);
+            var serializer = new Serializer(new IOStreamStreamWriter(m_outputStream, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)), m_gcHeapDump);
             serializer.Close();
         }
 

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -18,7 +18,7 @@
 
   <PropertyGroup>
     <!-- NuGet won't know to restore the x64 build unless we add it explicitly -->
-    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' == 'AnyCPU'">

--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -18,7 +18,7 @@
 
   <PropertyGroup>
     <!-- NuGet won't know to restore the x64 build unless we add it explicitly -->
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' == 'AnyCPU'">

--- a/src/MemoryGraph/MemoryGraph.cs
+++ b/src/MemoryGraph/MemoryGraph.cs
@@ -31,7 +31,7 @@ namespace Graphs
         }
         public static MemoryGraph ReadFromBinaryFile(string inputFileName)
         {
-            Deserializer deserializer = new Deserializer(inputFileName, new SerializationSettings());
+            Deserializer deserializer = new Deserializer(inputFileName, SerializationSettings.Default);
             deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
             deserializer.RegisterFactory(typeof(MemoryGraph), delegate () { return new MemoryGraph(1); });
             deserializer.RegisterFactory(typeof(Graphs.Module), delegate () { return new Graphs.Module(0); });

--- a/src/MemoryGraph/MemoryGraph.cs
+++ b/src/MemoryGraph/MemoryGraph.cs
@@ -32,7 +32,6 @@ namespace Graphs
         public static MemoryGraph ReadFromBinaryFile(string inputFileName)
         {
             Deserializer deserializer = new Deserializer(inputFileName, SerializationSettings.Default);
-            deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
             deserializer.RegisterFactory(typeof(MemoryGraph), delegate () { return new MemoryGraph(1); });
             deserializer.RegisterFactory(typeof(Graphs.Module), delegate () { return new Graphs.Module(0); });
             return (MemoryGraph)deserializer.GetEntryObject();

--- a/src/MemoryGraph/MemoryGraph.cs
+++ b/src/MemoryGraph/MemoryGraph.cs
@@ -31,7 +31,7 @@ namespace Graphs
         }
         public static MemoryGraph ReadFromBinaryFile(string inputFileName)
         {
-            Deserializer deserializer = new Deserializer(inputFileName);
+            Deserializer deserializer = new Deserializer(inputFileName, new SerializationSettings());
             deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
             deserializer.RegisterFactory(typeof(MemoryGraph), delegate () { return new MemoryGraph(1); });
             deserializer.RegisterFactory(typeof(Graphs.Module), delegate () { return new Graphs.Module(0); });

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -465,8 +465,11 @@ namespace Graphs
             RootIndex = NodeIndex.Invalid;
             if (m_writer == null)
             {
-                m_writer = new SegmentedMemoryStreamWriter(m_expectedNodeCount * 8,
-                    m_isVeryLargeGraph ? new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.EightBytes } : null);
+                SerializationSettings settings = new SerializationSettings()
+                {
+                    StreamLabelWidth = m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes
+                };
+                m_writer = new SegmentedMemoryStreamWriter(m_expectedNodeCount * 8, settings);
             }
 
             m_totalSize = 0;
@@ -594,8 +597,11 @@ namespace Graphs
             // Read in the Blob stream.  
             // TODO be lazy about reading in the blobs.  
             int blobCount = deserializer.ReadInt();
-            SegmentedMemoryStreamWriter writer = new SegmentedMemoryStreamWriter(blobCount,
-                m_isVeryLargeGraph ? new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.EightBytes } : null);
+            SerializationSettings settings = new SerializationSettings()
+            {
+                StreamLabelWidth = m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes
+            };
+            SegmentedMemoryStreamWriter writer = new SegmentedMemoryStreamWriter(blobCount, settings);
 
             while (8 <= blobCount)
             {

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -466,7 +466,7 @@ namespace Graphs
             if (m_writer == null)
             {
                 SerializationSettings settings = SerializationSettings.Default
-                    .SetStreamLabelWith(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
+                    .SetStreamLabelWidth(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
                 m_writer = new SegmentedMemoryStreamWriter(m_expectedNodeCount * 8, settings);
             }
 
@@ -596,7 +596,7 @@ namespace Graphs
             // TODO be lazy about reading in the blobs.  
             int blobCount = deserializer.ReadInt();
             SerializationSettings settings = SerializationSettings.Default
-                .SetStreamLabelWith(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
+                .SetStreamLabelWidth(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
             SegmentedMemoryStreamWriter writer = new SegmentedMemoryStreamWriter(blobCount, settings);
 
             while (8 <= blobCount)

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -466,7 +466,7 @@ namespace Graphs
             if (m_writer == null)
             {
                 SerializationSettings settings = SerializationSettings.Default
-                    .SetStreamLabelWidth(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
+                    .WithStreamLabelWidth(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
                 m_writer = new SegmentedMemoryStreamWriter(m_expectedNodeCount * 8, settings);
             }
 
@@ -596,7 +596,7 @@ namespace Graphs
             // TODO be lazy about reading in the blobs.  
             int blobCount = deserializer.ReadInt();
             SerializationSettings settings = SerializationSettings.Default
-                .SetStreamLabelWidth(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
+                .WithStreamLabelWidth(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
             SegmentedMemoryStreamWriter writer = new SegmentedMemoryStreamWriter(blobCount, settings);
 
             while (8 <= blobCount)

--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -465,10 +465,8 @@ namespace Graphs
             RootIndex = NodeIndex.Invalid;
             if (m_writer == null)
             {
-                SerializationSettings settings = new SerializationSettings()
-                {
-                    StreamLabelWidth = m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes
-                };
+                SerializationSettings settings = SerializationSettings.Default
+                    .SetStreamLabelWith(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
                 m_writer = new SegmentedMemoryStreamWriter(m_expectedNodeCount * 8, settings);
             }
 
@@ -597,10 +595,8 @@ namespace Graphs
             // Read in the Blob stream.  
             // TODO be lazy about reading in the blobs.  
             int blobCount = deserializer.ReadInt();
-            SerializationSettings settings = new SerializationSettings()
-            {
-                StreamLabelWidth = m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes
-            };
+            SerializationSettings settings = SerializationSettings.Default
+                .SetStreamLabelWith(m_isVeryLargeGraph ? StreamLabelWidth.EightBytes : StreamLabelWidth.FourBytes);
             SegmentedMemoryStreamWriter writer = new SegmentedMemoryStreamWriter(blobCount, settings);
 
             while (8 <= blobCount)

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher, IFastSerializable, IFastSerializableVersion
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes), 0x20000), fileName, false)
+        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes), 0x20000), fileName, false)
         {
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes).SetStreamReaderAlignment(StreamReaderAlignment.OneByte)), "stream", true)
+            : this(new PinnedStreamReader(stream, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes).WithStreamReaderAlignment(StreamReaderAlignment.OneByte)), "stream", true)
         {
         }
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher, IFastSerializable, IFastSerializableVersion
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }, 0x20000), fileName, false)
+        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes), 0x20000), fileName, false)
         {
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "stream", true)
+            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), "stream", true)
         {
         }
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher, IFastSerializable, IFastSerializableVersion
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes), 0x20000), fileName, false)
+        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes), 0x20000), fileName, false)
         {
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), "stream", true)
+            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), "stream", true)
         {
         }
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher, IFastSerializable, IFastSerializableVersion
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, 0x20000, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), fileName, false)
+        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }, 0x20000), fileName, false)
         {
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "stream", true)
+            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "stream", true)
         {
         }
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tracing
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, alignment: StreamReaderAlignment.OneByte, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), "stream", true)
+            : this(new PinnedStreamReader(stream, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes).SetStreamReaderAlignment(StreamReaderAlignment.OneByte)), "stream", true)
         {
         }
 

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -327,7 +327,7 @@ namespace TraceEventTests
         [Fact]
         public void GotoWorksForPositionsGreaterThanAlignment()
         {
-            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), bufferSize: 0x4000 /* 16KB */, alignment: StreamReaderAlignment.EightBytes))
+            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), settings: new SerializationSettings(), bufferSize: 0x4000 /* 16KB */, alignment: StreamReaderAlignment.EightBytes))
             {
                 reader.Goto((StreamLabel)0x148);
                 var buf = new byte[100_000];

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -327,7 +327,7 @@ namespace TraceEventTests
         [Fact]
         public void GotoWorksForPositionsGreaterThanAlignment()
         {
-            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), settings: SerializationSettings.Default, bufferSize: 0x4000 /* 16KB */, alignment: StreamReaderAlignment.EightBytes))
+            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), settings: SerializationSettings.Default.SetStreamReaderAlignment(StreamReaderAlignment.EightBytes), bufferSize: 0x4000 /* 16KB */))
             {
                 reader.Goto((StreamLabel)0x148);
                 var buf = new byte[100_000];

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -327,7 +327,7 @@ namespace TraceEventTests
         [Fact]
         public void GotoWorksForPositionsGreaterThanAlignment()
         {
-            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), settings: new SerializationSettings(), bufferSize: 0x4000 /* 16KB */, alignment: StreamReaderAlignment.EightBytes))
+            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), settings: SerializationSettings.Default, bufferSize: 0x4000 /* 16KB */, alignment: StreamReaderAlignment.EightBytes))
             {
                 reader.Goto((StreamLabel)0x148);
                 var buf = new byte[100_000];

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -327,7 +327,7 @@ namespace TraceEventTests
         [Fact]
         public void GotoWorksForPositionsGreaterThanAlignment()
         {
-            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), settings: SerializationSettings.Default.SetStreamReaderAlignment(StreamReaderAlignment.EightBytes), bufferSize: 0x4000 /* 16KB */))
+            using (var reader = new PinnedStreamReader(new MockHugeStream((long)uint.MaxValue + 5_000_000), settings: SerializationSettings.Default.WithStreamReaderAlignment(StreamReaderAlignment.EightBytes), bufferSize: 0x4000 /* 16KB */))
             {
                 reader.Goto((StreamLabel)0x148);
                 var buf = new byte[100_000];

--- a/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
@@ -63,7 +63,7 @@ namespace TraceEventTests
 
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
-            Serializer s = new Serializer(new IOStreamStreamWriter(ms, settings, leaveOpen:true), sample);
+            Serializer s = new Serializer(new IOStreamStreamWriter(ms, settings, leaveOpen: true), sample);
             s.Dispose();
 
             Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings), "name");

--- a/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
@@ -23,7 +23,7 @@ namespace TraceEventTests
             writer.Write((long)0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.EightBytes)), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.EightBytes)), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -42,7 +42,7 @@ namespace TraceEventTests
             writer.Write(0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -59,7 +59,7 @@ namespace TraceEventTests
         public void WriteAndParseFourByteStreamLabel()
         {
             SerializationSettings settings = SerializationSettings.Default
-                .SetStreamLabelWidth(StreamLabelWidth.FourBytes);
+                .WithStreamLabelWidth(StreamLabelWidth.FourBytes);
 
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
@@ -77,7 +77,7 @@ namespace TraceEventTests
         public void WriteAndParseEightByteStreamLabel()
         {
             SerializationSettings settings = SerializationSettings.Default
-                .SetStreamLabelWidth(StreamLabelWidth.EightBytes);
+                .WithStreamLabelWidth(StreamLabelWidth.EightBytes);
 
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
@@ -109,7 +109,7 @@ namespace TraceEventTests
         public void SuccessfullyDeserializeRegisteredType()
         {
             SerializationSettings settings = SerializationSettings.Default
-                .SetStreamLabelWidth(StreamLabelWidth.EightBytes);
+                .WithStreamLabelWidth(StreamLabelWidth.EightBytes);
 
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();

--- a/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
@@ -23,7 +23,7 @@ namespace TraceEventTests
             writer.Write((long)0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.EightBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.EightBytes)), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -42,7 +42,7 @@ namespace TraceEventTests
             writer.Write(0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -60,10 +60,10 @@ namespace TraceEventTests
         {
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
-            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen:true, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), sample);
+            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen:true, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), sample);
             s.Dispose();
 
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), "name");
             d.RegisterFactory(typeof(SampleSerializableType), () => new SampleSerializableType(0));
             SampleSerializableType serializable = (SampleSerializableType)d.ReadObject();
             Assert.Equal(SampleSerializableType.ConstantValue, serializable.BeforeValue);
@@ -75,10 +75,10 @@ namespace TraceEventTests
         {
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
-            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen: true, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.EightBytes }), sample);
+            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen: true, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.EightBytes)), sample);
             s.Dispose();
 
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.EightBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.EightBytes)), "name");
             d.RegisterFactory(typeof(SampleSerializableType), () => new SampleSerializableType(0));
             SampleSerializableType serializable = (SampleSerializableType)d.ReadObject();
             Assert.Equal(SampleSerializableType.ConstantValue, serializable.BeforeValue);

--- a/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
@@ -23,7 +23,7 @@ namespace TraceEventTests
             writer.Write((long)0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.EightBytes)), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.EightBytes)), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -42,7 +42,7 @@ namespace TraceEventTests
             writer.Write(0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWidth(StreamLabelWidth.FourBytes)), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -58,12 +58,15 @@ namespace TraceEventTests
         [Fact]
         public void WriteAndParseFourByteStreamLabel()
         {
+            SerializationSettings settings = SerializationSettings.Default
+                .SetStreamLabelWidth(StreamLabelWidth.FourBytes);
+
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
-            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen:true, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), sample);
+            Serializer s = new Serializer(new IOStreamStreamWriter(ms, settings, leaveOpen:true), sample);
             s.Dispose();
 
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.FourBytes)), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings), "name");
             d.RegisterFactory(typeof(SampleSerializableType), () => new SampleSerializableType(0));
             SampleSerializableType serializable = (SampleSerializableType)d.ReadObject();
             Assert.Equal(SampleSerializableType.ConstantValue, serializable.BeforeValue);
@@ -73,12 +76,15 @@ namespace TraceEventTests
         [Fact]
         public void WriteAndParseEightByteStreamLabel()
         {
+            SerializationSettings settings = SerializationSettings.Default
+                .SetStreamLabelWidth(StreamLabelWidth.EightBytes);
+
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
-            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen: true, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.EightBytes)), sample);
+            Serializer s = new Serializer(new IOStreamStreamWriter(ms, settings,leaveOpen: true), sample);
             s.Dispose();
 
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: SerializationSettings.Default.SetStreamLabelWith(StreamLabelWidth.EightBytes)), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings), "name");
             d.RegisterFactory(typeof(SampleSerializableType), () => new SampleSerializableType(0));
             SampleSerializableType serializable = (SampleSerializableType)d.ReadObject();
             Assert.Equal(SampleSerializableType.ConstantValue, serializable.BeforeValue);

--- a/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Serialization/FastSerializerTests.cs
@@ -23,7 +23,7 @@ namespace TraceEventTests
             writer.Write((long)0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.EightBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.EightBytes }), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -42,7 +42,7 @@ namespace TraceEventTests
             writer.Write(0xf1234567);
 
             ms.Position = 0;
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "name");
             Assert.Equal((StreamLabel)0, d.ReadLabel());
             Assert.Equal((StreamLabel)19, d.ReadLabel());
             Assert.Equal((StreamLabel)1_000_000, d.ReadLabel());
@@ -60,10 +60,10 @@ namespace TraceEventTests
         {
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
-            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen:true, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), sample);
+            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen:true, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), sample);
             s.Dispose();
 
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.FourBytes }), "name");
             d.RegisterFactory(typeof(SampleSerializableType), () => new SampleSerializableType(0));
             SampleSerializableType serializable = (SampleSerializableType)d.ReadObject();
             Assert.Equal(SampleSerializableType.ConstantValue, serializable.BeforeValue);
@@ -75,10 +75,10 @@ namespace TraceEventTests
         {
             SampleSerializableType sample = new SampleSerializableType(SampleSerializableType.ConstantValue);
             MemoryStream ms = new MemoryStream();
-            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen: true, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.EightBytes }), sample);
+            Serializer s = new Serializer(new IOStreamStreamWriter(ms, leaveOpen: true, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.EightBytes }), sample);
             s.Dispose();
 
-            Deserializer d = new Deserializer(new PinnedStreamReader(ms, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.EightBytes }), "name");
+            Deserializer d = new Deserializer(new PinnedStreamReader(ms, settings: new SerializationSettings() { StreamLabelWidth = StreamLabelWidth.EightBytes }), "name");
             d.RegisterFactory(typeof(SampleSerializableType), () => new SampleSerializableType(0));
             SampleSerializableType serializable = (SampleSerializableType)d.ReadObject();
             Assert.Equal(SampleSerializableType.ConstantValue, serializable.BeforeValue);

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3604,7 +3604,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             // As of TraceLog version 74, all StreamLabels are 64-bit.  See IFastSerializableVersion for details.
             Deserializer deserializer = new Deserializer(new PinnedStreamReader(etlxFilePath, SerializationSettings.Default, 0x10000), etlxFilePath);
-            deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
 
             // when the deserializer needs a TraceLog we return the current instance.  We also assert that
             // we only do this once.
@@ -3639,18 +3638,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 return new DynamicTraceEventData(null, 0, 0, null, Guid.Empty, 0, null, Guid.Empty, null);
             });
 
-            // when the serializer needs any TraceEventParser class, we assume that its constructor
-            // takes an argument of type TraceEventSource and that you can pass null to make an
-            // 'empty' parser to fill in with FromStream.
-            deserializer.RegisterDefaultFactory(delegate (Type typeToMake)
-            {
-                if (typeToMake.GetTypeInfo().IsSubclassOf(typeof(TraceEventParser)))
-                {
-                    return (IFastSerializable)Activator.CreateInstance(typeToMake, new object[] { null });
-                }
-
-                return null;
-            });
+            deserializer.RegisterType(typeof(KernelTraceEventParserState));
+            deserializer.RegisterType(typeof(KernelToUserDriveMapping));
+            deserializer.RegisterType(typeof(DynamicTraceEventParserState));
+            deserializer.RegisterType(typeof(ExternalTraceEventParserState));
+            deserializer.RegisterType(typeof(ClrTraceEventParserState));
+            deserializer.RegisterType(typeof(TraceCodeAddresses.ILToNativeMap));
 
             IFastSerializable entry = deserializer.GetEntryObject();
 

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3603,7 +3603,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             Debug.Assert(sizeof(TraceEventNativeMethods.EVENT_HEADER) == 0x50 && sizeof(TraceEventNativeMethods.ETW_BUFFER_CONTEXT) == 4);
 
             // As of TraceLog version 74, all StreamLabels are 64-bit.  See IFastSerializableVersion for details.
-            Deserializer deserializer = new Deserializer(new PinnedStreamReader(etlxFilePath, 0x10000), etlxFilePath);
+            Deserializer deserializer = new Deserializer(new PinnedStreamReader(etlxFilePath, new SerializationSettings(), 0x10000), etlxFilePath);
             deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
 
             // when the deserializer needs a TraceLog we return the current instance.  We also assert that

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -3603,7 +3603,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             Debug.Assert(sizeof(TraceEventNativeMethods.EVENT_HEADER) == 0x50 && sizeof(TraceEventNativeMethods.ETW_BUFFER_CONTEXT) == 4);
 
             // As of TraceLog version 74, all StreamLabels are 64-bit.  See IFastSerializableVersion for details.
-            Deserializer deserializer = new Deserializer(new PinnedStreamReader(etlxFilePath, new SerializationSettings(), 0x10000), etlxFilePath);
+            Deserializer deserializer = new Deserializer(new PinnedStreamReader(etlxFilePath, SerializationSettings.Default, 0x10000), etlxFilePath);
             deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
 
             // when the deserializer needs a TraceLog we return the current instance.  We also assert that


### PR DESCRIPTION
Implements a set of breaking changes for `FastSerialization`.

Highlights:
 - `SerializationSettings` are now required when creating a stream for use with `FastSerialization`.
 - All non-primitive types must be registered with `Deserializer` before they can be deserialized.  Failure to do so will cause the deserialization operation to fail.

More Details:
 - Rename `SerializationConfiguration` to `SerializationSettings` and make it a required parameter when creating a stream for use with `FastSerialization`.
 - Make `SerializationSettings` read-only once passed into a reader or writer implementation by cloning the object whenever a setting is changed.
 - Move `StreamReaderAlignment` from an optional parameter to reader constructors to a property on `SerializationSettings`.
 - All non-primitive types must be registered with `Deserializer` before they can be deserialized.  Failure to do so will cause the deserialization operation to fail.  Registration can occur via a call to `Deserializer.RegisterType` or `Deserializer.RegisterFactory`.
 - `Deserializer` also supports on-the-fly registration of types and factories via the `Deserializer.OnUnregisteredType` event.
 - Removed `Deserializer.RegisterDefaultFactory` and `Deserializer.TypeResolver` in favor of `Deserializer.OnUnregisteredType` which allows for type resolution and factory creation to be performed in one place instead of two.