### PR TITLE
Fix NetTrace parsing for Start/Stop event names

### DIFF
--- a/src/TraceEvent/EventPipe/EventPipeMetadata.cs
+++ b/src/TraceEvent/EventPipe/EventPipeMetadata.cs
@@ -771,6 +771,8 @@ namespace Microsoft.Diagnostics.Tracing
             {
                 ExtractImpliedOpcode();
             }
+            
+            StripStartStopInEventName();
         }
 
         public static Guid GetProviderGuidFromProviderName(string name)
@@ -875,7 +877,7 @@ namespace Microsoft.Diagnostics.Tracing
 
         /// <summary>
         /// If the event doesn't have an explicit Opcode and the event name ends with "Start" or "Stop",
-        /// then we strip the "Start" or "Stop" from the event name and set the Opcode accordingly.
+        /// then we set the Opcode to Start or Stop respectively.
         /// </summary>
         private void ExtractImpliedOpcode()
         {
@@ -884,11 +886,28 @@ namespace Microsoft.Diagnostics.Tracing
                 if (EventName.EndsWith("Start", StringComparison.OrdinalIgnoreCase))
                 {
                     Opcode = (int)TraceEventOpcode.Start;
-                    EventName = EventName.Substring(0, EventName.Length - 5);
                 }
                 else if (EventName.EndsWith("Stop", StringComparison.OrdinalIgnoreCase))
                 {
                     Opcode = (int)TraceEventOpcode.Stop;
+                }
+            }
+        }
+
+        /// <summary>
+        /// If the event has a Stop/Start opcode and also ends with the word "Start" or "Stop", then
+        /// remove the "Start" or "Stop" from the event name.
+        /// </summary>
+        private void StripStartStopInEventName()
+        {
+            if (EventName != null)
+            {
+                if (Opcode == (int)TraceEventOpcode.Start && EventName.EndsWith("Start", StringComparison.OrdinalIgnoreCase))
+                {
+                    EventName = EventName.Substring(0, EventName.Length - 5);
+                }
+                else if (Opcode == (int)TraceEventOpcode.Stop && EventName.EndsWith("Stop", StringComparison.OrdinalIgnoreCase))
+                {
                     EventName = EventName.Substring(0, EventName.Length - 4);
                 }
             }


### PR DESCRIPTION
The work to add V6 NetTrace parsing regressed the special name handling for names that end with "Start" or "Stop". Prior to this fix the suffix was correctly removed when the opcode in the trace was 0, but it was not removed if the opcode reported in the file was Start or Stop.

The fixed code removes the "Start" and "Stop" suffixes when the opcode is either 0 or when it is already set to start/stop respectively. An old V4 nettrace produced by the runtime would have opcode = 0 whereas a newer V5 nettrace from the runtime would have the opcode set.

Ideally the runtime would be doing this event name transform on its own and the parser would not be in the business of making these changes but for backwards compat we must.

@wiktork - this PR looks like it should fix the issue you were hitting
@brianrob @mdh1418 - PTAL, thanks!