### PR TITLE
Implement Nettrace Support for Traces with Universal Providers

### DIFF
--- a/src/MemoryGraph/graph.cs
+++ b/src/MemoryGraph/graph.cs
@@ -1070,7 +1070,7 @@ namespace Graphs
         /// <summary>
         /// The size of the image when loaded in memory
         /// </summary>
-        public int Size;
+        public long Size;
         /// <summary>
         /// The time when this image was built (There is a field in the PE header).   May be MinimumValue if unknonwn. 
         /// </summary>

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -9532,23 +9532,30 @@ table {
 
             if (m_traceLog != null)
             {
-                if (hasUniversalSystem)
+                if (hasUniversalSystem) // universal
                 {
                     m_Children.Add(new PerfViewProcesses(this));
-                }
 
-                if (hasUniversalCPU)
+                    if (hasUniversalCPU)
+                    {
+                        m_Children.Add(new PerfViewStackSource(this, "CPU"));
+                    }
+                }
+                else // dotnet-trace
                 {
-                    m_Children.Add(new PerfViewStackSource(this, "CPU"));
+                    if (hasAnyStacks)
+                    {
+                        m_Children.Add(new PerfViewStackSource(this, "Thread Time (with StartStop Activities)"));
+                    }
                 }
 
+                // Source agnostic
                 m_Children.Add(new PerfViewEventSource(this));
-                m_Children.Add(new PerfViewEventStats(this));
+                advanced.AddChild(new PerfViewEventStats(this));
 
                 if (hasAnyStacks)
                 {
-                    m_Children.Add(new PerfViewStackSource(this, "Thread Time (with StartStop Activities)"));
-                    m_Children.Add(new PerfViewStackSource(this, "Any"));
+                    advanced.AddChild(new PerfViewStackSource(this, "Any"));
                 }
 
                 if (hasGC)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -9405,6 +9405,29 @@ table {
 
         private string m_extraTopStats;
 
+        public override bool SupportsProcesses => m_supportsProcesses;
+
+        private bool m_supportsProcesses;
+
+        public override List<IProcess> GetProcesses(TextWriter log)
+        {
+            var eventLog = GetTraceLog(log);
+            var processes = new List<IProcess>(eventLog.Processes.Count);
+            foreach (var process in eventLog.Processes)
+            {
+                var iprocess = new IProcessForStackSource(process.Name);
+                iprocess.StartTime = process.StartTime;
+                iprocess.EndTime = process.EndTime;
+                iprocess.CPUTimeMSec = process.CPUMSec;
+                iprocess.ParentID = process.ParentID;
+                iprocess.CommandLine = process.CommandLine;
+                iprocess.ProcessID = process.ProcessID;
+                processes.Add(iprocess);
+            }
+            processes.Sort();
+            return processes;
+        }
+
         protected internal override EventSource OpenEventSourceImpl(TextWriter log)
         {
             var traceLog = GetTraceLog(log);
@@ -9493,10 +9516,12 @@ table {
                     else if (eventStats.ProviderGuid == UniversalSystemTraceEventParser.ProviderGuid)
                     {
                         hasUniversalSystem = true;
+                        m_supportsProcesses = true;
                     }
                     else if (eventStats.ProviderGuid == UniversalEventsTraceEventParser.ProviderGuid && eventStats.EventName.StartsWith("cpu"))
                     {
                         hasUniversalCPU = true;
+                        m_supportsProcesses = true;
                     }
                 }
             }

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -42,7 +42,6 @@ using Microsoft.Diagnostics.Tracing.Parsers.Tpl;
 using Utilities;
 using Address = System.UInt64;
 using EventSource = EventSources.EventSource;
-using System.Security;
 using Microsoft.Diagnostics.Tracing.Parsers.Universal.Events;
 
 namespace PerfView

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -6017,7 +6017,7 @@ table {
                                     {
                                         const int numBuckets = 20;
                                         int bucket = (int)(normalizeDistance * numBuckets);
-                                        int bucketSizeInPages = module.ModuleFile.ImageSize / (numBuckets * 4096);
+                                        int bucketSizeInPages = (int)(module.ModuleFile.ImageSize / (numBuckets * 4096));
                                         string bucketName = "Image Bucket " + bucket + " Size " + bucketSizeInPages + " Pages";
                                         stackIndex = stackSource.Interner.CallStackIntern(stackSource.Interner.FrameIntern(bucketName), stackIndex);
                                     }
@@ -9433,6 +9433,7 @@ table {
             bool hasAspNetCoreHosting = false;
             bool hasContention = false;
             bool hasWaitHandle = false;
+            bool hasUniversalSystem = false;
             if (m_traceLog != null)
             {
                 foreach (TraceEventCounts eventStats in m_traceLog.Stats)
@@ -9486,6 +9487,10 @@ table {
                     {
                         hasWaitHandle = true;
                     }
+                    else if (eventStats.ProviderGuid == UniversalSystemTraceEventParser.ProviderGuid)
+                    {
+                        hasUniversalSystem = true;
+                    }
                 }
             }
 
@@ -9495,6 +9500,11 @@ table {
 
             if (m_traceLog != null)
             {
+                if (hasUniversalSystem)
+                {
+                    m_Children.Add(new PerfViewProcesses(this));
+                }
+
                 m_Children.Add(new PerfViewEventSource(this));
                 m_Children.Add(new PerfViewEventStats(this));
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 // in the code below we set sessionEndTimeQPC to be the timestamp of the last event.
                 // Thus the new timestamp should be later, and not more than 1 day later.
-                //Debug.Assert(sessionEndTimeQPC <= eventRecord->EventHeader.TimeStamp);
+                Debug.Assert(sessionEndTimeQPC <= eventRecord->EventHeader.TimeStamp);
                 Debug.Assert(sessionEndTimeQPC == 0 || eventRecord->EventHeader.TimeStamp - sessionEndTimeQPC < _QPCFreq * 24 * 3600);
 
                 var traceEvent = Lookup(eventRecord);

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 // in the code below we set sessionEndTimeQPC to be the timestamp of the last event.
                 // Thus the new timestamp should be later, and not more than 1 day later.
-                Debug.Assert(sessionEndTimeQPC <= eventRecord->EventHeader.TimeStamp);
+                //Debug.Assert(sessionEndTimeQPC <= eventRecord->EventHeader.TimeStamp);
                 Debug.Assert(sessionEndTimeQPC == 0 || eventRecord->EventHeader.TimeStamp - sessionEndTimeQPC < _QPCFreq * 24 * 3600);
 
                 var traceEvent = Lookup(eventRecord);

--- a/src/TraceEvent/EventPipe/UniversalProviders.md
+++ b/src/TraceEvent/EventPipe/UniversalProviders.md
@@ -5,7 +5,7 @@ This document describes the definitions of a set of universal machine-wide traci
 
 ## Format Restrictions
  - Any format that can be converted to a TraceLog (ETLX) by TraceEvent can use these event definitions.  At this time, PerfView will only consume them from nettrace files.
- - Formats must provide a common set of fields with each event.  These fields are used by in addition to the payloads listed in this document to interpret the events.  The fields do not explicitly required data types.  If they don't match what TraceEvent uses for storage, then TraceEvent will need to convert them.  It is recommended to use the types specified in the field descriptions below (if specified).
+ - Formats must provide a common set of fields with each event.  These fields are used by in addition to the payloads listed in this document to interpret the events.  The fields do not explicitly require data types.  If they don't match what TraceEvent uses for storage, then TraceEvent will need to convert them.  It is recommended to use the types specified in the field descriptions below (if specified).
  - Formats must provide the QPC frequency to ensure that times that are stored in the Value fields of the Universal Events Provider can be interpreted.
 
 ### Required Fields

--- a/src/TraceEvent/EventPipe/UniversalProviders.md
+++ b/src/TraceEvent/EventPipe/UniversalProviders.md
@@ -1,0 +1,63 @@
+# Universal Providers Tracing Events
+
+## Overview
+This document describes the definitions of a set of universal machine-wide tracing events that are consumed by TraceEvent and exposed in PerfView.
+
+## Format Restrictions
+Any format that can be converted to a TraceLog (ETLX) by TraceEvent can use these event definitions.  At this time, PerfView will only consume them from nettrace files.
+
+## Common Format Information
+ - All integers are of type varint encoded in ULEB64/7-bit encoded format.
+ - All strings are length-prefixed (16-bit unsigned integer) followed by UTF8 bytes.  Not null-terminated.
+
+## Universal System Provider
+The universal system provider is named "Universal.System". It's purpose is to provide system-level events for reconstructing the state of a machine and its processes during a period of time.
+
+### Event Definitions
+- **Event Name**: ProcessCreate
+    - **Description**: Identifies a newly created processes. The process ID is inferred from the format's process ID field.
+    - **Field: NamespaceId**: varint - The actual process ID on the system within the running namespace.
+    - **Field: Name**: string - The name of the process.
+    - **Field: NamespaceName**: string - Namespace of the process. Can be used to convey a set of related processes.
+
+- **Event Name**: ProcessExit
+    - **Description**: Identifies a process that has exited. The process ID is inferred from the format's process ID field.
+
+- **Event Name**: ProcessMapping
+    - **Description**: Identifies a mapping (file, memory, etc.) associated with a specific process.
+    - **Field: Id**: varint - A trace-wide unique id for the mapping.  Used to identify this mapping in other events.
+    - **Field: ProcessId**: varint - The process ID on the system that the mapping is for.
+    - **Field: StartAddress**: varint - Starting virtual address of the mapping within the process.
+    - **Field: EndAddress**: varint - Ending virtual address of the mapping within the process.
+    - **Field: FileOffset**: varint - Offset of the actual file on disk that StartAddress correlates to.  For PE files this is always zero.
+    - **Field: FileName**: string - Name of the file the mapping represents.  Empty if none.
+    - **Field: MetadataId**: varint - Identifier for a matcing ProcessMappingMetadataEvent.  0 means no metadata exists for this mapping.
+
+- **Event Name**: ProcessMappingMetadata
+    - **Description**: Contains symbol and version information for the mapping if available.
+    - **Field: Id**: varint - Trace-wide unique identifier for the mapping metadata. Often seen in multiple ProcessMapping events when the same executable file is loaded into multiple processes.
+    - **Field: SymbolMetadata**: string - Symbol metadata in JSON.  Describes the type (ELF/PE) and details that enable looking up symbols locally or remotely.
+    - **Field: VersionMetadata**: string - Version metadata in JSON.  Describes the build and version details.
+
+- **Event Name**: ProcessSymbol
+    - **Description**: Maps a range of address space to a readable name (symbol).
+    - **Field: Id**: varint - Trace-wide unique identifier for the symbol.
+    - **Field: MappingId**: varint - Id of the ProcessMapping that contains the symbol.
+    - **Field: StartAddress**: varint - Starting virtual address of the symbol within the mapping.
+    - **Field: EndAddress**: varint - Ending virtual address of the symbol within the mapping.
+    - **Field: Name**: string - Name of the symbol.
+
+## Universal Events Provider
+The universal events provider is named "Universal.Events". It's purpose is to provide events that contain a value and have a callstack. There are no stable event IDs, but there will be a set of stable names.
+
+### Current Stable Event Names
+ - cpu - Represents a CPU sample.
+ - cswitch - Represents a machine-level context switch.
+
+### Event Definition
+ - **Field: Value**: varint - Value of the event.
+
+### Example: cpu
+ - Each cpu event represents a CPU sample.
+ - The value represents the weight of the sample.
+ - As an example if emitting one CPU sample per core per millisecond, emit an event with Value=1 per core every millisecond.

--- a/src/TraceEvent/EventPipe/UniversalProviders.md
+++ b/src/TraceEvent/EventPipe/UniversalProviders.md
@@ -4,7 +4,15 @@
 This document describes the definitions of a set of universal machine-wide tracing events that are consumed by TraceEvent and exposed in PerfView.
 
 ## Format Restrictions
-Any format that can be converted to a TraceLog (ETLX) by TraceEvent can use these event definitions.  At this time, PerfView will only consume them from nettrace files.
+ - Any format that can be converted to a TraceLog (ETLX) by TraceEvent can use these event definitions.  At this time, PerfView will only consume them from nettrace files.
+ - Formats must provide a common set of fields with each event.  These fields are used by in addition to the payloads listed in this document to interpret the events.  The fields do not explicitly required data types.  If they don't match what TraceEvent uses for storage, then TraceEvent will need to convert them.  It is recommended to use the types specified in the field descriptions below (if specified).
+ - Formats must provide the QPC frequency to ensure that times that are stored in the Value fields of the Universal Events Provider can be interpreted.
+
+### Required Fields
+ - TimeStamp: The time that the event occurred.
+ - Process ID: The integer identifier of the process that caused the event to be written.
+ - Thread ID: The integer identifier of the thread that caused the event to be written.
+ - Processor ID: The integer identifier of the processor associated with the event.
 
 ## Common Format Information
  - All integers are of type varint encoded in ULEB64/7-bit encoded format.
@@ -48,7 +56,7 @@ The universal system provider is named "Universal.System". It's purpose is to pr
     - **Field: Name**: string - Name of the symbol.
 
 ## Universal Events Provider
-The universal events provider is named "Universal.Events". It's purpose is to provide events that contain a value and have a callstack. There are no stable event IDs, but there will be a set of stable names.
+The universal events provider is named "Universal.Events". It's purpose is to provide events that contain a value and have a callstack. There are no stable event IDs, but there will be a set of stable names.  Required fields as listed above in this document are used to assist tools in interpreting the events.
 
 ### Current Stable Event Names
  - cpu - Represents a CPU sample.
@@ -61,3 +69,10 @@ The universal events provider is named "Universal.Events". It's purpose is to pr
  - Each cpu event represents a CPU sample.
  - The value represents the weight of the sample.
  - As an example if emitting one CPU sample per core per millisecond, emit an event with Value=1 per core every millisecond.
+
+### Example: cswitch
+ - Each cswitch event represents an OS-level context switch.
+ - The thread ID provided in the set of required fields is the thread being switched in.
+ - The CPU number provided in the set of required fields is the CPU involved.
+ - The value represents the amount of time that that has elapsed since the thread last executed (switched out time).  Times are based on the QPC frequency from the source containing the events.
+ - The callstack associated with the event is the stack where the thread switched out (blocked).

--- a/src/TraceEvent/Parsers/UniversalEventsTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalEventsTraceEventParser.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using Address = System.UInt64;
+
+#pragma warning disable 1591        // disable warnings on XML comments not being present
+
+namespace Microsoft.Diagnostics.Tracing.Parsers
+{
+    using Microsoft.Diagnostics.Tracing.Parsers.Universal.Events;
+
+    public sealed class UniversalEventsTraceEventParser: TraceEventParser
+    {
+        public static string ProviderName = "Universal.Events";
+        public static Guid ProviderGuid = new Guid("bc5e5d63-9799-5873-33d9-fba8316cef71");
+        public enum Keywords : long
+        {
+            None = 0x0,
+        };
+
+        public UniversalEventsTraceEventParser(TraceEventSource source) : base(source) { }
+
+        public event Action<SampleTraceData> cpu
+        {
+            add
+            {
+                source.RegisterEventTemplate(new SampleTraceData(value, 1, (int)TraceEventTask.Default, "cpu", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 1, Guid.Empty);
+            }
+        }
+
+        public event Action<SampleTraceData> cswitch
+        {
+            add
+            {
+                source.RegisterEventTemplate(new SampleTraceData(value, 2, (int)TraceEventTask.Default, "cswitch", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 2, Guid.Empty);
+            }
+        }
+
+        #region private
+        protected override string GetProviderName() { return ProviderName; }
+
+        static private volatile TraceEvent[] s_templates;
+
+        protected internal override void EnumerateTemplates(Func<string, string, EventFilterResponse> eventsToObserve, Action<TraceEvent> callback)
+        {
+            if (s_templates == null)
+            {
+                var templates = new TraceEvent[2];
+                templates[0] = new SampleTraceData(null, 1, (int)TraceEventTask.Default, "cpu", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                templates[1] = new SampleTraceData(null, 2, (int)TraceEventTask.Default, "cswitch", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                s_templates = templates;
+            }
+            foreach (var template in s_templates)
+                if (eventsToObserve == null || eventsToObserve(template.ProviderName, template.EventName) == EventFilterResponse.AcceptEvent)
+                    callback(template);
+        }
+
+        #endregion
+    }
+}
+
+namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
+{
+    public sealed class SampleTraceData : TraceEvent
+    {
+
+        public int ProcessId { get { return GetInt32At(0); } }
+        public Address Value { get { return GetAddressAt(4); } }
+
+        #region Private
+        internal SampleTraceData(Action<SampleTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+        protected internal override void Validate()
+        {
+            Debug.Assert(!(Version == 0 && EventDataLength != 12));
+        }
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<SampleTraceData>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ProcessId", ProcessId);
+            XmlAttrib(sb, "Value", Value);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ProcessId", "Value" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ProcessId;
+                case 1:
+                    return Value;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        public static ulong GetKeywords() { return 0; }
+        public static string GetProviderName() { return UniversalEventsTraceEventParser.ProviderName; }
+        public static Guid GetProviderGuid() { return UniversalEventsTraceEventParser.ProviderGuid; }
+        private event Action<SampleTraceData> Action;
+        #endregion
+    }
+}

--- a/src/TraceEvent/Parsers/UniversalEventsTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalEventsTraceEventParser.cs
@@ -71,9 +71,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 {
     public sealed class SampleTraceData : TraceEvent
     {
-
-        public int ProcessId { get { return GetInt32At(0); } }
-        public Address Value { get { return GetAddressAt(4); } }
+        public Address Value { get { return GetVarUIntAt(0); } }
 
         #region Private
         internal SampleTraceData(Action<SampleTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -85,10 +83,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
         {
             Action(this);
         }
-        protected internal override void Validate()
-        {
-            Debug.Assert(!(Version == 0 && EventDataLength != 12));
-        }
+
         protected internal override Delegate Target
         {
             get { return Action; }
@@ -97,7 +92,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
-            XmlAttrib(sb, "ProcessId", ProcessId);
             XmlAttrib(sb, "Value", Value);
             sb.Append("/>");
             return sb;
@@ -108,7 +102,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "ProcessId", "Value" };
+                    payloadNames = new string[] { "Value" };
                 return payloadNames;
             }
         }
@@ -118,8 +112,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
             switch (index)
             {
                 case 0:
-                    return ProcessId;
-                case 1:
                     return Value;
                 default:
                     Debug.Assert(false, "Bad field index");

--- a/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
@@ -1,0 +1,402 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using Address = System.UInt64;
+
+#pragma warning disable 1591        // disable warnings on XML comments not being present
+
+namespace Microsoft.Diagnostics.Tracing.Parsers
+{
+    using Microsoft.Diagnostics.Tracing.Parsers.Universal.Events;
+
+    public sealed class UniversalSystemTraceEventParser : TraceEventParser
+    {
+        public static string ProviderName = "Universal.System";
+        public static Guid ProviderGuid = new Guid("8c107b6c-79f8-5231-4de6-2a0e20a3f562");
+        public enum Keywords : long
+        {
+            None = 0x0,
+        };
+
+        public UniversalSystemTraceEventParser(TraceEventSource source) : base(source) { }
+
+        public event Action<ProcessCreateTraceData> ExistingProcess
+        {
+            add
+            {
+                source.RegisterEventTemplate(new ProcessCreateTraceData(value, 0, (int)TraceEventTask.Default, "ExistingProcess", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 0, Guid.Empty);
+            }
+        }
+
+        public event Action<ProcessCreateTraceData> ProcessCreate
+        {
+            add
+            {
+                source.RegisterEventTemplate(new ProcessCreateTraceData(value, 1, (int)TraceEventTask.Default, "ProcessCreate", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 1, Guid.Empty);
+            }
+        }
+
+        public event Action<ProcessExitTraceData> ProcessExit
+        {
+            add
+            {
+                source.RegisterEventTemplate(new ProcessExitTraceData(value, 2, (int)TraceEventTask.Default, "ProcessExit", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 2, Guid.Empty);
+            }
+        }
+
+        public event Action<ProcessMappingTraceData> ProcessMapping
+        {
+            add
+            {
+                source.RegisterEventTemplate(new ProcessMappingTraceData(value, 3, (int)TraceEventTask.Default, "ProcessMapping", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 3, Guid.Empty);
+            }
+        }
+
+        public event Action<ProcessSymbolTraceData> ProcessSymbol
+        {
+            add
+            {
+                source.RegisterEventTemplate(new ProcessSymbolTraceData(value, 4, (int)TraceEventTask.Default, "ProcessSymbol", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+            }
+            remove
+            {
+                source.UnregisterEventTemplate(value, 4, Guid.Empty);
+            }
+        }
+
+        #region private
+        protected override string GetProviderName() { return ProviderName; }
+
+        static private volatile TraceEvent[] s_templates;
+
+        protected internal override void EnumerateTemplates(Func<string, string, EventFilterResponse> eventsToObserve, Action<TraceEvent> callback)
+        {
+            if (s_templates == null)
+            {
+                var templates = new TraceEvent[5];
+                templates[0] = new ProcessCreateTraceData(null, 0, (int)TraceEventTask.Default, "ExistingProcess", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                templates[1] = new ProcessCreateTraceData(null, 1, (int)TraceEventTask.Default, "ProcessCreate", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                templates[2] = new ProcessExitTraceData(null, 2, (int)TraceEventTask.Default, "ProcessExit", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                templates[3] = new ProcessMappingTraceData(null, 3, (int)TraceEventTask.Default, "ProcessMapping", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                templates[4] = new ProcessSymbolTraceData(null, 4, (int)TraceEventTask.Default, "ProcessSymbol", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                s_templates = templates;
+            }
+            foreach (var template in s_templates)
+                if (eventsToObserve == null || eventsToObserve(template.ProviderName, template.EventName) == EventFilterResponse.AcceptEvent)
+                    callback(template);
+        }
+
+        #endregion
+    }
+}
+
+namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
+{
+    public sealed class ProcessCreateTraceData : TraceEvent
+    {
+        public int Id { get { return GetInt32At(0); } }
+        public int NamespaceId { get { return GetInt32At(4); } }
+
+        public string Name { get { return GetUnicodeStringAt(8); } }
+
+        public string NamespaceName { get { return GetUnicodeStringAt(SkipUnicodeString(8)); } }
+
+        #region Private
+        internal ProcessCreateTraceData(Action<ProcessCreateTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<ProcessCreateTraceData>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "Id", Id);
+            XmlAttrib(sb, "NamespaceId", NamespaceId);
+            XmlAttrib(sb, "Name", Name);
+            XmlAttrib(sb, "NamespaceName", NamespaceName);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "Id", "NamespaceId", "Name", "NamespaceName" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return Id;
+                case 1:
+                    return NamespaceId;
+                case 2:
+                    return Name;
+                case 3:
+                    return NamespaceName;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        public static ulong GetKeywords() { return 0; }
+        public static string GetProviderName() { return UniversalEventsTraceEventParser.ProviderName; }
+        public static Guid GetProviderGuid() { return UniversalEventsTraceEventParser.ProviderGuid; }
+        private event Action<ProcessCreateTraceData> Action;
+        #endregion
+    }
+
+    public sealed class ProcessExitTraceData : TraceEvent
+    {
+        public int ProcessId { get { return GetInt32At(0); } }
+
+        #region Private
+        internal ProcessExitTraceData(Action<ProcessExitTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<ProcessExitTraceData>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "ProcessId", ProcessId);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "ProcessId" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return ProcessId;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        public static ulong GetKeywords() { return 0; }
+        public static string GetProviderName() { return UniversalEventsTraceEventParser.ProviderName; }
+        public static Guid GetProviderGuid() { return UniversalEventsTraceEventParser.ProviderGuid; }
+        private event Action<ProcessExitTraceData> Action;
+        #endregion
+    }
+
+    public sealed class ProcessMappingTraceData : TraceEvent
+    {
+        public int Id { get { return GetInt32At(0); } }
+
+        public int ProcessId { get { return GetInt32At(4); } }
+
+        public Address StartAddress { get { return (Address)GetInt64At(8); } }
+
+        public Address EndAddress { get { return (Address)GetInt64At(16); } }
+
+        public Address FileOffset { get { return (Address)GetInt64At(24); } }
+
+        public string FileName { get { return GetUnicodeStringAt(32); } }
+
+        public string SymbolIndex { get { return GetUnicodeStringAt(SkipUnicodeString(32)); } }
+
+        #region Private
+        internal ProcessMappingTraceData(Action<ProcessMappingTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<ProcessMappingTraceData>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "Id", Id);
+            XmlAttrib(sb, "ProcessId", ProcessId);
+            XmlAttrib(sb, "StartAddress", StartAddress);
+            XmlAttrib(sb, "EndAddress", EndAddress);
+            XmlAttrib(sb, "FileOffset", FileOffset);
+            XmlAttrib(sb, "FileName", FileName);
+            XmlAttrib(sb, "SymbolIndex", SymbolIndex);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "Id", "ProcessId", "StartAddress", "EndAddress", "FileOffset", "FileName", "SymbolIndex" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return Id;
+                case 1:
+                    return ProcessId;
+                case 2:
+                    return StartAddress;
+                case 3:
+                    return EndAddress;
+                case 4:
+                    return FileOffset;
+                case 5:
+                    return FileName;
+                case 6:
+                    return SymbolIndex;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        public static ulong GetKeywords() { return 0; }
+        public static string GetProviderName() { return UniversalEventsTraceEventParser.ProviderName; }
+        public static Guid GetProviderGuid() { return UniversalEventsTraceEventParser.ProviderGuid; }
+        private event Action<ProcessMappingTraceData> Action;
+        #endregion
+    }
+
+    public sealed class ProcessSymbolTraceData : TraceEvent
+    {
+        public int Id { get { return GetInt32At(0); } }
+
+        public int MappingId { get { return GetInt32At(4); } }
+
+        public Address StartAddress { get { return (Address)GetInt64At(8); } }
+
+        public Address EndAddress { get { return (Address)GetInt64At(16); } }
+
+        public string Name { get { return GetUnicodeStringAt(24); } }
+
+        #region Private
+        internal ProcessSymbolTraceData(Action<ProcessSymbolTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
+            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
+        {
+            Action = action;
+        }
+        protected internal override void Dispatch()
+        {
+            Action(this);
+        }
+
+        protected internal override Delegate Target
+        {
+            get { return Action; }
+            set { Action = (Action<ProcessSymbolTraceData>)value; }
+        }
+        public override StringBuilder ToXml(StringBuilder sb)
+        {
+            Prefix(sb);
+            XmlAttrib(sb, "Id", Id);
+            XmlAttrib(sb, "MappingId", MappingId);
+            XmlAttrib(sb, "StartAddress", StartAddress);
+            XmlAttrib(sb, "EndAddress", EndAddress);
+            XmlAttrib(sb, "Name", Name);
+            sb.Append("/>");
+            return sb;
+        }
+
+        public override string[] PayloadNames
+        {
+            get
+            {
+                if (payloadNames == null)
+                    payloadNames = new string[] { "Id", "MappingId", "StartAddress", "EndAddress", "Name" };
+                return payloadNames;
+            }
+        }
+
+        public override object PayloadValue(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    return Id;
+                case 1:
+                    return MappingId;
+                case 2:
+                    return StartAddress;
+                case 3:
+                    return EndAddress;
+                case 4:
+                    return Name;
+                default:
+                    Debug.Assert(false, "Bad field index");
+                    return null;
+            }
+        }
+
+        public static ulong GetKeywords() { return 0; }
+        public static string GetProviderName() { return UniversalEventsTraceEventParser.ProviderName; }
+        public static Guid GetProviderGuid() { return UniversalEventsTraceEventParser.ProviderGuid; }
+        private event Action<ProcessSymbolTraceData> Action;
+        #endregion
+    }
+}

--- a/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 {
     public sealed class ProcessCreateTraceData : TraceEvent
     {
-        public long NamespaceId { get { return (long)GetVarUIntAt(0); } }
+        public ulong NamespaceId { get { return GetVarUIntAt(0); } }
 
         public string Name { get { return GetShortUTF8StringAt(SkipVarInt(0)); } }
 
@@ -177,7 +177,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 
     public sealed class ProcessMappingTraceData : TraceEvent
     {
-        public long Id { get { return (long)GetVarUIntAt(0); } }
+        public ulong Id { get { return GetVarUIntAt(0); } }
 
         public Address StartAddress { get { return GetVarUIntAt(SkipVarInt(0)); } }
 
@@ -187,7 +187,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 
         public string FileName { get { return GetShortUTF8StringAt(SkipVarInt(SkipVarInt(SkipVarInt(SkipVarInt(0))))); } }
 
-        public long MetadataId { get { return (long)GetVarUIntAt(SkipShortUTF8String(SkipVarInt(SkipVarInt(SkipVarInt(SkipVarInt(0)))))); } }
+        public ulong MetadataId { get { return GetVarUIntAt(SkipShortUTF8String(SkipVarInt(SkipVarInt(SkipVarInt(SkipVarInt(0)))))); } }
 
         #region Private
         internal ProcessMappingTraceData(Action<ProcessMappingTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -259,9 +259,9 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 
     public sealed class ProcessSymbolTraceData : TraceEvent
     {
-        public long Id { get { return (long)GetVarUIntAt(0); } }
+        public ulong Id { get { return GetVarUIntAt(0); } }
 
-        public long MappingId { get { return (long)GetVarUIntAt(SkipVarInt(0)); } }
+        public ulong MappingId { get { return GetVarUIntAt(SkipVarInt(0)); } }
 
         public Address StartAddress { get { return GetVarUIntAt(SkipVarInt(SkipVarInt(0))); } }
 

--- a/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             }
         }
 
-        public event Action<ProcessExitTraceData> ProcessExit
+        public event Action<EmptyTraceData> ProcessExit
         {
             add
             {
-                source.RegisterEventTemplate(new ProcessExitTraceData(value, 2, (int)TraceEventTask.Default, "ProcessExit", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
+                source.RegisterEventTemplate(new EmptyTraceData(value, 2, (int)TraceEventTask.Default, "ProcessExit", Guid.Empty, 0, "Default", ProviderGuid, ProviderName));
             }
             remove
             {
@@ -92,7 +92,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 var templates = new TraceEvent[5];
                 templates[0] = new ProcessCreateTraceData(null, 0, (int)TraceEventTask.Default, "ExistingProcess", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
                 templates[1] = new ProcessCreateTraceData(null, 1, (int)TraceEventTask.Default, "ProcessCreate", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
-                templates[2] = new ProcessExitTraceData(null, 2, (int)TraceEventTask.Default, "ProcessExit", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
+                templates[2] = new EmptyTraceData(null, 2, (int)TraceEventTask.Default, "ProcessExit", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
                 templates[3] = new ProcessMappingTraceData(null, 3, (int)TraceEventTask.Default, "ProcessMapping", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
                 templates[4] = new ProcessSymbolTraceData(null, 4, (int)TraceEventTask.Default, "ProcessSymbol", Guid.Empty, 0, "Default", ProviderGuid, ProviderName);
                 s_templates = templates;
@@ -110,12 +110,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 {
     public sealed class ProcessCreateTraceData : TraceEvent
     {
-        public int Id { get { return GetInt32At(0); } }
-        public int NamespaceId { get { return GetInt32At(4); } }
+        public long NamespaceId { get { return (long)GetVarUIntAt(0); } }
 
-        public string Name { get { return GetUnicodeStringAt(8); } }
+        public string Name { get { return GetShortUTF8StringAt(SkipVarInt(0)); } }
 
-        public string NamespaceName { get { return GetUnicodeStringAt(SkipUnicodeString(8)); } }
+        public string NamespaceName { get { return GetShortUTF8StringAt(SkipShortUTF8String(SkipVarInt(0))); } }
 
         #region Private
         internal ProcessCreateTraceData(Action<ProcessCreateTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -136,7 +135,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
-            XmlAttrib(sb, "Id", Id);
             XmlAttrib(sb, "NamespaceId", NamespaceId);
             XmlAttrib(sb, "Name", Name);
             XmlAttrib(sb, "NamespaceName", NamespaceName);
@@ -149,7 +147,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "Id", "NamespaceId", "Name", "NamespaceName" };
+                    payloadNames = new string[] { "NamespaceId", "Name", "NamespaceName" };
                 return payloadNames;
             }
         }
@@ -159,12 +157,10 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
             switch (index)
             {
                 case 0:
-                    return Id;
-                case 1:
                     return NamespaceId;
-                case 2:
+                case 1:
                     return Name;
-                case 3:
+                case 2:
                     return NamespaceName;
                 default:
                     Debug.Assert(false, "Bad field index");
@@ -179,78 +175,19 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
         #endregion
     }
 
-    public sealed class ProcessExitTraceData : TraceEvent
-    {
-        public int ProcessId { get { return GetInt32At(0); } }
-
-        #region Private
-        internal ProcessExitTraceData(Action<ProcessExitTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
-            : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
-        {
-            Action = action;
-        }
-        protected internal override void Dispatch()
-        {
-            Action(this);
-        }
-
-        protected internal override Delegate Target
-        {
-            get { return Action; }
-            set { Action = (Action<ProcessExitTraceData>)value; }
-        }
-        public override StringBuilder ToXml(StringBuilder sb)
-        {
-            Prefix(sb);
-            XmlAttrib(sb, "ProcessId", ProcessId);
-            sb.Append("/>");
-            return sb;
-        }
-
-        public override string[] PayloadNames
-        {
-            get
-            {
-                if (payloadNames == null)
-                    payloadNames = new string[] { "ProcessId" };
-                return payloadNames;
-            }
-        }
-
-        public override object PayloadValue(int index)
-        {
-            switch (index)
-            {
-                case 0:
-                    return ProcessId;
-                default:
-                    Debug.Assert(false, "Bad field index");
-                    return null;
-            }
-        }
-
-        public static ulong GetKeywords() { return 0; }
-        public static string GetProviderName() { return UniversalEventsTraceEventParser.ProviderName; }
-        public static Guid GetProviderGuid() { return UniversalEventsTraceEventParser.ProviderGuid; }
-        private event Action<ProcessExitTraceData> Action;
-        #endregion
-    }
-
     public sealed class ProcessMappingTraceData : TraceEvent
     {
-        public int Id { get { return GetInt32At(0); } }
+        public long Id { get { return (long)GetVarUIntAt(0); } }
 
-        public int ProcessId { get { return GetInt32At(4); } }
+        public Address StartAddress { get { return GetVarUIntAt(SkipVarInt(0)); } }
 
-        public Address StartAddress { get { return (Address)GetInt64At(8); } }
+        public Address EndAddress { get { return GetVarUIntAt(SkipVarInt(SkipVarInt(0))); } }
 
-        public Address EndAddress { get { return (Address)GetInt64At(16); } }
+        public Address FileOffset { get { return GetVarUIntAt(SkipVarInt(SkipVarInt(SkipVarInt(0)))); } }
 
-        public Address FileOffset { get { return (Address)GetInt64At(24); } }
+        public string FileName { get { return GetShortUTF8StringAt(SkipVarInt(SkipVarInt(SkipVarInt(SkipVarInt(0))))); } }
 
-        public string FileName { get { return GetUnicodeStringAt(32); } }
-
-        public string SymbolIndex { get { return GetUnicodeStringAt(SkipUnicodeString(32)); } }
+        public long MetadataId { get { return (long)GetVarUIntAt(SkipShortUTF8String(SkipVarInt(SkipVarInt(SkipVarInt(SkipVarInt(0)))))); } }
 
         #region Private
         internal ProcessMappingTraceData(Action<ProcessMappingTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -272,12 +209,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
         {
             Prefix(sb);
             XmlAttrib(sb, "Id", Id);
-            XmlAttrib(sb, "ProcessId", ProcessId);
             XmlAttrib(sb, "StartAddress", StartAddress);
             XmlAttrib(sb, "EndAddress", EndAddress);
             XmlAttrib(sb, "FileOffset", FileOffset);
             XmlAttrib(sb, "FileName", FileName);
-            XmlAttrib(sb, "SymbolIndex", SymbolIndex);
+            XmlAttrib(sb, "MetadataId", MetadataId);
             sb.Append("/>");
             return sb;
         }
@@ -287,7 +223,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "Id", "ProcessId", "StartAddress", "EndAddress", "FileOffset", "FileName", "SymbolIndex" };
+                    payloadNames = new string[] { "Id", "StartAddress", "EndAddress", "FileOffset", "FileName", "MetadataId" };
                 return payloadNames;
             }
         }
@@ -299,17 +235,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
                 case 0:
                     return Id;
                 case 1:
-                    return ProcessId;
-                case 2:
                     return StartAddress;
-                case 3:
+                case 2:
                     return EndAddress;
-                case 4:
+                case 3:
                     return FileOffset;
-                case 5:
+                case 4:
                     return FileName;
-                case 6:
-                    return SymbolIndex;
+                case 5:
+                    return MetadataId;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;
@@ -325,15 +259,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 
     public sealed class ProcessSymbolTraceData : TraceEvent
     {
-        public int Id { get { return GetInt32At(0); } }
+        public long Id { get { return (long)GetVarUIntAt(0); } }
 
-        public int MappingId { get { return GetInt32At(4); } }
+        public long MappingId { get { return (long)GetVarUIntAt(SkipVarInt(0)); } }
 
-        public Address StartAddress { get { return (Address)GetInt64At(8); } }
+        public Address StartAddress { get { return GetVarUIntAt(SkipVarInt(SkipVarInt(0))); } }
 
-        public Address EndAddress { get { return (Address)GetInt64At(16); } }
+        public Address EndAddress { get { return GetVarUIntAt(SkipVarInt(SkipVarInt(SkipVarInt(0)))); } }
 
-        public string Name { get { return GetUnicodeStringAt(24); } }
+        public string Name { get { return GetShortUTF8StringAt(SkipVarInt(SkipVarInt(SkipVarInt(SkipVarInt(0))))); } }
 
         #region Private
         internal ProcessSymbolTraceData(Action<ProcessSymbolTraceData> action, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)

--- a/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
+++ b/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Universal.Events;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Tracing.SourceConverters
+{
+    internal sealed class NettraceUniversalConverter
+    {
+        private List<ProcessSymbolTraceData> _dynamicSymbols = new List<ProcessSymbolTraceData>();
+        private Dictionary<int, TraceProcess> _mappingIdToProcesses = new Dictionary<int, TraceProcess>();
+
+        internal NettraceUniversalConverter()
+        {
+        }
+
+        public static void RegisterParsers(TraceLog traceLog)
+        {
+            new UniversalEventsTraceEventParser(traceLog);
+            new UniversalSystemTraceEventParser(traceLog);
+        }
+
+        public void BeforeProcess(TraceLog traceLog, TraceEventDispatcher source)
+        {
+            UniversalSystemTraceEventParser universalParser = new UniversalSystemTraceEventParser(source);
+            universalParser.ExistingProcess += delegate (ProcessCreateTraceData data)
+            {
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.Id, data.TimeStampQPC);
+                process.UniversalProcessStart(data);
+            };
+            universalParser.ProcessCreate += delegate (ProcessCreateTraceData data)
+            {
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.Id, data.TimeStampQPC, isProcessStartEvent: true);
+                process.UniversalProcessStart(data);
+            };
+            universalParser.ProcessExit += delegate (ProcessExitTraceData data)
+            {
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessId, data.TimeStampQPC);
+                process.UniversalProcessStop(data);
+            };
+            universalParser.ProcessMapping += delegate (ProcessMappingTraceData data)
+            {
+                // TODO: All mappings currently get dumped into a single process because CPU and CSwitch events don't have a process or thread associated with them.
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
+                TraceModuleFile moduleFile = process.LoadedModules.UniversalMapping(data);
+
+                _mappingIdToProcesses[data.Id] = process;
+            };
+            universalParser.ProcessSymbol += delegate (ProcessSymbolTraceData data)
+            {
+                _dynamicSymbols.Add((ProcessSymbolTraceData)data.Clone());
+            };
+        }
+
+        public void AfterProcess(TraceLog traceLog)
+        {
+            foreach (var universalProcessSymbol in _dynamicSymbols)
+            {
+                if (_mappingIdToProcesses.TryGetValue(universalProcessSymbol.MappingId, out TraceProcess process))
+                {
+                    traceLog.CodeAddresses.AddUniversalDynamicSymbol(universalProcessSymbol, process);
+                }
+            }
+        }
+    }
+}

--- a/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
+++ b/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Tracing.SourceConverters
     internal sealed class NettraceUniversalConverter
     {
         private List<ProcessSymbolTraceData> _dynamicSymbols = new List<ProcessSymbolTraceData>();
-        private Dictionary<int, TraceProcess> _mappingIdToProcesses = new Dictionary<int, TraceProcess>();
+        private Dictionary<long, TraceProcess> _mappingIdToProcesses = new Dictionary<long, TraceProcess>();
 
         internal NettraceUniversalConverter()
         {
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tracing.SourceConverters
                 TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC, isProcessStartEvent: true);
                 process.UniversalProcessStart(data);
             };
-            universalSystemParser.ProcessExit += delegate (ProcessExitTraceData data)
+            universalSystemParser.ProcessExit += delegate (EmptyTraceData data)
             {
                 TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
                 process.UniversalProcessStop(data);

--- a/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
+++ b/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Tracing.SourceConverters
     internal sealed class NettraceUniversalConverter
     {
         private List<ProcessSymbolTraceData> _dynamicSymbols = new List<ProcessSymbolTraceData>();
-        private Dictionary<long, TraceProcess> _mappingIdToProcesses = new Dictionary<long, TraceProcess>();
+        private Dictionary<ulong, TraceProcess> _mappingIdToProcesses = new Dictionary<ulong, TraceProcess>();
 
         internal NettraceUniversalConverter()
         {

--- a/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
+++ b/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
@@ -25,22 +25,21 @@ namespace Microsoft.Diagnostics.Tracing.SourceConverters
             UniversalSystemTraceEventParser universalSystemParser = new UniversalSystemTraceEventParser(source);
             universalSystemParser.ExistingProcess += delegate (ProcessCreateTraceData data)
             {
-                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.Id, data.TimeStampQPC);
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
                 process.UniversalProcessStart(data);
             };
             universalSystemParser.ProcessCreate += delegate (ProcessCreateTraceData data)
             {
-                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.Id, data.TimeStampQPC, isProcessStartEvent: true);
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC, isProcessStartEvent: true);
                 process.UniversalProcessStart(data);
             };
             universalSystemParser.ProcessExit += delegate (ProcessExitTraceData data)
             {
-                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessId, data.TimeStampQPC);
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
                 process.UniversalProcessStop(data);
             };
             universalSystemParser.ProcessMapping += delegate (ProcessMappingTraceData data)
             {
-                // TODO: All mappings currently get dumped into a single process because CPU and CSwitch events don't have a process or thread associated with them.
                 TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
                 TraceModuleFile moduleFile = process.LoadedModules.UniversalMapping(data);
 
@@ -54,7 +53,7 @@ namespace Microsoft.Diagnostics.Tracing.SourceConverters
             UniversalEventsTraceEventParser universalEventsParser = new UniversalEventsTraceEventParser(source);
             universalEventsParser.cpu += delegate(SampleTraceData data)
             {
-                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessId, data.TimeStampQPC);
+                TraceProcess process = traceLog.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
                 TraceThread thread = traceLog.Threads.GetOrCreateThread(data.ThreadID, data.TimeStampQPC, process);
                 thread.cpuSamples++;
             };

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -1584,6 +1584,17 @@ namespace Microsoft.Diagnostics.Tracing
         }
 
         /// <summary>
+        /// Skip a UTF8 string that is prepended by its size, stored as a 2-byte unsigned integer.
+        /// </summary>
+        /// <returns>Offset just after the string</returns>
+        protected internal int SkipShortUTF8String(int offset)
+        {
+            IntPtr mofData = DataStart;
+            ushort length = (ushort)TraceEventRawReaders.ReadInt16(mofData, offset);
+            return offset + 2 + length; // + 2 for the length field
+        }
+
+        /// <summary>
         /// Skip UTF8 string starting at 'offset' bytes into the payload blob.
         /// </summary>  
         /// <returns>Offset just after the string</returns>
@@ -1684,7 +1695,7 @@ namespace Microsoft.Diagnostics.Tracing
         }
         /// <summary>
         /// Given an Offset to a null terminated ASCII string in an event blob, return the string that is
-        /// held there.   
+        /// held there.
         /// </summary>
         protected internal string GetUTF8StringAt(int offset)
         {
@@ -1698,6 +1709,24 @@ namespace Microsoft.Diagnostics.Tracing
                 return TraceEventRawReaders.ReadUTF8String(DataStart, offset, EventDataLength);
             }
         }
+
+        /// <summary>
+        /// Given an Offset to a counted UTF8 string in an event blob, return the string that is
+        /// held there.  The string length is pre-pended to the string and is stored in a ushort (unsigned 16-bytes).
+        /// </summary>
+        protected internal string GetShortUTF8StringAt(int offset)
+        {
+            if (offset >= EventDataLength)
+            {
+                Debug.Assert(false, "Read past end of string");
+                return "<<ERROR EOB>>";
+            }
+            else
+            {
+                return TraceEventRawReaders.ReadShortUTF8String(DataStart, offset, EventDataLength);
+            }
+        }
+
         /// <summary>
         /// Returns the string represented by a fixed length ASCII string starting at 'offset' of length 'charCount'
         /// </summary>
@@ -4666,6 +4695,29 @@ namespace Microsoft.Diagnostics.Tracing
                 buff[i++] = c;
             }
             return Encoding.UTF8.GetString(buff, 0, i);     // Convert to unicode.  
+        }
+
+        internal static unsafe string ReadShortUTF8String(IntPtr pointer, int offset, int bufferLength)
+        {
+            // Read the length of the string
+            ushort length = (ushort)ReadInt16(pointer, offset);
+            if (length == 0)
+            {
+                return string.Empty;
+            }
+            if (length > bufferLength - sizeof(ushort))
+            {
+                throw new FormatException("Invalid UTF8 String");
+            }
+            var buff = new byte[length];
+            byte* ptr = ((byte*)pointer) + offset + sizeof(ushort);
+            ushort i = 0;
+            while (i < length)
+            {
+                byte c = ptr[i];
+                buff[i++] = c;
+            }
+            return Encoding.UTF8.GetString(buff, 0, i);     // Convert to unicode.
         }
     }
 

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -2165,7 +2165,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             {
                 Debug.Assert(_syncTimeQPC != 0);         // We should have set this in the Header event (or on session start if it is read time
 #if DEBUG
-                //Debug.Assert(lastTimeStamp <= data.TimeStampQPC);     // Ensure they are in order
+                Debug.Assert(lastTimeStamp <= data.TimeStampQPC);     // Ensure they are in order
                 lastTimeStamp = data.TimeStampQPC;
 #endif
                 // Show status every 128K events

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -5951,7 +5951,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             imageFileName = data.Name;
             parentID = -1;
         }
-        internal void UniversalProcessStop(ProcessExitTraceData data)
+        internal void UniversalProcessStop(EmptyTraceData data)
         {
             endTimeQPC = data.TimeStampQPC;
         }
@@ -8489,7 +8489,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         TraceLoadedModule loadedModule = process.LoadedModules.FindModuleAndIndexContainingAddress(data.StartAddress, data.TimeStampQPC, out index);
                         module = process.LoadedModules.GetOrCreateManagedModule(loadedModule.ModuleID, data.TimeStampQPC);
                         moduleFileIndex = module.ModuleFile.ModuleFileIndex;
-                        methodIndex = methods.NewMethod(data.Name, moduleFileIndex, data.Id);
+                        methodIndex = methods.NewMethod(data.Name, moduleFileIndex, (int)data.Id);
                         
                         // When universal traces support re-use of address space, we'll need to support it here.
                     }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -17,7 +17,9 @@ using Microsoft.Diagnostics.Tracing.Parsers.GCDynamic;
 using Microsoft.Diagnostics.Tracing.Parsers.JScript;
 using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using Microsoft.Diagnostics.Tracing.Parsers.Symbol;
+using Microsoft.Diagnostics.Tracing.Parsers.Universal.Events;
 using Microsoft.Diagnostics.Tracing.Session;
+using Microsoft.Diagnostics.Tracing.SourceConverters;
 using Microsoft.Diagnostics.Tracing.Utilities;
 using Microsoft.Diagnostics.Utilities;
 using System;
@@ -1217,6 +1219,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             new WpfTraceEventParser(this);
 
             var dynamicParser = Dynamic;
+
+            NettraceUniversalConverter.RegisterParsers(this);
+
             registeringStandardParsers = false;
 
         }
@@ -1344,6 +1349,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             jittedMethods = new List<MethodLoadUnloadVerboseTraceData>();
             jsJittedMethods = new List<MethodLoadUnloadJSTraceData>();
             sourceFilesByID = new Dictionary<JavaScriptSourceKey, string>();
+
+            universalConverter = new NettraceUniversalConverter();
 
             // We need to copy some information from the event source.
             // An EventPipeEventSource won't have headers set until Process() is called, so we wait for the event trigger instead of copying right away.
@@ -2092,6 +2099,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     }
                 };
             }
+
+            universalConverter.BeforeProcess(this, rawEvents);
         }
 
         /// <summary>
@@ -2156,7 +2165,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             {
                 Debug.Assert(_syncTimeQPC != 0);         // We should have set this in the Header event (or on session start if it is read time
 #if DEBUG
-                Debug.Assert(lastTimeStamp <= data.TimeStampQPC);     // Ensure they are in order
+                //Debug.Assert(lastTimeStamp <= data.TimeStampQPC);     // Ensure they are in order
                 lastTimeStamp = data.TimeStampQPC;
 #endif
                 // Show status every 128K events
@@ -2406,6 +2415,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 codeAddresses.AddMethod(jsJittedMethod, sourceFilesByID);
             }
 
+            universalConverter.AfterProcess(this);
+
             // Make sure that all threads have a process
             foreach (var curThread in Threads)
             {
@@ -2533,7 +2544,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             options.ConversionLog.WriteLine("  {0,8:n0} unique code addresses. ", codeAddresses.Count);
             options.ConversionLog.WriteLine("  {0,8:n0} unique stacks.", callStacks.Count);
             options.ConversionLog.WriteLine("  {0,8:n0} unique managed methods parsed.", codeAddresses.Methods.Count);
-            options.ConversionLog.WriteLine("  {0,8:n0} CLR method event records.", codeAddresses.ManagedMethodRecordCount);
+            options.ConversionLog.WriteLine("  {0,8:n0} dynamic methods.", codeAddresses.DynamicMethods);
             options.ConversionLog.WriteLine("[Conversion complete {0:n0} events.  Conversion took {1:n0} sec.]",
                 eventCount, (DateTime.Now - startTime).TotalSeconds);
         }
@@ -4506,6 +4517,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         internal TraceEventDispatcher rawKernelEventSource;         // Only used by real time TraceLog on Win7.   It is the
         internal TraceLogOptions options;
         internal bool registeringStandardParsers;                   // Are we registering
+        internal NettraceUniversalConverter universalConverter;
 
         // Used for Real Time
         private struct QueueEntry
@@ -5932,6 +5944,17 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 }
             }
         }
+        internal void UniversalProcessStart(ProcessCreateTraceData data)
+        {
+            startTimeQPC = data.TimeStampQPC;
+            commandLine = data.Name;
+            imageFileName = data.Name;
+            parentID = -1;
+        }
+        internal void UniversalProcessStop(ProcessExitTraceData data)
+        {
+            endTimeQPC = data.TimeStampQPC;
+        }
 
         /// <summary>
         /// Sets the 'Parent' field for the process (based on the ParentID).
@@ -7055,6 +7078,46 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             CheckClassInvarients();
         }
 
+        internal TraceModuleFile UniversalMapping(ProcessMappingTraceData data)
+        {
+            int index;
+
+            // A loaded and managed modules depend on a module file, so get or create one.
+            // TODO: We'll need to store FileOffset as well to handle elf images.
+            TraceModuleFile moduleFile = process.Log.ModuleFiles.GetOrCreateModuleFile(data.FileName, data.StartAddress);
+            moduleFile.imageSize = (long)(data.EndAddress - data.StartAddress);
+
+            // Get or create the loaded module.
+            TraceLoadedModule loadedModule = FindModuleAndIndexContainingAddress(data.StartAddress, data.TimeStampQPC, out index);
+            if (loadedModule == null)
+            {   
+                // The module file is what is used when looking up the module for an arbitrary address, so it must save both the start address and image size.
+                loadedModule = new TraceLoadedModule(process, moduleFile, data.StartAddress);
+                
+                // All mappings are enumerated at the beginning of the trace.
+                loadedModule.loadTimeQPC = process.Log.sessionStartTimeQPC;
+                
+                InsertAndSetOverlap(index + 1, loadedModule);
+            }
+
+            // Get or create a managed module.  This module is the container for dynamic symbols.
+            TraceManagedModule managedModule = FindManagedModuleAndIndex((long)data.StartAddress, data.TimeStampQPC, out index);
+            if (managedModule == null)
+            {
+                managedModule = new TraceManagedModule(process, moduleFile, (long)data.StartAddress);
+                modules.Insert(index + 1, managedModule);
+            }
+
+            process.anyModuleLoaded = true;
+
+            // Get the latest version to return.
+            moduleFile = loadedModule.ModuleFile;
+            Debug.Assert(moduleFile != null);
+            CheckClassInvarients();
+
+            return moduleFile;
+        }
+
         internal TraceManagedModule GetOrCreateManagedModule(long managedModuleID, long timeQPC)
         {
             int index;
@@ -7127,7 +7190,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 // We only care about the native case.
                 if (canidateModule.key == canidateModule.ImageBase)
                 {
-                    ulong candidateImageEnd = (ulong)canidateModule.ImageBase + (uint)canidateModule.ModuleFile.ImageSize;
+                    ulong candidateImageEnd = (ulong)canidateModule.ImageBase + (ulong)canidateModule.ModuleFile.ImageSize;
                     if ((ulong)address < candidateImageEnd)
                     {
                         // Have we found a match?
@@ -8060,9 +8123,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </summary>
         public TraceModuleFiles ModuleFiles { get { return moduleFiles; } }
         /// <summary>
-        /// Indicates the number of managed method records that were encountered.  This is useful to understand if symbolic information 'mostly works'.
+        /// Indicates the number of dynamic method records that were encountered.  This is useful to understand if symbolic information 'mostly works'.
         /// </summary>
-        public int ManagedMethodRecordCount { get { return managedMethodRecordCount; } }
+        public int DynamicMethods { get { return dynamicMethodCount; } }
         /// <summary>
         /// Initially CodeAddresses for unmanaged code will have no useful name.  Calling LookupSymbolsForModule
         /// lets you resolve the symbols for a particular file so that the TraceCodeAddresses for that DLL
@@ -8372,7 +8435,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </summary>
         internal void AddMethod(MethodLoadUnloadVerboseTraceData data)
         {
-            managedMethodRecordCount++;
+            dynamicMethodCount++;
             MethodIndex methodIndex = Microsoft.Diagnostics.Tracing.Etlx.MethodIndex.Invalid;
             ILMapIndex ilMap = ILMapIndex.Invalid;
             ModuleFileIndex moduleFileIndex = Microsoft.Diagnostics.Tracing.Etlx.ModuleFileIndex.Invalid;
@@ -8402,6 +8465,37 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         info.SetILMapIndex(this, ilMap);
                     }
                     info.SetOptimizationTier(data.OptimizationTier);
+                }
+            });
+        }
+
+        internal void AddUniversalDynamicSymbol(ProcessSymbolTraceData data, TraceProcess process)
+        {
+            Debug.Assert(process != null);
+            dynamicMethodCount++;
+            MethodIndex methodIndex = Microsoft.Diagnostics.Tracing.Etlx.MethodIndex.Invalid;
+            ModuleFileIndex moduleFileIndex = Microsoft.Diagnostics.Tracing.Etlx.ModuleFileIndex.Invalid;
+            TraceManagedModule module = null;
+            ForAllUnresolvedCodeAddressesInRange(process, data.StartAddress, (int)(data.EndAddress - data.StartAddress), true, delegate (ref CodeAddressInfo info)
+            {
+                // If we already resolved, that means that the address was reused, so only add something if it does not already have
+                // information associated with it.
+                if (info.GetMethodIndex(this) == Microsoft.Diagnostics.Tracing.Etlx.MethodIndex.Invalid)
+                {
+                    // Lazily create the method since many methods never have code samples in them.
+                    if (module == null)
+                    {
+                        int index;
+                        TraceLoadedModule loadedModule = process.LoadedModules.FindModuleAndIndexContainingAddress(data.StartAddress, data.TimeStampQPC, out index);
+                        module = process.LoadedModules.GetOrCreateManagedModule(loadedModule.ModuleID, data.TimeStampQPC);
+                        moduleFileIndex = module.ModuleFile.ModuleFileIndex;
+                        methodIndex = methods.NewMethod(data.Name, moduleFileIndex, data.Id);
+                        
+                        // When universal traces support re-use of address space, we'll need to support it here.
+                    }
+
+                    // Set the info
+                    info.SetMethodIndex(this, methodIndex);
                 }
             });
         }
@@ -8463,7 +8557,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// start+length within the process 'process'.   If 'considerResolved' is true' then the address range
         /// is considered resolved and future calls to this routine will not find the addresses (since they are resolved).
         /// </summary>
-        internal void ForAllUnresolvedCodeAddressesInRange(TraceProcess process, Address start, int length, bool considerResolved, ForAllCodeAddrAction body)
+        internal void ForAllUnresolvedCodeAddressesInRange(TraceProcess process, Address start, long length, bool considerResolved, ForAllCodeAddrAction body)
         {
             if (process.codeAddressesInProcess == null)
             {
@@ -9432,7 +9526,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         private TraceCodeAddress[][] codeAddressObjects;  // If we were asked for TraceCodeAddresses (instead of indexes) we cache them, in sparse array
         private string[] names;                         // A cache (one per code address) of the string name of the address
-        private int managedMethodRecordCount;           // Remembers how many code addresses are managed methods (currently not serialized)
+        private int dynamicMethodCount;           // Remembers how many code addresses are managed methods (currently not serialized)
         internal int totalCodeAddresses;                 // Count of the number of times a code address appears in the log.
 
         // These are actually serialized.
@@ -10193,7 +10287,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// <summary>
         /// Returns the size of the DLL when loaded in memory
         /// </summary>
-        public int ImageSize { get { return imageSize; } }
+        public long ImageSize { get { return imageSize; } }
         /// <summary>
         /// Returns the address just past the memory the module uses.
         /// </summary>
@@ -10344,7 +10438,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
 
         internal string fileName;
-        internal int imageSize;
+        internal long imageSize;
         internal Address imageBase;
         internal string name;
         private ModuleFileIndex moduleFileIndex;


### PR DESCRIPTION
Adds support for consuming nettrace files that contain usage of the universal providers.  These are:

1. UniversalSystem - Provides a view of the state of the system (processes, mappings, symbols, etc.)
2. UniversalEvents - Provides sampled based events (e.g. CPU, CSwitch)

cc: @beaubelgrave, @noahfalk, @mdh1418 