### PR TITLE
Make Copilot More Effective

### DIFF
--- a/.github/workflows/copilot-setup-setups.yml
+++ b/.github/workflows/copilot-setup-setups.yml
@@ -1,0 +1,29 @@
+name: "Copilot Setup Steps"
+
+# Allow testing of the setup steps from your repository's "Actions" tab.
+on: workflow_dispatch
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  # See https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - name: Restore TraceEvent
+        run: cd ./src/TraceEvent && dotnet restore --configfile ../../Nuget.config
+      - name: Restore TraceEvent.Tests
+        run: cd ./src/TraceEvent/TraceEvent.Tests && dotnet restore --configfile ../../../Nuget.config
+      - name: SymbolsAuth
+        run: cd ./src/SymbolsAuth && dotnet restore --configfile ../../Nuget.config
+      - name: SymbolsAuth.Tests
+        run: cd ./src/SymbolsAuth.Tests && dotnet restore --configfile ../../Nuget.config
+      - name: Restore MemoryGraph
+        run: cd ./src/MemoryGraph && dotnet restore --configfile ../../Nuget.config


### PR DESCRIPTION
Restore all Linux-buildable projects during copilot agent jobs.  This allows copilot to build these projects and react to any build breaks without human intervention.