### PR TITLE
Address NullReferenceException in Anti-Malware Realtime Scans View

### DIFF
--- a/src/PerfView/Computers/RealtimeAntimalwareComputer.cs
+++ b/src/PerfView/Computers/RealtimeAntimalwareComputer.cs
@@ -102,17 +102,27 @@ namespace PerfView
         {
             // Get the requesting user process based on the PID logged inside the engine.
             TraceProcess process = _traceLog.Processes.GetProcess(data.PID, data.TimeStampRelativeMSec);
-            ProcessIndex processIndex = process.ProcessIndex;
+            ProcessIndex processIndex = process?.ProcessIndex ?? ProcessIndex.Invalid;
             if (processIndex == ProcessIndex.Invalid)
                 return;
 
             // Get the file scan operation.
             Dictionary<ThreadIndex, FileScanOperation> processContainer = GetOrCreateProcessContainer(processIndex);
             FileScanOperation operation = processContainer.Values.Where(s => s.File.Equals(data.Path, System.StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-            if(operation != null)
+            if (operation != null)
             {
                 operation.StartTimeRelativeMSec = data.TimeStampRelativeMSec;
                 _engineThreadToScanMap[(int)data.Thread().ThreadIndex] = operation;
+            }
+            else
+            {
+                processContainer[data.Thread().ThreadIndex] = new FileScanOperation()
+                {
+                    File = data.Path,
+                    Reason = "Unknown",
+                    StartTimeRelativeMSec = data.TimeStampRelativeMSec,
+                    RequestorStack = _stackSource.GetCallStackForProcess(process)
+                };
             }
         }
 
@@ -120,7 +130,7 @@ namespace PerfView
         {
             // Get the requesting user process based on the PID logged inside the engine.
             TraceProcess process = _traceLog.Processes.GetProcess(data.PID, data.TimeStampRelativeMSec);
-            ProcessIndex processIndex = process.ProcessIndex;
+            ProcessIndex processIndex = process?.ProcessIndex ?? ProcessIndex.Invalid;
             if (processIndex == ProcessIndex.Invalid)
                 return;
 


### PR DESCRIPTION
- Address `NullReferenceException` when there is a missing process event.
- Show all scans even when the filter driver events aren't present.  This is especially useful when looking at traces generated by New-MpPerformanceRecording.  These events will show up with an "Unknown" reason and won't have a stack, since these are both generated by the filter driver events.