### PR TITLE
Add Explanations for CodeQL Suppressions

### DIFF
--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -664,11 +664,11 @@ namespace Microsoft.Diagnostics.Symbols
                 // 3 checksum generated with the SHA256 hashing algorithm.
                 if (sourceFile.checksumType == 1)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.MD5.Create(); // lgtm [cs/weak-crypto]
+                    _hashAlgorithm = System.Security.Cryptography.MD5.Create(); // lgtm [cs/weak-crypto] The PDB specifies the checksum algorithm.  This is not controlled by TraceEvent.
                 }
                 else if (sourceFile.checksumType == 2)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto]
+                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto] The PDB specifies the checksum algorithm.  This is not controlled by TraceEvent.
                 }
                 else if (sourceFile.checksumType == 3)
                 {
@@ -725,11 +725,11 @@ namespace Microsoft.Diagnostics.Symbols
 
                     if (srcFormat.Header.algorithmId == guidMD5)
                     {
-                        _hashAlgorithm = System.Security.Cryptography.MD5.Create(); // lgtm [cs/weak-crypto]
+                        _hashAlgorithm = System.Security.Cryptography.MD5.Create(); // lgtm [cs/weak-crypto] The checksum algorithm is specified by the injected source.  This is not controlled by TraceEvent.
                     }
                     else if (srcFormat.Header.algorithmId == guidSHA1)
                     {
-                        _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto]
+                        _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto] The checksum algorithm is specified by the injected source.  This is not controlled by TraceEvent.
                     }
                     else if (srcFormat.Header.algorithmId == guidSHA256)
                     {

--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Diagnostics.Symbols
                 Guid hashAlgorithmGuid = metaData.GetGuid(sourceFileDocument.HashAlgorithm);
                 if (hashAlgorithmGuid == HashAlgorithmSha1)
                 {
-                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto]
+                    _hashAlgorithm = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto] The PDB specifies the checksum algorithm.  This is not controlled by TraceEvent.
                 }
                 else if (hashAlgorithmGuid == HashAlgorithmSha256)
                 {

--- a/src/TraceEvent/TraceEventSession.cs
+++ b/src/TraceEvent/TraceEventSession.cs
@@ -3053,7 +3053,7 @@ namespace Microsoft.Diagnostics.Tracing.Session
             }
 
             // Compute the Sha1 hash
-            var sha1 = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto]
+            var sha1 = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto] The EventSource name to GUID protocol requires a SHA1 hash.
             byte[] hash = sha1.ComputeHash(bytes);
 
             // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)

--- a/src/TraceParserGen/Program.cs
+++ b/src/TraceParserGen/Program.cs
@@ -636,7 +636,7 @@ internal static class EventSourceFinder
         }
 
         // Compute the Sha1 hash
-        var sha1 = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto]
+        var sha1 = System.Security.Cryptography.SHA1.Create(); // lgtm [cs/weak-crypto] The EventSource name to GUID protocol requires a SHA1 hash.
         byte[] hash = sha1.ComputeHash(bytes);
 
         // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)


### PR DESCRIPTION
Suppressions must have an explanation in order to be effective.