### PR TITLE
Fix tab navigation to hyperlinks inside help ribbons

### DIFF
--- a/src/PerfView/Dialogs/MemoryDataDialog.xaml
+++ b/src/PerfView/Dialogs/MemoryDataDialog.xaml
@@ -21,19 +21,15 @@
         </Grid.RowDefinitions>
 
         <!-- Help message at top -->
-        <RichTextBox Grid.Row="0" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True" AutomationProperties.Name="Memory data collection help">
-            <RichTextBox.Document>
-                <FlowDocument>
-                    <Paragraph>
-                        This dialog gives options for collecting Memory (GC Heap) data.   Typically simply typing a few characters
-                        of the process name in the Filter text box and hitting &lt;Enter&gt; is enough.  See
-                        <Hyperlink Command="Help" CommandParameter="CollectingDataGCHeap">Collecting GC Heap Data.</Hyperlink> and
-                        <Hyperlink Command="Help" CommandParameter="UnderstandingPerfDataGCHeap">Understanding GC Heap Data.</Hyperlink>
-                        for more.
-                    </Paragraph>
-                </FlowDocument>
-            </RichTextBox.Document>
-        </RichTextBox>
+        <Border Grid.Row="0" BorderBrush="#ABADB3" BorderThickness="1">
+            <TextBlock Grid.Row="0" Background="{DynamicResource HelpRibbonBackground}" TextWrapping="Wrap" AutomationProperties.Name="Memory data collection help">
+                This dialog gives options for collecting Memory (GC Heap) data. Typically simply typing a few characters
+                of the process name in the Filter text box and hitting &lt;Enter&gt; is enough. See
+                <Hyperlink Command="Help" CommandParameter="CollectingDataGCHeap">Collecting GC Heap Data.</Hyperlink> and
+                <Hyperlink Command="Help" CommandParameter="UnderstandingPerfDataGCHeap">Understanding GC Heap Data.</Hyperlink>
+                for more.
+            </TextBlock>
+        </Border>
 
         <!-- Option 1 capturing memory from dmp files -->
         <Grid Grid.Row="1" Name="ProcessDumpRow">

--- a/src/PerfView/Dialogs/RunCommandDialog.xaml
+++ b/src/PerfView/Dialogs/RunCommandDialog.xaml
@@ -27,21 +27,16 @@
                 <ColumnDefinition Width="auto"/>
             </Grid.ColumnDefinitions>
             <!-- Help message at top -->
-            <RichTextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True" AutomationProperties.Name="Run collection help">
-                <RichTextBox.Document>
-                    <FlowDocument>
-                        <Paragraph Margin="0,0,0,0">
-                            This dialog give options for collecting ETW profile data.   The only required field the 'Command' field and
+            <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4" BorderBrush="#ABADB3" BorderThickness="1">
+                <TextBlock Background="{DynamicResource HelpRibbonBackground}" TextWrapping="Wrap" AutomationProperties.Name="Run collection help">
+                    This dialog give options for collecting ETW profile data. The only required field the 'Command' field and
                     this is only necessary when using the 'Run' command.
-                        </Paragraph>
-                        <Paragraph Margin="0,0,0,0">
-                            <Bold>If you wish to analyze on another machine use the Zip option when collecting data.</Bold>
-                            See
-                            <Hyperlink Command="Help" CommandParameter="CollectingData">Collecting ETW Profile Data.</Hyperlink> for more.
-                        </Paragraph>
-                    </FlowDocument>
-                </RichTextBox.Document>
-            </RichTextBox>
+                    <LineBreak/>
+                    <Bold>If you wish to analyze on another machine use the Zip option when collecting data.</Bold>
+                    See
+                    <Hyperlink Command="Help" CommandParameter="CollectingData">Collecting ETW Profile Data.</Hyperlink> for more.
+                </TextBlock>
+            </Border>
             <!-- CommandToRun section for running specific process -->
             <TextBlock Grid.Row="1" Grid.Column="0" x:Name="CommandToRunLabel" Margin="5,0" VerticalAlignment="Center" ToolTip="The command line of the process to run while collecting data.">
                 <Hyperlink Command="Help" CommandParameter="CommandToRunTextBox">Command:</Hyperlink>
@@ -161,7 +156,7 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="20*"/>
                         </Grid.ColumnDefinitions>
-                        
+
                         <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="5,2,5,2"
                            ToolTip="Fire an event (and stack trace) every time the processor switch from one thread to another." >
                             <Hyperlink Command="Help" CommandParameter="KernelBaseCheckBox">Kernel Base:</Hyperlink>

--- a/src/PerfView/Dialogs/SelectProcess.xaml
+++ b/src/PerfView/Dialogs/SelectProcess.xaml
@@ -14,20 +14,16 @@
         </Style>
     </Window.Resources>
     <DockPanel>
-        <RichTextBox DockPanel.Dock="Top" IsReadOnly="True" Background="{DynamicResource HelpRibbonBackground}" IsDocumentEnabled="True">
-            <RichTextBox.Document>
-                <FlowDocument>
-                    <Paragraph>
-                        The data collected was machine wide, but typically you are interested in only one process.
-                        This dialog box allows you to choose a particular process to focus on by either double clicking on a
-                        process or by selecting a process and hitting OK.
-                        The 'All Procs' button can be used if you wish to look at all data.
-                        See
-                        <Hyperlink Command="Help" CommandParameter="SelectProcessDialog">Selecting A Process Help</Hyperlink> for more.
-                    </Paragraph>
-                </FlowDocument>
-            </RichTextBox.Document>
-        </RichTextBox>
+        <Border DockPanel.Dock="Top" BorderBrush="#ABADB3" BorderThickness="1">
+            <TextBlock Background="{DynamicResource HelpRibbonBackground}" TextWrapping="Wrap" AutomationProperties.Name="Select process help">
+                The data collected was machine wide, but typically you are interested in only one process.
+                This dialog box allows you to choose a particular process to focus on by either double clicking on a
+                process or by selecting a process and hitting OK.
+                The 'All Procs' button can be used if you wish to look at all data.
+                See
+                <Hyperlink Command="Help" CommandParameter="SelectProcessDialog">Selecting A Process Help</Hyperlink> for more.
+            </TextBlock>
+        </Border>
         <Grid DockPanel.Dock="Top" >
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
After the last round of accessibility bug fixes, only one bug was sent back as unresolved, so this should fix that last accessibility bug. Essentially, the hyperlinks inside the help ribbons were not navigable by the keyboard using tab navigation. It seems that this is a bug with RichTextBox or FlowDocument as I was not able to get it to work, so I just converted it to a TextBlock and added a border to match the previous styling.

Comparing the help ribbons before and after the change, the styling is identical.