### PR TITLE
Switch to pipeline artifacts

### DIFF
--- a/.ado.yml
+++ b/.ado.yml
@@ -18,11 +18,12 @@ jobs:
       parameters:
         flavor: 'Debug'
 
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: 'Publish Artifacts'
       inputs:
-        PathtoPublish: '$(build.artifactstagingdirectory)'
-        ArtifactName: 'PerfViewBinaries-Debug'
+        targetPath: '$(build.artifactstagingdirectory)'
+        artifact: 'PerfViewBinaries-Debug'
+        parallel: true
       condition: succeededOrFailed()
 
   - job: PerfView_Release
@@ -38,11 +39,12 @@ jobs:
       parameters:
         flavor: 'Release'
 
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: 'Publish Artifact'
       inputs:
-        PathtoPublish: '$(build.artifactstagingdirectory)'
-        ArtifactName: 'PerfViewBinaries-Release'
+        targetPath: '$(build.artifactstagingdirectory)'
+        artifact: 'PerfViewBinaries-Release'
+        parallel: true
 
   - job: PerfCollect
     pool:


### PR DESCRIPTION
Per https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/publish-build-artifacts-v1 this is recommended and faster.

(#2192 from a "clean" branch name)