### PR TITLE
Update start stop activity computer to support OpenTelemetry-Sdk EventSource

### DIFF
--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -149,12 +149,6 @@ namespace Microsoft.Diagnostics.Tracing
                     }
                 }
 #endif
-                // Special case - OpenTelemetry-Sdk
-                else if (data.Opcode == TraceEventOpcode.Info && data.providerGuid == OpenTelemetrySdkProvider)
-                {
-                    FixAndProcessAzureMonitorOpenTelemetryEvents(data);
-                    return;
-                }
 
                 // TODO decide what the correct heuristic for deciding what start-stop events are interesting.  
                 // Currently I only do this for things that might be an EventSource 
@@ -182,6 +176,12 @@ namespace Microsoft.Diagnostics.Tracing
                     else if (data.Opcode == TraceEventOpcode.Info && data.ProviderGuid == AdoNetProvider)
                     {
                         FixAndProcessAdoNetEvents(data);
+                    }
+                    // Special case - OpenTelemetry-Sdk
+                    else if (data.Opcode == TraceEventOpcode.Info && data.providerGuid == OpenTelemetrySdkProvider)
+                    {
+                        FixAndProcessAzureMonitorOpenTelemetryEvents(data);
+                        return;
                     }
 
                     return;
@@ -717,7 +717,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 uint nibble = (uint)(*bytePtr >> 4);
                 bool secondNibble = false;              // are we reading the second nibble (low order bits) of the byte.
-                NextNibble:
+            NextNibble:
                 if (nibble == (uint)NumberListCodes.End)
                 {
                     break;

--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -181,7 +181,6 @@ namespace Microsoft.Diagnostics.Tracing
                     else if (data.Opcode == TraceEventOpcode.Info && data.providerGuid == OpenTelemetrySdkProvider)
                     {
                         FixAndProcessAzureMonitorOpenTelemetryEvents(data);
-                        return;
                     }
 
                     return;

--- a/src/TraceEvent/Computers/StartStopActivityComputer.cs
+++ b/src/TraceEvent/Computers/StartStopActivityComputer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Diagnostics.Tracing
                     // Special case - OpenTelemetry-Sdk
                     else if (data.Opcode == TraceEventOpcode.Info && data.providerGuid == OpenTelemetrySdkProvider)
                     {
-                        FixAndProcessAzureMonitorOpenTelemetryEvents(data);
+                        FixAndProcessOpenTelemetrySdkEvents(data);
                     }
 
                     return;
@@ -1138,7 +1138,7 @@ namespace Microsoft.Diagnostics.Tracing
             return false;
         }
 
-        private void FixAndProcessAzureMonitorOpenTelemetryEvents(TraceEvent data)
+        private void FixAndProcessOpenTelemetrySdkEvents(TraceEvent data)
         {
             Debug.Assert(data.ProviderGuid == OpenTelemetrySdkProvider);
             if (data.EventName == "ActivityStarted")


### PR DESCRIPTION
### Description

The OpenTelemetry SDK event source is emitting request start/stop information, but the format differs from what TraceEvent expects for start/stop operations. This mismatch prevents proper recognition of activities in the CallTree view.

This change introduces an exception to accommodate the OpenTelemetry SDK’s event format, ensuring that start/stop activities are correctly recognized and displayed in the CallTree view.

**Details:**  
For reference, see the implementation in the OpenTelemetry SDK:  
[OpenTelemetrySdkEventSource.cs](https://github.com/ualehosaini/opentelemetry-dotnet/blob/1e89b39d72236285081c727956439af6715ab782/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs)

**Before the change:**
![image](https://github.com/user-attachments/assets/8d381b7f-c8e2-4707-b51a-dbc623e4927e)

**After the change:**
![image](https://github.com/user-attachments/assets/96f53316-d8d2-4411-9d67-5e9107416747)

Tagging @brianrob for awareness.