### PR TITLE
Change NetTrace format version support, eliminate pinning, and improve UnsupportedVersionException

### DIFF
--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -21,18 +21,13 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         public event ParseBufferItemFunction OnEvent;
         public event Action<int> OnEventsDropped;
 
-        public void ProcessEventBlock(byte[] eventBlockData, long streamOffset)
+        public void ProcessEventBlock(Block block)
         {
-            PinnedBuffer buffer = new PinnedBuffer(eventBlockData);
-            SpanReader reader = new SpanReader(eventBlockData, streamOffset);
+            SpanReader reader = block.Reader;
 
             // parse the header
-            if (eventBlockData.Length < 20)
-            {
-                throw new FormatException("Expected EventBlock of at least 20 bytes");
-            }
             ushort headerSize = reader.ReadUInt16();
-            if(headerSize < 20 || headerSize > eventBlockData.Length)
+            if(headerSize < 20)
             {
                 throw new FormatException("Invalid EventBlock header size");
             }
@@ -43,22 +38,23 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             reader.ReadBytes(headerSize - 4);
 
             // parse the events
-            EventMarker eventMarker = new EventMarker(buffer);
+            EventPipeEventHeader eventHeader = default;
             long timestamp = 0;
+            long maxTimestamp = 0;
+            long lastFlushTimestamp = 0;
             SpanReader tempReader = reader;
-            _source.ReadEventHeader(ref tempReader, useHeaderCompression, ref eventMarker.Header);
-            EventPipeThread thread = _threads.GetOrAddThread(eventMarker.Header.CaptureThreadIndexOrId, eventMarker.Header.SequenceNumber - 1);
-            eventMarker = new EventMarker(buffer);
+            _source.ReadEventHeader(ref tempReader, useHeaderCompression, ref eventHeader);
+            EventPipeThread thread = _threads.GetOrAddThread(eventHeader.CaptureThreadIndexOrId, eventHeader.SequenceNumber - 1);
+            EventMarker eventMarker = new EventMarker();
             while (reader.RemainingBytes.Length > 0)
             {
                 _source.ReadEventHeader(ref reader, useHeaderCompression, ref eventMarker.Header);
                 bool isSortedEvent = eventMarker.Header.IsSorted;
-                timestamp = eventMarker.Header.TimeStamp;
+                thread.LastCachedEventTimestamp = timestamp = eventMarker.Header.TimeStamp;
+                maxTimestamp = Math.Max(maxTimestamp, timestamp);
                 int sequenceNumber = eventMarker.Header.SequenceNumber;
                 if (isSortedEvent)
                 {
-                    thread.LastCachedEventTimestamp = timestamp;
-
                     // sorted events are the only time the captureThreadId should change
                     long captureThreadId = eventMarker.Header.CaptureThreadIndexOrId;
                     thread = _threads.GetOrAddThread(captureThreadId, sequenceNumber - 1);
@@ -68,29 +64,35 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
 
                 if(isSortedEvent)
                 {
+                    lastFlushTimestamp = timestamp;
                     SortAndDispatch(timestamp);
                     OnEvent?.Invoke(ref eventMarker.Header);
                 }
                 else
                 {
                     thread.Events.Enqueue(eventMarker);
-
                 }
 
                 reader.ReadBytes(eventMarker.Header.PayloadSize);
                 EventMarker lastEvent = eventMarker;
-                eventMarker = new EventMarker(buffer);
+                eventMarker = new EventMarker();
                 eventMarker.Header = lastEvent.Header;
             }
-            thread.LastCachedEventTimestamp = timestamp;
+
+            // We need to keep the buffer around until all events are processed
+            EventBlockBuffer buffer = new EventBlockBuffer(block.TakeOwnership(), maxTimestamp);
+            _buffers.Enqueue(buffer);
+
+            // get rid of old buffers if all their events are older than an event we already flushed
+            FreeOldEventBuffers(lastFlushTimestamp);
         }
 
-        public void ProcessSequencePointBlockV5OrLess(byte[] sequencePointBytes, long streamOffset)
+        public void ProcessSequencePointBlockV5OrLess(Block block)
         {
-            SpanReader reader = new SpanReader(sequencePointBytes, streamOffset);
+            SpanReader reader = block.Reader;
             long timestamp = (long)reader.ReadUInt64();
             int threadCount = (int)reader.ReadUInt32();
-            Flush(timestamp);
+            Flush();
             TrimEventsAfterSequencePoint();
             for (int i = 0; i < threadCount; i++)
             {
@@ -105,13 +107,13 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             FlushThreads = 1
         }
 
-        public void ProcessSequencePointBlockV6OrGreater(byte[] sequencePointBytes, long streamOffset)
+        public void ProcessSequencePointBlockV6OrGreater(Block block)
         {
-            SpanReader reader = new SpanReader(sequencePointBytes, streamOffset);
+            SpanReader reader = block.Reader;
             long timestamp = (long)reader.ReadUInt64();
             uint flags = reader.ReadUInt32();
             int threadCount = (int)reader.ReadUInt32();
-            Flush(timestamp);
+            Flush();
             TrimEventsAfterSequencePoint();
             for (int i = 0; i < threadCount; i++)
             {
@@ -127,14 +129,12 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         }
 
         /// <summary>
-        /// After all events have been parsed we could have some straglers that weren't
-        /// earlier than any sorted event. Sort and dispatch those now.
+        /// Flush all remaining events, free all buffers, and remove any threads that are pending removal.
         /// </summary>
-        public void Flush() => Flush(long.MaxValue);
-
-        private void Flush(long timestamp)
+        public void Flush()
         {
-            SortAndDispatch(timestamp);
+            SortAndDispatch(long.MaxValue);
+            FreeOldEventBuffers(long.MaxValue);
             CheckForPendingThreadRemoval();
         }
 
@@ -188,7 +188,6 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                 {
                     EventMarker eventMarker = oldestEventQueue.Dequeue();
                     OnEvent?.Invoke(ref eventMarker.Header);
-                    GC.KeepAlive(eventMarker);
                 }
             }
 
@@ -201,6 +200,23 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                 if(q.Count == 0)
                 {
                     q.TrimExcess();
+                }
+            }
+        }
+
+        private void FreeOldEventBuffers(long stopTimestamp)
+        {
+            while (_buffers.Count > 0)
+            {
+                EventBlockBuffer blockBuffer = _buffers.Peek();
+                if (blockBuffer.MaxEventTimestamp < stopTimestamp)
+                {
+                    _buffers.Dequeue();
+                    ((IDisposable)blockBuffer.Buffer).Dispose();
+                }
+                else
+                {
+                    break;
                 }
             }
         }
@@ -243,18 +259,25 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             }
         }
 
+        struct EventBlockBuffer
+        {
+            public EventBlockBuffer(FixedBuffer buffer, long maxTimestamp)
+            {
+                Buffer = buffer;
+                MaxEventTimestamp = maxTimestamp;
+            }
+            public FixedBuffer Buffer;
+            public long MaxEventTimestamp;
+        }
+
         EventPipeEventSource _source;
         ThreadCache _threads;
+        Queue<EventBlockBuffer> _buffers = new Queue<EventBlockBuffer>();
     }
 
     internal class EventMarker
     {
-        public EventMarker(PinnedBuffer buffer)
-        {
-            Buffer = buffer;
-        }
         public EventPipeEventHeader Header;
-        public PinnedBuffer Buffer;
     }
 
     internal class PinnedBuffer

--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tracing.EventPipe
 {

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -29,19 +29,19 @@ namespace Microsoft.Diagnostics.Tracing
     /// </summary>
     public unsafe class EventPipeEventSource : TraceEventDispatcher
     {
-        public EventPipeEventSource(string fileName) : this(new PinnedStreamReader(fileName, SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes), 0x20000), fileName, false)
+        public EventPipeEventSource(string fileName)
+            : this(new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete), false)
         {
         }
 
         public EventPipeEventSource(Stream stream)
-            : this(new PinnedStreamReader(stream, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes).WithStreamReaderAlignment(StreamReaderAlignment.OneByte)), "stream", true)
+            : this(stream, true)
         {
         }
 
-        private EventPipeEventSource(PinnedStreamReader streamReader, string name, bool isStreaming)
+        private EventPipeEventSource(Stream stream, bool isStreaming)
         {
-            _reader = streamReader;
-            _fileName = name;
+            _stream = new RewindableStream(stream);
             _isStreaming = isStreaming;
             osVersion = new Version("0.0.0.0");
             cpuSpeedMHz = 10;
@@ -51,7 +51,8 @@ namespace Microsoft.Diagnostics.Tracing
                 ParseHeadersAndInitCaches();
         }
 
-        const int MaxSupportedMajorVersion = 5;
+        internal const int MinSupportedMajorVersion = 3;
+        internal const int MaxSupportedMajorVersion = 6;
 
         private void ParseHeadersAndInitCaches()
         {
@@ -62,16 +63,15 @@ namespace Microsoft.Diagnostics.Tracing
         // Parses the stream headers + TraceBlock and inits the right _parser implementation depending on file format version.
         private void ParseHeaders()
         {
-            StreamLabel start = _reader.Current;
             byte[] netTraceMagic = new byte[8];
-            _reader.Read(netTraceMagic, 0, netTraceMagic.Length);
+            _stream.Read(netTraceMagic);
             byte[] expectedMagic = Encoding.UTF8.GetBytes("Nettrace");
             bool isNetTrace = true;
             bool isFastSerialization = true;
             if (!netTraceMagic.SequenceEqual(expectedMagic))
             {
                 // The older netperf format didn't have this 'Nettrace' magic on it.
-                _reader.Goto(start);
+                _stream.CacheUnusedBytes(netTraceMagic);
                 isNetTrace = false;
             }
 
@@ -79,27 +79,26 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 // After the NetTrace header is either a reserved 4 byte zero field: version >= 6
                 // or the FastSerialization header: version <= 5
-                StreamLabel afterNetTraceHeader = _reader.Current;
-                int reserved = _reader.ReadInt32();
+                Span<byte> reservedBytes = stackalloc byte[4];
+                _stream.Read(reservedBytes);
+                int reserved = MemoryMarshal.Read<int>(reservedBytes);
                 if (reserved != 0)
                 {
-                    _reader.Goto(afterNetTraceHeader);
+                    _stream.CacheUnusedBytes(reservedBytes);
                     // the FastSerializationObjectParser will set FileFormatVersionNumber when it parses the TraceBlock
                 }
                 else
                 {
-                    int major = _reader.ReadInt32();
+                    int major = _stream.Read<int>();
                     if (major < 6)
                     {
                         throw new FormatException($"Invalid NetTrace versioning header");
                     }
-                    else if (major > MaxSupportedMajorVersion)
-                    {
-                        throw new UnsupportedFormatVersionException(major);
-                    }
+                    ThrowIfMajorVersionNotSupported(major);
+
                     // we don't use minor version for anything yet. Minor version bumps are for non-breaking changes so this reader
                     // should be compatible regardless of the minor version.
-                    int minor = _reader.ReadInt32();
+                    int minor = _stream.Read<int>();
                     FileFormatVersionNumber = major;
                     isFastSerialization = false;
                 }
@@ -107,14 +106,22 @@ namespace Microsoft.Diagnostics.Tracing
 
             if (isFastSerialization)
             {
-                _parser = new FastSerializationObjectParser(this, _reader, _fileName, isNetTrace);
+                _parser = new FastSerializationObjectParser(this, _stream, isNetTrace);
             }
             else
             {
-                _parser = new V6BlockParser(this, _reader);
+                _parser = new V6BlockParser(this, _stream);
             }
 
             _parser.ParseTraceBlock();
+        }
+
+        internal void ThrowIfMajorVersionNotSupported(int majorVersion)
+        {
+            if (majorVersion < MinSupportedMajorVersion || majorVersion > MaxSupportedMajorVersion)
+            {
+                throw new UnsupportedFormatVersionException(majorVersion, MinSupportedMajorVersion, MaxSupportedMajorVersion);
+            }
         }
 
         private void InitCaches()
@@ -176,8 +183,9 @@ namespace Microsoft.Diagnostics.Tracing
 
 
 #if SUPPORT_V1_V2
-        internal void ReadTraceObjectV1To2(IStreamReader reader)
+        internal void ReadTraceObjectV1To2(Block block)
         {
+            SpanReader reader = block.Reader;
             // The start time is stored as a SystemTime which is a bunch of shorts, convert to DateTime.
             short year = reader.ReadInt16();
             short month = reader.ReadInt16();
@@ -198,8 +206,9 @@ namespace Microsoft.Diagnostics.Tracing
         }
 #endif
 
-        internal void ReadTraceObjectV3To5(IStreamReader reader)
+        internal void ReadTraceObjectV3To5(Block block)
         {
+            SpanReader reader = block.Reader;
             // The start time is stored as a SystemTime which is a bunch of shorts, convert to DateTime.
             short year = reader.ReadInt16();
             short month = reader.ReadInt16();
@@ -220,8 +229,9 @@ namespace Microsoft.Diagnostics.Tracing
             _expectedCPUSamplingRate = reader.ReadInt32();
         }
 
-        internal void ReadTraceBlockV6OrGreater(SpanReader reader)
+        internal void ReadTraceBlockV6OrGreater(Block block)
         {
+            SpanReader reader = block.Reader;
             short year = reader.ReadInt16();
             short month = reader.ReadInt16();
             short dayOfWeek = reader.ReadInt16();
@@ -260,23 +270,23 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
-        internal void ReadEventBlockV3OrLess(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadEventBlockV3OrLess(Block block)
         {
-            SpanReader eventBlockReader = new SpanReader(blockBytes, startBlockStreamOffset);
+            SpanReader eventBlockReader = block.Reader;
             while (eventBlockReader.RemainingBytes.Length > 0)
             {
                 ReadAndProcessEvent(ref eventBlockReader);
             }
         }
 
-        internal void ReadEventBlockV4OrGreater(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadEventBlockV4OrGreater(Block block)
         {
-            EventCache.ProcessEventBlock(blockBytes, startBlockStreamOffset);
+            EventCache.ProcessEventBlock(block);
         }
 
-        internal void ReadMetadataBlockV6OrGreater(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadMetadataBlockV6OrGreater(Block block)
         {
-            SpanReader reader = new SpanReader(blockBytes, startBlockStreamOffset);
+            SpanReader reader = block.Reader;
             int headerSize = reader.ReadUInt16();
             reader.ReadBytes(headerSize);
             while(reader.RemainingBytes.Length > 0)
@@ -285,16 +295,16 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
-        internal void ReadMetadataBlockV5OrLess(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadMetadataBlockV5OrLess(Block block)
         {
-            SpanReader metadataReader = new SpanReader(blockBytes, startBlockStreamOffset);
+            SpanReader metadataReader = block.Reader;
 
             short headerSize = metadataReader.ReadInt16();
             if(headerSize < 20)
             {
                 throw new FormatException($"Invalid metadata header size {headerSize}");
             }
-            SpanReader headerReader = new SpanReader(metadataReader.ReadBytes(headerSize-2), (long)startBlockStreamOffset + 2);
+            SpanReader headerReader = metadataReader.CreateChildReader(headerSize - 2);
             short flags = headerReader.ReadInt16();
 
             EventPipeEventHeader eventHeader = new EventPipeEventHeader();
@@ -307,28 +317,28 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
-        internal void ReadSequencePointBlockV5OrLess(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadSequencePointBlockV5OrLess(Block block)
         {
-            EventCache.ProcessSequencePointBlockV5OrLess(blockBytes, startBlockStreamOffset);
+            EventCache.ProcessSequencePointBlockV5OrLess(block);
             StackCache.Flush();
             LabelListCache.Flush();
         }
 
-        internal void ReadSequencePointBlockV6OrGreater(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadSequencePointBlockV6OrGreater(Block block)
         {
-            EventCache.ProcessSequencePointBlockV6OrGreater(blockBytes, startBlockStreamOffset);
+            EventCache.ProcessSequencePointBlockV6OrGreater(block);
             StackCache.Flush();
             LabelListCache.Flush();
         }
 
-        internal void ReadStackBlock(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadStackBlock(Block block)
         {
-            StackCache.ProcessStackBlock(blockBytes);
+            StackCache.ProcessStackBlock(block);
         }
 
-        internal void ReadLabelListBlock(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadLabelListBlock(Block block)
         {
-            LabelListCache.ProcessLabelListBlock(blockBytes, startBlockStreamOffset);
+            LabelListCache.ProcessLabelListBlock(block);
         }
 
         enum ThreadInfoKind
@@ -339,11 +349,11 @@ namespace Microsoft.Diagnostics.Tracing
             KeyValue = 4
         }
 
-        internal void ReadThreadBlock(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadThreadBlock(Block block)
         {
             Debug.Assert(FileFormatVersionNumber >= 6);
 
-            SpanReader reader = new SpanReader(blockBytes, startBlockStreamOffset);
+            SpanReader reader = block.Reader;
             while(reader.RemainingBytes.Length > 0)
             {
                 ushort size = reader.ReadUInt16();
@@ -382,11 +392,11 @@ namespace Microsoft.Diagnostics.Tracing
             }
         }
 
-        internal void ReadRemoveThreadBlock(byte[] blockBytes, long startBlockStreamOffset)
+        internal void ReadRemoveThreadBlock(Block block)
         {
             Debug.Assert(FileFormatVersionNumber >= 6);
 
-            SpanReader reader = new SpanReader(blockBytes, startBlockStreamOffset);
+            SpanReader reader = block.Reader;
             while (reader.RemainingBytes.Length > 0)
             {
                 long streamOffset = reader.StreamOffset;
@@ -395,24 +405,6 @@ namespace Microsoft.Diagnostics.Tracing
                 EventCache.CheckpointThreadAndPendRemoval(index, sequenceNumber);
             }
         }
-
-#if SUPPORT_V1_V2
-        /// <summary>
-        /// Parses one event from the stream. If it is a metadata event it is cached for later use.
-        /// If it is a regular event it is dispatched to the registered event handlers.
-        /// </summary>
-        internal void ReadAndProcessEvent(PinnedStreamReader reader)
-        {
-            Debug.Assert(FileFormatVersionNumber <= 2);
-            byte* headerPtr = reader.GetPointer(EventPipeEventHeader.GetHeaderSize(FileFormatVersionNumber));
-            int totalSize = EventPipeEventHeader.GetTotalEventSize(headerPtr, FileFormatVersionNumber);
-            headerPtr = reader.GetPointer(totalSize); // now we now the real size and get read entire event
-            ReadOnlySpan<byte> eventSpan = new ReadOnlySpan<byte>(headerPtr, totalSize);
-            SpanReader eventReader = new SpanReader(eventSpan, (long)reader.Current);
-            ReadAndProcessEvent(ref eventReader);
-            reader.Skip(totalSize);
-        }
-#endif
 
         /// <summary>
         /// Parses one event from the stream. If it is a metadata event it is cached for later use.
@@ -649,15 +641,14 @@ namespace Microsoft.Diagnostics.Tracing
         }
 
         private Dictionary<int, EventPipeMetadata> _eventMetadataDictionary = new Dictionary<int, EventPipeMetadata>();
-        private IBlockParser _parser;
+        private BlockParser _parser;
         private Dictionary<TraceEvent, DynamicTraceEventData> _metadataTemplates =
             new Dictionary<TraceEvent, DynamicTraceEventData>(new ExternalTraceEventParserState.TraceEventComparer());
         private int _eventsLost;
         private int _lastLabelListId;
         internal int _processId;
         internal int _expectedCPUSamplingRate;
-        private PinnedStreamReader _reader;
-        private string _fileName;
+        private RewindableStream _stream;
         private bool _isStreaming;
         private ThreadCache _threadCache;
         #endregion
@@ -666,351 +657,389 @@ namespace Microsoft.Diagnostics.Tracing
 
     public class UnsupportedFormatVersionException : FormatException
     {
-        public UnsupportedFormatVersionException(int requestedVersion) : base($"NetTrace file format version {requestedVersion} is unsupported.")
+        public UnsupportedFormatVersionException(int requestedVersion, int minSupportedVersion, int maxSupportedVersion) 
+            : base($"NetTrace file format version {requestedVersion} is unsupported.")
         {
             RequestedVersion = requestedVersion;
+            MinSupportedVersion = minSupportedVersion;
+            MaxSupportedVersion = maxSupportedVersion;
         }
 
         public int RequestedVersion { get; }
+        public int MinSupportedVersion { get; }
+        public int MaxSupportedVersion { get; }
     }
 
 #region private classes
 
-// This interfaces abstracts the logic that parses either the FastSerialization objects used up to version 5
-// or the simplified block format used in version 6 and later.
-internal interface IBlockParser : IDisposable
+    // This interfaces abstracts the logic that parses either the FastSerialization objects used up to version 5
+    // or the simplified block format used in version 6 and later.
+    internal interface IBlockParser : IDisposable
     {
         void ParseTraceBlock();
         void ParseRemainder();
     }
 
-    internal class V6BlockParser : IBlockParser
+    internal abstract class BlockParser : IDisposable
     {
-        PinnedStreamReader _reader;
-        EventPipeEventSource _source;
-
-        public V6BlockParser(EventPipeEventSource source, PinnedStreamReader reader)
+        protected EventPipeEventSource _source;
+        protected RewindableStream _stream;
+        private int _afterBlockCacheSize;
+        protected BlockParser(EventPipeEventSource source, RewindableStream stream, int afterBlockCacheSize)
         {
-            _reader = reader;
             _source = source;
+            _stream = stream;
+            _afterBlockCacheSize = afterBlockCacheSize;
         }
+
+        protected abstract void ParseBlock(Block block);
+        protected abstract BlockHeader ReadBlockHeader();
+        protected abstract void ReadBlockFooter();
+
 
         public void ParseTraceBlock()
         {
-            BlockHeader header = ReadBlockHeader();
-            if (header.Kind != BlockKind.Trace)
+            using (Block block = ReadBlock())
             {
-                throw new FormatException($"Expected Trace block, but got Kind={header.Kind} at stream offset 0x{_reader.Current.Add(-4):x}");
+                if (block.Kind != BlockKind.Trace)
+                {
+                    throw new FormatException($"Expected Trace block, but got Kind={block.Kind} at stream offset 0x{block.StreamOffset:x}");
+                }
+                ParseBlock(block);
             }
-            StreamLabel startOfBlock = _reader.Current;
-            byte[] blockBytes = new byte[header.Length];
-            _reader.Read(blockBytes, 0, blockBytes.Length);
-            _source.ReadTraceBlockV6OrGreater(new SpanReader(blockBytes,(long)_reader.Current));
+            ReadBlockFooter();
         }
 
         public void ParseRemainder()
-        { 
-            while(true)
+        {
+            while (true)
             {
-                BlockHeader header = ReadBlockHeader();
-                long blockStartOffset = (long)_reader.Current;
-                byte[] blockBytes = new byte[header.Length];
-                _reader.Read(blockBytes, 0, blockBytes.Length);
-                switch (header.Kind)
+                using (Block block = ReadBlock())
                 {
-                    case BlockKind.Event:
-                        _source.ReadEventBlockV4OrGreater(blockBytes, blockStartOffset);
-                        break;
-                    case BlockKind.Metadata:
-                        _source.ReadMetadataBlockV6OrGreater(blockBytes, blockStartOffset);
-                        break;
-                    case BlockKind.SequencePoint:
-                        _source.ReadSequencePointBlockV6OrGreater(blockBytes, blockStartOffset);
-                        break;
-                    case BlockKind.StackBlock:
-                        _source.ReadStackBlock(blockBytes, blockStartOffset);
-                        break;
-                    case BlockKind.Thread:
-                        _source.ReadThreadBlock(blockBytes, blockStartOffset);
-                        break;
-                    case BlockKind.RemoveThread:
-                        _source.ReadRemoveThreadBlock(blockBytes, blockStartOffset);
-                        break;
-                    case BlockKind.LabelList:
-                        _source.ReadLabelListBlock(blockBytes, blockStartOffset);
-                        break;
-                    case BlockKind.EndOfStream:
-                        _source.EventCache.Flush();
-                        return;
-                    default:
-                        break; // ignore unknown block types so that the file format can be extended in the future
+                    ParseBlock(block);
+                    if (block.Kind == BlockKind.EndOfStream) break;
+                    ReadBlockFooter();
                 }
             }
         }
 
         public void Dispose()
         {
-            _reader?.Dispose();
+            _stream.Dispose();
         }
 
-        private BlockHeader ReadBlockHeader()
+        private Block ReadBlock()
         {
-            int headerInt = _reader.ReadInt32();
-            BlockHeader header = new BlockHeader()
+            BlockHeader header = ReadBlockHeader();
+            long blockStartOffset = _stream.Position;
+            FixedBuffer buffer = new FixedBuffer(header.Length + _afterBlockCacheSize);
+            bool success = false;
+            long streamOffset = _stream.Position;
+            try
             {
-                Kind = (BlockKind)(headerInt >> 24),
-                Length = headerInt & 0xFFFFFF
-            };
-            return header;
+                int bytesRead = _stream.ReadAtLeast(buffer.Memory.Span, header.Length);
+                if (bytesRead > header.Length)
+                {
+                    _stream.CacheUnusedBytes(buffer.Memory.Span.Slice(header.Length, bytesRead - header.Length));
+                }
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    ((IDisposable)buffer).Dispose();
+                }
+            }
+            return new Block(header.Kind, streamOffset, buffer.Memory.Slice(0, header.Length), buffer);
         }
 
-        struct BlockHeader
+        protected struct BlockHeader
         {
+            public BlockHeader(BlockKind kind, int length)
+            {
+                Kind = kind;
+                Length = length;
+            }
             public BlockKind Kind;
             public int Length;
         }
+    }
 
-        enum BlockKind
+    internal class V6BlockParser : BlockParser
+    {
+
+        public V6BlockParser(EventPipeEventSource source, RewindableStream stream) : base(source, stream, 4) { }
+
+        protected override BlockHeader ReadBlockHeader()
         {
-            EndOfStream = 0,
-            Trace = 1,
-            Event = 2,
-            Metadata = 3,
-            SequencePoint = 4,
-            StackBlock = 5,
-            Thread = 6,
-            RemoveThread = 7,
-            LabelList = 8
+            int headerInt = _stream.Read<int>();
+            return new BlockHeader((BlockKind)(headerInt >> 24), headerInt & 0xFFFFFF);
+        }
+
+        protected override void ReadBlockFooter()
+        {
+            // do nothing, the V6 format doesn't have a footer
+        }
+
+        protected override void ParseBlock(Block block)
+        {
+            switch (block.Kind)
+            {
+                case BlockKind.Trace:
+                    _source.ReadTraceBlockV6OrGreater(block);
+                    break;
+                case BlockKind.Event:
+                    _source.ReadEventBlockV4OrGreater(block);
+                    break;
+                case BlockKind.Metadata:
+                    _source.ReadMetadataBlockV6OrGreater(block);
+                    break;
+                case BlockKind.SequencePoint:
+                    _source.ReadSequencePointBlockV6OrGreater(block);
+                    break;
+                case BlockKind.StackBlock:
+                    _source.ReadStackBlock(block);
+                    break;
+                case BlockKind.Thread:
+                    _source.ReadThreadBlock(block);
+                    break;
+                case BlockKind.RemoveThread:
+                    _source.ReadRemoveThreadBlock(block);
+                    break;
+                case BlockKind.LabelList:
+                    _source.ReadLabelListBlock(block);
+                    break;
+                case BlockKind.EndOfStream:
+                    _source.EventCache.Flush();
+                    return;
+                default:
+                    break; // ignore unknown block types so that the file format can be extended in the future
+            }
+        }
+
+    }
+
+    internal class FastSerializationObjectParser : BlockParser
+    {
+        bool _isNetTrace;
+        public FastSerializationObjectParser(EventPipeEventSource source, RewindableStream stream, bool isNetTrace) : base(source, stream, 64)
+        {
+            _isNetTrace = isNetTrace;
+            ValidateFastSerializationHeader();
+        }
+
+        private void ValidateFastSerializationHeader()
+        {
+            byte[] fastSerializationMagic = UTF8Encoding.UTF8.GetBytes("!FastSerialization.1");
+            if (_stream.Read<int>() != fastSerializationMagic.Length)
+            {
+                throw new FormatException("Invalid FastSerialization header");
+            }
+            Span<byte> streamMagic = stackalloc byte[fastSerializationMagic.Length];
+            _stream.Read(streamMagic);
+            if (!streamMagic.SequenceEqual(fastSerializationMagic))
+            {
+                throw new FormatException("Invalid FastSerialization header");
+            }
+        }
+
+        protected override BlockHeader ReadBlockHeader()
+        {
+            byte tag = _stream.Read<byte>();
+            if (tag == (byte)FastSerializationTag.NullReference)
+            {
+                return new BlockHeader(BlockKind.EndOfStream, 0);
+            }
+            FastSerializationTag expectedBeginTag = _isNetTrace ? FastSerializationTag.BeginPrivateObject : FastSerializationTag.BeginObject;
+            AssertTag(tag, expectedBeginTag);
+            AssertTag(expectedBeginTag);
+            AssertTag(FastSerializationTag.NullReference);
+            int version = _stream.Read<int>();
+            int minVersion = _stream.Read<int>();
+            int typeLen = _stream.Read<int>();
+            int maxLen = BlockName.EventPipeFile.Length;
+            if (typeLen > maxLen)
+            {
+                throw new FormatException($"Invalid FastSerialization object type length {typeLen}");
+            }
+            Span<byte> typeName = stackalloc byte[typeLen];
+            _stream.Read(typeName);
+            AssertTag(FastSerializationTag.EndObject);
+
+
+            int blockSize;
+            BlockKind type;
+            if (typeLen == BlockName.Trace.Length && typeName.SequenceEqual(BlockName.Trace))
+            {
+                type = BlockKind.Trace;
+            }
+            else if (typeLen == BlockName.EventPipeFile.Length && typeName.SequenceEqual(BlockName.EventPipeFile))
+            {
+                type = BlockKind.Trace;
+            }
+            else if (typeLen == BlockName.EventBlock.Length && typeName.SequenceEqual(BlockName.EventBlock))
+            {
+                type = BlockKind.Event;
+            }
+            else if (typeLen == BlockName.MetadataBlock.Length && typeName.SequenceEqual(BlockName.MetadataBlock))
+            {
+                type = BlockKind.Metadata;
+            }
+            else if (typeLen == BlockName.StackBlock.Length && typeName.SequenceEqual(BlockName.StackBlock))
+            {
+                type = BlockKind.StackBlock;
+            }
+            else if (typeLen == BlockName.SPBlock.Length && typeName.SequenceEqual(BlockName.SPBlock))
+            {
+                type = BlockKind.SequencePoint;
+            }
+            else
+            {
+                throw new FormatException("Unrecognized FastSerialization object type");
+            }
+
+            if (type == BlockKind.Trace)
+            {
+                if (version > 4)
+                {
+                    throw new FormatException("Unrecognized TraceBlock format version: " + version);
+                }
+                if((version == 4) != _isNetTrace)
+                {
+                    throw new FormatException("Unexpected TraceBlock format version: " + version);
+                }
+                _source.ThrowIfMajorVersionNotSupported(version);
+                _source.FileFormatVersionNumber = version;
+
+                blockSize = (version >= 3) ? 48 : 32;
+                return new BlockHeader(BlockKind.Trace, blockSize);
+            }
+
+            if (version > 2)
+            {
+                throw new FormatException("Unrecognized block version: " + version);
+            }
+
+            blockSize = _stream.Read<int>();
+            int curAlign = (int)(_stream.Position & 0x3);
+            int alignPad = (4 - curAlign) & 0x3;
+            Span<byte> alignPadBytes = stackalloc byte[alignPad];
+            _stream.Read(alignPadBytes);
+            return new BlockHeader(type, blockSize);
+        }
+
+        protected override void ReadBlockFooter()
+        {
+            AssertTag(FastSerializationTag.EndObject);
+        }
+
+        protected override void ParseBlock(Block block)
+        {
+            switch (block.Kind)
+            {
+                case BlockKind.Trace:
+
+                    
+                    _source.ReadTraceObjectV3To5(block);
+                    break;
+
+                case BlockKind.Event:
+                    if (_source.FileFormatVersionNumber >= 4)
+                    {
+                        _source.ReadEventBlockV4OrGreater(block);
+                    }
+                    else
+                    {
+                        _source.ReadEventBlockV3OrLess(block);
+                    }
+                    break;
+
+                case BlockKind.Metadata:
+                    _source.ReadMetadataBlockV5OrLess(block);
+                    break;
+                case BlockKind.SequencePoint:
+                    _source.ReadSequencePointBlockV5OrLess(block);
+                    break;
+                case BlockKind.StackBlock:
+                    _source.ReadStackBlock(block);
+                    break;
+                case BlockKind.EndOfStream:
+                    _source.EventCache.Flush();
+                    return;
+                default:
+                    throw new FormatException($"Unrecognized block type {block.Kind} at stream offset 0x{block.StreamOffset:x}");
+            }
+        }
+
+        private void AssertTag(FastSerializationTag expected) => AssertTag(_stream.Read<byte>(), expected);
+
+        private void AssertTag(byte tag, FastSerializationTag expected)
+        {
+            if (tag != (byte)expected)
+            {
+                throw new FormatException($"Expected tag {expected}, but got {tag}");
+            }
+        }
+
+        enum FastSerializationTag : byte
+        {
+            NullReference = 1,
+            BeginObject = 4,
+            BeginPrivateObject = 5,
+            EndObject = 6
+        }
+
+        static class BlockName
+        {
+            public static byte[] EventPipeFile = Encoding.UTF8.GetBytes("Microsoft.DotNet.Runtime.EventPipeFile");
+            public static byte[] Trace = Encoding.UTF8.GetBytes("Trace");
+            public static byte[] MetadataBlock = Encoding.UTF8.GetBytes("MetadataBlock");
+            public static byte[] StackBlock = Encoding.UTF8.GetBytes("StackBlock");
+            public static byte[] EventBlock = Encoding.UTF8.GetBytes("EventBlock");
+            public static byte[] SPBlock = Encoding.UTF8.GetBytes("SPBlock");
+        }
+
+    }
+
+    class Block : IDisposable
+    {
+        public Block(BlockKind kind, long streamOffset, Memory<byte> contents, FixedBuffer owner)
+        {
+            Kind = kind;
+            StreamOffset = streamOffset;
+            Contents = contents;
+            _owner = owner;
+        }
+
+        private FixedBuffer _owner;
+        public BlockKind Kind { get; }
+        public Memory<byte> Contents { get; }
+        public SpanReader Reader => new SpanReader(Contents.Span, StreamOffset);
+        public long StreamOffset { get; }
+        public FixedBuffer TakeOwnership()
+        {
+            FixedBuffer result = _owner;
+            _owner = null;
+            return result;
+        }
+        public void Dispose()
+        {
+            (_owner as IDisposable)?.Dispose();
         }
     }
 
-    internal class FastSerializationObjectParser : IBlockParser, IFastSerializable, IFastSerializableVersion
+    enum BlockKind
     {
-
-        EventPipeEventSource _source;
-        Deserializer _deserializer;
-        bool _isNetTrace;
-#if SUPPORT_V1_V2
-        StreamLabel _endOfEventStream;
-#endif
-
-        public FastSerializationObjectParser(EventPipeEventSource source, PinnedStreamReader streamReader, string fileName, bool isNetTrace)
-        {
-            _source = source;
-            _deserializer = new Deserializer(streamReader, fileName);
-            _isNetTrace = isNetTrace;
-#if SUPPORT_V1_V2
-            // This is only here for V2 and V1.  V3+ should use the name EventTrace, it can be removed when we drop support.
-            _deserializer.RegisterFactory("Microsoft.DotNet.Runtime.EventPipeFile", delegate { return this; });
-#endif
-            _deserializer.RegisterFactory("Trace", delegate { return this; });
-            _deserializer.RegisterFactory("EventBlock", delegate { return new EventPipeEventBlock(_source); });
-            _deserializer.RegisterFactory("MetadataBlock", delegate { return new EventPipeMetadataBlock(_source); });
-            _deserializer.RegisterFactory("SPBlock", delegate { return new EventPipeSequencePointBlock(_source); });
-            _deserializer.RegisterFactory("StackBlock", delegate { return new EventPipeStackBlock(_source); });
-        }
-
-
-        public void ParseTraceBlock()
-        {
-            var entryObj = _deserializer.GetEntryObject(); // this call invokes FromStream and reads header data
-            if ((_source.FileFormatVersionNumber >= 4) != _isNetTrace)
-            {
-                //NetTrace header should be present iff the version is >= 4
-                throw new SerializationException("Invalid NetTrace file format version");
-            }
-            // Because we told the deserialize to use 'this' when creating a EventPipeFile, we
-            // expect the entry object to be 'this'.
-            Debug.Assert(entryObj == this);
-        }
-
-        unsafe public void ParseRemainder()
-        {
-            if (_source.FileFormatVersionNumber >= 3)
-            {
-                // loop through the stream until we hit a null object.  Deserialization of
-                // EventPipeEventBlocks will cause dispatch to happen.
-                // ReadObject uses registered factories and recognizes types by names, then derserializes them with FromStream
-                while (_deserializer.ReadObject() != null)
-                { }
-
-                if (_source.FileFormatVersionNumber >= 4)
-                {
-                    // Ensure all events have been sorted and dispatched
-                    _source.EventCache.Flush();
-                }
-            }
-#if SUPPORT_V1_V2
-            else
-            {
-                PinnedStreamReader deserializerReader = (PinnedStreamReader)_deserializer.Reader;
-                while (deserializerReader.Current < _endOfEventStream)
-                {
-                    _source.ReadAndProcessEvent(deserializerReader);
-                }
-            }
-#endif
-        }
-
-        public void ToStream(Serializer serializer) => throw new InvalidOperationException("We dont ever serialize one of these in managed code so we don't need to implement ToSTream");
-
-        public void FromStream(Deserializer deserializer)
-        {
-            _source.FileFormatVersionNumber = deserializer.VersionBeingRead;
-
-#if SUPPORT_V1_V2
-            if (deserializer.VersionBeingRead < 3)
-            {
-                ForwardReference reference = deserializer.ReadForwardReference();
-                _endOfEventStream = deserializer.ResolveForwardReference(reference, preserveCurrent: true);
-                _source.ReadTraceObjectV1To2(deserializer.Reader);
-            }
-#endif
-            else
-            {
-                _source.ReadTraceObjectV3To5(deserializer.Reader);
-            }
-        }
-
-        public void Dispose()
-        {
-            _deserializer?.Dispose();
-        }
-
-        /// <summary>
-        /// This is the version number reader and writer (although we don't don't have a writer at the moment)
-        /// It MUST be updated (as well as MinimumReaderVersion), if breaking changes have been made.
-        /// If your changes are forward compatible (old readers can still read the new format) you
-        /// don't have to update the version number but it is useful to do so (while keeping MinimumReaderVersion unchanged)
-        /// so that readers can quickly determine what new content is available.
-        /// </summary>
-        public int Version => 5;
-
-        /// <summary>
-        /// This field is only used for writers, and this code does not have writers so it is not used.
-        /// It should be set to Version unless changes since the last version are forward compatible
-        /// (old readers can still read this format), in which case this should be unchanged.
-        /// </summary>
-        public int MinimumReaderVersion => Version;
-
-        /// <summary>
-        /// This is the smallest version that the deserializer here can read.   Currently
-        /// we are careful about backward compat so our deserializer can read anything that
-        /// has ever been produced.   We may change this when we believe old writers basically
-        /// no longer exist (and we can remove that support code).
-        /// </summary>
-        public int MinimumVersionCanRead => 0;
-
-        /// <summary>
-        /// The Nettrace format is divided up into various blocks - this is a base class that handles the common
-        /// aspects for all of them.
-        /// </summary>
-        internal abstract class EventPipeBlock : IFastSerializable, IFastSerializableVersion
-        {
-            public EventPipeBlock(EventPipeEventSource source) => _source = source;
-
-            protected abstract void ReadBlockContents(byte[] blockBytes, long blockStartStreamOffset);
-
-            public unsafe void FromStream(Deserializer deserializer)
-            {
-                // blockSizeInBytes does not include padding bytes to ensure alignment.
-                var blockSizeInBytes = deserializer.ReadInt();
-
-                // after the block size comes eventual padding, we just need to skip it by jumping to the nearest aligned address
-                if ((long)deserializer.Current % 4 != 0)
-                {
-                    var nearestAlignedAddress = deserializer.Current.Add((int)(4 - ((long)deserializer.Current % 4)));
-                    deserializer.Goto(nearestAlignedAddress);
-                }
-
-                _startEventData = deserializer.Current;
-                _endEventData = _startEventData.Add(blockSizeInBytes);
-
-                PinnedStreamReader deserializerReader = (PinnedStreamReader)deserializer.Reader;
-                int blockLength = (int)_endEventData.Sub(_startEventData);
-                byte[] blockBytes = new byte[blockLength];
-                deserializerReader.Read(blockBytes, 0, blockBytes.Length);
-                ReadBlockContents(blockBytes, (long)_startEventData);
-            }
-
-            public void ToStream(Serializer serializer) => throw new InvalidOperationException();
-
-            protected StreamLabel _startEventData;
-            protected StreamLabel _endEventData;
-            protected EventPipeEventSource _source;
-
-            public int Version => 2;
-
-            public int MinimumVersionCanRead => Version;
-
-            public int MinimumReaderVersion => 0;
-        }
-
-        /// <summary>
-        /// An EventPipeEventBlock represents a block of events. In V3 and earlier, this block contains
-        /// a mixture of real events and metadata carrying events. In V4 onwards it contains only real events
-        /// and metadata was moved to a separate block.
-        /// </summary>
-        internal class EventPipeEventBlock : EventPipeBlock
-        {
-            public EventPipeEventBlock(EventPipeEventSource source) : base(source) { }
-
-            protected override void ReadBlockContents(byte[] blockBytes, long blockStartStreamOffset)
-            {
-                if (_source.FileFormatVersionNumber >= 4)
-                {
-                    _source.ReadEventBlockV4OrGreater(blockBytes, blockStartStreamOffset);
-                }
-                else
-                {
-                    _source.ReadEventBlockV3OrLess(blockBytes, blockStartStreamOffset);
-                }
-            }
-        }
-
-        /// <summary>
-        /// A block of metadata carrying events. These 'events' aren't dispatched by EventPipeEventSource - they carry
-        /// the metadata that allows the payloads of non-metadata events to be decoded.
-        /// </summary>
-        internal class EventPipeMetadataBlock : EventPipeBlock
-        {
-            public EventPipeMetadataBlock(EventPipeEventSource source) : base(source) { }
-
-            protected override void ReadBlockContents(byte[] blockBytes, long blockStartStreamOffset)
-            {
-                _source.ReadMetadataBlockV5OrLess(blockBytes, blockStartStreamOffset);
-            }
-        }
-
-        /// <summary>
-        /// An EventPipeSequencePointBlock represents a stream divider that contains
-        /// updates for all thread event sequence numbers, indicates that all queued
-        /// events can be sorted and dispatched, and that all cached events/stacks can
-        /// be flushed.
-        /// </summary>
-        internal class EventPipeSequencePointBlock : EventPipeBlock
-        {
-            public EventPipeSequencePointBlock(EventPipeEventSource source) : base(source) { }
-
-            protected override void ReadBlockContents(byte[] blockBytes, long blockStartStreamOffset)
-            {
-                _source.ReadSequencePointBlockV5OrLess(blockBytes, blockStartStreamOffset);
-            }
-        }
-
-        /// <summary>
-        /// An EventPipeStackBlock represents a block of interned stacks. Events refer
-        /// to stacks by an id.
-        /// </summary>
-        internal class EventPipeStackBlock : EventPipeBlock
-        {
-            public EventPipeStackBlock(EventPipeEventSource source) : base(source) { }
-
-            protected override void ReadBlockContents(byte[] blockBytes, long blockStartStreamOffset)
-            {
-                _source.ReadStackBlock(blockBytes, blockStartStreamOffset);
-            }
-        }
+        EndOfStream = 0,
+        Trace = 1,
+        Event = 2,
+        Metadata = 3,
+        SequencePoint = 4,
+        StackBlock = 5,
+        Thread = 6,
+        RemoveThread = 7,
+        LabelList = 8
     }
 
     internal enum EventBlockFlags : short
@@ -1315,5 +1344,5 @@ internal interface IBlockParser : IDisposable
             return header->RelatedActivityID;
         }
     }
-    #endregion
+#endregion
 }

--- a/src/TraceEvent/EventPipe/EventPipeMetadata.cs
+++ b/src/TraceEvent/EventPipe/EventPipeMetadata.cs
@@ -5,7 +5,6 @@ using Microsoft.Diagnostics.Tracing.Session;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Tracing

--- a/src/TraceEvent/EventPipe/EventPipeTraceEventParser.cs
+++ b/src/TraceEvent/EventPipe/EventPipeTraceEventParser.cs
@@ -1,7 +1,4 @@
-using FastSerialization;
 using Microsoft.Diagnostics.Tracing.Parsers;
-using System;
-using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.Tracing.EventPipe
 {

--- a/src/TraceEvent/EventPipe/FixedBuffer.cs
+++ b/src/TraceEvent/EventPipe/FixedBuffer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Tracing.EventPipe
+{
+    internal sealed class FixedBuffer : MemoryManager<byte>
+    {
+        private IntPtr _pointer;
+        private int _length;
+
+        internal FixedBuffer(int length)
+        {
+            _pointer = Marshal.AllocHGlobal(length);
+            _length = length;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Marshal.FreeHGlobal(_pointer);
+            _pointer = IntPtr.Zero;
+            _length = 0;
+        }
+
+        public unsafe override Span<byte> GetSpan()
+        {
+            return new Span<byte>(_pointer.ToPointer(), _length);
+        }
+
+        public override MemoryHandle Pin(int elementIndex = 0)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Unpin()
+        {
+        }
+    }
+}

--- a/src/TraceEvent/EventPipe/LabelListCache.cs
+++ b/src/TraceEvent/EventPipe/LabelListCache.cs
@@ -112,9 +112,9 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
     {
         Dictionary<int, LabelList> _labelLists = new Dictionary<int, LabelList>();
 
-        public void ProcessLabelListBlock(byte[] labelListBlock, long startBlockStreamOffset)
+        public void ProcessLabelListBlock(Block block)
         {
-            SpanReader reader = new SpanReader(labelListBlock, startBlockStreamOffset);
+            SpanReader reader = block.Reader;
 
             int curIndex = reader.ReadInt32();
             int count = reader.ReadInt32();

--- a/src/TraceEvent/EventPipe/RewindableStream.cs
+++ b/src/TraceEvent/EventPipe/RewindableStream.cs
@@ -1,0 +1,167 @@
+﻿using PEFile;
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Tracing.EventPipe
+{
+
+    /// <summary>
+    /// RewindableStream provides a limited ability to rewind in a stream that doesn't support seeking. This is useful in a couple cases:
+    /// - We can peek ahead in the stream interpreting data one way, then if we find that the data is actually in a different format, we can back up and call a different
+    ///   code path to read it a different way
+    /// - We can reduce the number of read system calls by reading a larger chunk than what we need, and then caching the extra bytes for later use.
+    ///   Opportunistically we can issue one read syscall per block by trying to include the next block's header.
+    /// 
+    /// To rewind the caller first uses Read or ReadAtLeast to read some bytes, then call CacheUnusedBytes() with some suffix of what was read to logically
+    /// rewind - returning those bytes back to the stream.
+    /// </summary>
+    internal class RewindableStream : IDisposable
+    {
+        protected Stream _stream;
+
+        // this cache has bytes that have already been read from the stream but not yet parsed
+        // it fills back to front and empties from front to back
+        byte[] _cachedBytes;
+        // the file position _cacheStreamOffset corresponds to _cachedBytes position _cacheArrayOffset
+        int _cacheArrayOffset;
+        long _cacheStreamOffset;
+        // the number of bytes available to be read in the cache
+        int _cacheBytesAvailable;
+
+        public RewindableStream(Stream stream, int maxCacheSize = 64)
+        {
+            _stream = stream;
+            _cachedBytes = new byte[maxCacheSize];
+            _cacheArrayOffset = _cachedBytes.Length;
+        }
+
+        public long Position => _cacheStreamOffset;
+
+        public int MaxCacheSize => _cachedBytes.Length;
+
+        private int ReadFromCache(Span<byte> buffer)
+        {
+            int bytesRead = Math.Min(_cacheBytesAvailable, buffer.Length);
+            if (bytesRead > 0)
+            {
+                _cachedBytes.AsSpan(_cacheArrayOffset, bytesRead).CopyTo(buffer);
+                _cacheArrayOffset += bytesRead;
+                _cacheStreamOffset += bytesRead;
+                _cacheBytesAvailable -= bytesRead;
+            }
+            return bytesRead;
+        }
+
+        public T Read<T>() where T : struct
+        {
+            Span<byte> buffer = stackalloc byte[Unsafe.SizeOf<T>()];
+            Read(buffer);
+            return MemoryMarshal.Read<T>(buffer);
+        }
+
+        public void Read(Span<byte> buffer) => ReadAtLeast(buffer, buffer.Length);
+
+        public int ReadAtLeast(Span<byte> buffer, int minLength)
+        {
+            // consume bytes from the cache first
+            int bytesRead = ReadFromCache(buffer);
+
+            // if the cache didn't satisfy the minimum read, read from the stream
+            while (bytesRead < minLength)
+            {
+                Debug.Assert(_cacheBytesAvailable == 0);
+                int read = _stream.Read(buffer.Slice(bytesRead));
+                if (read == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+                bytesRead += read;
+                _cacheStreamOffset += read;
+            }
+            return bytesRead;
+        }
+
+        // Readers are allowed to read more than they need, then give the extra bytes back to be stored in the cache for later.
+        // We only support caching bytes from the most recent call to Read/ReadAtLeast, and only up to the maximum cache size
+        // specified in the constructor.
+        public void CacheUnusedBytes(ReadOnlySpan<byte> extraBytes)
+        {
+            if (extraBytes.Length + _cacheBytesAvailable > MaxCacheSize)
+            {
+                // This should never happen unless there is a bug in the code
+                throw new InvalidOperationException($"Cache overflow");
+            }
+            // copy the new data into the cache
+            _cacheBytesAvailable += extraBytes.Length;
+            _cacheStreamOffset -= extraBytes.Length;
+            _cacheArrayOffset -= extraBytes.Length;
+            extraBytes.CopyTo(_cachedBytes.AsSpan(_cacheArrayOffset));
+        }
+
+
+        public void Dispose()
+        {
+            _stream.Dispose();
+        }
+    }
+
+    internal static class StreamExtensions
+    {
+        delegate int StreamReadDelegate(Stream stream, Span<byte> buffer);
+
+        private static readonly StreamReadDelegate s_streamReadDelegate = InitSpanRead();
+
+        private static StreamReadDelegate InitSpanRead()
+        {
+            // Opportunistically use it if reflection shows it is available, otherwise fallback to
+            // the slower Read(byte[], int, int) method + a copy.
+            MethodInfo method = typeof(Stream).GetMethod("Read", new Type[] { typeof(Span<byte>) });
+            if (method != null)
+            {
+                return (StreamReadDelegate)method.CreateDelegate(typeof(StreamReadDelegate), null);
+            }
+            else
+            {
+                return SlowStreamRead;
+            }
+        }
+
+        // A slower fallback for when Stream.Read(Span<byte>) is not available.
+        private static int SlowStreamRead(Stream stream, Span<byte> buffer)
+        {
+            byte[] arrayBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            int ret = stream.Read(arrayBuffer, 0, buffer.Length);
+            if (ret > 0)
+            {
+                arrayBuffer.AsSpan(0, ret).CopyTo(buffer);
+            }
+            ArrayPool<byte>.Shared.Return(arrayBuffer);
+            return ret;
+        }
+
+        public static int Read(this Stream stream, Span<byte> buffer)
+        {
+            return s_streamReadDelegate(stream, buffer);
+        }
+
+        public static int ReadAtLeast(this Stream stream, Span<byte> buffer, int minLength)
+        {
+            int bytesRead = 0;
+            while (bytesRead < minLength)
+            {
+                int read = stream.Read(buffer.Slice(bytesRead));
+                if (read == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+                bytesRead += read;
+            }
+            return bytesRead;
+        }
+    }
+}

--- a/src/TraceEvent/EventPipe/SpanReader.cs
+++ b/src/TraceEvent/EventPipe/SpanReader.cs
@@ -59,6 +59,23 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             }
         }
 
+        /// <summary>
+        /// This reader skips ahead length bytes and returns a new reader that can read the skipped bytes
+        /// </summary>
+        public SpanReader CreateChildReader(int length)
+        {
+            long offset = StreamOffset;
+            return new SpanReader(ReadBytes(length), offset);
+        }
+
+        /// <summary>
+        /// Returns a pointer to the start of the span. This is only safe if you know the Span is backed by fixed memory.
+        /// </summary>
+        public unsafe IntPtr UnsafeGetFixedReadPointer()
+        {
+            return (IntPtr)Unsafe.AsPointer<byte>(ref MemoryMarshal.GetReference(RemainingBytes));
+        }
+
         public ReadOnlySpan<byte> ReadBytes(int length)
         {
             if(_buffer.Length >= length)

--- a/src/TraceEvent/EventPipe/SpanReader.cs
+++ b/src/TraceEvent/EventPipe/SpanReader.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/TraceEvent/EventPipe/StackCache.cs
+++ b/src/TraceEvent/EventPipe/StackCache.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -26,38 +28,23 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             }
         }
 
-        public void ProcessStackBlock(byte[] stackBlock)
+        public void ProcessStackBlock(Block block)
         {
-            PinnedBuffer buffer = new PinnedBuffer(stackBlock);
-            if(stackBlock.Length < 8)
-            {
-                Debug.Assert(false, "Bad stack block size");
-                return;
-            }
-            int cursor = 0;
-            int firstStackId = BitConverter.ToInt32(stackBlock, cursor);
-            cursor += 4;
-            int countStackIds = BitConverter.ToInt32(stackBlock, cursor);
-            cursor += 4;
+            _buffers.Add(block.TakeOwnership());
+            SpanReader reader = block.Reader;
+            int firstStackId = reader.ReadInt32();
+            int countStackIds = reader.ReadInt32();
             int nextStackId = firstStackId;
-            while (cursor < stackBlock.Length)
+            while (reader.RemainingBytes.Length > 0)
             {
                 StackMarker marker = new StackMarker();
-                marker.BackingBuffer = buffer;
                 int stackId = nextStackId++;
-                marker.StackBytesSize = BitConverter.ToInt32(stackBlock, cursor);
-                cursor += 4;
-                if (cursor + marker.StackBytesSize <= stackBlock.Length)
-                {
-                    marker.StackBytes = buffer.PinningHandle.AddrOfPinnedObject() + cursor;
-                    cursor += marker.StackBytesSize;
-                    _stacks.Add(stackId, marker);
-                }
-                else
-                {
-                    Debug.Assert(false, "Stack size exceeds stack block region");
-                    break;
-                }
+                marker.StackBytesSize = reader.ReadInt32();
+                // This is safe because the span is backed by FixedBuffer and it can't move
+                // The StackCache will keep ownership of the buffer until it is flushed
+                marker.StackBytes = reader.UnsafeGetFixedReadPointer();
+                reader.ReadBytes(marker.StackBytesSize);
+                _stacks.Add(stackId, marker);
             }
             Debug.Assert(nextStackId == firstStackId + countStackIds);
         }
@@ -65,15 +52,20 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         public void Flush()
         {
             _stacks.Clear();
+            foreach(FixedBuffer buffer in _buffers)
+            {
+                ((IDisposable)buffer).Dispose();
+            }
+            _buffers.Clear();
         }
 
         struct StackMarker
         {
             public int StackBytesSize;
             public IntPtr StackBytes;
-            public PinnedBuffer BackingBuffer;
         }
 
         Dictionary<int, StackMarker> _stacks = new Dictionary<int, StackMarker>();
+        List<FixedBuffer> _buffers = new List<FixedBuffer>();
     }
 }

--- a/src/TraceEvent/EventPipe/StackCache.cs
+++ b/src/TraceEvent/EventPipe/StackCache.cs
@@ -1,12 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tracing.EventPipe
 {

--- a/src/TraceEvent/EventPipe/ThreadCache.cs
+++ b/src/TraceEvent/EventPipe/ThreadCache.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 
 namespace Microsoft.Diagnostics.Tracing.EventPipe
 {

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -218,26 +218,49 @@ namespace TraceEventTests
         }
 
         [Fact]
-        public void CanParseHeaderOfV1EventPipeFile()
+        public void V1IsUnsupported()
         {
             PrepareTestData();
-
             const string eventPipeFileName = "eventpipe-dotnetcore2.0-linux-objver1.netperf";
-
             string eventPipeFilePath = Path.Combine(UnZippedDataDir, eventPipeFileName);
 
-            using (var eventPipeSource = new EventPipeEventSource(eventPipeFilePath))
+            Assert.Throws<UnsupportedFormatVersionException>(() =>
             {
-                Assert.Equal(8, eventPipeSource.PointerSize);
-                Assert.Equal(0, eventPipeSource._processId);
-                Assert.Equal(1, eventPipeSource.NumberOfProcessors);
+                try
+                {
+                    using (var eventPipeSource = new EventPipeEventSource(eventPipeFilePath)) { }
+                }
+                catch (UnsupportedFormatVersionException ex)
+                {
+                    Assert.Equal(1, ex.RequestedVersion);
+                    Assert.Equal(3, ex.MinSupportedVersion);
+                    Assert.Equal(6, ex.MaxSupportedVersion);
+                    throw;
+                }
+            });
+        }
 
-                Assert.Equal(636414354195130000, eventPipeSource._syncTimeUTC.Ticks);
-                Assert.Equal(1477613380157300, eventPipeSource._syncTimeQPC);
-                Assert.Equal(1000000000, eventPipeSource._QPCFreq);
+        [Fact]
+        public void V2IsUnsupported()
+        {
+            PrepareTestData();
+            const string eventPipeFileName = "eventpipe-dotnetcore2.0-linux-objver2.netperf";
+            string eventPipeFilePath = Path.Combine(UnZippedDataDir, eventPipeFileName);
 
-                Assert.Equal(10, eventPipeSource.CpuSpeedMHz);
-            }
+            Assert.Throws<UnsupportedFormatVersionException>(() =>
+            {
+                try
+                {
+                    using (var eventPipeSource = new EventPipeEventSource(eventPipeFilePath)) { }
+                }
+                catch (UnsupportedFormatVersionException ex)
+                {
+                    Assert.Equal(2, ex.RequestedVersion);
+                    Assert.Equal(3, ex.MinSupportedVersion);
+                    Assert.Equal(6, ex.MaxSupportedVersion);
+                    throw;
+                }
+            });
         }
 
         [Fact]
@@ -812,7 +835,7 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseMinimalTraceV6()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -834,25 +857,26 @@ namespace TraceEventTests
             writer.WriteHeaders(new Dictionary<string, string>(), 7, 0);
             MemoryStream stream = new MemoryStream(writer.ToArray());
 
-            // Confirm we can parse the event payloads even though the parameters were not described in
-            // the metadata.
-            EventPipeEventSource source = new EventPipeEventSource(stream);
-            try
+            using (EventPipeEventSource source = new EventPipeEventSource(stream))
             {
-                source.Process();
-                Assert.Fail("Expected an UnsupportedFormatVersionException");
-            }
-            catch (UnsupportedFormatVersionException e)
-            {
-                Assert.Equal(7, e.RequestedVersion);
-            }
-            catch (Exception e)
-            {
-                Assert.Fail($"Expected an UnsupportedFormatVersionException but got {e}");
+                Assert.Throws<UnsupportedFormatVersionException>(() =>
+                {
+                    try
+                    {
+                        source.Process();
+                    }
+                    catch (UnsupportedFormatVersionException e)
+                    {
+                        Assert.Equal(7, e.RequestedVersion);
+                        Assert.Equal(3, e.MinSupportedVersion);
+                        Assert.Equal(6, e.MaxSupportedVersion);
+                        throw;
+                    }
+                });
             }
         }
 
-        [Fact(Skip ="NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void MinorVersionIncrementsAreSupported()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -864,7 +888,7 @@ namespace TraceEventTests
             Assert.Equal(6, source.FileFormatVersionNumber);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6TraceBlockStandardFields()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -881,7 +905,7 @@ namespace TraceEventTests
             Assert.Equal(0, source.NumberOfProcessors);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6TraceBlockKeyValuePairs()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -929,7 +953,7 @@ namespace TraceEventTests
         }
 
         // In the V6 format readers are expected to skip over any block types they don't recognize. This allows future extensibility.
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6UnrecognizedBlockTypesAreSkipped()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -948,7 +972,7 @@ namespace TraceEventTests
             Assert.Equal(6, source.FileFormatVersionNumber);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6Metadata()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -991,7 +1015,7 @@ namespace TraceEventTests
         }
 
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6MetadataArrayParam()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1029,7 +1053,7 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6MetadataObjectParam()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1069,7 +1093,7 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6OptionalMetadata()
         {
             Guid testGuid = Guid.Parse("CA0A7B93-622D-42C9-AFF8-7A09FDA2E30C");
@@ -1109,7 +1133,7 @@ namespace TraceEventTests
         }
 
         // Ensure that we can add extra bytes into the metadata encoding everywhere the format says we should be allowed to
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void SkipExtraMetadataSpaceV6()
         {
             Guid testGuid = Guid.Parse("CA0A7B93-622D-42C9-AFF8-7A09FDA2E30C");
@@ -1161,7 +1185,7 @@ namespace TraceEventTests
             Assert.Equal("TestEvent2", metadata2.EventName);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6LengthPrefixedStrings()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1220,7 +1244,7 @@ namespace TraceEventTests
         }
 
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6VarInts()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1292,7 +1316,7 @@ namespace TraceEventTests
         }
 
         // Ensure that the new string and varint types still work properly nested inside a struct
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6NestedVarIntsAndStrings()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1336,7 +1360,7 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6MissingThreadBlockThrowsException()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1352,7 +1376,7 @@ namespace TraceEventTests
             Assert.Throws<FormatException>(() => source.Process());
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6MismatchedRemoveThreadBlockThrowsException()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1376,7 +1400,7 @@ namespace TraceEventTests
             Assert.Throws<FormatException>(() => source.Process());
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6RefAfterRemoveThreadBlockThrowsException()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1400,7 +1424,7 @@ namespace TraceEventTests
             Assert.Throws<FormatException>(() => source.Process());
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6DoubleRemoveThreadBlockThrowsException()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1428,7 +1452,7 @@ namespace TraceEventTests
             Assert.Throws<FormatException>(() => source.Process());
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6ParseSimpleThreadBlock()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1472,7 +1496,7 @@ namespace TraceEventTests
             Assert.Equal(3, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6ParseMultipleThreadBlocks()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1561,7 +1585,7 @@ namespace TraceEventTests
             Assert.Equal(8, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6ParseOptionalThreadData()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1601,7 +1625,7 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
-        [Theory(Skip = "NetTrace V6 Support Disabled")]
+        [Theory] //V6
         [InlineData(true)]
         [InlineData(false)]
         public void V6ParseEventLabelLists(bool useCompressedEventHeaders)
@@ -1719,7 +1743,7 @@ namespace TraceEventTests
         }
 
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void ParseV6CompressedEventHeaders()
         {
             // these are arbitrary random constants
@@ -1815,7 +1839,7 @@ namespace TraceEventTests
             Assert.Equal(7, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6SequencePointDoesNotFlushThreadsByDefault()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1845,7 +1869,7 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6RedefinedThreadIndexThrowsFormatException()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1867,7 +1891,7 @@ namespace TraceEventTests
             Assert.Throws<FormatException>(() => source.Process());
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6SequencePointCanFlushThreadsOnDemand()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -1901,7 +1925,7 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
-        [Fact(Skip = "NetTrace V6 Support Disabled")]
+        [Fact] //V6
         public void V6SequencePointDetectsDroppedEvents()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -1942,6 +1942,48 @@ namespace TraceEventTests
             source.Process();
             Assert.Equal(5, source.EventsLost);
         }
+
+        [Fact] //V6
+        public void V6IncompleteTraceThrowsException()
+        {
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            // deliberately missing writer.WriteEndBlock();
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            EventPipeEventSource source = new EventPipeEventSource(stream);
+
+            // Past versions of TraceEvent threw System.Exception instead of FormatException
+            // Now we are trying to hold this behavior consistent
+            Assert.Throws<FormatException>(() => source.Process()); 
+        }
+
+        [Fact]
+        public void V5IncompleteTraceThrowsException()
+        {
+            EventPipeWriterV5 writer = new EventPipeWriterV5();
+            writer.WriteHeaders();
+            // deliberately missing writer.WriteEndBlock();
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            EventPipeEventSource source = new EventPipeEventSource(stream);
+
+            // Past versions of TraceEvent threw System.Exception instead of FormatException
+            // Now we are trying to hold this behavior consistent
+            Assert.Throws<FormatException>(() => source.Process());
+        }
+
+#if NETCOREAPP
+        [Fact]
+        public void StreamExtensionsUsesFastPath()
+        {
+            Assert.True(StreamExtensions.IsFastSpanReadAvailable);
+        }
+#else
+        [Fact]
+        public void StreamExtensionsDoesNotUseFastPath()
+        {
+            Assert.False(StreamExtensions.IsFastSpanReadAvailable);
+        }
+#endif
     }
 
 

--- a/src/TraceEvent/TraceEvent.Tests/Platform/EventPipeTestBase.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Platform/EventPipeTestBase.cs
@@ -24,7 +24,8 @@ namespace TraceEventTests
         // The test data is contained in files of the same name, but with a .zip extension.
         // Only the names are returned since the extracted files will be in a different directory.
         public static IEnumerable<object[]> TestEventPipeFiles
-            => TestEventPipeZipFiles.Select(file => new[] { Path.GetFileNameWithoutExtension(file) });
+            => TestEventPipeZipFiles.Where(file => !file.Contains("dotnetcore2.0")) // Exclude the no longer supported formats
+                                    .Select(file => new[] { Path.GetFileNameWithoutExtension(file)});
 
         // Only the subset of data files starting in 2.1 were in a format capable of streaming
         public static IEnumerable<object[]> StreamableTestEventPipeFiles

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -146,7 +146,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
-    <None Include="EventPipe\EventPipeFormat.md" />
 
     <None Include="Microsoft.Diagnostics.Tracing.TraceEvent.nuspec" />
     <None Include="Microsoft.Diagnostics.Tracing.TraceEvent.props" />


### PR DESCRIPTION

- Re-enabling support for parsing format V6 and re-enabling the tests
- Removed support for ancient netperf format version 1 and 2 that were only used during .NET Core 2.0 (not even 2.1).
- The implementation of the Nettrace reader was doing a bunch of pinning because the TraceEvent internal model of events uses unmanaged pointers, however the pinning was creating bad GC performance. TraceEvent builds for .NET standard so we don't have guaranteed access to the pinned heap and I didn't want to start doing lots of copying and/or managing pools of pinned arrays. Instead I switched the stream reading over to using spans backed by native heap allocations and explicit block lifetime tracking. As a side benefit it also brings the V3-5 block iteration code a bit closer to the V6 block iteration and removed all the dependencies on the existing FastSerialization library.
- Add MinSupportedVersion and MaxSupportedVersion to the UnsupportedVersionException




@wiktork - This may fix the GC issues you were seeing in dotnet-monitor
@karpinsn - Exception improvements should help with version error messages in Dev18

@mdh1418, @brianrob, @lateralusX, @beaubelgrave - aside from turning back on V6 support hopefully the behavior should be nearly identical to before despite all the code churn in there.
