### PR TITLE
Remove uses of DefaultAzureCredential

### DIFF
--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -60,12 +60,9 @@ internal class Program
             string inputSpec = null;
             int minSecForTrigger = -1;
 
-            DefaultAzureCredential symbolsTokenCredential = new DefaultAzureCredential(
-                new DefaultAzureCredentialOptions()
-                {
-                    ExcludeInteractiveBrowserCredential = false,
-                    ExcludeManagedIdentityCredential = true,
-                });
+            ChainedTokenCredential symbolsTokenCredential = new ChainedTokenCredential(
+                new VisualStudioCredential(),
+                new InteractiveBrowserCredential());
 
             var dumper = new GCHeapDumper(Console.Out, symbolsTokenCredential);
 

--- a/src/PerfView/Authentication.cs
+++ b/src/PerfView/Authentication.cs
@@ -256,13 +256,7 @@ namespace PerfView
         /// <returns>This instance for fluent chaining.</returns>
         public static SymbolReaderAuthenticationHandler AddSymwebAuthentication(this SymbolReaderAuthenticationHandler httpHandler, TextWriter log, bool silent = false)
         {
-            DefaultAzureCredentialOptions options = new DefaultAzureCredentialOptions
-            {
-                ExcludeInteractiveBrowserCredential = silent,
-                ExcludeManagedIdentityCredential = true // This is not designed to be used in a service.
-            };
-
-            return httpHandler.AddHandler(new SymwebHandler(log, new DefaultAzureCredential(options)));
+            return httpHandler.AddHandler(new SymwebHandler(log, CreateTokenCredential()));
         }
 
         /// <summary>
@@ -285,13 +279,7 @@ namespace PerfView
         /// <returns>This instance for fluent chaining.</returns>
         public static SymbolReaderAuthenticationHandler AddAzureDevOpsAuthentication(this SymbolReaderAuthenticationHandler httpHandler, TextWriter log, bool silent = false)
         {
-            DefaultAzureCredentialOptions options = new DefaultAzureCredentialOptions
-            {
-                ExcludeInteractiveBrowserCredential = silent,
-                ExcludeManagedIdentityCredential = true // This is not designed to be used in a service.
-            };
-
-            return httpHandler.AddHandler(new AzureDevOpsHandler(log, new DefaultAzureCredential(options)));
+            return httpHandler.AddHandler(new AzureDevOpsHandler(log, CreateTokenCredential()));
         }
 
         /// <summary>
@@ -306,6 +294,13 @@ namespace PerfView
 
         public static SymbolReaderAuthenticationHandler AddBasicHttpAuthentication(this SymbolReaderAuthenticationHandler httpHandler, TextWriter log, Window mainWindow)
             => httpHandler.AddHandler(new BasicHttpAuthHandler(log));
+
+        private static ChainedTokenCredential CreateTokenCredential()
+        {
+            return new ChainedTokenCredential(
+                new VisualStudioCredential(),
+                new InteractiveBrowserCredential());
+        }
 
         /// <summary>
         /// Get the HWND of the given WPF window in a way that honors WPF

--- a/src/SymbolsAuth/Samples/1_InteractivePopupAuth.cs
+++ b/src/SymbolsAuth/Samples/1_InteractivePopupAuth.cs
@@ -37,12 +37,7 @@ namespace Samples
             /*** Begin Example ***/
 
             // Setup the token credential that the handler will use to authenticate.
-            DefaultAzureCredential credential = new DefaultAzureCredential(
-                new DefaultAzureCredentialOptions()
-                {
-                    ExcludeInteractiveBrowserCredential = false,
-                    ExcludeManagedIdentityCredential = true,
-                });
+            InteractiveBrowserCredential credential = new InteractiveBrowserCredential();
 
             // Create a new symbols authentication handler and configure it for authentication to symweb.
             SymbolReaderAuthenticationHandler symbolReaderAuthHandler = new SymbolReaderAuthenticationHandler()


### PR DESCRIPTION
Provide a more deterministic set of chained credentials:

1. Visual Studio credentials (if present)
2. Prompt the user.

NOTE: This only affects interactive uses of PerfView.  Users of TraceEvent's symbol authentication functionality have always been required to provide a `TokenCredential` directly.