### PR TITLE
Use themed background brush for menu and filter

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -71,7 +71,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Menu Grid.Column="0" Background="{DynamicResource {x:Static SystemColors.MenuBarBrushKey}}" AutomationProperties.Name="Navigation">
+            <Menu Grid.Column="0" Background="{DynamicResource ControlDefaultBackground}" AutomationProperties.Name="Navigation">
                 <MenuItem Header="_File">
                     <MenuItem Header="_Clear Temp Files" Click="DoClearTempFiles" ToolTip="Some operations create temporary files.  This command clears all of these."/>
                     <MenuItem Header="Clear User Config" Click="DoClearUserConfig" ToolTip="Reset all user preferences back to their defaults when PerfView was first installed."/>
@@ -145,7 +145,7 @@
                     <MenuItem Header="_About" Click="DoAbout"/>
                 </MenuItem>
             </Menu>
-            <Rectangle Grid.Column="1" Grid.ColumnSpan="11" Fill="{DynamicResource {x:Static SystemColors.MenuBarBrushKey}}"/>
+            <Rectangle Grid.Column="1" Grid.ColumnSpan="11" Fill="{DynamicResource ControlDefaultBackground}"/>
             <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center"  Margin="3,0" TextWrapping="Wrap">
                 <Hyperlink Command="Help" CommandParameter="MainViewerQuickStart">Main View Help (F1)</Hyperlink>
             </TextBlock>
@@ -174,7 +174,7 @@
                 <ColumnDefinition Width="auto"/>
                 <ColumnDefinition Width="619*"/>
             </Grid.ColumnDefinitions>
-            <DockPanel Background="Gray" Grid.Column="0">
+            <DockPanel Background="{DynamicResource PanelBackground}" Grid.Column="0">
                 <controls:HistoryComboBox x:Name="Directory" DockPanel.Dock="Top" AutomationProperties.Name="Directory Search Bar"
                          ToolTip="This is the directory to search for performance data files." TextEntered="DoTextEnteredInDirectoryTextBox" />
                 <Grid DockPanel.Dock="Top" >
@@ -182,7 +182,7 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="100*"/>
                     </Grid.ColumnDefinitions>
-                    <Rectangle Grid.Column="0" Grid.ColumnSpan="3" Fill="{DynamicResource {x:Static SystemColors.MenuBarBrushKey}}"/>
+                    <Rectangle Grid.Column="0" Grid.ColumnSpan="3" Fill="{DynamicResource ControlDefaultBackground}"/>
                     <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,0,0" ToolTip="Only files that match this RegEx filter pattern are displayed.">
                     <Hyperlink Command="Help" CommandParameter="FileFilterTextBox">Filter:</Hyperlink>
                     </TextBlock>


### PR DESCRIPTION
Without this the menu and filter are white on white in dark mode.

Before:

<img width="924" height="526" alt="image" src="https://github.com/user-attachments/assets/74d35ff8-0d8d-4432-bbef-4f3ca03ab225" />

After:

<img width="1213" height="659" alt="image" src="https://github.com/user-attachments/assets/c86d3133-ba25-406f-b55c-ff1eeb28e206" />

<img width="1199" height="652" alt="image" src="https://github.com/user-attachments/assets/a2d2c029-9725-40e2-b079-8581042893d0" />
