### PR TITLE
Add win-x64 RID to HeapDump.csproj

### DIFF
--- a/src/HeapDump/HeapDump.csproj
+++ b/src/HeapDump/HeapDump.csproj
@@ -18,7 +18,7 @@
 
   <PropertyGroup>
     <!-- NuGet won't know to restore the x64 build unless we add it explicitly -->
-    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win7-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' == 'AnyCPU'">


### PR DESCRIPTION
New versions of Visual Studio fail to build `HeapDump.csproj` with the following error: 

```
"D:\a\1\s\src\HeapDump\HeapDump.csproj" (Build target) (5:3) ->
(ResolvePackageAssets target) -> 
  C:\hostedtoolcache\windows\dotnet\sdk\8.0.403\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1047: Assets file 'D:\a\1\s\src\HeapDump\obj\project.assets.json' doesn't have a target for 'net462/win-x64'. Ensure that restore has run and that you have included 'net462' in the TargetFrameworks for your project. You may also need to include 'win-x64' in your project's RuntimeIdentifiers. [D:\a\1\s\src\HeapDump\HeapDump.csproj::TargetFramework=net462]
```

If we replace `win7-x64` with `win-x64`, then the CI fails with a similar error because `win7-x64` can't be found.

To address this, we can include both RIDs.