### PR TITLE
More efficient build in PRs

### DIFF
--- a/.pipelines/perfview-job.yml
+++ b/.pipelines/perfview-job.yml
@@ -7,23 +7,13 @@ steps:
   inputs:
     version: 8.0.x
 
-- task: NuGetToolInstaller@1
-  displayName: 'Install NuGet.exe'
-  inputs:
-    versionSpec: 6.3.0
-
-- task: NuGetCommand@2
-  displayName: 'NuGet Restore PerfView.sln'
-  inputs:
-    restoreSolution: PerfView.sln
-    feedsToUse: config
-    includeNuGetOrg: false
-    nugetConfigPath: '.\NuGet.config'
-
 - task: MSBuild@1
   displayName: 'Build PerfView.sln'
   inputs:
     solution: PerfView.sln
+    maximumCpuCount: true
+    msbuildArchitecture: 'x64'
+    msbuildArguments: '/restore'
     configuration: ${{ parameters.flavor }}
 
 - task: VSTest@2


### PR DESCRIPTION
Enable amd64 MSBuild, in multiproc mode, and include the NuGet restore in a single step.

(this time with a name that shouldn't anger GitHub: https://github.com/microsoft/perfview/pull/2191#issuecomment-2859426506).