### PR TITLE
Implement Duration Column Sorting

### DIFF
--- a/src/PerfView/Dialogs/SelectProcess.xaml
+++ b/src/PerfView/Dialogs/SelectProcess.xaml
@@ -91,6 +91,7 @@
                     <WPFToolKit:DataGridTextColumn
                 Header="Duration"
                 Binding="{Binding Duration}"
+                SortMemberPath="TotalDurationSeconds"
                 ElementStyle="{StaticResource RightAlign}"/>
                     <WPFToolKit:DataGridTextColumn
                 Header="CommandLine"

--- a/src/PerfView/HeapView/Toolbox.cs
+++ b/src/PerfView/HeapView/Toolbox.cs
@@ -52,6 +52,14 @@ namespace PerfView
             }
         }
 
+        public double TotalDurationSeconds
+        {
+            get
+            {
+                return (EndTime - StartTime).TotalSeconds;
+            }
+        }
+
         public int ProcessID { get; internal set; }
 
         public int ParentID { get; internal set; }

--- a/src/PerfView/IProcess.cs
+++ b/src/PerfView/IProcess.cs
@@ -10,6 +10,7 @@ namespace PerfView
         DateTime StartTime { get; }
         DateTime EndTime { get; }
         string Duration { get; }
+        double TotalDurationSeconds { get; }  // Added for proper Duration column sorting
         int ProcessID { get; }
         int ParentID { get; }
         double CPUTimeMSec { get; }
@@ -26,11 +27,18 @@ namespace PerfView
         public string CommandLine { get { return Process.CommandLine; } }
         public DateTime StartTime { get { return Process.CreationDate; } }
         public DateTime EndTime { get { return DateTime.Now; } }
+        public double TotalDurationSeconds
+        {
+            get 
+            { 
+                return (DateTime.Now - Process.CreationDate).TotalSeconds; 
+            }
+        }
         public string Duration
         {
             get
             {
-                double duration = (DateTime.Now - Process.CreationDate).TotalSeconds;
+                double duration = TotalDurationSeconds;
                 if (duration < 60)
                 {
                     return duration.ToString("f2") + " sec";
@@ -142,11 +150,18 @@ namespace PerfView
         public DateTime StartTime { get; internal set; }
         public DateTime EndTime { get; internal set; }
         public string CommandLine { get; internal set; }
+        public double TotalDurationSeconds
+        {
+            get
+            {
+                return (EndTime - StartTime).TotalSeconds;
+            }
+        }
         public string Duration
         {
             get
             {
-                double duration = (EndTime - StartTime).TotalSeconds;
+                double duration = TotalDurationSeconds;
                 if (duration < 60)
                 {
                     return duration.ToString("f2") + " sec";


### PR DESCRIPTION
When selecting one or more processes to display in a stack viewer, the `Duration` field is sorted as a text string instead of a duration.

Fixes sorting by using a floating point value representing total seconds and telling WPF to sort by that value instead of the text value.

cc: @bwadswor 