### PR TITLE
feat: allow setting rundown providers for realtime EventPipe Tracelog

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -256,6 +256,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 return new EventPipeRundownConfiguration(client);
             }
 
+            /// <summary>
+            /// Adds a provider to use when initializing the rundown session.
+            /// The first call resets the list, removing the default provider (CLR).
+            /// You can use this if you need to tune the event level, keywords, etc.
+            /// </summary>
             public void AddProvider(EventPipeProvider provider)
             {
                 if (m_providers == null)

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -235,10 +235,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             internal readonly DiagnosticsClient m_client;
             internal List<EventPipeProvider> m_providers;
 
-            private EventPipeRundownConfiguration(DiagnosticsClient client)
-            {
-                m_client = client;
-            }
+            private EventPipeRundownConfiguration(DiagnosticsClient client) { m_client = client; }
 
             /// <summary>
             /// No rundown will be requested, thus it may be impossible to symbolicate events. This is OK, if you don't

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             public static EventPipeRundownConfiguration Enable(DiagnosticsClient client, IEnumerable<EventPipeProvider> providers = null)
             {
                 if (providers == null)
-            {
+                {
                     providers = new[]{
                         new EventPipeProvider(ClrTraceEventParser.ProviderName, EventLevel.Informational, (long)ClrTraceEventParser.Keywords.Default)
                     };


### PR DESCRIPTION
Allows consumers of realtime session to configure providers for rundown, same way they do for actual session.