### PR TITLE
Added missing time info fields in the Raw XML View in GCStats

### DIFF
--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -561,37 +561,37 @@ namespace Stats
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkHandles]);
                             }
 
-                            writer.Write(" MarkSizedRef =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSizedRef]);
+                            writer.Write("\" MarkSizedRef =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSizedRef]);
                             if (mt.MarkPromoted != null)
                             {
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkSizedRef]);
                             }
 
-                            writer.Write(" MarkOverflow =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkOverflow]);
+                            writer.Write("\" MarkOverflow =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkOverflow]);
                             if (mt.MarkPromoted != null)
                             {
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkOverflow]);
                             }
 
-                            writer.Write(" MarkDependentHandles =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkDependentHandles]);
+                            writer.Write("\" MarkDependentHandles =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkDependentHandles]);
                             if (mt.MarkPromoted != null)
                             {
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkDependentHandles]);
                             }
 
-                            writer.Write(" MarkNewFQ =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkNewFQ]);
+                            writer.Write("\" MarkNewFQ =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkNewFQ]);
                             if (mt.MarkPromoted != null)
                             {
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkNewFQ]);
                             }
 
-                            writer.Write(" MarkSteal =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSteal]);
+                            writer.Write("\" MarkSteal =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSteal]);
                             if (mt.MarkPromoted != null)
                             {
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkSteal]);
                             }
 
-                            writer.Write(" MarkBGCRoots =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkBGCRoots]);
+                            writer.Write("\" MarkBGCRoots =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkBGCRoots]);
                             if (mt.MarkPromoted != null)
                             {
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkBGCRoots]);
@@ -607,14 +607,6 @@ namespace Stats
                                 }
 
                                 writer.Write("\"");
-                            }
-                            if (mt.MarkTimes[(int)MarkRootType.MarkOverflow] != 0.0)
-                            {
-                                writer.Write(" MarkOverflow =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkOverflow]);
-                                if (mt.MarkPromoted != null)
-                                {
-                                    writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkOverflow]);
-                                }
                             }
                         }
                         if (gc.LOHCompactInfos.Count > 0)

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -515,6 +515,7 @@ namespace Stats
                 {
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkRoot].HasValue) { writer.Write(" MarkRoot=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkRoot].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkScanFinalization].HasValue) { writer.Write(" MarkScanFinalization=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkScanFinalization].Value); }
+                    if (gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].HasValue) { writer.Write(" MarkShortWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkLongWeak].HasValue) { writer.Write(" MarkLongWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkLongWeak].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Plan].HasValue) { writer.Write(" Plan=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Plan].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Relocate].HasValue) { writer.Write(" Relocate=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Relocate].Value); }
@@ -558,6 +559,42 @@ namespace Stats
                             if (mt.MarkPromoted != null)
                             {
                                 writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkHandles]);
+                            }
+
+                            writer.Write(" MarkSizedRef =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSizedRef]);
+                            if (mt.MarkPromoted != null)
+                            {
+                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkSizedRef]);
+                            }
+
+                            writer.Write(" MarkOverflow =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkOverflow]);
+                            if (mt.MarkPromoted != null)
+                            {
+                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkOverflow]);
+                            }
+
+                            writer.Write(" MarkDependentHandles =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkDependentHandles]);
+                            if (mt.MarkPromoted != null)
+                            {
+                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkDependentHandles]);
+                            }
+
+                            writer.Write(" MarkNewFQ =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkNewFQ]);
+                            if (mt.MarkPromoted != null)
+                            {
+                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkNewFQ]);
+                            }
+
+                            writer.Write(" MarkSteal =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSteal]);
+                            if (mt.MarkPromoted != null)
+                            {
+                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkSteal]);
+                            }
+
+                            writer.Write(" MarkBGCRoots =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkBGCRoots]);
+                            if (mt.MarkPromoted != null)
+                            {
+                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkBGCRoots]);
                             }
 
                             writer.Write("\"");

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -543,69 +543,48 @@ namespace Stats
 
                         if (mt != null)
                         {
-                            writer.Write(" MarkStack =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkStack]);
-                            if (mt.MarkPromoted != null)
+                            void WriteDetailsAboutMarkRootType(MarkRootType type)
                             {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkStack]);
-                            }
-
-                            writer.Write("\" MarkFQ =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkFQ]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkFQ]);
-                            }
-
-                            writer.Write("\" MarkHandles =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkHandles]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkHandles]);
-                            }
-
-                            writer.Write("\" MarkSizedRef =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSizedRef]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkSizedRef]);
-                            }
-
-                            writer.Write("\" MarkOverflow =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkOverflow]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkOverflow]);
-                            }
-
-                            writer.Write("\" MarkDependentHandles =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkDependentHandles]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkDependentHandles]);
-                            }
-
-                            writer.Write("\" MarkNewFQ =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkNewFQ]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkNewFQ]);
-                            }
-
-                            writer.Write("\" MarkSteal =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkSteal]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkSteal]);
-                            }
-
-                            writer.Write("\" MarkBGCRoots =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkBGCRoots]);
-                            if (mt.MarkPromoted != null)
-                            {
-                                writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkBGCRoots]);
-                            }
-
-                            writer.Write("\"");
-                            if (gc.Generation != 2)
-                            {
-                                writer.Write(" MarkOldGen =\"{0:n3}", mt.MarkTimes[(int)MarkRootType.MarkOlder]);
+                                writer.Write(" {0}=\"{1:n3}", type, mt.MarkTimes[(int)type]);
                                 if (mt.MarkPromoted != null)
                                 {
-                                    writer.Write("({0})", mt.MarkPromoted[(int)MarkRootType.MarkOlder]);
+                                    writer.Write("({0})", mt.MarkPromoted[(int)type]);
                                 }
+                                writer.Write("\"");
+                            }
 
+                            WriteDetailsAboutMarkRootType(MarkRootType.MarkStack);
+                            WriteDetailsAboutMarkRootType(MarkRootType.MarkFQ);
+                            WriteDetailsAboutMarkRootType(MarkRootType.MarkHandles);
+
+                            // Condition:  if ((condemned_gen_number == max_generation) && (num_sizedrefs > 0))
+                            if (gc.Generation == 2)
+                            {
+                                WriteDetailsAboutMarkRootType(MarkRootType.MarkSizedRef);
+                            }
+
+                            WriteDetailsAboutMarkRootType(MarkRootType.MarkOverflow);
+                            WriteDetailsAboutMarkRootType(MarkRootType.MarkDependentHandles);
+                            WriteDetailsAboutMarkRootType(MarkRootType.MarkNewFQ);
+
+                            // Condition: if (do_mark_steal_p)
+                            // if (full_p && total_heap_size > (100 * 1024 * 1024))
+                            if (gc.Generation == 2)
+                            {
+                                WriteDetailsAboutMarkRootType(MarkRootType.MarkSteal);
+                            }
+
+                            // Condition: if (gc_heap::background_running_p())
+                            if (gc.Type == GCType.BackgroundGC || gc.Type == GCType.ForegroundGC)
+                            {
+                                WriteDetailsAboutMarkRootType(MarkRootType.MarkBGCRoots);
+                            }
+
+                            // Condition: if !Gen2
+                            if (gc.Generation != 2)
+                            {
+                                writer.Write("\"");
+                                WriteDetailsAboutMarkRootType(MarkRootType.MarkOlder);
                                 writer.Write("\"");
                             }
                         }


### PR DESCRIPTION
Updated the following in the Raw XML View in GCStats:

1. Added the `MarkShortWeak` entry to the GlobalHeapHistory node that was missing.
2.  Added the `MarkSizedRef`, `MarkOverflow`, `MarkDependentHandles`, `MarkNewFQ`, `MarkSteal` and `MarkBGCRoots` entries to the PerHeapHistory node.