### PR TITLE
Fix IndexOutOfRangeException when we iterate over all the Generations and try to access GenData

### DIFF
--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -2946,7 +2946,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         // Per generation stats.
         internal static double GetGenSizeBeforeMB(List<TraceGC> GCs, TraceGC gc, Gens gen)
         {
-            if (gc.PerHeapHistories != null && gc.PerHeapHistories.Count > 0 && gc.PerHeapHistories[0].GenData.Length > (int)gen)
+            if (ValidGenData(gc.PerHeapHistories, gen))
             {
                 double ret = 0.0;
                 for (int HeapIndex = 0; HeapIndex < gc.PerHeapHistories.Count; HeapIndex++)
@@ -3101,7 +3101,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
                 {
                     // If the prevous GC has that heap get its size.
                     var perHeapGenData = GCs[gc.Index - 1].PerHeapHistories;
-                    if (perHeapGenData?.Count > 0 && HeapIndex < perHeapGenData.Count && perHeapGenData[HeapIndex].GenData.Length > (int)gen)
+                    if (ValidGenData(perHeapGenData, gen))
                     {
                         return perHeapGenData[HeapIndex].GenData[(int)gen].Budget;
                     }

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -15,7 +15,6 @@ using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using Microsoft.Diagnostics.Tracing.Parsers.Symbol;
 using Microsoft.Diagnostics.Tracing.Stacks;
 using Microsoft.Diagnostics.Utilities;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -3040,7 +3039,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
             Debug.Assert(HeapIndex < gc.PerHeapHistories.Count);
 
             // If the gen data isn't available for the specific PerHeapHistory, we can't calculate.
-            if (ValidGenData(gc.PerHeapHistories, gen) == false)
+            if (!ValidGenData(gc.PerHeapHistories, gen))
             {
                 return 0;
             }

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -3039,12 +3039,18 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         {
             Debug.Assert(HeapIndex < gc.PerHeapHistories.Count);
 
+            // If the gen data isn't available for the specific PerHeapHistory, we can't calculate.
+            if (ValidGenData(gc.PerHeapHistories, gen) == false)
+            {
+                return 0;
+            }
+
             long prevObjSize = 0;
             if (gc.Index > 0)
             {
                 // If the previous GC has that heap get its size.
                 var perHeapGenData = GCs[gc.Index - 1].PerHeapHistories;
-                if (perHeapGenData?.Count > 0 && HeapIndex < perHeapGenData.Count && perHeapGenData[0].GenData.Length > (int)gen)
+                if (perHeapGenData?.Count > 0 && HeapIndex < perHeapGenData.Count)
                 {
                     prevObjSize = perHeapGenData[HeapIndex].GenData[(int)gen].ObjSizeAfter;
                     // Note that for gen3 or gen4 we need to do something extra as its after data may not be updated if the last

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -1979,7 +1979,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
         /// Amount of memory allocated since last GC.  Requires GCAllocationTicks enabled.  The
         /// data is split into small and large heaps
         /// </summary>
-        public double[] AllocedSinceLastGCBasedOnAllocTickMB = { 0.0, 0.0 };// Set in HeapStats
+        public double[] AllocedSinceLastGCBasedOnAllocTickMB = { 0.0, 0.0, 0.0 };// Set in HeapStats
         /// <summary>
         /// Number of heaps.  -1 is the default
         /// </summary>


### PR DESCRIPTION
This PR fixes cases where we are accessing GenData for cases where certain generations e.g., POH don't exist.

CC: @Maoni0 

Tested:

1. On a trace with no POH allocations.
2. On a trace with POH allocations.
3. On a trace from .NET Framework.