### PR TITLE
FIX: perfcollect install script Azure Linux 3

### DIFF
--- a/src/perfcollect/perfcollect
+++ b/src/perfcollect/perfcollect
@@ -948,7 +948,7 @@ IsMariner()
     if [ -f /etc/lsb-release ]
     then
         local flavor=`cat /etc/lsb-release | grep DISTRIB_ID`
-        if [ "$flavor" == "DISTRIB_ID=\"Mariner\"" ]
+        if [ "$flavor" == "DISTRIB_ID=\"Mariner\"" ] || [ "$flavor" == "DISTRIB_ID=\"azurelinux\"" ]
         then
             mariner=1
         fi


### PR DESCRIPTION
WHY:
Azure Linux and Mariner are the same image with different branding however the `DISTRIB_ID` on Azure Linux 3.0 onwards is changed from "mariner" to "azurelinux"

FIX:
Include checking for "azurelinux" when setting the Ismariner flag.

Bug/Fix discovered with @faluciano

Fixes https://github.com/microsoft/perfview/issues/2134

![CleanShot 2024-12-03 at 19 26 11@2x](https://github.com/user-attachments/assets/2bcf4535-07e8-4c3c-aa8c-2e3684e85943)
