### PR TITLE
Further accessibility fixes

### DIFF
--- a/src/PerfView/Dialogs/FileInputAndOutput.xaml
+++ b/src/PerfView/Dialogs/FileInputAndOutput.xaml
@@ -56,7 +56,7 @@
 
         <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" FlowDirection="RightToLeft">
             <Button Margin="10,5,10,5" Width="80" Content="OK" Click="OKClicked"/>
-            <Button Margin="10,5,10,5" KeyboardNavigation.IsTabStop="False" Width="80" Content="Cancel" Click="CancelClicked"/>
+            <Button Margin="10,5,10,5" Width="80" Content="Cancel" Click="CancelClicked"/>
         </StackPanel>
     </Grid>
 </src:WindowBase>

--- a/src/PerfView/Dialogs/ManagePresetsDialog.xaml
+++ b/src/PerfView/Dialogs/ManagePresetsDialog.xaml
@@ -53,7 +53,7 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="Preset" KeyboardNavigation.IsTabStop="False">Name:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="Preset">Name:</Hyperlink>
                 </TextBlock>
                 <TextBox Grid.Row="0" Grid.Column="1" Name="PresetName" Margin="10,2,10,2" HorizontalScrollBarVisibility="Hidden">
                     <TextBox.ToolTip>
@@ -66,7 +66,7 @@
                 </TextBox>
 
                 <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="GroupPatsTextBox" KeyboardNavigation.IsTabStop="False">GroupPats:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="GroupPatsTextBox">GroupPats:</Hyperlink>
                 </TextBlock>
                 <TextBox Grid.Row="1" Grid.Column="1" Name="GroupPatsTextBox" Margin="10,2,10,2" HorizontalScrollBarVisibility="Hidden">
                     <TextBox.ToolTip>
@@ -83,7 +83,7 @@
                     </TextBox.ToolTip>
                 </TextBox>
                 <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
-                <Hyperlink Command="Help" CommandParameter="FoldPercentTextBox" KeyboardNavigation.IsTabStop="False">Fold%:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="FoldPercentTextBox">Fold%:</Hyperlink>
                 </TextBlock>
                 <TextBox Name="FoldPercentTextBox" Grid.Row="2" Grid.Column="1" Margin="10,2,10,2" HorizontalScrollBarVisibility="Hidden">
                     <TextBox.ToolTip>
@@ -94,7 +94,7 @@
                     </TextBox.ToolTip>
                 </TextBox>
                 <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
-                <Hyperlink Command="Help" CommandParameter="FoldPatsTextBox" KeyboardNavigation.IsTabStop="False">FoldPats:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="FoldPatsTextBox">FoldPats:</Hyperlink>
                 </TextBlock>
                 <TextBox Name="FoldRegExTextBox" Grid.Row="3" Grid.Column="1" MinWidth="80" Margin="10,2,10,2" HorizontalScrollBarVisibility="Hidden">
                     <TextBox.ToolTip>
@@ -107,7 +107,7 @@
                     </TextBox.ToolTip>
                 </TextBox>
                 <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Top" Margin="5,0,1,0">
-                <Hyperlink Command="Help" CommandParameter="Preset" KeyboardNavigation.IsTabStop="False">Comment:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="Preset">Comment:</Hyperlink>
                 </TextBlock>
                 <TextBox Name="CommentTextBox" Grid.Row="4" Grid.Column="1"  MinWidth="80" Margin="10,2,10,2" HorizontalScrollBarVisibility="Hidden" TextWrapping="Wrap" AcceptsReturn="True" Height="72">
                     <TextBox.ToolTip>

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml
@@ -5,7 +5,7 @@
         Style="{DynamicResource CustomWindowStyle}"
         Background="{StaticResource ControlDarkerBackground}"
         Title="Collecting Memory Data"
-        Width="900" MinWidth="500" Height="400">
+        Width="900" MinWidth="500" Height="400" MinHeight="400">
     <Window.CommandBindings>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp"/>
     </Window.CommandBindings>
@@ -13,7 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="100*"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -41,7 +41,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="100*"/>
             </Grid.ColumnDefinitions>
-            <TextBlock  Grid.Column="0"  Margin="5,0" Width="100" VerticalAlignment="Center" ToolTip="The file name of the process dump file from which to extract the GC heap.">
+            <TextBlock  Grid.Column="0"  Margin="5,0" VerticalAlignment="Center" ToolTip="The file name of the process dump file from which to extract the GC heap.">
                 <Hyperlink Command="Help" CommandParameter="ProcessDumpTextBox">Process Dump File:</Hyperlink>
             </TextBlock>
             <TextBox  Margin="0,5,5,0" Grid.Column="1" Name="ProcessDumpTextBox" VerticalAlignment="Center" KeyDown="ProcessDumpKeyDown" AutomationProperties.Name="Process Dump File"  />
@@ -51,7 +51,7 @@
         <Grid Grid.Row="2" Name="ProcessRow">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="100*"/>
+                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Grid Grid.Row="0" Margin="0,5,0,0">
                 <Grid.ColumnDefinitions>
@@ -72,18 +72,21 @@
                 </TextBlock>
                 <CheckBox Grid.Column="3" Name="AllProcsCheckBox" VerticalAlignment="Center"  IsChecked="true" Click="AllProcsClick" AutomationProperties.Name="All Processes" />
 
-                <TextBlock Grid.Column="4" Margin="15,0,0,0" VerticalAlignment="Center" Name="ElevateWarning">
-                    Only Processes you have perission to inspect to are shown.
+                <TextBlock Grid.Column="4" Margin="15,0,0,0" VerticalAlignment="Center" Name="ElevateWarning" TextWrapping="Wrap">
+                    Only Processes you have permission to inspect to are shown.
                     <Hyperlink Click="ElevateToAdminClick">Elevate to Admin</Hyperlink> to see all processes.
                 </TextBlock>
             </Grid>
-            <ListBox Margin="5,28,5,12" MinHeight="80" Name="Processes" MouseDoubleClick="ProcessesMouseDoubleClick" SelectionChanged="Processes_SelectionChanged" FontFamily="Courier New" Grid.RowSpan="2" AutomationProperties.Name="Processes">
-                <ListBox.ItemContainerStyle>
-                    <Style TargetType="ListBoxItem">
-                        <Setter Property="AutomationProperties.Name" Value="{Binding ShortDescription}" />
-                    </Style>
-                </ListBox.ItemContainerStyle>
-            </ListBox>
+            <Grid Margin="5,11,5,12" Grid.Row="1" VerticalAlignment="Stretch">
+                <ListBox Name="Processes" MouseDoubleClick="ProcessesMouseDoubleClick" SelectionChanged="Processes_SelectionChanged" FontFamily="Courier New" AutomationProperties.Name="Processes"
+                    Height="{Binding Path=ActualHeight, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Grid}}">
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="ListBoxItem">
+                            <Setter Property="AutomationProperties.Name" Value="{Binding ShortDescription}" />
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                </ListBox>
+            </Grid>
         </Grid>
 
         <!-- Output Data file row -->
@@ -94,7 +97,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock  Grid.Column="0" Width="100" Margin="5,0" VerticalAlignment="Center" ToolTip="The name of the data file to create." >
+            <TextBlock  Grid.Column="0" Margin="5,0" VerticalAlignment="Center" ToolTip="The name of the data file to create." >
                 <Hyperlink Command="Help" CommandParameter="GCHeapDataFileNameTextBox">Output Data File:</Hyperlink>
             </TextBlock>
             <TextBox Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" AutomationProperties.Name="Output Data Filename" />
@@ -105,52 +108,49 @@
         <!-- Row with FreezeProcess ... -->
         <Grid Grid.Row="4"  Margin="0,2,0,-1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="1*"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-
-            <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="5,0,5,0" ToolTip="If the heap has more object than this (in Kilo objects) than this, only a sample is taken." >
+            <WrapPanel Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If object count exceeds this (in thousands), old events are discarded.">
                         <Hyperlink Command="Help" CommandParameter="MaxDumpTextBox">Max Dump<LineBreak/>K Objs:</Hyperlink>
-            </TextBlock>
-            <TextBox Grid.Column="2" Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0" AutomationProperties.Name="Maximum dump size in kilo objects"/>
+                    </TextBlock>
+                    <TextBox Name="MaxDumpTextBox" VerticalAlignment="Center" Width="50" Margin="5,0" AutomationProperties.Name="Max Dump K Objs"/>
+                </StackPanel>
 
-            <TextBlock Grid.Column="3" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked the process will be frozen during the dump.">
-                    <Hyperlink Command="Help" CommandParameter="FreezeCheckBox">Freeze:</Hyperlink>
-            </TextBlock>
-            <CheckBox Grid.Column="4" Name="FreezeCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" AutomationProperties.Name="Freeze"/>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked, freezes the process during the collection.">
+                        <Hyperlink Command="Help" CommandParameter="FreezeCheckBox">Freeze:</Hyperlink>
+                    </TextBlock>
+                    <CheckBox Name="FreezeCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" AutomationProperties.Name="Freeze"/>
+                </StackPanel>
 
-            <!-- TODO FIX NOW Add DumpData back in.
-            <TextBlock Grid.Column="5" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked the data in objects as well as the connectivity information is dumped.">
-            <Hyperlink Command="Help" CommandParameter="DumpDataCheckBox">Dump<LineBreak/>Data:</Hyperlink>
-            </TextBlock>
-            <CheckBox Grid.Column="6" Name="DumpDataCheckBox" VerticalAlignment="Center" Margin="0,0,10,0"/>
-            -->
+                <!-- TODO FIX NOW Add DumpData back in.
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked will dump additional data." >
+                        <Hyperlink Command="Help" CommandParameter="DumpDataCheckBox">Dump Data:</Hyperlink>
+                    </TextBlock>
+                    <CheckBox Name="DumpDataCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" AutomationProperties.Name="Dump Data"/>
+                </StackPanel>
+                -->
 
-            <TextBlock Grid.Column="7" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked Dump will be in Clr Profiler format.">
-                <Hyperlink Command="Help" CommandParameter="SaveETLCheckBox">Save<LineBreak/>ETL:</Hyperlink>
-            </TextBlock>
-            <CheckBox Grid.Column="8" Name="SaveETLCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" AutomationProperties.Name="Save ETL"/>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked Dump will be in Clr Profiler format.">
+                        <Hyperlink Command="Help" CommandParameter="SaveETLCheckBox">Save<LineBreak/>ETL:</Hyperlink>
+                    </TextBlock>
+                    <CheckBox Name="SaveETLCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" AutomationProperties.Name="Save ETL"/>
+                </StackPanel>
+            </WrapPanel>
 
-            <Button Name="GCButton" Grid.Column="12" Margin="5,0,20,5" Width="60" VerticalAlignment="Center"  Click="GCButtonClick"
-                    ToolTip="Causes a GC to happen in the selected process">Force GC</Button>
-            <Button Grid.Column="13" Margin="5,0,5,5" Width="100" VerticalAlignment="Center"  Click="DumpClick" IsDefault="True"
-                    ToolTip="Take a Heap Snapshot of the selected process leaving the dialog box open.  Double Click will close after dump." >Dump GC Heap</Button>
-            <Button Grid.Column="14" Margin="5,0,5,5" Width="50" VerticalAlignment="Center"  Click="CloseClick" >Close</Button>
+            <WrapPanel Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center">
+                <Button Name="GCButton" Margin="5,0,20,5" VerticalAlignment="Center" Click="GCButtonClick" 
+                        ToolTip="Causes a GC to happen in the selected process">Force GC</Button>
+                <Button Margin="5,0,5,5" VerticalAlignment="Center" Click="DumpClick" IsDefault="True" 
+                        ToolTip="Take a Heap Snapshot of the selected process leaving the dialog box open. Double Click will close after dump.">Dump GC Heap</Button>
+                <Button Margin="5,0,5,5" VerticalAlignment="Center" Click="CloseClick">Close</Button>
+            </WrapPanel>
         </Grid>
 
         <Rectangle Grid.Row="5" Fill="#FF727171"  Margin="0,8,0,0" Height="1"/>

--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml
@@ -25,7 +25,7 @@
             <RichTextBox.Document>
                 <FlowDocument>
                     <Paragraph>
-                        This dialog give options for collecting Memory (GC Heap) data.   Typically simply typing a few characters
+                        This dialog gives options for collecting Memory (GC Heap) data.   Typically simply typing a few characters
                         of the process name in the Filter text box and hitting &lt;Enter&gt; is enough.  See
                         <Hyperlink Command="Help" CommandParameter="CollectingDataGCHeap">Collecting GC Heap Data.</Hyperlink> and
                         <Hyperlink Command="Help" CommandParameter="UnderstandingPerfDataGCHeap">Understanding GC Heap Data.</Hyperlink>
@@ -65,7 +65,7 @@
                 <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Only processes that match this RegEx filter pattern are displayed.">
                     <Hyperlink Command="Help" CommandParameter="ProcessFilterTextBox">Filter:</Hyperlink>
                 </TextBlock>
-                <TextBox KeyboardNavigation.TabIndex="0" VerticalAlignment="Center" Grid.Column="1" Width="100" Margin="5,0,0,0"  Name="FilterTextBox" TextChanged="FilterTextChanged" PreviewKeyDown="FilterTextKeyDown" AutomationProperties.Name="Process Filter"/>
+                <TextBox VerticalAlignment="Center" Grid.Column="1" Width="100" Margin="5,0,0,0"  Name="FilterTextBox" TextChanged="FilterTextChanged" PreviewKeyDown="FilterTextKeyDown" AutomationProperties.Name="Process Filter"/>
 
                 <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Normally only processed with GC heaps are displayed.  Checking this shows all processes.">
                     <Hyperlink Command="Help" CommandParameter="AllProcsCheckBox">All Procs:</Hyperlink>
@@ -77,7 +77,7 @@
                     <Hyperlink Click="ElevateToAdminClick">Elevate to Admin</Hyperlink> to see all processes.
                 </TextBlock>
             </Grid>
-            <ListBox KeyboardNavigation.TabIndex="1" Margin="5,28,5,12" MinHeight="80" Name="Processes" MouseDoubleClick="ProcessesMouseDoubleClick" SelectionChanged="Processes_SelectionChanged" FontFamily="Courier New" Grid.RowSpan="2" AutomationProperties.Name="Processes">
+            <ListBox Margin="5,28,5,12" MinHeight="80" Name="Processes" MouseDoubleClick="ProcessesMouseDoubleClick" SelectionChanged="Processes_SelectionChanged" FontFamily="Courier New" Grid.RowSpan="2" AutomationProperties.Name="Processes">
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
                         <Setter Property="AutomationProperties.Name" Value="{Binding ShortDescription}" />

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -42,14 +42,14 @@
             </RichTextBox.Document>
         </RichTextBox>
         <!-- CommandToRun section for running specific process -->
-        <TextBlock Grid.Row="1" Grid.Column="0" x:Name="CommandToRunLabel" Margin="5,0" VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False" ToolTip="The command line of the process to run while collecting data.">
+        <TextBlock Grid.Row="1" Grid.Column="0" x:Name="CommandToRunLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="The command line of the process to run while collecting data.">
                 <Hyperlink Command="Help" CommandParameter="CommandToRunTextBox">Command:</Hyperlink>
         </TextBlock>
         <controls:HistoryComboBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="CommandToRunTextBox" VerticalAlignment="Center" KeyDown="CommandToRunKeyDown" AutomationProperties.Name="Command to run" />
 
         <!-- FocusProcess section for Collect command-->
         <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
-            <TextBlock Name="FocusProcessLabel" Margin="5,0" VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False" ToolTip="Name or PID of the process to collect user-mode events for.">
+            <TextBlock Name="FocusProcessLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="Name or PID of the process to collect user-mode events for.">
                 <Hyperlink Command="Help" CommandParameter="FocusProcessTextBox">Focus process:</Hyperlink>
             </TextBlock>
             <CheckBox Name="FocusProcessCheckBox" VerticalAlignment="Center" Margin="1,2,2,0" Click="FocusProcessCheckBoxClicked" IsChecked="false" AutomationProperties.Name="Focus process" />
@@ -57,14 +57,14 @@
         <TextBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="FocusProcessTextBox" VerticalAlignment="Center" />
 
         <!-- Data file name row -->
-        <TextBlock Grid.Row="2" Grid.Column="0" Margin="5,0" VerticalAlignment="Center" KeyboardNavigation.IsTabStop="False" ToolTip="The name of the data file to create." >
+        <TextBlock Grid.Row="2" Grid.Column="0" Margin="5,0" VerticalAlignment="Center" ToolTip="The name of the data file to create." >
             <Hyperlink Command="Help" CommandParameter="DataFileNameTextBox">Data File:</Hyperlink>
         </TextBlock>
         <TextBox  Grid.Row="2" Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" AutomationProperties.Name="Data File" />
         <Button Grid.Row="2" Grid.Column="2" Content="..."  Width="25" Margin="5,5"
                 VerticalAlignment="Center" Click="DataFileButtonClick" ToolTip="Click to select the file name in a file chooser dialog." />
 
-        <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0" KeyboardNavigation.IsTabStop="False" ToolTip="The directory in which the command is run.">
+        <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0" ToolTip="The directory in which the command is run.">
                 <Hyperlink Command="Help" CommandParameter="CurrentDirTextBox">Current Dir:</Hyperlink>
         </TextBlock>
         <TextBox  Grid.Row="3" Grid.Column="1"  Name="CurrentDirTextBox" VerticalAlignment="Center" AutomationProperties.Name="Current Directory" />
@@ -89,29 +89,29 @@
                 <ColumnDefinition Width="auto"/>
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="Use this option if you wish to analyze on another machine.">
+            <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="Use this option if you wish to analyze on another machine.">
                 <Hyperlink Command="Help" CommandParameter="ZipCheckBox">Zip:</Hyperlink>
             </TextBlock>
             <CheckBox Grid.Column="1" Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" AutomationProperties.Name="Zip" />
 
-            <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="After this size (in megabytes) old events are thown away to keep file size under control" >
+            <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="After this size (in megabytes) old events are thown away to keep file size under control" >
                         <Hyperlink Command="Help" CommandParameter="CircularTextBox">Circular<LineBreak/>MB:</Hyperlink>
             </TextBlock>
 
             <TextBox Grid.Column="3" Name="CircularTextBox" VerticalAlignment="Center" Width="35" Margin="5,0" AutomationProperties.Name="Circular Buffer Size in Megabytes"/>
 
-            <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="If checked will merge data into a single file, implied by Zip.">
+            <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked will merge data into a single file, implied by Zip.">
                 <Hyperlink Command="Help" CommandParameter="MergeCheckBox">Merge:</Hyperlink>
             </TextBlock>
             <CheckBox Grid.Column="5" Name="MergeCheckBox" VerticalAlignment="Center" Click="MergeCheckBoxClicked" Margin="0,0,10,0" AutomationProperties.Name="Merge"/>
 
-            <TextBlock  Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2" KeyboardNavigation.IsTabStop="False"
+            <TextBlock  Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                                ToolTip="Needed for Thread Time views.  Fire an event (and stack trace) every time the processor switch from one thread to another." >
                     <Hyperlink Command="Help" CommandParameter="ThreadTimeCheckbox">Thread<LineBreak/>Time:</Hyperlink>
             </TextBlock>
             <CheckBox Grid.Column="7" Name="ThreadTimeCheckbox" VerticalAlignment="Center" AutomationProperties.Name="Thread Time" />
 
-            <TextBlock Grid.Column="8" VerticalAlignment="Center" Margin="5,0,2,0" KeyboardNavigation.IsTabStop="False" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed." >
+            <TextBlock Grid.Column="8" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed." >
                 <Hyperlink Command="Help" CommandParameter="MarkTextBox">Mark Text:</Hyperlink>
             </TextBlock>
             <TextBox Grid.Column="9" Name="MarkTextBox" VerticalAlignment="Center" Width="150" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
@@ -407,7 +407,7 @@
                             ToolTip="Click to browse the available ETW providers."/>
                     <TextBlock  Grid.Column="3" Margin="2,0,10,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12
                                 ">
-                        <Hyperlink Command="Help" CommandParameter="ProviderBrowser">?</Hyperlink>
+                        <Hyperlink Command="Help" CommandParameter="ProviderBrowser" AutomationProperties.Name="Help with Provider Browser">?</Hyperlink>
                     </TextBlock>
                 </Grid>
 

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -6,507 +6,494 @@
         Style="{DynamicResource CustomWindowStyle}"
         Background="{StaticResource ControlDarkerBackground}"
         Title="Collecting ETW Data while running a command"
-        Height="304" Width="900" MinHeight="210" MinWidth="900">
+        Height="304" Width="950" MinHeight="210" MinWidth="950">
     <Window.CommandBindings>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp" />
     </Window.CommandBindings>
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="100*"/>
-            <RowDefinition Height="100*"/>
-            <RowDefinition Height="100*"/>
-            <RowDefinition Height="100*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="auto"/>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="auto"/>
-        </Grid.ColumnDefinitions>
-        <!-- Help message at top -->
-        <RichTextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True" AutomationProperties.Name="Run collection help">
-            <RichTextBox.Document>
-                <FlowDocument>
-                    <Paragraph Margin="0,0,0,0">
-                        This dialog give displays options for collecting ETW profile data.   The only required field the 'Command' field and
-                        this is only necessary when using the 'Run' command.
-                    </Paragraph>
-                    <Paragraph Margin="0,0,0,0">
-                        <Bold>If you wish to analyze on another machine use the Zip option when collecting data.</Bold>
-                        See
-                        <Hyperlink Command="Help" CommandParameter="CollectingData">Collecting ETW Profile Data.</Hyperlink> for more.
-                    </Paragraph>
-                </FlowDocument>
-            </RichTextBox.Document>
-        </RichTextBox>
-        <!-- CommandToRun section for running specific process -->
-        <TextBlock Grid.Row="1" Grid.Column="0" x:Name="CommandToRunLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="The command line of the process to run while collecting data.">
-                <Hyperlink Command="Help" CommandParameter="CommandToRunTextBox">Command:</Hyperlink>
-        </TextBlock>
-        <controls:HistoryComboBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="CommandToRunTextBox" VerticalAlignment="Center" KeyDown="CommandToRunKeyDown" AutomationProperties.Name="Command to run" />
-
-        <!-- FocusProcess section for Collect command-->
-        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
-            <TextBlock Name="FocusProcessLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="Name or PID of the process to collect user-mode events for.">
-                <Hyperlink Command="Help" CommandParameter="FocusProcessTextBox">Focus process:</Hyperlink>
-            </TextBlock>
-            <CheckBox Name="FocusProcessCheckBox" VerticalAlignment="Center" Margin="1,2,2,0" Click="FocusProcessCheckBoxClicked" IsChecked="false" AutomationProperties.Name="Focus process" />
-        </StackPanel>
-        <TextBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="FocusProcessTextBox" VerticalAlignment="Center" />
-
-        <!-- Data file name row -->
-        <TextBlock Grid.Row="2" Grid.Column="0" Margin="5,0" VerticalAlignment="Center" ToolTip="The name of the data file to create." >
-            <Hyperlink Command="Help" CommandParameter="DataFileNameTextBox">Data File:</Hyperlink>
-        </TextBlock>
-        <TextBox  Grid.Row="2" Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" AutomationProperties.Name="Data File" />
-        <Button Grid.Row="2" Grid.Column="2" Content="..."  Width="25" Margin="5,5"
-                VerticalAlignment="Center" Click="DataFileButtonClick" ToolTip="Click to select the file name in a file chooser dialog." />
-
-        <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0" ToolTip="The directory in which the command is run.">
-                <Hyperlink Command="Help" CommandParameter="CurrentDirTextBox">Current Dir:</Hyperlink>
-        </TextBlock>
-        <TextBox  Grid.Row="3" Grid.Column="1"  Name="CurrentDirTextBox" VerticalAlignment="Center" AutomationProperties.Name="Current Directory" />
-
-        <!-- Row with Merge, run button cancel ... -->
-        <Grid Grid.Row="4" Grid.ColumnSpan="3" Margin="0,2,0,-1">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="1*"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
-                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="Use this option if you wish to analyze on another machine.">
+            <!-- Help message at top -->
+            <RichTextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True" AutomationProperties.Name="Run collection help">
+                <RichTextBox.Document>
+                    <FlowDocument>
+                        <Paragraph Margin="0,0,0,0">
+                            This dialog give options for collecting ETW profile data.   The only required field the 'Command' field and
+                    this is only necessary when using the 'Run' command.
+                        </Paragraph>
+                        <Paragraph Margin="0,0,0,0">
+                            <Bold>If you wish to analyze on another machine use the Zip option when collecting data.</Bold>
+                            See
+                            <Hyperlink Command="Help" CommandParameter="CollectingData">Collecting ETW Profile Data.</Hyperlink> for more.
+                        </Paragraph>
+                    </FlowDocument>
+                </RichTextBox.Document>
+            </RichTextBox>
+            <!-- CommandToRun section for running specific process -->
+            <TextBlock Grid.Row="1" Grid.Column="0" x:Name="CommandToRunLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="The command line of the process to run while collecting data.">
+            <Hyperlink Command="Help" CommandParameter="CommandToRunTextBox">Command:</Hyperlink>
+            </TextBlock>
+            <controls:HistoryComboBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="CommandToRunTextBox" VerticalAlignment="Center" KeyDown="CommandToRunKeyDown" AutomationProperties.Name="Command to run" />
+
+            <!-- FocusProcess section for Collect command-->
+            <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
+                <TextBlock Name="FocusProcessLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="Name or PID of the process to collect user-mode events for.">
+            <Hyperlink Command="Help" CommandParameter="FocusProcessTextBox">Focus process:</Hyperlink>
+                </TextBlock>
+                <CheckBox Name="FocusProcessCheckBox" VerticalAlignment="Center" Margin="1,2,2,0" Click="FocusProcessCheckBoxClicked" IsChecked="false" AutomationProperties.Name="Focus process" />
+            </StackPanel>
+            <TextBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="FocusProcessTextBox" VerticalAlignment="Center" />
+
+            <!-- Data file name row -->
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="5,0" VerticalAlignment="Center" ToolTip="The name of the data file to create." >
+        <Hyperlink Command="Help" CommandParameter="DataFileNameTextBox">Data File:</Hyperlink>
+            </TextBlock>
+            <TextBox  Grid.Row="2" Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" AutomationProperties.Name="Data File" />
+            <Button Grid.Row="2" Grid.Column="2" Content="..."  Width="25" Margin="5,5"
+            VerticalAlignment="Center" Click="DataFileButtonClick" ToolTip="Click to select the file name in a file chooser dialog." />
+
+            <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0" ToolTip="The directory in which the command is run.">
+            <Hyperlink Command="Help" CommandParameter="CurrentDirTextBox">Current Dir:</Hyperlink>
+            </TextBlock>
+            <TextBox  Grid.Row="3" Grid.Column="1"  Name="CurrentDirTextBox" VerticalAlignment="Center" AutomationProperties.Name="Current Directory" />
+
+            <!-- Row with Merge, run button cancel ... -->
+            <Grid Grid.Row="4" Grid.ColumnSpan="3" Margin="0,2,0,-1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="18*"/>
+                    <ColumnDefinition Width="11*"/>
+                </Grid.ColumnDefinitions>
+                <WrapPanel Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center">
+
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="Use this option if you wish to analyze on another machine.">
                 <Hyperlink Command="Help" CommandParameter="ZipCheckBox">Zip:</Hyperlink>
-            </TextBlock>
-            <CheckBox Grid.Column="1" Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" AutomationProperties.Name="Zip" />
+                    </TextBlock>
+                    <CheckBox Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" AutomationProperties.Name="Zip" />
 
-            <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="After this size (in megabytes) old events are thown away to keep file size under control" >
-                        <Hyperlink Command="Help" CommandParameter="CircularTextBox">Circular<LineBreak/>MB:</Hyperlink>
-            </TextBlock>
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="After this size (in megabytes) old events are thrown away to keep file size under control">
+                <Hyperlink Command="Help" CommandParameter="CircularTextBox">Circular<LineBreak/>MB:</Hyperlink>
+                    </TextBlock>
+                    <TextBox Name="CircularTextBox" VerticalAlignment="Center" Width="35" Margin="5,0" AutomationProperties.Name="Circular Buffer Size in Megabytes"/>
 
-            <TextBox Grid.Column="3" Name="CircularTextBox" VerticalAlignment="Center" Width="35" Margin="5,0" AutomationProperties.Name="Circular Buffer Size in Megabytes"/>
-
-            <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked will merge data into a single file, implied by Zip.">
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked will merge data into a single file, implied by Zip.">
                 <Hyperlink Command="Help" CommandParameter="MergeCheckBox">Merge:</Hyperlink>
-            </TextBlock>
-            <CheckBox Grid.Column="5" Name="MergeCheckBox" VerticalAlignment="Center" Click="MergeCheckBoxClicked" Margin="0,0,10,0" AutomationProperties.Name="Merge"/>
+                    </TextBlock>
+                    <CheckBox Name="MergeCheckBox" VerticalAlignment="Center" Click="MergeCheckBoxClicked" Margin="0,0,10,0" AutomationProperties.Name="Merge"/>
 
-            <TextBlock  Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Needed for Thread Time views.  Fire an event (and stack trace) every time the processor switch from one thread to another." >
-                    <Hyperlink Command="Help" CommandParameter="ThreadTimeCheckbox">Thread<LineBreak/>Time:</Hyperlink>
-            </TextBlock>
-            <CheckBox Grid.Column="7" Name="ThreadTimeCheckbox" VerticalAlignment="Center" AutomationProperties.Name="Thread Time" />
+                    <TextBlock VerticalAlignment="Center" Margin="8,2,5,2" ToolTip="Needed for Thread Time views. Fire an event (and stack trace) every time the processor switches from one thread to another.">
+                <Hyperlink Command="Help" CommandParameter="ThreadTimeCheckbox">Thread<LineBreak/>Time:</Hyperlink>
+                    </TextBlock>
+                    <CheckBox Name="ThreadTimeCheckbox" VerticalAlignment="Center" AutomationProperties.Name="Thread Time" />
 
-            <TextBlock Grid.Column="8" VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed." >
+                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed.">
                 <Hyperlink Command="Help" CommandParameter="MarkTextBox">Mark Text:</Hyperlink>
-            </TextBlock>
-            <TextBox Grid.Column="9" Name="MarkTextBox" VerticalAlignment="Center" Width="150" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
-            <Button Name="MarkButton" Grid.Column="10" Margin="5,0" Padding="5,1" Width="auto" VerticalAlignment="Center"
-                    ToolTip="Click this button to enter a mark event into the data collected."
-                    Click="MarkButtonClick">Mark</Button>
-
-            <Button Name="CopyCommandLineButton" Grid.Column="12" Margin="5,0" Padding="5,1" Width="auto" VerticalAlignment="Center"  Click="CopyCommandLineButtonClick" IsDefault="True">Copy Command Line</Button>
-            <Button Name="OKButton" Grid.Column="13" Margin="5,0" Padding="5,1" Width="auto" VerticalAlignment="Center"  Click="OKButtonClick" IsDefault="True">Run Command</Button>
-            <Button Name="LogButton" Grid.Column="14" Margin="5,0" Padding="5,1" Width="auto" VerticalAlignment="Center"  Click="LogButtonClick" IsCancel="True">Log</Button>
-            <Button Name="CancelButton" Grid.Column="15" Margin="5,0" Padding="5,1" Width="auto" VerticalAlignment="Center"  Click="CancelButtonClick" IsCancel="True">Cancel</Button>
-        </Grid>
-
-        <TextBlock Grid.Row="5" Grid.Column="0" Margin="5,0" HorizontalAlignment="Right" VerticalAlignment="Center" Text="Status:" />
-
-        <TextBox Grid.Row="5" Grid.Column="1" Name="StatusTextBox"  Grid.ColumnSpan="2"  Margin="5,0,5,0" VerticalAlignment="Center" IsEnabled="false"
-                     Text="Enter a command to run." ToolTip="Status information."/>
-
-        <Expander Grid.Row="6" Header="Advanced Options" Grid.ColumnSpan="3" Expanded="DoExpand" Collapsed="DoCollapsed">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="100*"/>
-                    <RowDefinition Height="100*"/>
-                    <RowDefinition Height="100*"/>
-                    <RowDefinition Height="100*"/>
-                    <RowDefinition Height="100*"/>  <!-- Row 4 Additional Providers -->
-                    <RowDefinition Height="100*"/>
-                    <RowDefinition Height="100*"/>
-                    <RowDefinition Height="100*"/>
-                </Grid.RowDefinitions>
-
-                <!-- Check boxes for individual kernel events -->
-                <Grid Grid.Row="0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="20*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="5,2,5,2"
-                               ToolTip="Fire an event (and stack trace) every time the processor switch from one thread to another." >
-                        <Hyperlink Command="Help" CommandParameter="KernelBaseCheckBox">Kernel Base:</Hyperlink>
                     </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="KernelBaseCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Kernel Base"/>
+                    <TextBox Name="MarkTextBox" VerticalAlignment="Center" Width="150" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
 
-                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Fire an event after every time a small amount (typicaly 1MSec) of CPU is consumed." >
-                        <Hyperlink Command="Help" CommandParameter="CpuSamplesCheckBox">Cpu Samples:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="CpuSamplesCheckBox" VerticalAlignment="Center" AutomationProperties.Name="CPU Samples"/>
+                    <Button Name="MarkButton" Margin="5,0" Padding="5,1" VerticalAlignment="Center" Click="MarkButtonClick">Mark</Button>
+                </WrapPanel>
 
-                    <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Fire an event (and stack trace) on page faults and other virtual memory transitions." >
-                    <Hyperlink Command="Help" CommandParameter="MemoryCheckBox">Page Faults:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="5" Name="MemoryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Page Faults" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Fire an event (and a stack trace) when various file operations occur (even if the disk is not accessed)." >
-                    <Hyperlink Command="Help" CommandParameter="FileIOCheckBox">File I/O:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="7" Name="FileIOCheckBox" VerticalAlignment="Center" AutomationProperties.Name="File I/O" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Fire an event (and a stack trace) when various registry operations occur." >
-                    <Hyperlink Command="Help" CommandParameter="RegistryCheckBox">Registry:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="9" Name="RegistryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Registry"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Fire an event (and a stack trace) when low level VirtualAlloc VirtualFree calls are made." >
-                    <Hyperlink Command="Help" CommandParameter="VirtualAllocCheckBox">VirtAlloc:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="11" Name="VirtualAllocCheckBox" VerticalAlignment="Center" AutomationProperties.Name="VirtualAlloc"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Fire an event every half second to monitor memory stats for each process on the system.." >
-                    <Hyperlink Command="Help" CommandParameter="MemInfoCheckBox">MemInfo:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="13" Name="MemInfoCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Memory Info"/>
-                </Grid>
-
-                <!-- Check boxes for more kernel events -->
-                <Grid Grid.Row="1">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="92*"/>
-                        <ColumnDefinition Width="13*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="104*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="21*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
-                               ToolTip="Collect information about creation and closing of Windows OS handles." >
-                    <Hyperlink Command="Help" CommandParameter="HandleCheckBox">Handle:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="HandleCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Handle"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Collect detailed information on memory usage of all processes." >
-                    <Hyperlink Command="Help" CommandParameter="RefSetCheckBox">RefSet:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="RefSetCheckBox" VerticalAlignment="Center" AutomationProperties.Name="RefSet"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Collect detailed information Internet Information Services (IIS)" >
-                    <Hyperlink Command="Help" CommandParameter="IISCheckBox">IIS:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="5" Name="IISCheckBox" VerticalAlignment="Center" AutomationProperties.Name="IIS"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
-                               ToolTip="Collect a _Netmon.etl file that can be used with NetMon.  Also implies NetCap." >
-                    <Hyperlink Command="Help" CommandParameter="NetMonCheckBox">NetMon:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Column="7" Name="NetMonCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="NetMon"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
-                               ToolTip="Capture the full payload of all network packets that enter or leave the machine." Grid.ColumnSpan="2">
-                    <Hyperlink Command="Help" CommandParameter="NetCaptureCheckBox">Net Capture:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Column="10" Name="NetCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Net Capture" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="11" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
-                               ToolTip="Capture events from the Task Parallel Library." >
-                    <Hyperlink Command="Help" CommandParameter="TplCaptureCheckBox">Tasks (TPL):</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Column="12" Name="TplCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Tasks (TPL)" />
-
-                    <CheckBox Grid.Row="0" Grid.Column="14" Name="Box7" VerticalAlignment="Center" Visibility="Hidden" Margin="0,2" />
-                </Grid>
-
-                <!-- Check boxes for clr events -->
-                <Grid Grid.Row="2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="20*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="These are the default .NET runtime events.  They should usually be left on." >
-                    <Hyperlink Command="Help" CommandParameter="ClrCheckBox">.NET :</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="ClrCheckBox" AutomationProperties.Name=".NET" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Turn on logging of the .NET STress log, which logs unusual events that help track down random failure." >
-                    <Hyperlink Command="Help" CommandParameter="StressCheckBox">.NET Stress:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="StressCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Stress" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Turn on events associated with background JIT compilation." >
-                    <Hyperlink Command="Help" CommandParameter="BackgroundJITCheckBox">Background JIT:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="5" Name="BackgroundJITCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Background JIT" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Log an event every time a method is called (expensive!)." >
-                    <Hyperlink Command="Help" CommandParameter="DotNetCallsCheckBox">.NET Calls:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetCallsCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Calls"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Log information about successful and failed inlining attempts." >
-                    <Hyperlink Command="Help" CommandParameter="JITInliningCheckBox">JIT Inlining:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="9" Name="JITInliningCheckBox" VerticalAlignment="Center" AutomationProperties.Name="JIT Inlining"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                                ToolTip="Log information about .NET Native CCW Ref Counting.">
-                     <Hyperlink Command="Help" CommandParameter="CCWRefCountCheckBox"> .NET Native CCW:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="11" Name="CCWRefCountCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Native CCW"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Log extended information about .NET Runtime loading including R2R and type load events." >
-                    <Hyperlink Command="Help" CommandParameter="RuntimeLoadingCheckBox">.NET Loader:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="13" Name="RuntimeLoadingCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Loader" />
-                </Grid>
-
-                <!-- Check boxes for more clr events (GC Heap related) -->
-                <Grid Grid.Row="3">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="92*"/>
-                        <ColumnDefinition Width="13*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="105*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="104*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="21*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
-                               ToolTip="Turn off everything except events which happen when .NET Garbage Collections happen." >
-                    <Hyperlink Command="Help" CommandParameter="GCCollectOnlyCheckBox">GC Collect Only:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="1" Name="GCCollectOnlyCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="GC Collect Only" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,4,2"
-                               ToolTip="Turn off everything except events needed to trace .NET GC heap allocations." >
-                    <Hyperlink Command="Help" CommandParameter="GCOnlyCheckBox">GC Only:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="3" Name="GCOnlyCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="GC Only"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
-                               ToolTip="Fire an event whenever a .NET object is allocated capturing its stack." >
-                    <Hyperlink Command="Help" CommandParameter="DotNetAllocCheckBox">.NET Alloc:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Column="5" Name="DotNetAllocCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name=".NET Alloc" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
-                               ToolTip="Do smart sampling which aggressive trims commonly allocated types, and rare time not at all." >
-                    <Hyperlink Command="Help" CommandParameter="DotNetAllocSampledCheckBox">.NET SampAlloc:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name=".NET Sample Alloc" />
-
-                    <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="16.2,2,0,2"
-                               ToolTip="Do smart sampling which aggressive trims commonly allocated types, and rare time not at all." Grid.ColumnSpan="2" >
-                    <Hyperlink Command="Help" CommandParameter="ETWDotNetAllocSampledCheckBox">ETW .NET Alloc:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="10" Name="ETWDotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="ETW .NET Alloc"/>
-
-                    <TextBlock Grid.Row="0" Grid.Column="11" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
-                               ToolTip="Collect a heap snapshot prior to stopping collection." >
-                    <Hyperlink Command="Help" CommandParameter="HeapSnapshotCheckBox">Dump Heap:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Row="0" Grid.Column="12" Name="HeapSnapshotCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Dump Heap"/>
-
-                    <CheckBox Grid.Row="0" Grid.Column="14" VerticalAlignment="Center" Visibility="Hidden" Margin="0,2" />
-                </Grid>
-
-                <!-- Additional Providers -->
-                <Grid Grid.Row="4" Margin="0,2,0,2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="5,2,0,2"
-                               ToolTip="A comma separated list of additional providers to turn on during data collection." >
-                    <Hyperlink Command="Help" CommandParameter="AdditionalProvidersTextBox">Additional Providers:</Hyperlink>
-                    </TextBlock>
-                    <controls:HistoryComboBox  x:Name="AdditionalProvidersTextBox" Grid.Column="1" Margin="2,2,5,2" AutomationProperties.Name="Additional Providers" />
-                    <Button Grid.Column="2" Margin="0,2,5,2" Content=" Provider Browser " Click="ProviderBrowserButtonClick"
-                            ToolTip="Click to browse the available ETW providers."/>
-                    <TextBlock  Grid.Column="3" Margin="2,0,10,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12
-                                ">
-                        <Hyperlink Command="Help" CommandParameter="ProviderBrowser" AutomationProperties.Name="Help with Provider Browser">?</Hyperlink>
-                    </TextBlock>
-                </Grid>
-
-                <!-- CPU Sample interval CPU Ctrs, OS Heap stuff -->
-                <Grid Grid.Row="5" Margin="0,2,0,2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0"
-                               ToolTip="The number of MSec between CPU samples when sample profiling.   Can be less than 1MSec but needs to be > .125MSec.">
-                        <Hyperlink Command="Help" CommandParameter="SampleIntervalTextBox">CPU Sample<LineBreak/>Interval Msec</Hyperlink>
-                    </TextBlock>
-                    <TextBox Grid.Column="1" Name="SampleIntervalTextBox" VerticalAlignment="Center" Width="30" Margin="0,0,10,0" AutomationProperties.Name="CPU Sample Interval in milliseconds"/>
-
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0">
-                        <Hyperlink Command="Help" CommandParameter="CpuCountersTextBox">Cpu<LineBreak/>Ctrs</Hyperlink>
-                    </TextBlock>
-                    <Button Grid.Column="3" Name="CpuCountersListButton" Margin="2,0,0,2" Content="Ctrs" Height="20" Click="DoCpuCountersListClick"
-                    ToolTip="Displays a list you can shift click and ctrl-click to select columns to display." />
-                    <Popup Name="CpuCountersPopup" StaysOpen="false" PopupAnimation="Fade" PlacementTarget="{Binding ElementName=CpuCountersListButton}" Placement="Bottom" Margin="2,0,0,0" >
-                        <ListBox Name="CpuCountersListBox" SelectionMode="Extended" KeyDown="DoCpuCountersListBoxKey" MouseDoubleClick="DoCpuCountersListBoxDoubleClick" MaxHeight="300"/>
-                    </Popup>
-                    <controls:HistoryComboBox Grid.Column="4" Margin="2,0,0,0" Width="180" Height="20" x:Name="CpuCountersTextBox" AutomationProperties.Name="CPU Counters">
-                        <controls:HistoryComboBox.ToolTip>
-                            <TextBlock>A comma separated list of column #-# ranges to show in the 'data' field.</TextBlock>
-                        </controls:HistoryComboBox.ToolTip>
-                    </controls:HistoryComboBox>
-
-                    <TextBlock Grid.Column="5" VerticalAlignment="Center" Margin="15,0,0,0"
-                               ToolTip="Collect OS (unmanaged) heap allocation stacks for processes running this EXE fileName.">
-                        <Hyperlink Command="Help" CommandParameter="OSHeapExeTextBox">OS Heap<LineBreak/>Exe</Hyperlink>
-                    </TextBlock>
-                    <TextBox Grid.Column="6" Name="OSHeapExeTextBox" VerticalAlignment="Center" Width="100" Margin="1,0,0,0" AutomationProperties.Name="OS Heap Executable"/>
-
-                    <TextBlock Grid.Column="7" VerticalAlignment="Center" Margin="15,0,0,0"
-                               ToolTip="Collect OS (unmanaged) heap allocation stacks for processes with this process ID.">
-                        <Hyperlink Command="Help" CommandParameter="OSHeapProcessTextBox">OS Heap<LineBreak/>Process</Hyperlink>
-                    </TextBlock>
-                    <TextBox Grid.Column="8" Name="OSHeapProcessTextBox" VerticalAlignment="Center" Width="40" Margin="2,0,0,0" AutomationProperties.Name="OS Heap Process"/>
-                </Grid>
-
-                <!-- Net Symbol collection, rundown, ... -->
-                <Grid Grid.Row="6" Margin="0,5,0,2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="If checked will force all .NET processes to send symbolic info to running processes at data collection end.">
-                        <Hyperlink Command="Help" CommandParameter="RundownCheckBox">.NET Symbol<LineBreak/>Collection</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Column="1" Name="RundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" Click="RundownCheckboxClick" AutomationProperties.Name=".NET Symbol Collection"/>
-
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Version of the runtime before V4.0 requires an expensive rundown.  You can save time by skipping this if you only care about V4.0+ processes.">
-                        <Hyperlink Command="Help" CommandParameter="NoNGenRundownCheckBox">No V3.X NGEN<LineBreak/>Symbols</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Grid.Column="3" Name="NoNGenRundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" AutomationProperties.Name="No V3.X NGEN Symbols" />
-
-                    <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Maximum time (in seconds) to wait for .NET symbolic events." >
-                        <Hyperlink Command="Help" CommandParameter="RundownTimeoutTextBox">Symbol<LineBreak/>TimeOut</Hyperlink>
-                    </TextBlock>
-                    <TextBox Grid.Column="5" Name="RundownTimeoutTextBox" VerticalAlignment="Center" Width="30" IsEnabled="false" Margin="2,0,0,0" AutomationProperties.Name="Symbol Timeout"/>
-                </Grid>
-
-                <!-- Max Collect Sec, Stop Trigger ... -->
-                <Grid Grid.Row="7" Margin="0,5,0,2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Maximum time (in seconds) to collect data." >
-                        <Hyperlink Command="Help" CommandParameter="MaxCollectTextBox">Max Collect<LineBreak/>Sec</Hyperlink>
-                    </TextBlock>
-                    <TextBox Grid.Column="1" Name="MaxCollectTextBox" VerticalAlignment="Center" Margin="2,0,0,0" Width="30" AutomationProperties.Name="Maximum collection time in seconds" />
-
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Specifies a performance counter that will trigger the end of colletion." >
-                        <Hyperlink Command="Help" CommandParameter="StopTriggerTextBox">Stop<LineBreak/>Trigger</Hyperlink>
-                    </TextBlock>
-                    <TextBox Grid.Column="3" Name="StopTriggerTextBox" VerticalAlignment="Center" Margin="2,0,5,0" AutomationProperties.Name="Stop Trigger"/>
-                </Grid>
+                <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <Button Name="CopyCommandLineButton" Margin="5,2" Padding="5,1" Click="CopyCommandLineButtonClick" IsDefault="True">Copy Command Line</Button>
+                    <Button Name="OKButton" Margin="5,2" Padding="5,1" Click="OKButtonClick" IsDefault="True">Run Command</Button>
+                    <Button Name="LogButton" Margin="5,2" Padding="5,1" Click="LogButtonClick" IsCancel="True">Log</Button>
+                    <Button Name="CancelButton" Margin="5,2" Padding="5,1" Click="CancelButtonClick" IsCancel="True">Cancel</Button>
+                </WrapPanel>
             </Grid>
-        </Expander>
-    </Grid>
+
+            <TextBlock Grid.Row="5" Grid.Column="0" Margin="5,0" HorizontalAlignment="Right" VerticalAlignment="Center" Text="Status:" />
+
+            <TextBox Grid.Row="5" Grid.Column="1" Name="StatusTextBox"  Grid.ColumnSpan="2"  Margin="5,0,5,0" VerticalAlignment="Center" IsEnabled="false"
+                 Text="Enter a command to run." ToolTip="Status information."/>
+
+            <Expander Grid.Row="6" Header="Advanced Options" Grid.ColumnSpan="3" Expanded="DoExpand" Collapsed="DoCollapsed">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="100*"/>
+                        <RowDefinition Height="100*"/>
+                        <RowDefinition Height="100*"/>
+                        <RowDefinition Height="100*"/>
+                        <RowDefinition Height="100*"/>
+                        <!-- Row 4 Additional Providers -->
+                        <RowDefinition Height="100*"/>
+                        <RowDefinition Height="100*"/>
+                        <RowDefinition Height="100*"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- Check boxes for individual kernel events -->
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="20*"/>
+                        </Grid.ColumnDefinitions>
+                        
+                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="5,2,5,2"
+                           ToolTip="Fire an event (and stack trace) every time the processor switch from one thread to another." >
+                    <Hyperlink Command="Help" CommandParameter="KernelBaseCheckBox">Kernel Base:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="1" Name="KernelBaseCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Kernel Base"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Fire an event after every time a small amount (typicaly 1MSec) of CPU is consumed." >
+                    <Hyperlink Command="Help" CommandParameter="CpuSamplesCheckBox">Cpu Samples:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="3" Name="CpuSamplesCheckBox" VerticalAlignment="Center" AutomationProperties.Name="CPU Samples"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Fire an event (and stack trace) on page faults and other virtual memory transitions." >
+                <Hyperlink Command="Help" CommandParameter="MemoryCheckBox">Page Faults:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="5" Name="MemoryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Page Faults" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Fire an event (and a stack trace) when various file operations occur (even if the disk is not accessed)." >
+                <Hyperlink Command="Help" CommandParameter="FileIOCheckBox">File I/O:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="7" Name="FileIOCheckBox" VerticalAlignment="Center" AutomationProperties.Name="File I/O" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Fire an event (and a stack trace) when various registry operations occur." >
+                <Hyperlink Command="Help" CommandParameter="RegistryCheckBox">Registry:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="9" Name="RegistryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Registry"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Fire an event (and a stack trace) when low level VirtualAlloc VirtualFree calls are made." >
+                <Hyperlink Command="Help" CommandParameter="VirtualAllocCheckBox">VirtAlloc:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="11" Name="VirtualAllocCheckBox" VerticalAlignment="Center" AutomationProperties.Name="VirtualAlloc"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Fire an event every half second to monitor memory stats for each process on the system.." >
+                <Hyperlink Command="Help" CommandParameter="MemInfoCheckBox">MemInfo:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="13" Name="MemInfoCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Memory Info"/>
+                    </Grid>
+
+                    <!-- Check boxes for more kernel events -->
+                    <Grid Grid.Row="1">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="92*"/>
+                            <ColumnDefinition Width="13*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="104*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="21*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
+                           ToolTip="Collect information about creation and closing of Windows OS handles." >
+                <Hyperlink Command="Help" CommandParameter="HandleCheckBox">Handle:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="1" Name="HandleCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Handle"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Collect detailed information on memory usage of all processes." >
+                <Hyperlink Command="Help" CommandParameter="RefSetCheckBox">RefSet:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="3" Name="RefSetCheckBox" VerticalAlignment="Center" AutomationProperties.Name="RefSet"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Collect detailed information Internet Information Services (IIS)" >
+                <Hyperlink Command="Help" CommandParameter="IISCheckBox">IIS:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="5" Name="IISCheckBox" VerticalAlignment="Center" AutomationProperties.Name="IIS"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
+                           ToolTip="Collect a _Netmon.etl file that can be used with NetMon.  Also implies NetCap." >
+                <Hyperlink Command="Help" CommandParameter="NetMonCheckBox">NetMon:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Column="7" Name="NetMonCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="NetMon"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
+                           ToolTip="Capture the full payload of all network packets that enter or leave the machine." Grid.ColumnSpan="2">
+                <Hyperlink Command="Help" CommandParameter="NetCaptureCheckBox">Net Capture:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Column="10" Name="NetCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Net Capture" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="11" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
+                           ToolTip="Capture events from the Task Parallel Library." >
+                <Hyperlink Command="Help" CommandParameter="TplCaptureCheckBox">Tasks (TPL):</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Column="12" Name="TplCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Tasks (TPL)" />
+
+                        <CheckBox Grid.Row="0" Grid.Column="14" Name="Box7" VerticalAlignment="Center" Visibility="Hidden" Margin="0,2" />
+                    </Grid>
+
+                    <!-- Check boxes for clr events -->
+                    <Grid Grid.Row="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="20*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="These are the default .NET runtime events.  They should usually be left on." >
+                <Hyperlink Command="Help" CommandParameter="ClrCheckBox">.NET :</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="1" Name="ClrCheckBox" AutomationProperties.Name=".NET" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Turn on logging of the .NET STress log, which logs unusual events that help track down random failure." >
+                <Hyperlink Command="Help" CommandParameter="StressCheckBox">.NET Stress:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="3" Name="StressCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Stress" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Turn on events associated with background JIT compilation." >
+                <Hyperlink Command="Help" CommandParameter="BackgroundJITCheckBox">Background JIT:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="5" Name="BackgroundJITCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Background JIT" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Log an event every time a method is called (expensive!)." >
+                <Hyperlink Command="Help" CommandParameter="DotNetCallsCheckBox">.NET Calls:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetCallsCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Calls"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Log information about successful and failed inlining attempts." >
+                <Hyperlink Command="Help" CommandParameter="JITInliningCheckBox">JIT Inlining:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="9" Name="JITInliningCheckBox" VerticalAlignment="Center" AutomationProperties.Name="JIT Inlining"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                            ToolTip="Log information about .NET Native CCW Ref Counting.">
+                 <Hyperlink Command="Help" CommandParameter="CCWRefCountCheckBox"> .NET Native CCW:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="11" Name="CCWRefCountCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Native CCW"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Log extended information about .NET Runtime loading including R2R and type load events." >
+                <Hyperlink Command="Help" CommandParameter="RuntimeLoadingCheckBox">.NET Loader:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="13" Name="RuntimeLoadingCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Loader" />
+                    </Grid>
+
+                    <!-- Check boxes for more clr events (GC Heap related) -->
+                    <Grid Grid.Row="3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="92*"/>
+                            <ColumnDefinition Width="13*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="105*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="104*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="21*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
+                           ToolTip="Turn off everything except events which happen when .NET Garbage Collections happen." >
+                <Hyperlink Command="Help" CommandParameter="GCCollectOnlyCheckBox">GC Collect Only:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="1" Name="GCCollectOnlyCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="GC Collect Only" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,4,2"
+                           ToolTip="Turn off everything except events needed to trace .NET GC heap allocations." >
+                <Hyperlink Command="Help" CommandParameter="GCOnlyCheckBox">GC Only:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="3" Name="GCOnlyCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="GC Only"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
+                           ToolTip="Fire an event whenever a .NET object is allocated capturing its stack." >
+                <Hyperlink Command="Help" CommandParameter="DotNetAllocCheckBox">.NET Alloc:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Column="5" Name="DotNetAllocCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name=".NET Alloc" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
+                           ToolTip="Do smart sampling which aggressive trims commonly allocated types, and rare time not at all." >
+                <Hyperlink Command="Help" CommandParameter="DotNetAllocSampledCheckBox">.NET SampAlloc:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name=".NET Sample Alloc" />
+
+                        <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="16.2,2,0,2"
+                           ToolTip="Do smart sampling which aggressive trims commonly allocated types, and rare time not at all." Grid.ColumnSpan="2" >
+                <Hyperlink Command="Help" CommandParameter="ETWDotNetAllocSampledCheckBox">ETW .NET Alloc:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="10" Name="ETWDotNetAllocSampledCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="ETW .NET Alloc"/>
+
+                        <TextBlock Grid.Row="0" Grid.Column="11" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
+                           ToolTip="Collect a heap snapshot prior to stopping collection." >
+                <Hyperlink Command="Help" CommandParameter="HeapSnapshotCheckBox">Dump Heap:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Row="0" Grid.Column="12" Name="HeapSnapshotCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Dump Heap"/>
+
+                        <CheckBox Grid.Row="0" Grid.Column="14" VerticalAlignment="Center" Visibility="Hidden" Margin="0,2" />
+                    </Grid>
+
+                    <!-- Additional Providers -->
+                    <Grid Grid.Row="4" Margin="0,2,0,2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="5,2,0,2"
+                           ToolTip="A comma separated list of additional providers to turn on during data collection." >
+                <Hyperlink Command="Help" CommandParameter="AdditionalProvidersTextBox">Additional Providers:</Hyperlink>
+                        </TextBlock>
+                        <controls:HistoryComboBox  x:Name="AdditionalProvidersTextBox" Grid.Column="1" Margin="2,2,5,2" AutomationProperties.Name="Additional Providers" />
+                        <Button Grid.Column="2" Margin="0,2,5,2" Content=" Provider Browser " Click="ProviderBrowserButtonClick" ToolTip="Click to browse the available ETW providers."/>
+                        <TextBlock  Grid.Column="3" Margin="2,0,10,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12">
+                    <Hyperlink Command="Help" CommandParameter="ProviderBrowser" AutomationProperties.Name="Help with Provider Browser">?</Hyperlink>
+                        </TextBlock>
+                    </Grid>
+
+                    <!-- CPU Sample interval CPU Ctrs, OS Heap stuff -->
+                    <Grid Grid.Row="5" Margin="0,2,0,2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="The number of MSec between CPU samples when sample profiling. Can be less than 1MSec but needs to be > .125MSec.">
+                            <Hyperlink Command="Help" CommandParameter="SampleIntervalTextBox">CPU Sample<LineBreak/>Interval Msec</Hyperlink>
+                        </TextBlock>
+                        <TextBox Grid.Column="1" Name="SampleIntervalTextBox" VerticalAlignment="Center" Width="30" Margin="0,0,10,0" AutomationProperties.Name="CPU Sample Interval in milliseconds"/>
+
+                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0">
+                            <Hyperlink Command="Help" CommandParameter="CpuCountersTextBox">Cpu<LineBreak/>Ctrs</Hyperlink>
+                        </TextBlock>
+                        <Button Grid.Column="3" Name="CpuCountersListButton" Margin="2,0,0,2" Click="DoCpuCountersListClick" ToolTip="Displays a list you can shift click and ctrl-click to select columns to display." VerticalAlignment="Center">Ctrs</Button>
+                        <Popup Name="CpuCountersPopup" StaysOpen="false" PopupAnimation="Fade" PlacementTarget="{Binding ElementName=CpuCountersListButton}" Placement="Bottom" Margin="2,0,0,0">
+                            <ListBox Name="CpuCountersListBox" SelectionMode="Extended" KeyDown="DoCpuCountersListBoxKey" MouseDoubleClick="DoCpuCountersListBoxDoubleClick" MaxHeight="300"/>
+                        </Popup>
+                        <controls:HistoryComboBox Grid.Column="4" Margin="2,0,0,0" Width="180" x:Name="CpuCountersTextBox" AutomationProperties.Name="CPU Counters" VerticalAlignment="Center">
+                            <controls:HistoryComboBox.ToolTip>
+                                <TextBlock>A comma separated list of column #-# ranges to show in the 'data' field.</TextBlock>
+                            </controls:HistoryComboBox.ToolTip>
+                        </controls:HistoryComboBox>
+
+                        <TextBlock Grid.Column="5" VerticalAlignment="Center" Margin="15,0,0,0"
+                           ToolTip="Collect OS (unmanaged) heap allocation stacks for processes running this EXE fileName.">
+                    <Hyperlink Command="Help" CommandParameter="OSHeapExeTextBox">OS Heap<LineBreak/>Exe</Hyperlink>
+                        </TextBlock>
+                        <TextBox Grid.Column="6" Name="OSHeapExeTextBox" VerticalAlignment="Center" Width="100" Margin="1,0,0,0" AutomationProperties.Name="OS Heap Executable"/>
+
+                        <TextBlock Grid.Column="7" VerticalAlignment="Center" Margin="15,0,0,0"
+                           ToolTip="Collect OS (unmanaged) heap allocation stacks for processes with this process ID.">
+                    <Hyperlink Command="Help" CommandParameter="OSHeapProcessTextBox">OS Heap<LineBreak/>Process</Hyperlink>
+                        </TextBlock>
+                        <TextBox Grid.Column="8" Name="OSHeapProcessTextBox" VerticalAlignment="Center" Width="40" Margin="2,0,0,0" AutomationProperties.Name="OS Heap Process"/>
+                    </Grid>
+
+                    <!-- Net Symbol collection, rundown, ... -->
+                    <Grid Grid.Row="6" Margin="0,5,0,2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="If checked will force all .NET processes to send symbolic info to running processes at data collection end.">
+                    <Hyperlink Command="Help" CommandParameter="RundownCheckBox">.NET Symbol<LineBreak/>Collection</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Column="1" Name="RundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" Click="RundownCheckboxClick" AutomationProperties.Name=".NET Symbol Collection"/>
+
+                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Version of the runtime before V4.0 requires an expensive rundown.  You can save time by skipping this if you only care about V4.0+ processes.">
+                    <Hyperlink Command="Help" CommandParameter="NoNGenRundownCheckBox">No V3.X NGEN<LineBreak/>Symbols</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Grid.Column="3" Name="NoNGenRundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" AutomationProperties.Name="No V3.X NGEN Symbols" />
+
+                        <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Maximum time (in seconds) to wait for .NET symbolic events." >
+                    <Hyperlink Command="Help" CommandParameter="RundownTimeoutTextBox">Symbol<LineBreak/>TimeOut</Hyperlink>
+                        </TextBlock>
+                        <TextBox Grid.Column="5" Name="RundownTimeoutTextBox" VerticalAlignment="Center" Width="30" IsEnabled="false" Margin="2,0,0,0" AutomationProperties.Name="Symbol Timeout"/>
+                    </Grid>
+
+                    <!-- Max Collect Sec, Stop Trigger ... -->
+                    <Grid Grid.Row="7" Margin="0,5,0,2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="100*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Maximum time (in seconds) to collect data." >
+                    <Hyperlink Command="Help" CommandParameter="MaxCollectTextBox">Max Collect<LineBreak/>Sec</Hyperlink>
+                        </TextBlock>
+                        <TextBox Grid.Column="1" Name="MaxCollectTextBox" VerticalAlignment="Center" Margin="2,0,0,0" Width="30" AutomationProperties.Name="Maximum collection time in seconds" />
+
+                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Specifies a performance counter that will trigger the end of colletion." >
+                    <Hyperlink Command="Help" CommandParameter="StopTriggerTextBox">Stop<LineBreak/>Trigger</Hyperlink>
+                        </TextBlock>
+                        <TextBox Grid.Column="3" Name="StopTriggerTextBox" VerticalAlignment="Center" Margin="2,0,5,0" AutomationProperties.Name="Stop Trigger"/>
+                    </Grid>
+                </Grid>
+            </Expander>
+        </Grid>
+    </ScrollViewer>
 </src:WindowBase>

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -6,7 +6,7 @@
         Style="{DynamicResource CustomWindowStyle}"
         Background="{StaticResource ControlDarkerBackground}"
         Title="Collecting ETW Data while running a command"
-        Height="304" Width="950" MinHeight="210" MinWidth="950">
+        Height="222" Width="925" MinHeight="222" MinWidth="925">
     <Window.CommandBindings>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp" />
     </Window.CommandBindings>
@@ -44,14 +44,14 @@
             </RichTextBox>
             <!-- CommandToRun section for running specific process -->
             <TextBlock Grid.Row="1" Grid.Column="0" x:Name="CommandToRunLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="The command line of the process to run while collecting data.">
-            <Hyperlink Command="Help" CommandParameter="CommandToRunTextBox">Command:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="CommandToRunTextBox">Command:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox Grid.Row="1" Margin="0,5,0,0"  Grid.Column="1" x:Name="CommandToRunTextBox" VerticalAlignment="Center" KeyDown="CommandToRunKeyDown" AutomationProperties.Name="Command to run" />
 
             <!-- FocusProcess section for Collect command-->
             <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
                 <TextBlock Name="FocusProcessLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="Name or PID of the process to collect user-mode events for.">
-            <Hyperlink Command="Help" CommandParameter="FocusProcessTextBox">Focus process:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="FocusProcessTextBox">Focus process:</Hyperlink>
                 </TextBlock>
                 <CheckBox Name="FocusProcessCheckBox" VerticalAlignment="Center" Margin="1,2,2,0" Click="FocusProcessCheckBoxClicked" IsChecked="false" AutomationProperties.Name="Focus process" />
             </StackPanel>
@@ -59,51 +59,55 @@
 
             <!-- Data file name row -->
             <TextBlock Grid.Row="2" Grid.Column="0" Margin="5,0" VerticalAlignment="Center" ToolTip="The name of the data file to create." >
-        <Hyperlink Command="Help" CommandParameter="DataFileNameTextBox">Data File:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="DataFileNameTextBox">Data File:</Hyperlink>
             </TextBlock>
             <TextBox  Grid.Row="2" Grid.Column="1"  Name="DataFileNameTextBox" VerticalAlignment="Center" KeyDown="DataFileKeyDown" AutomationProperties.Name="Data File" />
             <Button Grid.Row="2" Grid.Column="2" Content="..."  Width="25" Margin="5,5"
             VerticalAlignment="Center" Click="DataFileButtonClick" ToolTip="Click to select the file name in a file chooser dialog." />
 
             <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="5,0" ToolTip="The directory in which the command is run.">
-            <Hyperlink Command="Help" CommandParameter="CurrentDirTextBox">Current Dir:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="CurrentDirTextBox">Current Dir:</Hyperlink>
             </TextBlock>
             <TextBox  Grid.Row="3" Grid.Column="1"  Name="CurrentDirTextBox" VerticalAlignment="Center" AutomationProperties.Name="Current Directory" />
 
             <!-- Row with Merge, run button cancel ... -->
-            <Grid Grid.Row="4" Grid.ColumnSpan="3" Margin="0,2,0,-1">
+            <Grid Grid.Row="4" Grid.ColumnSpan="3" Margin="0,2">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="18*"/>
                     <ColumnDefinition Width="11*"/>
                 </Grid.ColumnDefinitions>
                 <WrapPanel Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center">
-
-                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="Use this option if you wish to analyze on another machine.">
-                <Hyperlink Command="Help" CommandParameter="ZipCheckBox">Zip:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" AutomationProperties.Name="Zip" />
-
-                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="After this size (in megabytes) old events are thrown away to keep file size under control">
-                <Hyperlink Command="Help" CommandParameter="CircularTextBox">Circular<LineBreak/>MB:</Hyperlink>
-                    </TextBlock>
-                    <TextBox Name="CircularTextBox" VerticalAlignment="Center" Width="35" Margin="5,0" AutomationProperties.Name="Circular Buffer Size in Megabytes"/>
-
-                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked will merge data into a single file, implied by Zip.">
-                <Hyperlink Command="Help" CommandParameter="MergeCheckBox">Merge:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Name="MergeCheckBox" VerticalAlignment="Center" Click="MergeCheckBoxClicked" Margin="0,0,10,0" AutomationProperties.Name="Merge"/>
-
-                    <TextBlock VerticalAlignment="Center" Margin="8,2,5,2" ToolTip="Needed for Thread Time views. Fire an event (and stack trace) every time the processor switches from one thread to another.">
-                <Hyperlink Command="Help" CommandParameter="ThreadTimeCheckbox">Thread<LineBreak/>Time:</Hyperlink>
-                    </TextBlock>
-                    <CheckBox Name="ThreadTimeCheckbox" VerticalAlignment="Center" AutomationProperties.Name="Thread Time" />
-
-                    <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed.">
-                <Hyperlink Command="Help" CommandParameter="MarkTextBox">Mark Text:</Hyperlink>
-                    </TextBlock>
-                    <TextBox Name="MarkTextBox" VerticalAlignment="Center" Width="150" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
-
-                    <Button Name="MarkButton" Margin="5,0" Padding="5,1" VerticalAlignment="Center" Click="MarkButtonClick">Mark</Button>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="Use this option if you wish to analyze on another machine.">
+                            <Hyperlink Command="Help" CommandParameter="ZipCheckBox">Zip:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Name="ZipCheckBox" VerticalAlignment="Center" Margin="0,0,10,0" Click="ZipCheckBoxClicked" AutomationProperties.Name="Zip" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="After this size (in megabytes) old events are thrown away to keep file size under control">
+                            <Hyperlink Command="Help" CommandParameter="CircularTextBox">Circular<LineBreak/>MB:</Hyperlink>
+                        </TextBlock>
+                        <TextBox Name="CircularTextBox" VerticalAlignment="Center" Width="35" Margin="5,0" AutomationProperties.Name="Circular Buffer Size in Megabytes"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="If checked will merge data into a single file, implied by Zip.">
+                            <Hyperlink Command="Help" CommandParameter="MergeCheckBox">Merge:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Name="MergeCheckBox" VerticalAlignment="Center" Click="MergeCheckBoxClicked" Margin="0,0,10,0" AutomationProperties.Name="Merge"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="8,2,5,2" ToolTip="Needed for Thread Time views. Fire an event (and stack trace) every time the processor switches from one thread to another.">
+                            <Hyperlink Command="Help" CommandParameter="ThreadTimeCheckbox">Thread<LineBreak/>Time:</Hyperlink>
+                        </TextBlock>
+                        <CheckBox Name="ThreadTimeCheckbox" VerticalAlignment="Center" AutomationProperties.Name="Thread Time" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="5,0,2,0" ToolTip="This text is attached to the Mark event when the 'Mark' button is pressed.">
+                            <Hyperlink Command="Help" CommandParameter="MarkTextBox">Mark Text:</Hyperlink>
+                        </TextBlock>
+                        <TextBox Name="MarkTextBox" VerticalAlignment="Center" Width="150" Margin="5,0" KeyDown="MarkTextKeyDown" AutomationProperties.Name="Mark Text" />
+                        <Button Name="MarkButton" Margin="5,0" Padding="5,1" VerticalAlignment="Center" Click="MarkButtonClick">Mark</Button>
+                    </StackPanel>
                 </WrapPanel>
 
                 <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
@@ -119,8 +123,13 @@
             <TextBox Grid.Row="5" Grid.Column="1" Name="StatusTextBox"  Grid.ColumnSpan="2"  Margin="5,0,5,0" VerticalAlignment="Center" IsEnabled="false"
                  Text="Enter a command to run." ToolTip="Status information."/>
 
-            <Expander Grid.Row="6" Header="Advanced Options" Grid.ColumnSpan="3" Expanded="DoExpand" Collapsed="DoCollapsed">
-                <Grid>
+            <Expander Name="AdvancedOptionsExpander" Grid.Row="6" Header="Advanced Options" Grid.ColumnSpan="3" Expanded="DoExpand" Collapsed="DoCollapsed">
+                <Grid Name="AdvancedOptionsGrid">
+                    <Grid.Resources>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="TextWrapping" Value="Wrap"/>
+                        </Style>
+                    </Grid.Resources>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="100*"/>
                         <RowDefinition Height="100*"/>
@@ -155,43 +164,43 @@
                         
                         <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="5,2,5,2"
                            ToolTip="Fire an event (and stack trace) every time the processor switch from one thread to another." >
-                    <Hyperlink Command="Help" CommandParameter="KernelBaseCheckBox">Kernel Base:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="KernelBaseCheckBox">Kernel Base:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="1" Name="KernelBaseCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Kernel Base"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Fire an event after every time a small amount (typicaly 1MSec) of CPU is consumed." >
-                    <Hyperlink Command="Help" CommandParameter="CpuSamplesCheckBox">Cpu Samples:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="CpuSamplesCheckBox">Cpu Samples:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="3" Name="CpuSamplesCheckBox" VerticalAlignment="Center" AutomationProperties.Name="CPU Samples"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Fire an event (and stack trace) on page faults and other virtual memory transitions." >
-                <Hyperlink Command="Help" CommandParameter="MemoryCheckBox">Page Faults:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="MemoryCheckBox">Page Faults:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="5" Name="MemoryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Page Faults" />
 
                         <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Fire an event (and a stack trace) when various file operations occur (even if the disk is not accessed)." >
-                <Hyperlink Command="Help" CommandParameter="FileIOCheckBox">File I/O:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="FileIOCheckBox">File I/O:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="7" Name="FileIOCheckBox" VerticalAlignment="Center" AutomationProperties.Name="File I/O" />
 
                         <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Fire an event (and a stack trace) when various registry operations occur." >
-                <Hyperlink Command="Help" CommandParameter="RegistryCheckBox">Registry:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="RegistryCheckBox">Registry:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="9" Name="RegistryCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Registry"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Fire an event (and a stack trace) when low level VirtualAlloc VirtualFree calls are made." >
-                <Hyperlink Command="Help" CommandParameter="VirtualAllocCheckBox">VirtAlloc:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="VirtualAllocCheckBox">VirtAlloc:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="11" Name="VirtualAllocCheckBox" VerticalAlignment="Center" AutomationProperties.Name="VirtualAlloc"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Fire an event every half second to monitor memory stats for each process on the system.." >
-                <Hyperlink Command="Help" CommandParameter="MemInfoCheckBox">MemInfo:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="MemInfoCheckBox">MemInfo:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="13" Name="MemInfoCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Memory Info"/>
                     </Grid>
@@ -219,37 +228,37 @@
 
                         <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                            ToolTip="Collect information about creation and closing of Windows OS handles." >
-                <Hyperlink Command="Help" CommandParameter="HandleCheckBox">Handle:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="HandleCheckBox">Handle:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="1" Name="HandleCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Handle"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Collect detailed information on memory usage of all processes." >
-                <Hyperlink Command="Help" CommandParameter="RefSetCheckBox">RefSet:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="RefSetCheckBox">RefSet:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="3" Name="RefSetCheckBox" VerticalAlignment="Center" AutomationProperties.Name="RefSet"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Collect detailed information Internet Information Services (IIS)" >
-                <Hyperlink Command="Help" CommandParameter="IISCheckBox">IIS:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="IISCheckBox">IIS:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="5" Name="IISCheckBox" VerticalAlignment="Center" AutomationProperties.Name="IIS"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                            ToolTip="Collect a _Netmon.etl file that can be used with NetMon.  Also implies NetCap." >
-                <Hyperlink Command="Help" CommandParameter="NetMonCheckBox">NetMon:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="NetMonCheckBox">NetMon:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Column="7" Name="NetMonCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="NetMon"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                            ToolTip="Capture the full payload of all network packets that enter or leave the machine." Grid.ColumnSpan="2">
-                <Hyperlink Command="Help" CommandParameter="NetCaptureCheckBox">Net Capture:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="NetCaptureCheckBox">Net Capture:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Column="10" Name="NetCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Net Capture" />
 
                         <TextBlock Grid.Row="0" Grid.Column="11" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,2,5,2"
                            ToolTip="Capture events from the Task Parallel Library." >
-                <Hyperlink Command="Help" CommandParameter="TplCaptureCheckBox">Tasks (TPL):</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="TplCaptureCheckBox">Tasks (TPL):</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Column="12" Name="TplCaptureCheckBox" VerticalAlignment="Center" Margin="0,2" AutomationProperties.Name="Tasks (TPL)" />
 
@@ -278,43 +287,43 @@
 
                         <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="These are the default .NET runtime events.  They should usually be left on." >
-                <Hyperlink Command="Help" CommandParameter="ClrCheckBox">.NET :</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="ClrCheckBox">.NET :</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="1" Name="ClrCheckBox" AutomationProperties.Name=".NET" />
 
                         <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Turn on logging of the .NET STress log, which logs unusual events that help track down random failure." >
-                <Hyperlink Command="Help" CommandParameter="StressCheckBox">.NET Stress:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="StressCheckBox">.NET Stress:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="3" Name="StressCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Stress" />
 
                         <TextBlock Grid.Row="0" Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Turn on events associated with background JIT compilation." >
-                <Hyperlink Command="Help" CommandParameter="BackgroundJITCheckBox">Background JIT:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="BackgroundJITCheckBox">Background JIT:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="5" Name="BackgroundJITCheckBox" VerticalAlignment="Center" AutomationProperties.Name="Background JIT" />
 
                         <TextBlock Grid.Row="0" Grid.Column="6" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Log an event every time a method is called (expensive!)." >
-                <Hyperlink Command="Help" CommandParameter="DotNetCallsCheckBox">.NET Calls:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="DotNetCallsCheckBox">.NET Calls:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="7" Name="DotNetCallsCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Calls"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="8" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Log information about successful and failed inlining attempts." >
-                <Hyperlink Command="Help" CommandParameter="JITInliningCheckBox">JIT Inlining:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="JITInliningCheckBox">JIT Inlining:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="9" Name="JITInliningCheckBox" VerticalAlignment="Center" AutomationProperties.Name="JIT Inlining"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="10" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                             ToolTip="Log information about .NET Native CCW Ref Counting.">
-                 <Hyperlink Command="Help" CommandParameter="CCWRefCountCheckBox"> .NET Native CCW:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="CCWRefCountCheckBox"> .NET Native CCW:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="11" Name="CCWRefCountCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Native CCW"/>
 
                         <TextBlock Grid.Row="0" Grid.Column="12" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="8,2,5,2"
                            ToolTip="Log extended information about .NET Runtime loading including R2R and type load events." >
-                <Hyperlink Command="Help" CommandParameter="RuntimeLoadingCheckBox">.NET Loader:</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="RuntimeLoadingCheckBox">.NET Loader:</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Row="0" Grid.Column="13" Name="RuntimeLoadingCheckBox" VerticalAlignment="Center" AutomationProperties.Name=".NET Loader" />
                     </Grid>
@@ -435,13 +444,13 @@
 
                         <TextBlock Grid.Column="5" VerticalAlignment="Center" Margin="15,0,0,0"
                            ToolTip="Collect OS (unmanaged) heap allocation stacks for processes running this EXE fileName.">
-                    <Hyperlink Command="Help" CommandParameter="OSHeapExeTextBox">OS Heap<LineBreak/>Exe</Hyperlink>
+                                <Hyperlink Command="Help" CommandParameter="OSHeapExeTextBox">OS Heap<LineBreak/>Exe</Hyperlink>
                         </TextBlock>
                         <TextBox Grid.Column="6" Name="OSHeapExeTextBox" VerticalAlignment="Center" Width="100" Margin="1,0,0,0" AutomationProperties.Name="OS Heap Executable"/>
 
                         <TextBlock Grid.Column="7" VerticalAlignment="Center" Margin="15,0,0,0"
                            ToolTip="Collect OS (unmanaged) heap allocation stacks for processes with this process ID.">
-                    <Hyperlink Command="Help" CommandParameter="OSHeapProcessTextBox">OS Heap<LineBreak/>Process</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="OSHeapProcessTextBox">OS Heap<LineBreak/>Process</Hyperlink>
                         </TextBlock>
                         <TextBox Grid.Column="8" Name="OSHeapProcessTextBox" VerticalAlignment="Center" Width="40" Margin="2,0,0,0" AutomationProperties.Name="OS Heap Process"/>
                     </Grid>
@@ -458,17 +467,17 @@
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="If checked will force all .NET processes to send symbolic info to running processes at data collection end.">
-                    <Hyperlink Command="Help" CommandParameter="RundownCheckBox">.NET Symbol<LineBreak/>Collection</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="RundownCheckBox">.NET Symbol<LineBreak/>Collection</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Column="1" Name="RundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" Click="RundownCheckboxClick" AutomationProperties.Name=".NET Symbol Collection"/>
 
                         <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Version of the runtime before V4.0 requires an expensive rundown.  You can save time by skipping this if you only care about V4.0+ processes.">
-                    <Hyperlink Command="Help" CommandParameter="NoNGenRundownCheckBox">No V3.X NGEN<LineBreak/>Symbols</Hyperlink>
+                                <Hyperlink Command="Help" CommandParameter="NoNGenRundownCheckBox">No V3.X NGEN<LineBreak/>Symbols</Hyperlink>
                         </TextBlock>
                         <CheckBox Grid.Column="3" Name="NoNGenRundownCheckBox"  VerticalAlignment="Center" Margin="2,0,0,0" AutomationProperties.Name="No V3.X NGEN Symbols" />
 
                         <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Maximum time (in seconds) to wait for .NET symbolic events." >
-                    <Hyperlink Command="Help" CommandParameter="RundownTimeoutTextBox">Symbol<LineBreak/>TimeOut</Hyperlink>
+                                <Hyperlink Command="Help" CommandParameter="RundownTimeoutTextBox">Symbol<LineBreak/>TimeOut</Hyperlink>
                         </TextBlock>
                         <TextBox Grid.Column="5" Name="RundownTimeoutTextBox" VerticalAlignment="Center" Width="30" IsEnabled="false" Margin="2,0,0,0" AutomationProperties.Name="Symbol Timeout"/>
                     </Grid>
@@ -483,12 +492,12 @@
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Maximum time (in seconds) to collect data." >
-                    <Hyperlink Command="Help" CommandParameter="MaxCollectTextBox">Max Collect<LineBreak/>Sec</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="MaxCollectTextBox">Max Collect<LineBreak/>Sec</Hyperlink>
                         </TextBlock>
                         <TextBox Grid.Column="1" Name="MaxCollectTextBox" VerticalAlignment="Center" Margin="2,0,0,0" Width="30" AutomationProperties.Name="Maximum collection time in seconds" />
 
                         <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="15,0,0,0" ToolTip="Specifies a performance counter that will trigger the end of colletion." >
-                    <Hyperlink Command="Help" CommandParameter="StopTriggerTextBox">Stop<LineBreak/>Trigger</Hyperlink>
+                            <Hyperlink Command="Help" CommandParameter="StopTriggerTextBox">Stop<LineBreak/>Trigger</Hyperlink>
                         </TextBlock>
                         <TextBox Grid.Column="3" Name="StopTriggerTextBox" VerticalAlignment="Center" Margin="2,0,5,0" AutomationProperties.Name="Stop Trigger"/>
                     </Grid>

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -969,6 +969,7 @@ namespace PerfView
             }
             CpuCountersListBox.ItemsSource = cpuCounterSpecs;
             CpuCountersPopup.IsOpen = true;
+            Keyboard.Focus(CpuCountersListBox);
         }
         private void DoCpuCountersListBoxKey(object sender, KeyEventArgs e)
         {
@@ -983,6 +984,7 @@ namespace PerfView
             else if (e.Key == Key.Escape)
             {
                 CpuCountersPopup.IsOpen = false;
+                Keyboard.Focus(CpuCountersTextBox);
             }
         }
         private void DoCpuCountersListBoxDoubleClick(object sender, MouseButtonEventArgs e)
@@ -1000,6 +1002,7 @@ namespace PerfView
                 sep = " ";
             }
             CpuCountersTextBox.Text = CpuCounters;
+            Keyboard.Focus(CpuCountersTextBox);
         }
 
         private static string MergeProvider(string providerList, string additionalProvider, string providerKeys, string providerLevel)

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml.cs
@@ -941,12 +941,11 @@ namespace PerfView
 
         private void DoExpand(object sender, RoutedEventArgs e)
         {
-            // TODO I am trying to make the expander just grow the window, I do this by forcing the window height
-            // to change.  However this causes double-redraw, and it also requires me to figure out the right constant
-            // to add any time I change what is in the expander.   There is undoubtedly a better way...
             m_originalHeight = (int)Height;
-            Height = m_originalHeight + 180;
+            AdvancedOptionsGrid.Measure(new Size(AdvancedOptionsExpander.ActualWidth, double.PositiveInfinity));
+            Height += AdvancedOptionsGrid.DesiredSize.Height;
         }
+
         private void DoCollapsed(object sender, RoutedEventArgs e)
         {
             Height = m_originalHeight;

--- a/src/PerfView/Dialogs/SelectProcess.xaml
+++ b/src/PerfView/Dialogs/SelectProcess.xaml
@@ -8,6 +8,11 @@
     <Window.CommandBindings>
         <CommandBinding Command="Help" Executed="DoHyperlinkHelp" />
     </Window.CommandBindings>
+    <Window.Resources>
+        <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type WPFToolKit:DataGridColumnHeader}">
+            <Setter Property="Focusable" Value="True" />
+        </Style>
+    </Window.Resources>
     <DockPanel>
         <RichTextBox DockPanel.Dock="Top" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True">
             <RichTextBox.Document>
@@ -56,7 +61,8 @@
               Background="{DynamicResource BackgroundColour}"
               AutoGenerateColumns="False"
               MouseDoubleClick="OKClicked"
-              IsReadOnly="True">
+              IsReadOnly="True"
+              ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}">
                 <WPFToolKit:DataGrid.Resources>
                     <Style x:Key="RightAlign">
                         <Setter Property="TextBlock.TextAlignment" Value="Right"/>

--- a/src/PerfView/Dialogs/SelectProcess.xaml
+++ b/src/PerfView/Dialogs/SelectProcess.xaml
@@ -50,10 +50,10 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Button Name="OKButton" Margin="5,4" Grid.Column="1" Width="80" Content="OK" Click="OKClicked" IsDefault="True" />
-            <Button Name="AllProcsButton" Margin="5,4" Grid.Column="3" Width="80" Content="All Procs" Click="AllProcsClicked"
+            <Button Name="OKButton" Margin="5,4" Grid.Column="1" MinWidth="80" Content="OK" Click="OKClicked" IsDefault="True" />
+            <Button Name="AllProcsButton" Margin="5,4" Grid.Column="3" MinWidth="80" Content="All Procs" Click="AllProcsClicked"
                     ToolTip="Investigate all processes"/>
-            <Button Margin="5,4" Grid.Column="5" Width="80" Content="Cancel" Click="CancelClicked" IsCancel="True" />
+            <Button Margin="5,4" Grid.Column="5" MinWidth="80" Content="Cancel" Click="CancelClicked" IsCancel="True" />
         </Grid>
         <Grid PreviewKeyDown="GridKeyDownHander">
             <WPFToolKit:DataGrid Name="Grid"

--- a/src/PerfView/EventViewer/EventWindow.xaml
+++ b/src/PerfView/EventViewer/EventWindow.xaml
@@ -14,6 +14,9 @@
         <Style x:Key="CenterAlign">
             <Setter Property="TextBlock.TextAlignment" Value="Center" />
         </Style>
+        <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type WPFToolKit:DataGridColumnHeader}">
+            <Setter Property="Focusable" Value="True" />
+        </Style>
     </Window.Resources>
     <DockPanel Background="{DynamicResource BackgroundColour}">
         <DockPanel.CommandBindings>
@@ -109,7 +112,7 @@
             <StackPanel Orientation="Horizontal">
                 <Button Margin="3,2,3,2" FontSize="9" Click="DoUpdate" ToolTip="Update main window using current filter parameters (F5).">Update</Button>
                 <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="StartTextBox" KeyboardNavigation.IsTabStop="False">Start:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="StartTextBox">Start:</Hyperlink>
                 </TextBlock>
                 <controls:HistoryComboBox  x:Name="StartTextBox" Width="90" Enter="DoUpdate" AutomationProperties.Name="Start Time">
                     <controls:HistoryComboBox.ToolTip>
@@ -117,7 +120,7 @@
                     </controls:HistoryComboBox.ToolTip>
                 </controls:HistoryComboBox>
                 <TextBlock VerticalAlignment="Center" Margin="10,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="EndTextBox" KeyboardNavigation.IsTabStop="False">End:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="EndTextBox">End:</Hyperlink>
                 </TextBlock>
                 <controls:HistoryComboBox x:Name="EndTextBox" Width="90" Enter="DoUpdate" AutomationProperties.Name="End Time">
                     <controls:HistoryComboBox.ToolTip>
@@ -125,7 +128,7 @@
                     </controls:HistoryComboBox.ToolTip>
                 </controls:HistoryComboBox>
                 <TextBlock VerticalAlignment="Center" Margin="10,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="MaxRetTextBox" KeyboardNavigation.IsTabStop="False">MaxRet:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="MaxRetTextBox">MaxRet:</Hyperlink>
                 </TextBlock>
                 <controls:HistoryComboBox x:Name="MaxRetTextBox" Width="80" Enter="DoUpdate"  AutomationProperties.Name="Max Records Returned">
                     <controls:HistoryComboBox.ToolTip>
@@ -134,7 +137,7 @@
                 </controls:HistoryComboBox>
             </StackPanel>
             <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="20,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="FindTextBox" KeyboardNavigation.IsTabStop="False">Find:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="FindTextBox">Find:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox x:Name="FindTextBox" Grid.Column="2" MinWidth="100" Enter="DoFindEnter" AutomationProperties.Name="Find">
                 <controls:HistoryComboBox.ToolTip>
@@ -153,7 +156,7 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="20,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="ProcessFilterTextBox" KeyboardNavigation.IsTabStop="False">Process Filter:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="ProcessFilterTextBox">Process Filter:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox Grid.Column="1" Margin="0,3,0,3" x:Name="ProcessFilterTextBox" Enter="DoUpdate" AutomationProperties.Name="Process Filter" >
                 <controls:HistoryComboBox.ToolTip>
@@ -161,7 +164,7 @@
                 </controls:HistoryComboBox.ToolTip>
             </controls:HistoryComboBox>
             <TextBlock Grid.Column="2"  VerticalAlignment="Center" Margin="10,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="TextFilterTextBox" KeyboardNavigation.IsTabStop="False">Text Filter:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="TextFilterTextBox">Text Filter:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox Grid.Column="3" Margin="0,3,0,3" x:Name="TextFilterTextBox" Enter="DoUpdate" AutomationProperties.Name="Text Filter">
                 <controls:HistoryComboBox.ToolTip>
@@ -169,7 +172,7 @@
                 </controls:HistoryComboBox.ToolTip>
             </controls:HistoryComboBox>
             <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="10,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="ColumnsToDisplayTextBox" KeyboardNavigation.IsTabStop="False">Columns To Display:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="ColumnsToDisplayTextBox">Columns To Display:</Hyperlink>
             </TextBlock>
             <Button Grid.Column="5" Name="ListButton" Margin="3,3,3,3" Content="Cols" Click="DoColumnsToDisplayListClick"
                     ToolTip="Displays a list you can shift click and ctrl-click to select columns to display." />
@@ -240,7 +243,8 @@
                     SelectionMode="Extended" SelectionUnit="CellOrRowHeader"
                     SelectedCellsChanged="SelectedCellsChanged"
                     AlternatingRowBackground="{DynamicResource AlternateRowBackground}" 
-                    AutomationProperties.Name="Events Table">
+                    AutomationProperties.Name="Events Table"
+                    ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}">
                     <WPFToolKit:DataGrid.Columns>
                         <WPFToolKit:DataGridTextColumn
                         x:Name="EventNameColumn"

--- a/src/PerfView/GuiUtilities/HistoryComboBox/HistoryComboBox.cs
+++ b/src/PerfView/GuiUtilities/HistoryComboBox/HistoryComboBox.cs
@@ -13,9 +13,13 @@ namespace Controls
     /// </summary>
     public partial class HistoryComboBox : ComboBox
     {
+        static HistoryComboBox()
+        {
+            IsEditableProperty.OverrideMetadata(typeof(HistoryComboBox), new FrameworkPropertyMetadata(true));
+        }
+
         public HistoryComboBox()
         {
-            IsEditable = true;
             HistoryLength = 10;
             KeyDown += DoKeyDown;
             GotFocus += DoGotFocus;

--- a/src/PerfView/HeapView/GcInfoView.cs
+++ b/src/PerfView/HeapView/GcInfoView.cs
@@ -2,6 +2,7 @@ using Microsoft.Diagnostics.Tracing.Analysis.GC;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 using System;
 using System.Collections.Generic;
+using System.Drawing.Drawing2D;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Automation;
@@ -380,6 +381,7 @@ namespace PerfView
             m_grid.MouseRightButtonUp += MouseRightButtonUp;
             m_grid.AutoGenerateColumns = false;
             m_grid.IsReadOnly = true;
+            m_grid.ColumnHeaderStyle = Toolbox.FocusableDataGridColumnHeaderStyle(m_grid.ColumnHeaderStyle);
 
             // Columns
             m_grid.AddColumn(Toolbox.CreateTextBlock("GCIndex ", "GCIndex", OnHelp), "Number", true, Toolbox.CountFormatN0);

--- a/src/PerfView/HeapView/HeapAllocView.cs
+++ b/src/PerfView/HeapView/HeapAllocView.cs
@@ -160,6 +160,7 @@ namespace PerfView
 
             m_grid.AutoGenerateColumns = false;
             m_grid.IsReadOnly = true;
+            m_grid.ColumnHeaderStyle = Toolbox.FocusableDataGridColumnHeaderStyle(m_grid.ColumnHeaderStyle);
 
             AllocTickConverter converter = new AllocTickConverter(traceLog);
 

--- a/src/PerfView/HeapView/HeapDiagram.cs
+++ b/src/PerfView/HeapView/HeapDiagram.cs
@@ -1165,6 +1165,7 @@ namespace PerfView
                 m_metricGrid.Background = Brushes.LightGray;
                 m_metricGrid.AutoGenerateColumns = false;
                 m_metricGrid.IsReadOnly = true;
+                m_metricGrid.ColumnHeaderStyle = Toolbox.FocusableDataGridColumnHeaderStyle(m_metricGrid.ColumnHeaderStyle);
 
                 m_metricGrid.AddColumn("Metric", "Name", false);
                 m_metricGrid.AddColumn("Value", "Value", true);

--- a/src/PerfView/HeapView/IssueView.cs
+++ b/src/PerfView/HeapView/IssueView.cs
@@ -87,6 +87,7 @@ namespace PerfView
             m_grid.AddColumn("Description", "Description");
             m_grid.AddColumn("Suggestion", "Suggestion");
             m_grid.AddButtonColumn(typeof(Issue), "Action", "Action", OnClick);
+            m_grid.ColumnHeaderStyle = Toolbox.FocusableDataGridColumnHeaderStyle(m_grid.ColumnHeaderStyle);
 
             m_leftPanel = new StackPanel();
             m_leftPanel.Width = LeftPanelWidth;

--- a/src/PerfView/HeapView/ThreadView.cs
+++ b/src/PerfView/HeapView/ThreadView.cs
@@ -21,6 +21,7 @@ namespace PerfView
             m_grid = new DataGrid();
             m_grid.AutoGenerateColumns = false;
             m_grid.IsReadOnly = true;
+            m_grid.ColumnHeaderStyle = Toolbox.FocusableDataGridColumnHeaderStyle(m_grid.ColumnHeaderStyle);
 
             // Columns
             m_grid.AddColumn("Thread", "ThreadID");

--- a/src/PerfView/HeapView/Toolbox.cs
+++ b/src/PerfView/HeapView/Toolbox.cs
@@ -450,6 +450,15 @@ namespace PerfView
             return s;
         }
 
+        internal static Style FocusableDataGridColumnHeaderStyle(Style baseStyle)
+        {
+            Style columnHeaderStyle = new Style();
+            columnHeaderStyle.BasedOn = baseStyle;
+            columnHeaderStyle.TargetType = typeof(DataGridColumnHeader);
+            columnHeaderStyle.Setters.Add(new Setter(DataGridColumnHeader.FocusableProperty, true));
+            return columnHeaderStyle;
+        }
+
         /// <summary>
         /// Add Button column to DataGrid
         /// </summary>

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -150,22 +150,22 @@
                 </MenuItem>
             </Menu>
             <Rectangle Grid.Column="1" Grid.ColumnSpan="11" Fill="{DynamicResource ControlDefaultBackground}"/>
-            <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0">
+            <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="MainViewerQuickStart">Main View Help (F1)</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0,0,0">
+            <TextBlock Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0,0,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="Tutorial">Tutorial</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="3" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0">
+            <TextBlock Grid.Column="3" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="MainViewerTroubleshooting">Troubleshooting</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0">
+            <TextBlock Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="FAQ">FAQ</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0">
+            <TextBlock Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="MainViewerTips">Tips</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="6" Name="VideoLink" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10,0">
+            <TextBlock Grid.Column="6" Name="VideoLink" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10,0" TextWrapping="Wrap">
                 <Hyperlink Click="DoVideoClick">Videos</Hyperlink>
             </TextBlock>
             <Button Name="WikiButton" Grid.Column="7" Margin="5,1,10,1" Content="Wiki" FontSize="9"

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -98,17 +98,17 @@
                 <MenuItem Header="Si_ze">
                     <MenuItem Header="_DirectorySize"  Command="{x:Static src:MainWindow.DirectorySizeCommand}" ToolTip="Computes the disk usage (recursively) for a directory.">
                         <MenuItem.Icon>
-                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="14"><Hyperlink Command="Help" CommandParameter="DirectorySize">?</Hyperlink></TextBlock>
+                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="14"><Hyperlink Command="Help" CommandParameter="DirectorySize" AutomationProperties.Name="Help for Directory Size">?</Hyperlink></TextBlock>
                         </MenuItem.Icon>
                     </MenuItem>
                     <MenuItem Name="ImageSizeMenuItem" Visibility="Collapsed" Header="_ImageSize" Command="{x:Static src:MainWindow.ImageSizeCommand}"  ToolTip="Displays the breakdown of what is in a DLL or EXE by symbol. (needs PDB for DLL or EXE).">
                         <MenuItem.Icon>
-                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="14"><Hyperlink Command="Help" CommandParameter="ImageSize">?</Hyperlink></TextBlock>
+                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="14"><Hyperlink Command="Help" CommandParameter="ImageSize" AutomationProperties.Name="Help for Image Size">?</Hyperlink></TextBlock>
                         </MenuItem.Icon>
                     </MenuItem>
                     <MenuItem Name="ILSizeMenuItem" Visibility="Collapsed" Header="ILSize" Command="{x:Static src:MainWindow.ILSizeCommand}"  ToolTip="Displays the breakdown of what is in a DLL or EXE by symbol. (needs PDB for DLL or EXE).">
                         <MenuItem.Icon>
-                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="14"><Hyperlink Command="Help" CommandParameter="ILSize">?</Hyperlink></TextBlock>
+                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="14"><Hyperlink Command="Help" CommandParameter="ILSize" AutomationProperties.Name="Help for IL Size">?</Hyperlink></TextBlock>
                         </MenuItem.Icon>
                     </MenuItem>
                 </MenuItem>

--- a/src/PerfView/ObjectViewer/TreeViewGrid.xaml
+++ b/src/PerfView/ObjectViewer/TreeViewGrid.xaml
@@ -20,6 +20,9 @@
                 <TextBlock Name="Name" Text="{Binding Name}"/>
             </StackPanel>
         </DataTemplate>
+        <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type DataGridColumnHeader}">
+            <Setter Property="Focusable" Value="True" />
+        </Style>
     </UserControl.Resources>
     <DataGrid Name="Grid"
         AutoGenerateColumns="False"
@@ -29,7 +32,8 @@
         SelectedCellsChanged="SelectedCellsChanged"
         CanUserSortColumns="False"
         ClipboardCopyMode="IncludeHeader"
-        Margin="0,0,-23,0" PreparingCellForEdit="Grid_PreparingCellForEdit" >
+        Margin="0,0,-23,0" PreparingCellForEdit="Grid_PreparingCellForEdit"
+        ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}">
         <DataGrid.Columns>
             <DataGridTemplateColumn
                 HeaderStyle="{StaticResource CenterAlign}"
@@ -43,7 +47,7 @@
                 </DataGridTemplateColumn.CellTemplate>
                 <DataGridTemplateColumn.Header>
                     <TextBlock Name="NameColumn">
-                        Name <Hyperlink Click="DoHyperlinkHelp" Tag="NameColumn">?</Hyperlink>
+                        Name <Hyperlink Click="DoHyperlinkHelp" Tag="NameColumn" AutomationProperties.Name="Help for Name Column">?</Hyperlink>
                     </TextBlock>
                 </DataGridTemplateColumn.Header>
             </DataGridTemplateColumn>

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml
@@ -23,6 +23,9 @@
             <Setter Property="FontSize" Value="10"/>
             <Setter Property="IsReadOnly" Value="True"/>
         </Style>
+        <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type WPFToolKit:DataGridColumnHeader}">
+            <Setter Property="Focusable" Value="True" />
+        </Style>
     </UserControl.Resources>
     <WPFToolKit:DataGrid Name="Grid"
         SelectionMode="Extended" SelectionUnit="CellOrRowHeader"
@@ -32,7 +35,8 @@
         CanUserSortColumns="False"
         ClipboardCopyMode="IncludeHeader"
         Margin="0,0,-23,0" PreparingCellForEdit="Grid_PreparingCellForEdit"
-        AutomationProperties.Name="Data Grid">
+        AutomationProperties.Name="Data Grid"
+        ColumnHeaderStyle="{StaticResource ColumnHeaderStyle}">
         <WPFToolKit:DataGrid.Columns>
             <WPFToolKit:DataGridTemplateColumn
                 x:Name="DisplayNameColumn"
@@ -46,7 +50,7 @@
                 </WPFToolKit:DataGridTemplateColumn.CellTemplate>
                 <WPFToolKit:DataGridTemplateColumn.Header>
                     <TextBlock Name="NameColumn">
-                        Name <Hyperlink Click="DoHyperlinkHelp" Tag="NameColumn">?</Hyperlink>
+                        Name <Hyperlink Click="DoHyperlinkHelp" Tag="NameColumn" AutomationProperties.Name="Help with Name Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                       The name of the method or group (see GroupPat dialog box).
@@ -61,7 +65,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="IncPercentColumn">
-                       Inc % <Hyperlink  Click="DoHyperlinkHelp" Tag="IncPercentColumn">?</Hyperlink>
+                       Inc % <Hyperlink  Click="DoHyperlinkHelp" Tag="IncPercentColumn" AutomationProperties.Name="Help with Inclusive Percent Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                      The % of the total sample metric that occurred in this item or any of its callees.
@@ -76,7 +80,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header >
                     <TextBlock Margin="0,0,5,0" Name="IncColumn">
-                        Inc <Hyperlink Click="DoHyperlinkHelp" Tag="IncColumn">?</Hyperlink>
+                        Inc <Hyperlink Click="DoHyperlinkHelp" Tag="IncColumn" AutomationProperties.Name="Help with Inclusive Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                      The sum of the sample metric that occurred in this item or any of its callees.
@@ -93,7 +97,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="IncAvgColumn">
-                        Inc Avg <Hyperlink Click="DoHyperlinkHelp" Tag="IncAvgColumn">?</Hyperlink>
+                        Inc Avg <Hyperlink Click="DoHyperlinkHelp" Tag="IncAvgColumn" AutomationProperties.Name="Help with Inclusive Average Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                             <TextBlock>
                                      The average of the sample metric that occurred in this item or any of its callees.
@@ -109,7 +113,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="IncCountColumn">
-                        Inc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="IncCountColumn ">?</Hyperlink>
+                        Inc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="IncCountColumn" AutomationProperties.Name="Help with Inclusive Count Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                             <TextBlock>
                                     The count of the instances in item or its children.
@@ -125,7 +129,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="ExcPercentColumn">
-                        Exc % <Hyperlink Click="DoHyperlinkHelp" Tag="ExcPercentColumn">?</Hyperlink>
+                        Exc % <Hyperlink Click="DoHyperlinkHelp" Tag="ExcPercentColumn" AutomationProperties.Name="Help with Exclusive Percent Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                     The % of the total sample metric that occurred in this item exclusively (not its children, does include folding).
@@ -141,7 +145,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="ExcColumn">
-                        Exc <Hyperlink Click="DoHyperlinkHelp" Tag="ExcColumn">?</Hyperlink>
+                        Exc <Hyperlink Click="DoHyperlinkHelp" Tag="ExcColumn" AutomationProperties.Name="Help with Exclusive Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                     The sum of the sample metric that occurred in this item exclusively (not its children, does include folding).
@@ -157,7 +161,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="ExcCountColumn">
-                        Exc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="ExcCountColumn ">?</Hyperlink>
+                        Exc Ct <Hyperlink Click="DoHyperlinkHelp" Tag="ExcCountColumn" AutomationProperties.Name="Help with Exclusive Count Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                     The count of the instances in item (excluding its children, does include folding)
@@ -173,7 +177,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="FoldColumn">
-                        Fold <Hyperlink Click="DoHyperlinkHelp" Tag="FoldColumn">?</Hyperlink>
+                        Fold <Hyperlink Click="DoHyperlinkHelp" Tag="FoldColumn" AutomationProperties.Name="Help with Fold Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                     The exclusive metric that have been folded into this node (by FoldPat or Fold %).
@@ -189,7 +193,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="FoldCountColumn">
-                        Fold Ct <Hyperlink Click="DoHyperlinkHelp" Tag="FoldCountColumn ">?</Hyperlink>
+                        Fold Ct <Hyperlink Click="DoHyperlinkHelp" Tag="FoldCountColumn" AutomationProperties.Name="Help with Fold Count Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                     The count that have been folded into this node (by FoldPat or Fold %).
@@ -207,7 +211,7 @@
                 EditingElementStyle="{StaticResource HistogramEditCell}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="WhenColumn">
-                    When <Hyperlink Click="DoHyperlinkHelp" Tag="WhenColumn">?</Hyperlink>
+                    When <Hyperlink Click="DoHyperlinkHelp" Tag="WhenColumn" AutomationProperties.Name="Help with When Column">?</Hyperlink>
                     <TextBlock.ToolTip>
                                 <TextBlock TextAlignment="Left">
                                     The time interval (from Start to End) is divided up into 32 buckets.<LineBreak/>
@@ -247,7 +251,7 @@
                 EditingElementStyle="{StaticResource HistogramEditCell}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="WhichColumn">
-                    Which <Hyperlink Click="DoHyperlinkHelp" Tag="WhichColumn">?</Hyperlink>
+                    Which <Hyperlink Click="DoHyperlinkHelp" Tag="WhichColumn" AutomationProperties.Name="Help with Which Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                             <!-- TODO: update this tooltip help -->
                             <TextBlock TextAlignment="Left">
@@ -285,7 +289,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="FirstColumn">
-                        First <Hyperlink Click="DoHyperlinkHelp" Tag="FirstColumn">?</Hyperlink>
+                        First <Hyperlink Click="DoHyperlinkHelp" Tag="FirstColumn" AutomationProperties.Name="Help with First Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                     The time in of the first sample (msec from start of trace).
@@ -301,7 +305,7 @@
                 ElementStyle="{StaticResource RightAlign}">
                 <WPFToolKit:DataGridTextColumn.Header>
                     <TextBlock Margin="0,0,5,0" Name="LastColumn">
-                        Last <Hyperlink Click="DoHyperlinkHelp" Tag="LastColumn">?</Hyperlink>
+                        Last <Hyperlink Click="DoHyperlinkHelp" Tag="LastColumn" AutomationProperties.Name="Help with Last Column">?</Hyperlink>
                         <TextBlock.ToolTip>
                                 <TextBlock>
                                     The time in of the last sample (msec from start of trace).

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -281,7 +281,7 @@
                     </controls:HistoryComboBox.ToolTip>
                 </controls:HistoryComboBox>
                 <TextBlock VerticalAlignment="Center" Margin="10,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="EndTextBox" KeyboardNavigation.IsTabStop="False">End:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="EndTextBox">End:</Hyperlink>
                 </TextBlock>
                 <controls:HistoryComboBox x:Name="EndTextBox" Width="90" Enter="DoUpdate" AutomationProperties.Name="End Time">
                     <controls:HistoryComboBox.ToolTip>
@@ -324,7 +324,7 @@
                 </StackPanel>
             </StackPanel>
             <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="20,0,1,0">
-                        <Hyperlink Command="Help" CommandParameter="FindTextBox" KeyboardNavigation.IsTabStop="False">Find:</Hyperlink>
+                        <Hyperlink Command="Help" CommandParameter="FindTextBox">Find:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox x:Name="FindTextBox" Grid.Column="2" MinWidth="100" Enter="DoFindEnter" AutomationProperties.Name="Find">
                 <controls:HistoryComboBox.ToolTip>
@@ -348,7 +348,7 @@
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,1,0">
-                    <Hyperlink Command="Help" CommandParameter="GroupPatsTextBox" KeyboardNavigation.IsTabStop="False">GroupPats:</Hyperlink>
+                    <Hyperlink Command="Help" CommandParameter="GroupPatsTextBox">GroupPats:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox x:Name="GroupRegExTextBox" Grid.Column="1" MinWidth="80" Enter="DoUpdate" AutomationProperties.Name="Group Patterns">
                 <controls:HistoryComboBox.ToolTip>
@@ -365,7 +365,7 @@
                 </controls:HistoryComboBox.ToolTip>
             </controls:HistoryComboBox>
             <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5,0,1,0">
-                <Hyperlink Command="Help" CommandParameter="FoldPercentTextBox" KeyboardNavigation.IsTabStop="False">Fold%:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="FoldPercentTextBox">Fold%:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox x:Name="FoldPercentTextBox" Grid.Column="3" MinWidth="42" Enter="DoUpdate" Margin="0,0,5,0" AutomationProperties.Name="Fold Percent">
                 <controls:HistoryComboBox.ToolTip>
@@ -376,7 +376,7 @@
                 </controls:HistoryComboBox.ToolTip>
             </controls:HistoryComboBox>
             <TextBlock Grid.Column="4" VerticalAlignment="Center" Margin="5,0,1,0">
-                <Hyperlink Command="Help" CommandParameter="FoldPatsTextBox" KeyboardNavigation.IsTabStop="False">FoldPats:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="FoldPatsTextBox">FoldPats:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox x:Name="FoldRegExTextBox" Grid.Column="5" MinWidth="80" Enter="DoUpdate" AutomationProperties.Name="Fold Patterns">
                 <controls:HistoryComboBox.ToolTip>
@@ -389,7 +389,7 @@
                 </controls:HistoryComboBox.ToolTip>
             </controls:HistoryComboBox>
             <TextBlock Grid.Column="6" VerticalAlignment="Center" Margin="10,0,1,0">
-                <Hyperlink Command="Help" CommandParameter="IncPatsTextBox" KeyboardNavigation.IsTabStop="False">IncPats:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="IncPatsTextBox">IncPats:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox x:Name="IncludeRegExTextBox" Grid.Column="7"  MinWidth="80" Margin="0,0,5,0" Enter="DoUpdate" AutomationProperties.Name="Include Patterns">
                 <controls:HistoryComboBox.ToolTip>
@@ -403,7 +403,7 @@
                 </controls:HistoryComboBox.ToolTip>
             </controls:HistoryComboBox>
             <TextBlock Grid.Column="8" VerticalAlignment="Center" Margin="10,0,1,0">
-                <Hyperlink Command="Help" CommandParameter="ExcPatsTextBox" KeyboardNavigation.IsTabStop="False">ExcPats:</Hyperlink>
+                <Hyperlink Command="Help" CommandParameter="ExcPatsTextBox">ExcPats:</Hyperlink>
             </TextBlock>
             <controls:HistoryComboBox x:Name="ExcludeRegExTextBox" Grid.Column="9" MinWidth="80" Enter="DoUpdate" AutomationProperties.Name="Exclude Patterns">
                 <controls:HistoryComboBox.ToolTip>
@@ -430,7 +430,7 @@
                 <TabItem Name="ByNameTab">
                     <TabItem.Header>
                         <TextBlock>
-                        By Name <Hyperlink Command="Help" CommandParameter="ByNameView">?</Hyperlink>
+                        By Name <Hyperlink Command="Help" CommandParameter="ByNameView" AutomationProperties.Name="Help for By-Name View">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
                     <src:PerfDataGrid x:Name="ByNameDataGrid" Margin="0,0,20,0" MouseDoubleClick="ByName_MouseDoubleClick"/>
@@ -439,7 +439,7 @@
                 <TabItem Name="CallerCalleeTab" >
                     <TabItem.Header>
                         <TextBlock>
-                        Caller-Callee <Hyperlink Command="Help" CommandParameter="CallerCalleeView">?</Hyperlink>
+                        Caller-Callee <Hyperlink Command="Help" CommandParameter="CallerCalleeView" AutomationProperties.Name="Help for Caller-Callee View">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
                     <!-- TODO FIX NOW The margin is a hack.  I don't know why I need it... -->
@@ -449,7 +449,7 @@
                 <TabItem Name="CallTreeTab">
                     <TabItem.Header>
                         <TextBlock>
-                        CallTree <Hyperlink Command="Help" CommandParameter="CallTreeView">?</Hyperlink>
+                        CallTree <Hyperlink Command="Help" CommandParameter="CallTreeView" AutomationProperties.Name="Help for Call-Tree View">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
                     <src:PerfDataGrid x:Name="CallTreeDataGrid" Margin="0,0,20,0"/>
@@ -458,7 +458,7 @@
                 <TabItem Name="CallersTab">
                     <TabItem.Header>
                         <TextBlock>
-                        Callers <Hyperlink Command="Help" CommandParameter="CallersView">?</Hyperlink>
+                        Callers <Hyperlink Command="Help" CommandParameter="CallersView" AutomationProperties.Name="Help for Callers View">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
                     <Grid>
@@ -474,7 +474,7 @@
                 <TabItem Name="CalleesTab">
                     <TabItem.Header>
                         <TextBlock>
-                        Callees <Hyperlink Command="Help" CommandParameter="CalleesView">?</Hyperlink>
+                        Callees <Hyperlink Command="Help" CommandParameter="CalleesView" AutomationProperties.Name="Help for Callees View">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
                     <Grid>
@@ -490,16 +490,16 @@
                 <TabItem Name="FlameGraphTab" GotFocus="FlameGraphTab_GotFocus">
                     <TabItem.Header>
                         <TextBlock>
-                            Flame Graph <Hyperlink Command="Help" CommandParameter="FlameGraphView">?</Hyperlink>
+                            Flame Graph <Hyperlink Command="Help" CommandParameter="FlameGraphView" AutomationProperties.Name="Help for Flame Graph">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
-                    <src:FlameGraphDrawingCanvas x:Name="FlameGraphCanvas" Background="White" ClipToBounds="True" SizeChanged="FlameGraphCanvas_SizeChanged" CurrentFlameBoxChanged="FlameGraphCanvas_CurrentFlameBoxChanged" />
+                    <src:FlameGraphDrawingCanvas x:Name="FlameGraphCanvas" Background="#EEEEEE" ClipToBounds="True" SizeChanged="FlameGraphCanvas_SizeChanged" CurrentFlameBoxChanged="FlameGraphCanvas_CurrentFlameBoxChanged" AutomationProperties.Name="Flame Graph" />
                 </TabItem>
                 <!-- NotesTab -->
                 <TabItem Name="NotesTab" GotFocus="NotesTab_GotFocus" LostFocus="NotesTab_LostFocus">
                     <TabItem.Header>
                         <TextBlock>
-                        Notes <Hyperlink Command="Help" CommandParameter="NotesView">?</Hyperlink>
+                        Notes <Hyperlink Command="Help" CommandParameter="NotesView" AutomationProperties.Name="Help for Notes">?</Hyperlink>
                         </TextBlock>
                     </TabItem.Header>
                     <TextBox Name="NotesTabBody" AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" FontFamily="Courier New" FontSize="11" TextChanged="Notes_TextChanged" AutomationProperties.Name="Notes"/>

--- a/src/PerfView/StackViewer/StackWindow.xaml
+++ b/src/PerfView/StackViewer/StackWindow.xaml
@@ -226,19 +226,19 @@
                 </MenuItem>
             </Menu>
             <Rectangle Grid.Column="1" Grid.ColumnSpan="10" Fill="{DynamicResource ControlDefaultBackground}"/>
-            <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0">
+            <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="StackViewerQuickStart">Stack View Help (F1)</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0">
+            <TextBlock Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="UnderstandingPerfData">Understanding Perf Data</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="3" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0">
+            <TextBlock Grid.Column="3" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="StartingAnAnalysis">Starting an Analysis</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0">
+            <TextBlock Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="StackViewerTroubleshooting">Troubleshooting</Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0">
+            <TextBlock Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="StackViewerTips">Tips</Hyperlink>
             </TextBlock>
         </Grid>

--- a/src/PerfView/Themes/LightTheme.xaml
+++ b/src/PerfView/Themes/LightTheme.xaml
@@ -42,11 +42,11 @@ SOFTWARE.
     <SolidColorBrush x:Key="ControlDefaultForeground" Color="#FF040404" />
     <SolidColorBrush x:Key="ControlMOSelectForeground" Color="#FF040404" />
 
-    <SolidColorBrush x:Key="ControlDarkerBackground" Color="#FFC7C7C7" />
+    <SolidColorBrush x:Key="ControlDarkerBackground" Color="#FFE7E7E7" />
     <SolidColorBrush x:Key="ControlDarkerBorderBrush" Color="#FFBEBEBE" />
-    <SolidColorBrush x:Key="ControlDefaultBackground" Color="#FFE1E1E1" />
+    <SolidColorBrush x:Key="ControlDefaultBackground" Color="#FFF3F3F3" />
     <SolidColorBrush x:Key="ControlDefaultBorderBrush" Color="#FFAFAFAF" />
-    <SolidColorBrush x:Key="ControlBrightDefaultBackground" Color="#FFCDCDCD" />
+    <SolidColorBrush x:Key="ControlBrightDefaultBackground" Color="#FFF0F0F0" />
     <SolidColorBrush x:Key="ControlBrightDefaultBorderBrush" Color="#FFAFAFAF" />
     <SolidColorBrush x:Key="ControlDisabledBackground" Color="#FFB4B4B4" />
     <SolidColorBrush x:Key="ControlDisabledBorderBrush" Color="#FF8C8C8C" />
@@ -73,7 +73,8 @@ SOFTWARE.
 
     <!-- Custom Window style (unaffected by win32 style stuff) -->
     <Style x:Key="CustomWindowStyle" TargetType="{x:Type Window}">
-        <!-- Leave empty, keep default style -->
+        <!-- Better for rendering small text -->
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
     </Style>
 
 </ResourceDictionary>

--- a/src/PerfView/Themes/LightTheme.xaml
+++ b/src/PerfView/Themes/LightTheme.xaml
@@ -77,4 +77,301 @@ SOFTWARE.
         <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
     </Style>
 
+    <!-- Custom MenuItem style which resolves color contrast issue with menu border brushes -->
+    <!-- Only two modifications to default control template: MenuItem.Selected.Border and MenuItem.Highlight.Border modified to #FF2084E8 -->
+    <SolidColorBrush x:Key="Menu.Static.Background" Color="#FFF0F0F0"/>
+    <SolidColorBrush x:Key="Menu.Static.Border" Color="#FF999999"/>
+    <SolidColorBrush x:Key="Menu.Static.Foreground" Color="#FF212121"/>
+    <SolidColorBrush x:Key="Menu.Static.Separator" Color="#FFD7D7D7"/>
+    <SolidColorBrush x:Key="Menu.Disabled.Foreground" Color="#FF707070"/>
+    <SolidColorBrush x:Key="MenuItem.Selected.Background" Color="#3D26A0DA"/>
+    <SolidColorBrush x:Key="MenuItem.Selected.Border" Color="#FF2084E8"/>
+    <SolidColorBrush x:Key="MenuItem.Highlight.Background" Color="#3D26A0DA"/>
+    <SolidColorBrush x:Key="MenuItem.Highlight.Border" Color="#FF2084E8"/>
+    <SolidColorBrush x:Key="MenuItem.Highlight.Disabled.Background" Color="#0A000000"/>
+    <SolidColorBrush x:Key="MenuItem.Highlight.Disabled.Border" Color="#21000000"/>
+    <MenuScrollingVisibilityConverter x:Key="MenuScrollingVisibilityConverter"/>
+    <Geometry x:Key="DownArrow">M 0,0 L 3.5,4 L 7,0 Z</Geometry>
+    <Geometry x:Key="UpArrow">M 0,4 L 3.5,0 L 7,4 Z</Geometry>
+    <Geometry x:Key="RightArrow">M 0,0 L 4,3.5 L 0,7 Z</Geometry>
+    <Geometry x:Key="Checkmark">F1 M 10.0,1.2 L 4.7,9.1 L 4.5,9.1 L 0,5.2 L 1.3,3.5 L 4.3,6.1L 8.3,0 L 10.0,1.2 Z</Geometry>
+    <Style x:Key="MenuScrollButton" BasedOn="{x:Null}" TargetType="{x:Type RepeatButton}">
+        <Setter Property="ClickMode" Value="Hover"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                    <Border x:Name="templateRoot" Background="Transparent" BorderBrush="Transparent" BorderThickness="1" SnapsToDevicePixels="true">
+                        <ContentPresenter HorizontalAlignment="Center" Margin="6" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="{ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}" BasedOn="{x:Null}" TargetType="{x:Type ScrollViewer}">
+        <Setter Property="HorizontalScrollBarVisibility" Value="Hidden"/>
+        <Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid SnapsToDevicePixels="true">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Border Grid.Column="0" Grid.Row="1">
+                            <ScrollContentPresenter CanContentScroll="{TemplateBinding CanContentScroll}" Margin="{TemplateBinding Padding}"/>
+                        </Border>
+                        <RepeatButton Command="{x:Static ScrollBar.LineUpCommand}" CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}" Grid.Column="0" Focusable="false" Grid.Row="0" Style="{StaticResource MenuScrollButton}">
+                            <RepeatButton.Visibility>
+                                <MultiBinding ConverterParameter="0" Converter="{StaticResource MenuScrollingVisibilityConverter}" FallbackValue="Visibility.Collapsed">
+                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                </MultiBinding>
+                            </RepeatButton.Visibility>
+                            <Path Data="{StaticResource UpArrow}" Fill="{StaticResource Menu.Static.Foreground}"/>
+                        </RepeatButton>
+                        <RepeatButton Command="{x:Static ScrollBar.LineDownCommand}" CommandTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}" Grid.Column="0" Focusable="false" Grid.Row="2" Style="{StaticResource MenuScrollButton}">
+                            <RepeatButton.Visibility>
+                                <MultiBinding ConverterParameter="100" Converter="{StaticResource MenuScrollingVisibilityConverter}" FallbackValue="Visibility.Collapsed">
+                                    <Binding Path="ComputedVerticalScrollBarVisibility" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="VerticalOffset" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ExtentHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    <Binding Path="ViewportHeight" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                </MultiBinding>
+                            </RepeatButton.Visibility>
+                            <Path Data="{StaticResource DownArrow}" Fill="{StaticResource Menu.Static.Foreground}"/>
+                        </RepeatButton>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <ControlTemplate x:Key="{ComponentResourceKey ResourceId=TopLevelItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" SnapsToDevicePixels="true">
+            <Grid VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon" ContentSource="Icon" HorizontalAlignment="Center" Height="16" Margin="3" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Width="16"/>
+                <Path x:Name="GlyphPanel" Data="{StaticResource Checkmark}" FlowDirection="LeftToRight" Fill="{StaticResource Menu.Static.Foreground}" Margin="3" VerticalAlignment="Center" Visibility="Collapsed"/>
+                <ContentPresenter ContentSource="Header" Grid.Column="1" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="true">
+                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Background}"/>
+                <Setter Property="BorderBrush" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Border}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="TextElement.Foreground" TargetName="templateRoot" Value="{StaticResource Menu.Disabled.Foreground}"/>
+                <Setter Property="Fill" TargetName="GlyphPanel" Value="{StaticResource Menu.Disabled.Foreground}"/>
+            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsHighlighted" Value="True"/>
+                    <Condition Property="IsEnabled" Value="False"/>
+                </MultiTrigger.Conditions>
+                <Setter Property="Background" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Disabled.Background}"/>
+                <Setter Property="BorderBrush" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Disabled.Border}"/>
+            </MultiTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+    <ControlTemplate x:Key="{ComponentResourceKey ResourceId=TopLevelHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" SnapsToDevicePixels="true">
+            <Grid VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon" ContentSource="Icon" HorizontalAlignment="Center" Height="16" Margin="3" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Width="16"/>
+                <Path x:Name="GlyphPanel" Data="{StaticResource Checkmark}" FlowDirection="LeftToRight" Fill="{TemplateBinding Foreground}" Margin="3" VerticalAlignment="Center" Visibility="Collapsed"/>
+                <ContentPresenter ContentSource="Header" Grid.Column="1" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                <Popup x:Name="PART_Popup" AllowsTransparency="true" Focusable="false" IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}" Placement="Bottom" PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}" PlacementTarget="{Binding ElementName=templateRoot}">
+                    <Border x:Name="SubMenuBorder" Background="{StaticResource Menu.Static.Background}" BorderBrush="{StaticResource Menu.Static.Border}" BorderThickness="1" Padding="2">
+                        <ScrollViewer x:Name="SubMenuScrollViewer" Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">
+                                    <Rectangle x:Name="OpaqueRect" Fill="{Binding Background, ElementName=SubMenuBorder}" Height="{Binding ActualHeight, ElementName=SubMenuBorder}" Width="{Binding ActualWidth, ElementName=SubMenuBorder}"/>
+                                </Canvas>
+                                <Rectangle Fill="{StaticResource Menu.Static.Separator}" HorizontalAlignment="Left" Margin="29,2,0,2" Width="1"/>
+                                <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" Grid.IsSharedSizeScope="true" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" KeyboardNavigation.TabNavigation="Cycle"/>
+                            </Grid>
+                        </ScrollViewer>
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsSuspendingPopupAnimation" Value="true">
+                <Setter Property="PopupAnimation" TargetName="PART_Popup" Value="None"/>
+            </Trigger>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="true">
+                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Background}"/>
+                <Setter Property="BorderBrush" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Border}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="TextElement.Foreground" TargetName="templateRoot" Value="{StaticResource Menu.Disabled.Foreground}"/>
+                <Setter Property="Fill" TargetName="GlyphPanel" Value="{StaticResource Menu.Disabled.Foreground}"/>
+            </Trigger>
+            <Trigger Property="ScrollViewer.CanContentScroll" SourceName="SubMenuScrollViewer" Value="false">
+                <Setter Property="Canvas.Top" TargetName="OpaqueRect" Value="{Binding VerticalOffset, ElementName=SubMenuScrollViewer}"/>
+                <Setter Property="Canvas.Left" TargetName="OpaqueRect" Value="{Binding HorizontalOffset, ElementName=SubMenuScrollViewer}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+    <ControlTemplate x:Key="{ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Height="22" SnapsToDevicePixels="true">
+            <Grid Margin="-1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="22" SharedSizeGroup="MenuItemIconColumnGroup" Width="Auto"/>
+                    <ColumnDefinition Width="13"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="30"/>
+                    <ColumnDefinition SharedSizeGroup="MenuItemIGTColumnGroup" Width="Auto"/>
+                    <ColumnDefinition Width="20"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon" ContentSource="Icon" HorizontalAlignment="Center" Height="16" Margin="3" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Width="16"/>
+                <Border x:Name="GlyphPanel" Background="{StaticResource MenuItem.Selected.Background}" BorderBrush="{StaticResource MenuItem.Selected.Border}" BorderThickness="1" ClipToBounds="False" HorizontalAlignment="Center" Height="22" Margin="-1,0,0,0" VerticalAlignment="Center" Visibility="Hidden" Width="22">
+                    <Path x:Name="Glyph" Data="{StaticResource Checkmark}" FlowDirection="LeftToRight" Fill="{StaticResource Menu.Static.Foreground}" Height="11" Width="10"/>
+                </Border>
+                <ContentPresenter x:Name="menuHeaderContainer" ContentSource="Header" Grid.Column="2" HorizontalAlignment="Left" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center"/>
+                <TextBlock x:Name="menuGestureText" Grid.Column="4" Margin="{TemplateBinding Padding}" Opacity="0.7" Text="{TemplateBinding InputGestureText}" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Background}"/>
+                <Setter Property="BorderBrush" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Border}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="TextElement.Foreground" TargetName="templateRoot" Value="{StaticResource Menu.Disabled.Foreground}"/>
+                <Setter Property="Fill" TargetName="Glyph" Value="{StaticResource Menu.Disabled.Foreground}"/>
+            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsHighlighted" Value="True"/>
+                    <Condition Property="IsEnabled" Value="False"/>
+                </MultiTrigger.Conditions>
+                <Setter Property="Background" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Disabled.Background}"/>
+                <Setter Property="BorderBrush" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Disabled.Border}"/>
+            </MultiTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+    <ControlTemplate x:Key="{ComponentResourceKey ResourceId=SubmenuHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Height="22" SnapsToDevicePixels="true">
+            <Grid Margin="-1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="22" SharedSizeGroup="MenuItemIconColumnGroup" Width="Auto"/>
+                    <ColumnDefinition Width="13"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="30"/>
+                    <ColumnDefinition SharedSizeGroup="MenuItemIGTColumnGroup" Width="Auto"/>
+                    <ColumnDefinition Width="20"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon" ContentSource="Icon" HorizontalAlignment="Center" Height="16" Margin="3" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Width="16"/>
+                <Border x:Name="GlyphPanel" Background="{StaticResource MenuItem.Highlight.Background}" BorderBrush="{StaticResource MenuItem.Highlight.Border}" BorderThickness="1" Height="22" Margin="-1,0,0,0" VerticalAlignment="Center" Visibility="Hidden" Width="22">
+                    <Path x:Name="Glyph" Data="{DynamicResource Checkmark}" FlowDirection="LeftToRight" Fill="{StaticResource Menu.Static.Foreground}" Height="11" Width="9"/>
+                </Border>
+                <ContentPresenter ContentSource="Header" Grid.Column="2" HorizontalAlignment="Left" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="4" Margin="{TemplateBinding Padding}" Opacity="0.7" Text="{TemplateBinding InputGestureText}" VerticalAlignment="Center"/>
+                <Path x:Name="RightArrow" Grid.Column="5" Data="{StaticResource RightArrow}" Fill="{StaticResource Menu.Static.Foreground}" HorizontalAlignment="Left" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                <Popup x:Name="PART_Popup" AllowsTransparency="true" Focusable="false" HorizontalOffset="-2" IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}" Placement="Right" PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}" VerticalOffset="-3">
+                    <Border x:Name="SubMenuBorder" Background="{StaticResource Menu.Static.Background}" BorderBrush="{StaticResource Menu.Static.Border}" BorderThickness="1" Padding="2">
+                        <ScrollViewer x:Name="SubMenuScrollViewer" Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">
+                                    <Rectangle x:Name="OpaqueRect" Fill="{Binding Background, ElementName=SubMenuBorder}" Height="{Binding ActualHeight, ElementName=SubMenuBorder}" Width="{Binding ActualWidth, ElementName=SubMenuBorder}"/>
+                                </Canvas>
+                                <Rectangle Fill="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" HorizontalAlignment="Left" Margin="29,2,0,2" Width="1"/>
+                                <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle" Grid.IsSharedSizeScope="true" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" KeyboardNavigation.TabNavigation="Cycle"/>
+                            </Grid>
+                        </ScrollViewer>
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsSuspendingPopupAnimation" Value="true">
+                <Setter Property="PopupAnimation" TargetName="PART_Popup" Value="None"/>
+            </Trigger>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Visibility" TargetName="GlyphPanel" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="Icon" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" TargetName="templateRoot" Value="Transparent"/>
+                <Setter Property="BorderBrush" TargetName="templateRoot" Value="{StaticResource MenuItem.Highlight.Border}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="TextElement.Foreground" TargetName="templateRoot" Value="{StaticResource Menu.Disabled.Foreground}"/>
+                <Setter Property="Fill" TargetName="Glyph" Value="{StaticResource Menu.Disabled.Foreground}"/>
+                <Setter Property="Fill" TargetName="RightArrow" Value="{StaticResource Menu.Disabled.Foreground}"/>
+            </Trigger>
+            <Trigger Property="ScrollViewer.CanContentScroll" SourceName="SubMenuScrollViewer" Value="false">
+                <Setter Property="Canvas.Top" TargetName="OpaqueRect" Value="{Binding VerticalOffset, ElementName=SubMenuScrollViewer}"/>
+                <Setter Property="Canvas.Left" TargetName="OpaqueRect" Value="{Binding HorizontalOffset, ElementName=SubMenuScrollViewer}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+    <Style x:Key="MenuItemStyle1" TargetType="{x:Type MenuItem}">
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
+        <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+        <Style.Triggers>
+            <Trigger Property="Role" Value="TopLevelHeader">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderBrush" Value="Transparent"/>
+                <Setter Property="Foreground" Value="{StaticResource Menu.Static.Foreground}"/>
+                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=TopLevelHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+                <Setter Property="Padding" Value="6,0"/>
+            </Trigger>
+            <Trigger Property="Role" Value="TopLevelItem">
+                <Setter Property="Background" Value="{StaticResource Menu.Static.Background}"/>
+                <Setter Property="BorderBrush" Value="{StaticResource Menu.Static.Border}"/>
+                <Setter Property="Foreground" Value="{StaticResource Menu.Static.Foreground}"/>
+                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=TopLevelItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+                <Setter Property="Padding" Value="6,0"/>
+            </Trigger>
+            <Trigger Property="Role" Value="SubmenuHeader">
+                <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuHeaderTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
 </ResourceDictionary>


### PR DESCRIPTION
This PR resolves some more accessibility bugs with PerfView. 

There were some major changes to the flame graph:
- Fixed a bug where only two of the 100 randomly generated flame graph colors were used, now we have our random colors again
- Updated the color generator to ensure that all colors have sufficient contrast with the text and background
- Added a border around flame boxes to allow for light coloured flame boxes (e.g. yellow) to have sufficient contrast against the background
- Fixed some bugs regarding rendering at different zoom levels. We now re-render every time the zoom level is updated. This might need some additional testing on some large traces to ensure it can handle it, but it seemed to handle fine on my machine with some test traces I made.
- Allowed keyboard focus on the entire flame graph canvas and ensured that it would get announced as a flame graph to screen readers, however there is still no ability to perform keyboard navigation inside the flame graph. 
- The help link for the flame graph is now keyboard navigable, so users with screen readers will be able to use that and understand that the flame graph is an alternate visualization of data that can be accessed using the other windows in the stack viewer. This should be sufficient for us to not have to implement a full automation peer for the flame graph (although that would be nice as a future PR) and comply with accessibility requirements.

New flame graph look with color contrasting and borders for both colour schemes:
![image](https://github.com/user-attachments/assets/13073c99-f4ce-4ee7-ae7e-fb8368ce3030)
![image](https://github.com/user-attachments/assets/69d70f31-71de-4622-925e-8757550e380a)

In addition, there were also the following changes:
- Ensured that all help links are keyboard navigable, some were disabled as a tab stop.
- Ensured that all help links have appropriate automation names as some were just a wrapper around a "?"
- Fixed keyboard focusing issues with the Cpu Ctrs box in the Run Command dialog
- Ensured that DataGrid column headers are focusable (and can be navigated to with tabs)
- Changed default text formatting to use "Display" mode, which works better for small text which we have a lot of.
- Changed some of the background colours to be a bit lighter to add more contrast.

There are three more bugs I want to resolve before I merge in this PR, but am making this PR now to get the review process started:
- The border that shows up when hovering over a menu item does not have sufficient contrast with the background
  - It seems the only way to fix this is to clone the >600 line ControlTemplate for `MenuItem` just so that we can change the BorderBrush when highlighted or selected. But want to make sure there is not a cleaner way to do that first.
- Some controls do not handle window resizing or text size 200% well and it leads to text being truncated
- `HistoryComboBox` controls do not announce the currently selected item when using the keyboard.
  - I believe this might be a bug with Windows Narrator, but will confirm with WPF team to be sure and if so will not need to address this in this PR.