### PR TITLE
[WIP] Adding OOM Diagnostics to GCStats

### DIFF
--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -597,7 +597,6 @@ namespace Stats
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkScanFinalization].HasValue) { writer.Write(" MarkScanFinalization=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkScanFinalization].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].HasValue) { writer.Write(" MarkShortWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkLongWeak].HasValue) { writer.Write(" MarkLongWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkLongWeak].Value); }
-                    if (gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].HasValue) { writer.Write(" MarkShortWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Plan].HasValue) { writer.Write(" Plan=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Plan].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Relocate].HasValue) { writer.Write(" Relocate=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Relocate].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Compact].HasValue) { writer.Write(" Compact=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Compact].Value); }

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -6,14 +6,11 @@ using Microsoft.Diagnostics.Tracing.Parsers.GCDynamic;
 using Microsoft.Diagnostics.Utilities;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Net.Http.Headers;
 using System.Security;
 using System.Text;
 using System.Threading;
-using System.Windows.Forms;
 using Utilities;
 
 namespace Stats
@@ -288,7 +285,7 @@ namespace Stats
                         $"<TD Align=\"Center\">{InterpretOOMReason(oomDetails.Reason)}</TD>" +
                         $"<TD Align=\"Center\">{InterpretFailureGetMemory(oomDetails.FailureToGetMemory)}</TD>" +
                         $"<TD Align=\"Center\">{oomDetails.IsLOH}</TD>" +
-                        $"<TD Align=\"Center\">{oomDetails.AvailablePageFileMB}</TD>" +
+                        $"<TD Align=\"Center\">{oomDetails.AvailablePageFileMB.ToString("N0")}</TD>" +
                         $"<TD Align=\"Center\">{oomDetails.MemoryLoad}</TD>" +
                         "</TR>");
                 }

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -517,6 +517,7 @@ namespace Stats
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkScanFinalization].HasValue) { writer.Write(" MarkScanFinalization=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkScanFinalization].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].HasValue) { writer.Write(" MarkShortWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.MarkLongWeak].HasValue) { writer.Write(" MarkLongWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkLongWeak].Value); }
+                    if (gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].HasValue) { writer.Write(" MarkShortWeak=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.MarkShortWeak].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Plan].HasValue) { writer.Write(" Plan=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Plan].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Relocate].HasValue) { writer.Write(" Relocate=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Relocate].Value); }
                     if (gc.TimingInfo[(int)TraceGC.TimingType.Compact].HasValue) { writer.Write(" Compact=\"{0}\"", gc.TimingInfo[(int)TraceGC.TimingType.Compact].Value); }

--- a/src/TraceEvent/Computers/TraceManagedProcess.cs
+++ b/src/TraceEvent/Computers/TraceManagedProcess.cs
@@ -5007,7 +5007,7 @@ namespace Microsoft.Diagnostics.Tracing.Analysis.GC
             _event.OOMDetails.Add(new OOMDetails
             {
                 GCIndex = oomDetailsTrace.GCIndex,
-                Allocated = oomDetailsTrace.Allocated,
+                //Allocated = oomDetailsTrace.Allocated,
                 Size = oomDetailsTrace.Size,
             });
         }

--- a/src/TraceEvent/Parsers/GCDynamicTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/GCDynamicTraceEventParser.cs
@@ -365,15 +365,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
     public sealed class OOMDetailsTraceEvent : GCDynamicEventBase
     {
         public short Version { get { return BitConverter.ToInt16(DataField, 0); } }
-        public ulong GCIndex { get { return BitConverter.ToUInt64(DataField, 2); } }
-        public ushort Allocated { get { return BitConverter.ToUInt16(DataField, 10); } }
-        public ushort Reserved { get { return BitConverter.ToUInt16(DataField, 12); } }
-        public ulong AllocSize { get { return BitConverter.ToUInt64(DataField, 14); } }
-        public ushort Reason { get { return BitConverter.ToUInt16(DataField, 22); } }
-        public ushort FailToGetMemory { get { return BitConverter.ToUInt16(DataField, 24); } }
-        public ulong Size { get { return BitConverter.ToUInt16(DataField, 26); } }
-        public ushort IsLOH { get { return BitConverter.ToUInt16(DataField, 34); } }
-        public uint MemoryLoad { get { return BitConverter.ToUInt16(DataField, 36); } }
+        public long GCIndex { get { return BitConverter.ToInt64(DataField, 2); } }
+        public long AllocSize { get { return BitConverter.ToInt64(DataField, 10); } }
+        public short Reason { get { return BitConverter.ToInt16(DataField, 18); } }
+        public short FailToGetMemory { get { return BitConverter.ToInt16(DataField, 20); } }
+        public long Size { get { return BitConverter.ToInt64(DataField, 22); } }
+        public short IsLOH { get { return BitConverter.ToInt16(DataField, 30); } }
+        public int MemoryLoad { get { return BitConverter.ToInt32(DataField, 32); } }
+        public long AvailablePageFileMB { get { return BitConverter.ToInt64(DataField, 36); } }
 
         internal override TraceEventID ID => TraceEventID.Illegal - 12;
 
@@ -390,7 +389,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
             {
                 if (_payloadNames == null)
                 {
-                    _payloadNames = new string[] { "Version", "GCIndex", "Allocated", "Reserved", "AllocSize", "Reason", "FailToGetMemory", "Size", "IsLOH", "MemoryLoad", "AvailablePageFileMB" };
+                    _payloadNames = new string[] { "Version", "GCIndex", "AllocSize", "Reason", "FailToGetMemory", "Size", "IsLOH", "MemoryLoad", "AvailablePageFileMB" };
                 }
 
                 return _payloadNames;
@@ -403,15 +402,13 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
             {
                 yield return new KeyValuePair<string, object>("Version", Version);
                 yield return new KeyValuePair<string, object>("GCIndex", GCIndex);
-                yield return new KeyValuePair<string, object>("Allocated", Allocated);
-                yield return new KeyValuePair<string, object>("Reserved", Reserved);
                 yield return new KeyValuePair<string, object>("AllocSize", AllocSize);
                 yield return new KeyValuePair<string, object>("Reason", Reason);
                 yield return new KeyValuePair<string, object>("FailToGetMemory", FailToGetMemory);
                 yield return new KeyValuePair<string, object>("Size", Size);
                 yield return new KeyValuePair<string, object>("IsLOH", IsLOH);
                 yield return new KeyValuePair<string, object>("MemoryLoad", MemoryLoad);
-                yield return new KeyValuePair<string, object>("AvailablePageFileMB", MemoryLoad);
+                yield return new KeyValuePair<string, object>("AvailablePageFileMB", AvailablePageFileMB);
             }
         }
 
@@ -424,21 +421,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
                 case 1:
                     return GCIndex;
                 case 2:
-                    return Allocated;
-                case 3:
-                    return Reserved;
-                case 4:
                     return AllocSize;
-                case 5:
+                case 3:
                     return Reason;
-                case 6:
+                case 4:
                     return FailToGetMemory;
-                case 7:
+                case 5:
                     return Size;
-                case 8:
+                case 6:
                     return IsLOH;
-                case 9:
+                case 7:
                     return MemoryLoad;
+                case 8:
+                    return AvailablePageFileMB;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
@@ -448,15 +443,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
 
     public sealed class OOMDetails
     {
-        public ulong GCIndex { get; internal set; }
-        public ushort Allocated { get; internal set; }
-        public ushort Reserved { get; internal set; }
-        public ulong AllocSize { get; internal set; }
-        public ushort Reason { get; internal set; }
-        public ushort FailToGetMemory { get; internal set; }
-        public ulong Size { get; internal set; }
-        public ushort IsLOH { get; internal set; }
-        public uint MemoryLoad { get; internal set; }
+        public long GCIndex { get; internal set; }
+        public long AllocSize { get; internal set; }
+        public short Reason { get; internal set; }
+        public short FailToGetMemory { get; internal set; }
+        public long Size { get; internal set; }
+        public short IsLOH { get; internal set; }
+        public int MemoryLoad { get; internal set; }
+        public long AvailablePageFileMB { get; internal set; }
     }
 
     public sealed class CommittedUsageTraceEvent : GCDynamicEventBase

--- a/src/TraceEvent/Parsers/GCDynamicTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/GCDynamicTraceEventParser.cs
@@ -368,11 +368,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
         public long GCIndex { get { return BitConverter.ToInt64(DataField, 2); } }
         public long AllocSize { get { return BitConverter.ToInt64(DataField, 10); } }
         public short Reason { get { return BitConverter.ToInt16(DataField, 18); } }
-        public short FailToGetMemory { get { return BitConverter.ToInt16(DataField, 20); } }
+        public short FailureGetMemory { get { return BitConverter.ToInt16(DataField, 20); } }
         public long Size { get { return BitConverter.ToInt64(DataField, 22); } }
-        public short IsLOH { get { return BitConverter.ToInt16(DataField, 30); } }
-        public int MemoryLoad { get { return BitConverter.ToInt32(DataField, 32); } }
-        public long AvailablePageFileMB { get { return BitConverter.ToInt64(DataField, 36); } }
+        public bool IsLOH { get { return BitConverter.ToBoolean(DataField, 30); } }
+        public int MemoryLoad { get { return BitConverter.ToInt32(DataField, 31); } }
+        public long AvailablePageFileMB { get { return BitConverter.ToInt64(DataField, 35); } }
 
         internal override TraceEventID ID => TraceEventID.Illegal - 12;
 
@@ -389,7 +389,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
             {
                 if (_payloadNames == null)
                 {
-                    _payloadNames = new string[] { "Version", "GCIndex", "AllocSize", "Reason", "FailToGetMemory", "Size", "IsLOH", "MemoryLoad", "AvailablePageFileMB" };
+                    _payloadNames = new string[] { "Version", "GCIndex", "AllocSize", "Reason", "FailureGetMemory", "Size", "IsLOH", "MemoryLoad", "AvailablePageFileMB" };
                 }
 
                 return _payloadNames;
@@ -404,7 +404,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
                 yield return new KeyValuePair<string, object>("GCIndex", GCIndex);
                 yield return new KeyValuePair<string, object>("AllocSize", AllocSize);
                 yield return new KeyValuePair<string, object>("Reason", Reason);
-                yield return new KeyValuePair<string, object>("FailToGetMemory", FailToGetMemory);
+                yield return new KeyValuePair<string, object>("FailureGetMemory", FailureGetMemory);
                 yield return new KeyValuePair<string, object>("Size", Size);
                 yield return new KeyValuePair<string, object>("IsLOH", IsLOH);
                 yield return new KeyValuePair<string, object>("MemoryLoad", MemoryLoad);
@@ -425,7 +425,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
                 case 3:
                     return Reason;
                 case 4:
-                    return FailToGetMemory;
+                    return FailureGetMemory;
                 case 5:
                     return Size;
                 case 6:
@@ -441,14 +441,36 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
         }
     }
 
+    public enum FailureGetMemory
+    {
+        NoFailure = 0,
+        ReserveSegment = 1,
+        CommitSegmentBeg = 2,
+        CommitEphSegment = 3,
+        GrowTable = 4,
+        CommitTable = 5,
+        CommitHeap = 6
+    };
+
+    public enum OOMReason
+    {
+        NoFailure = 0,
+        Budget = 1,
+        CantCommit = 2,
+        CantReserve = 3,
+        LOH = 4,
+        LowMemory = 5,
+        UnproductiveFullGC = 6
+    }
+
     public sealed class OOMDetails
     {
         public long GCIndex { get; internal set; }
         public long AllocSize { get; internal set; }
-        public short Reason { get; internal set; }
-        public short FailToGetMemory { get; internal set; }
+        public OOMReason Reason { get; internal set; }
+        public FailureGetMemory FailureToGetMemory { get; internal set; }
         public long Size { get; internal set; }
-        public short IsLOH { get; internal set; }
+        public bool IsLOH { get; internal set; }
         public int MemoryLoad { get; internal set; }
         public long AvailablePageFileMB { get; internal set; }
     }

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -2972,6 +2972,7 @@ namespace Microsoft.Diagnostics.Tracing
             if (string.Equals(GetType().Name, nameof(GCDynamicTraceEventParser), StringComparison.OrdinalIgnoreCase))
             {
                 declaredSet.Remove("CommittedUsage");
+                declaredSet.Remove("OOMDetails");
             }
 
             var enumSet = new SortedDictionary<string, string>();
@@ -3682,7 +3683,8 @@ namespace Microsoft.Diagnostics.Tracing
                             // Make sure that the assert below doesn't fail by checking if _any_ of the event header ids match.
                             bool gcDynamicTemplateEventHeaderMatch =
                                  eventRecord->EventHeader.Id == (ushort)GCDynamicEventBase.GCDynamicTemplate.ID ||
-                                 eventRecord->EventHeader.Id == (ushort)GCDynamicEventBase.CommittedUsageTemplate.ID;
+                                 eventRecord->EventHeader.Id == (ushort)GCDynamicEventBase.CommittedUsageTemplate.ID ||
+                                 eventRecord->EventHeader.Id == (ushort)GCDynamicEventBase.OOMDetailsTemplate.ID;
 
                             // Ignore the failure for GC dynamic events because they are all
                             // dispatched through the same template and we vary the event ID.


### PR DESCRIPTION
This PR adds a separate section for OOM details emitted as a dynamic event from the runtime. 

Example of the details (if an OOM exists in the trace) in GCStats:
![image](https://github.com/user-attachments/assets/56b0afee-38c3-45af-8a11-003b219f3224)

Interpretation of the Dynamic Event in the Events View:
![image](https://github.com/user-attachments/assets/f41dd6f3-2f35-4a11-8796-5c4ead4eb205)