### PR TITLE
NRE when calling TraceEventProviders.GetProviderGuidByName

### DIFF
--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -1762,7 +1762,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
                             }
                             else
                             {
-                                Trace.WriteLine("TdhEnumerateProviders failed HR = " + hr);
+                                throw new Exception("TdhEnumerateProviders failed HR = " + hr);
                             }
                         }
                     }


### PR DESCRIPTION
Then TraceEventSession.ProviderNameToGuid is called code assumes this never results in null. See TraceEventProviders.GetProviderGuidByName. Then TraceEventNativeMethods.TdhEnumerateProviders results return a hr != 0 or providersDesc == null then Trace.WriteLine will be called and the function returns null. This pull request changes the behavior to return an incomplete list instead of crashing with a NRE. A point can me made to change the Trace.WriteLine to a throw new Exception(.