### PR TITLE
Add /OSHeapMaxMB to set a max size for OS heap sessions

### DIFF
--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -132,6 +132,7 @@ namespace PerfView
         public bool JITInlining;            // Turn on logging of successful and failed JIT inlining
         public int OSHeapProcess;           // Turn on OS Heap tracing for the process with the given process ID.
         public string OSHeapExe;            // Turn on OS heap tracing for any process with the given EXE
+        public int OSHeapMaxMB;             // Maximum size of the heap ETL file.
 
         public bool NetworkCapture;         // Capture the full packets of every incoming and outgoing  packet
         public bool NetMonCapture;          // Capture a NetMon-only trace as well as a standard ETW trace (implies NetworkCapture)  
@@ -546,6 +547,7 @@ namespace PerfView
             parser.DefineOptionalQualifier("UserCritContention", ref UserCritContention, "Turn on UserCrit contention events.");
             parser.DefineOptionalQualifier("OSHeapProcess", ref OSHeapProcess, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given process ID.");
             parser.DefineOptionalQualifier("OSHeapExe", ref OSHeapExe, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given EXE (only filename WITH extension).");
+            parser.DefineOptionalQualifier("HeapMaxMB", ref OSHeapMaxMB, "Approximate maximum size of OS heap etl file.");
 
             parser.DefineOptionalQualifier("NetworkCapture", ref NetworkCapture, "Captures the full data of every network packet entering or leaving the OS.");
             parser.DefineOptionalQualifier("NetMonCapture", ref NetMonCapture, "Create _netmon.etl file that NetMon.exe can read, along with the standard ETL file.   Implies /NetworkCapture.");

--- a/src/PerfView/CommandLineArgs.cs
+++ b/src/PerfView/CommandLineArgs.cs
@@ -547,7 +547,7 @@ namespace PerfView
             parser.DefineOptionalQualifier("UserCritContention", ref UserCritContention, "Turn on UserCrit contention events.");
             parser.DefineOptionalQualifier("OSHeapProcess", ref OSHeapProcess, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given process ID.");
             parser.DefineOptionalQualifier("OSHeapExe", ref OSHeapExe, "Turn on per-allocation profiling of allocation from the OS heap for the process with the given EXE (only filename WITH extension).");
-            parser.DefineOptionalQualifier("HeapMaxMB", ref OSHeapMaxMB, "Approximate maximum size of OS heap etl file.");
+            parser.DefineOptionalQualifier("OSHeapMaxMB", ref OSHeapMaxMB, "Approximate maximum size of OS heap ETL file.");
 
             parser.DefineOptionalQualifier("NetworkCapture", ref NetworkCapture, "Captures the full data of every network packet entering or leaving the OS.");
             parser.DefineOptionalQualifier("NetMonCapture", ref NetMonCapture, "Create _netmon.etl file that NetMon.exe can read, along with the standard ETL file.   Implies /NetworkCapture.");

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -517,9 +517,15 @@ namespace PerfView
                     // Default is 256Meg and twice whatever the others are
                     heapSession.BufferSizeMB = Math.Max(256, parsedArgs.BufferSizeMB * 2);
 
-                    if (parsedArgs.CircularMB != 0)
+                    if (parsedArgs.CircularMB != 0 && parsedArgs.OSHeapMaxMB == 0)
                     {
-                        LogFile.WriteLine("[Warning: OS Heap provider does not use Circular buffering.]");
+                        LogFile.WriteLine("[Warning: OS Heap provider does not use Circular buffering. Use /OSHeapMaxMB to limit OS heap file size.]");
+                    }
+
+                    if (parsedArgs.OSHeapMaxMB > 0)
+                    {
+                        LogFile.WriteLine($"Maximum OS heap file size is {parsedArgs.OSHeapMaxMB}MB. Use /OSHeapMaxMB to change it.");
+                        heapSession.MaximumFileMB = parsedArgs.OSHeapMaxMB;
                     }
 
                     if (parsedArgs.OSHeapProcess != 0)

--- a/src/PerfView/CommandProcessor.cs
+++ b/src/PerfView/CommandProcessor.cs
@@ -3097,6 +3097,11 @@ namespace PerfView
                 cmdLineArgs += " /OSHeapProcess:" + parsedArgs.OSHeapProcess.ToString();
             }
 
+            if (parsedArgs.OSHeapMaxMB != 0)
+            {
+                cmdLineArgs += " /OSHeapMaxMB:" + parsedArgs.OSHeapMaxMB;
+            }
+
             if (parsedArgs.NetworkCapture)
             {
                 cmdLineArgs += " /NetworkCapture";


### PR DESCRIPTION
The OS heap provider technically supports circular buffering, but it's very sensitive to lost events (dropped or overwritten). So, it doesn't make sense to use circular buffering to limit its size. This PR adds a new flag to set a max file size on the heap session, which enforces the size even if PerfView is killed before the session is stopped.

I tested the flag on my machine by killing PerfView in the middle of a collection and confirming that the heap file stopped at the specified max size.