### PR TITLE
Implement Stale PR Handling and Update Stale Issue Handling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,20 +1,7 @@
 name: 'Stale: Label and Close Issues'
 on:
   schedule:
-    - cron: '23 2,14 * * *' # Twice daily at 19 minutes after the hour (random/uncommon time)
-
-  workflow_dispatch:
-    # Manual triggering through the GitHub UI, API, or CLI
-    inputs:
-      daysBeforeStale:
-        required: true
-        default: "365"
-      daysBeforeClose:
-        required: true
-        default: "30"
-      operationsPerRun:
-        required: true
-        default: "4000"
+    - cron: '23 2,14 * * *' # Twice daily at 23 minutes after the hour (random/uncommon time)
 
 permissions:
   actions: write # For managing the operation state cache
@@ -32,8 +19,10 @@ jobs:
           stale-issue-label: 'stale'
           stale-issue-message: "Due to lack of recent activity, this issue has been labeled as 'stale'. It will be closed if no further activity occurs within 30 more days. Any new comment will remove the label."
           close-issue-message: "This issue will now be closed since it has been labeled 'stale' without activity for 30 days."
-          days-before-stale: ${{ fromJson(inputs.daysBeforeStale || 2192) }} # Default to 6 years if not specified as input
-          days-before-close: ${{ fromJson(inputs.daysBeforeClose || 30  ) }} # Default to 30 days if not specified as input
-          days-before-pr-stale: -1 # Do not label PRs as 'stale'
-          days-before-pr-close: -1 # Do not close PRs labeled as 'stale'
-          operations-per-run: ${{ fromJson(inputs.operationsPerRun || 4000 )}}
+          stale-pr-message: "Due to lack of recent activity, this PR has been labeled as 'stale'. It will be closed if no further activity occurs within 7 more days. Any new comment will remove the label."
+          close-pr-message: "This PR will now be closed since it has been labeled 'stale' without activity for 30 days."
+          days-before-stale: 2192 # 6 years
+          days-before-close: 30
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          operations-per-run: 4000


### PR DESCRIPTION
Use actions/stale to perform the following actions twice daily:

 - Mark PRs that haven't been touched for 30 days as stale.
 - Close PRs that have been marked stale for 7 days without an update.

Update stale issue handling:
 - Mark issues that haven't been touched in 6 years as stale (increased from 1 year).
 - Remove inputs section and directly specify values, as the inputs section was not being properly referenced and default values were being used.