### PR TITLE
Set the timestamp as a QPC value based on UTC time

### DIFF
--- a/src/TraceEvent/ETWReloggerTraceEventSource.cs
+++ b/src/TraceEvent/ETWReloggerTraceEventSource.cs
@@ -157,7 +157,14 @@ namespace Microsoft.Diagnostics.Tracing
                 newEvent.SetEventDescriptor(ref *ptrDescr);
                 newEvent.SetProviderId(ref providerId);
                 _LARGE_INTEGER fileTimeStamp = new _LARGE_INTEGER();
-                fileTimeStamp.QuadPart = timeStamp.ToFileTimeUtc();
+                if (DateTimeKind.Utc != timeStamp.Kind)
+                {
+                    fileTimeStamp.QuadPart = UTCDateTimeToQPC(timeStamp.ToUniversalTime());
+                }
+                else
+                {
+                    fileTimeStamp.QuadPart = UTCDateTimeToQPC(timeStamp);
+                }
                 newEvent.SetTimeStamp(ref fileTimeStamp);
                 newEvent.SetProcessId((uint)processId);
                 newEvent.SetProcessorIndex((uint)processorIndex);

--- a/src/TraceEvent/ETWReloggerTraceEventSource.cs
+++ b/src/TraceEvent/ETWReloggerTraceEventSource.cs
@@ -156,16 +156,16 @@ namespace Microsoft.Diagnostics.Tracing
 
                 newEvent.SetEventDescriptor(ref *ptrDescr);
                 newEvent.SetProviderId(ref providerId);
-                _LARGE_INTEGER fileTimeStamp = new _LARGE_INTEGER();
+                _LARGE_INTEGER qpcTimeStamp = new _LARGE_INTEGER();
                 if (DateTimeKind.Utc != timeStamp.Kind)
                 {
-                    fileTimeStamp.QuadPart = UTCDateTimeToQPC(timeStamp.ToUniversalTime());
+                    qpcTimeStamp.QuadPart = UTCDateTimeToQPC(timeStamp.ToUniversalTime());
                 }
                 else
                 {
-                    fileTimeStamp.QuadPart = UTCDateTimeToQPC(timeStamp);
+                    qpcTimeStamp.QuadPart = UTCDateTimeToQPC(timeStamp);
                 }
-                newEvent.SetTimeStamp(ref fileTimeStamp);
+                newEvent.SetTimeStamp(ref qpcTimeStamp);
                 newEvent.SetProcessId((uint)processId);
                 newEvent.SetProcessorIndex((uint)processorIndex);
                 newEvent.SetThreadId((uint)threadID);


### PR DESCRIPTION
When using relogger to writes an event that did not exist previously into the data stream, the context data and timestamp is given explicitly.  The newEvent.SetTimeStamp expects a QPC time based on UTC time.