### PR TITLE
Improve rendering and dark mode

### DIFF
--- a/PerfView.sln
+++ b/PerfView.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.32821.20
 MinimumVisualStudioVersion = 15.0
@@ -38,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CONTRIBUTING.md = CONTRIBUTING.md
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
+		src\Directory.Packages.props = src\Directory.Packages.props
 		src\PerfViewCollect\PerfViewCollect.csproj = src\PerfViewCollect\PerfViewCollect.csproj
 		README.md = README.md
 	EndProjectSection
@@ -407,13 +409,13 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{DE35BED9-0E03-4DAC-A003-1ACBBF816973} = {1CAEF854-2923-45FA-ACB8-6523A7E45896}
+	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F85A2A3-E0DF-4826-9BBA-4DFFA0F17150}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = PerfView2.vsmdi
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{DE35BED9-0E03-4DAC-A003-1ACBBF816973} = {1CAEF854-2923-45FA-ACB8-6523A7E45896}
 	EndGlobalSection
 EndGlobal

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Features>strict</Features>
   </PropertyGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,27 +19,27 @@
     <PackageVersion Include="Azure.Identity" Version="1.11.4" />
     <PackageVersion Include="MicroBuild.Core" Version="0.3.1" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.510501" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.61.3" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
-    <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="7.1.2" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="7.1.2" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.74.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.74.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="8.13.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.13.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.13.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
-    <PackageVersion Include="System.Buffers" Version="4.5.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
+    <PackageVersion Include="System.Buffers" Version="4.6.1" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.8" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="System.Numerics.Vectors" Version="4.6.1" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.8" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.8" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
   <!-- ClrMD -->

--- a/src/PerfView/ClrStats.cs
+++ b/src/PerfView/ClrStats.cs
@@ -16,20 +16,41 @@ namespace Stats
         {
             if (!justBody)
             {
-                writer.WriteLine("<html>");
-                writer.WriteLine("<head>");
-                writer.WriteLine("<title>{0}</title>", Path.GetFileNameWithoutExtension(fileName));
-                writer.WriteLine("<meta charset=\"UTF-8\"/>");
-                writer.WriteLine("<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"/>");
-                writer.WriteLine("</head>");
-                writer.WriteLine("<body>");
+                writer.WriteLine($$"""
+                    <html>
+                      <head>
+                        <title>{{Path.GetFileNameWithoutExtension(fileName)}}</title>
+                        <meta charset="UTF-8"/>
+                        <style>
+                          :root[data-theme="light"] {
+                            color-scheme: light;
+                            --error-color: #B3261E;   /* dark red for light mode (accessible on white) */
+                            --hover-color: #eeeeee;   /* light grey for hover on light bg */
+                          }
+                    
+                          :root[data-theme="dark"] {
+                            color-scheme: dark;
+                            --error-color: #ffb4ab;   /* soft red/pink for dark mode (better on dark) */
+                            --hover-color: #333333;   /* dark grey for hover on dark bg */
+                          }
+
+                          .error {
+                            color: var(--error-color);
+                            font-weight: bold;
+                          }
+                        </style>
+                      </head>
+                      <body>
+                        <H2>{{title}}</H2>
+                    """);
             }
-            writer.WriteLine("<H2>{0}</H2>", title);
+
             List<TraceProcess> sortedProcs = perProc;
             if (type == ReportType.JIT)
             {
                 sortedProcs.Sort((TraceProcess p1, TraceProcess p2) => { return -p1.LoadedDotNetRuntime().JIT.Stats().TotalCpuTimeMSec.CompareTo(p2.LoadedDotNetRuntime().JIT.Stats().TotalCpuTimeMSec); });
             }
+
             else if (type == ReportType.GC)
             {
                 sortedProcs.Sort((TraceProcess p1, TraceProcess p2) => { return -p1.LoadedDotNetRuntime().GC.Stats().MaxSizePeakMB.CompareTo(p2.LoadedDotNetRuntime().GC.Stats().MaxSizePeakMB); });
@@ -110,8 +131,15 @@ namespace Stats
             writer.WriteLine("<BR/><BR/><BR/><BR/><BR/><BR/><BR/><BR/><BR/><BR/>");
             if (!justBody)
             {
-                writer.WriteLine("</body>");
-                writer.WriteLine("</html>");
+                writer.WriteLine("""
+                    <script>
+                      // Set theme based on user preference
+                      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+                    </script>
+                  </body>
+                </html>
+                """);
             }
         }
 

--- a/src/PerfView/Dialogs/SelectProcess.xaml
+++ b/src/PerfView/Dialogs/SelectProcess.xaml
@@ -11,6 +11,8 @@
     <Window.Resources>
         <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type WPFToolKit:DataGridColumnHeader}">
             <Setter Property="Focusable" Value="True" />
+            <Setter Property="Background" Value="{DynamicResource ControlDefaultBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource ControlText}" />
         </Style>
     </Window.Resources>
     <DockPanel>

--- a/src/PerfView/EventViewer/EventWindow.xaml
+++ b/src/PerfView/EventViewer/EventWindow.xaml
@@ -16,6 +16,8 @@
         </Style>
         <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type WPFToolKit:DataGridColumnHeader}">
             <Setter Property="Focusable" Value="True" />
+            <Setter Property="Background" Value="{DynamicResource ControlDefaultBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource ControlText}" />
         </Style>
         <WPFToolKit:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </Window.Resources>

--- a/src/PerfView/GcStats.cs
+++ b/src/PerfView/GcStats.cs
@@ -20,11 +20,14 @@ namespace Stats
 
         public static void ToHtml(TextWriter writer, TraceProcess stats, TraceLoadedDotNetRuntime runtime, string fileName, bool doServerGCReport = false)
         {
-            writer.WriteLine("<H3><A Name=\"Stats_{0}\"><font color=\"blue\">GC Stats for Process {1,5}: {2}</font><A></H3>", stats.ProcessID, stats.ProcessID, stats.Name);
-            writer.WriteLine("<UL>");
+            writer.WriteLine($"""
+                <H3><A Name="Stats_{stats.ProcessID}"><font color="blue">GC Stats for Process {stats.ProcessID,5}: {stats.Name}</font><A></H3>
+                <UL>
+                """);
+
             if (runtime.GC.Stats().GCVersionInfoMismatch)
             {
-                writer.WriteLine("<LI><Font size=3 color=\"red\">Warning: Did not recognize the V4.0 GC Information events.  Falling back to V2.0 behavior.</font></LI>");
+                writer.WriteLine("""<LI><Font class=".error">Warning: Did not recognize the V4.0 GC Information events.  Falling back to V2.0 behavior.</font></LI>""");
             }
 
             if (!string.IsNullOrEmpty(stats.CommandLine))
@@ -33,7 +36,7 @@ namespace Stats
             }
 
             var runtimeBuiltTime = "";
-            if (runtime.RuntimeBuiltTime != default(DateTime))
+            if (runtime.RuntimeBuiltTime != default)
             {
                 runtimeBuiltTime = string.Format(" (built on {0})", runtime.RuntimeBuiltTime);
             }
@@ -1215,11 +1218,11 @@ namespace Stats
             switch (gen)
             {
                 case 2:
-                    return "bgcolor=#56A5EC";
+                    return "class=\"row-vibrant\"";
                 case 1:
-                    return "bgcolor=#82CAFF";
+                    return "class=\"row-medium\"";
                 default:
-                    return "bgcolor=#BDEDFF";
+                    return "class=\"row-subtle\"";
             }
         }
         #endregion

--- a/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
+++ b/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
@@ -6,8 +6,8 @@
         Style="{DynamicResource CustomWindowStyle}"
         Closing="Window_Closing"
         Title="Web Browser" Height="700" Width="1100">
-    <DockPanel>
-        <Grid DockPanel.Dock="Top">
+    <DockPanel Background="{DynamicResource ControlDefaultBackground}">
+        <Grid DockPanel.Dock="Top" Background="{DynamicResource ControlDefaultBackground}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>

--- a/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml.cs
+++ b/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml.cs
@@ -52,9 +52,9 @@ namespace PerfView.GuiUtilities
         /// </summary>
         private void Navigate()
         {
-            if (!_disposed && Source != null && _Browser.CoreWebView2 != null)
+            if (!_disposed && Source?.ToString() is { } source)
             {
-                _Browser.CoreWebView2.Navigate(Source.ToString());
+                Browser?.CoreWebView2.Navigate(source);
             }
         }
 
@@ -89,9 +89,9 @@ namespace PerfView.GuiUtilities
             else
             {
                 // Dispose WebView2 to prevent finalizer crashes
-                if (!_disposed && _Browser != null)
+                if (!_disposed)
                 {
-                    _Browser.Dispose();
+                    Browser?.Dispose();
                     _disposed = true;
                 }
             }
@@ -109,6 +109,7 @@ namespace PerfView.GuiUtilities
 
             var userDataFolder = Path.Combine(SupportFiles.SupportFileDir, "WebView2");
             Directory.CreateDirectory(userDataFolder);
+
             var environmentAwaiter = CoreWebView2Environment
                 .CreateAsync(userDataFolder: userDataFolder)
                 .ConfigureAwait(true)
@@ -122,12 +123,18 @@ namespace PerfView.GuiUtilities
                 }
 
                 var environment = environmentAwaiter.GetResult();
-                await _Browser.EnsureCoreWebView2Async(environment).ConfigureAwait(true);
+                await Browser.EnsureCoreWebView2Async(environment).ConfigureAwait(true);
+
+                // Set the preferred color scheme directly on the profile
+                Browser.CoreWebView2.Profile.PreferredColorScheme = GuiApp.MainWindow.ThemeViewModel.IsLightTheme
+                    ? CoreWebView2PreferredColorScheme.Light
+                    : CoreWebView2PreferredColorScheme.Dark;
 
                 // Navigate to the current specified source
                 Navigate();
             });
         }
+
         #endregion
     }
 }

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -174,7 +174,7 @@
                 <ColumnDefinition Width="auto"/>
                 <ColumnDefinition Width="619*"/>
             </Grid.ColumnDefinitions>
-            <DockPanel Background="{DynamicResource PanelBackground}" Grid.Column="0">
+            <DockPanel Background="{DynamicResource ContainerBackground}" Grid.Column="0">
                 <controls:HistoryComboBox x:Name="Directory" DockPanel.Dock="Top" AutomationProperties.Name="Directory Search Bar"
                          ToolTip="This is the directory to search for performance data files." TextEntered="DoTextEnteredInDirectoryTextBox" />
                 <Grid DockPanel.Dock="Top" >

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -72,6 +72,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="app.manifest"/>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero" />
@@ -511,14 +512,14 @@
       <Link>Microsoft.Identity.Client.Extensions.Msal.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_Abstractions)\lib\net461\Microsoft.IdentityModel.Abstractions.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_Abstractions)\lib\net462\Microsoft.IdentityModel.Abstractions.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.IdentityModel.Abstractions.dll</LogicalName>
       <Link>Microsoft.IdentityModel.Abstractions.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_JsonWebTokens)\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_JsonWebTokens)\lib\net462\Microsoft.IdentityModel.JsonWebTokens.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.IdentityModel.JsonWebTokens.dll</LogicalName>
@@ -567,14 +568,14 @@
       <Link>runtimes\win-arm64\native\WebView2Loader.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_Tokens)\lib\net461\Microsoft.IdentityModel.Tokens.dll">
+    <EmbeddedResource Include="$(PkgMicrosoft_IdentityModel_Tokens)\lib\net462\Microsoft.IdentityModel.Tokens.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\Microsoft.IdentityModel.Tokens.dll</LogicalName>
       <Link>Microsoft.IdentityModel.Tokens.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgSystem_Buffers)\lib\net461\System.Buffers.dll">
+    <EmbeddedResource Include="$(PkgSystem_Buffers)\lib\net462\System.Buffers.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Buffers.dll</LogicalName>
@@ -588,21 +589,21 @@
       <Link>System.Diagnostics.DiagnosticSource.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgSystem_Memory)\lib\net461\System.Memory.dll">
+    <EmbeddedResource Include="$(PkgSystem_Memory)\lib\net462\System.Memory.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Memory.dll</LogicalName>
       <Link>System.Memory.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgSystem_Numerics_Vectors)\lib\net46\System.Numerics.Vectors.dll">
+    <EmbeddedResource Include="$(PkgSystem_Numerics_Vectors)\lib\net462\System.Numerics.Vectors.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Numerics.Vectors.dll</LogicalName>
       <Link>System.Numerics.Vectors.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgSystem_Security_Cryptography_ProtectedData)\lib\net461\System.Security.Cryptography.ProtectedData.dll">
+    <EmbeddedResource Include="$(PkgSystem_Security_Cryptography_ProtectedData)\lib\net462\System.Security.Cryptography.ProtectedData.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Security.Cryptography.ProtectedData.dll</LogicalName>
@@ -623,7 +624,7 @@
       <Link>System.Text.Json.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PkgSystem_Threading_Tasks_Extensions)\lib\net461\System.Threading.Tasks.Extensions.dll">
+    <EmbeddedResource Include="$(PkgSystem_Threading_Tasks_Extensions)\lib\net462\System.Threading.Tasks.Extensions.dll">
       <Type>Non-Resx</Type>
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Threading.Tasks.Extensions.dll</LogicalName>

--- a/src/PerfView/StackViewer/PerfDataGrid.xaml
+++ b/src/PerfView/StackViewer/PerfDataGrid.xaml
@@ -25,6 +25,8 @@
         </Style>
         <Style x:Key="ColumnHeaderStyle" TargetType="{x:Type WPFToolKit:DataGridColumnHeader}">
             <Setter Property="Focusable" Value="True" />
+            <Setter Property="Background" Value="{DynamicResource ControlDefaultBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource ControlText}" />
         </Style>
     </UserControl.Resources>
     <WPFToolKit:DataGrid Name="Grid"

--- a/src/PerfView/SupportFiles/EventCounterVisualization.html
+++ b/src/PerfView/SupportFiles/EventCounterVisualization.html
@@ -4,9 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="color-scheme" content="light dark">
     <title>Event Counter Visualization</title>
     <style>
+        :root {
+            color-scheme: dark light;
+        }
+
         body {
             font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
             font-weight: 400;

--- a/src/PerfView/SupportFiles/HtmlReportUsersGuide.htm
+++ b/src/PerfView/SupportFiles/HtmlReportUsersGuide.htm
@@ -3,9 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="color-scheme" content="light dark">
     <title>Understand Perf Reports</title>
     <style>
+        :root {
+            color-scheme: dark light;
+        }
+
         body {
             font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
             font-weight: 400;
@@ -335,6 +339,10 @@
     <p>&nbsp;</p>
     <p>&nbsp;</p>
     <p>&nbsp;</p>
-</body>
-
+    <script>
+      // Set theme based on user preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+    </script>
+  </body>
 </html>

--- a/src/PerfView/SupportFiles/PerfViewWebVideos.htm
+++ b/src/PerfView/SupportFiles/PerfViewWebVideos.htm
@@ -3,9 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="color-scheme" content="light dark">
     <title>PerfView Videos</title>
     <style>
+        :root[data-theme="light"] {
+            color-scheme: light;
+        }
+
+        :root[data-theme="dark"] {
+            color-scheme: dark;
+        }
+
         body {
             font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
             font-weight: 400;
@@ -174,6 +182,10 @@
         <li><a href="https://docs.microsoft.com/en-us/shows/perfview-tutorial/tutorial-10-investigating-net-heap-memory-leaks-part1-collecting-data">Investigating .NET Heap Memory Leaks: Part 1: Collecting the Data</a> (8 min) This is the first of a two part video of step-by-step instructions for using PerfView to investigate a &#39;Leak&#39; in the .NET GC heap.&nbsp; This first part goes through the mechanics of collecting the data which involves taking two heap snapshots at appropriate times.&nbsp; </li>
         <li><a href="https://docs.microsoft.com/en-us/shows/perfview-tutorial/tutorial-11-investigating-net-heap-memory-leaks-part2-analyzing-data">Investigation .NET Heap Memory Leaks: Part 2: Analyzing the Data </a>(11 min).&nbsp; In this second part we take the two snapshots collected in part 1 and walk though the mechanics of doing a &#39;diff&#39; of the two memory heaps to determine how the heap grew between the two points in time.&nbsp; This lets us home in on places where we were not dropping references to objects (which caused them to &#39;leak&#39;).&nbsp; </li>
     </ol>
-
-</body>
+    <script>
+      // Set theme based on user preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+    </script>
+  </body>
 </html>

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -1,24 +1,31 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="color-scheme" content="light dark">
     <title>PerfView User's Guide</title>
     <style>
-        body {
-            font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
-            font-weight: 400;
-            text-rendering: optimizeLegibility;
-            -webkit-font-smoothing: antialiased;
-        }
+      :root[data-theme="light"] {
+          color-scheme: light;
+      }
+      :root[data-theme="dark"] {
+          color-scheme: dark;
+      }
 
-        hr {
-            border-top: 3px double gray;
-        }
+      body {
+        font-family: Segoe UI,SegoeUI,Segoe WP,Helvetica Neue,Helvetica,Tahoma,Arial,sans-serif;
+        font-weight: 400;
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      hr {
+        border-top: 3px double gray;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <!--  ************************************************************************************* -->
     <h1>
         <a id="UsersGuide">PerfView User's Guide</a>
@@ -2441,7 +2448,7 @@
                             <strong><a id="ContentionStacks">Contention Stacks</a></strong> - This view aggregates Contention events.&nbsp;
                             Contention event is fired when a thread tries to acquire a managed lock that is currently owned
                             by another thread. Note that each event has useful event data that is folded by default.
-                            For example, unfolding <code>EventData DurationNs</code> reveals individual pauses of each thread: this can be useful 
+                            For example, unfolding <code>EventData DurationNs</code> reveals individual pauses of each thread: this can be useful
                             to correlate a particular long wait to another events in the trace. Note that not all contention events
                             are real OS-level waits: the runtime may first spin wait to try acquire the lock fast. The metric
                             represents the amount of time spent to acquire the lock in milliseconds.
@@ -8031,7 +8038,7 @@
     </h3>
     <p>
         If your symbols are on an Azure DevOps artifacts store, or your source code is not public,
-        then PerfView may prompt you to sign in. Support currently exists for Azure DevOps and private 
+        then PerfView may prompt you to sign in. Support currently exists for Azure DevOps and private
         GitHub repositories. If installed, PerfView will try to use the <a href="https://github.com/GitCredentialManager">Git Credential Manager</a>
         which is typically installed with Git For Windows. If Git Credential Manager is not installed,
         PerfView will fall back to alternate authentication mechanisms. The authentication mechanisms
@@ -8042,7 +8049,7 @@
                 <strong>Git Credential Manager</strong>. This is the most flexible option for developers
                 using Git. It works alongside your Git installation to sign into private repositories.
                 Support is currently enabled for Azure DevOps and GitHub. We hope to add GitLab and BitBucket
-                support in the future. 
+                support in the future.
                 PerfView will search for the Git Credential Manager executable (git-credential-manager-core.exe)
                 in a number of well-known locations, but if it can't be found, then the option will be
                 unavailable. If you have installed Git Credential Manager in a non-standard location, you can
@@ -8058,12 +8065,12 @@
                 into Visual Studio or VS Code using credentials that can access your Azure DevOps repo.
                 If you sign into Visual Studio with several different accounts, you may need to select the
                 right one in Tools/Options/Azure Service Authentication.
-                See the <a href="https://devblogs.microsoft.com/azure-sdk/authentication-and-the-azure-sdk/">Authentication and the Azure SDK</a> 
+                See the <a href="https://devblogs.microsoft.com/azure-sdk/authentication-and-the-azure-sdk/">Authentication and the Azure SDK</a>
                 blog posting for more information.
             </li>
             <li>
                 <strong>Device Code Flow for GitHub</strong>. This option, for GitHub only, uses a Device Code
-                to grant PerfView access to GitHub private repositories. 
+                to grant PerfView access to GitHub private repositories.
                 PerfView will prompt you with an 8 digit device code which you use to log into GitHub.com using
                 any web browser. The browser could be running on a different device, if necessary.
                 When you enter the code into the browser and approve the app, the dialog will automatically close
@@ -8071,10 +8078,10 @@
                 to access.
             </li>
             <li>
-	            <strong>Basic HTTP Authentication</strong>. This option allows you to use Basic HTTP authentication
-	            when connecting to a symbol server. To use it, you should specify the username and password in the URL for your symbol server. For example:
-	            <i>SRV*SymbolCachePath*https://username:password@symbolstore.url;</i>. This scheme is active by default but
-	            used only if the URL contains <i>username</i> and <i>password</i> information.
+                <strong>Basic HTTP Authentication</strong>. This option allows you to use Basic HTTP authentication
+                when connecting to a symbol server. To use it, you should specify the username and password in the URL for your symbol server. For example:
+                <i>SRV*SymbolCachePath*https://username:password@symbolstore.url;</i>. This scheme is active by default but
+                used only if the URL contains <i>username</i> and <i>password</i> information.
             </li>
         </ul>
     </p>
@@ -9164,63 +9171,64 @@
 }
                 </pre>
                 </li>
+            </ul>
+        <li>
+            Version 1.8.28 2/4/16
+            <ul>
                 <li>
-                    Version 1.8.28 2/4/16
-                    <ul>
-                        <li>
-                            Added support doing performance investigations with Linux Perf Events data.   Basically if
-                            collect data with the bash script https://raw.githubusercontent.com/dotnet/corefx-tools/master/src/performance/perfcollect/perfcollect
-                            it will runt the Linux 'perf' tool that will collect CPU samples, convert them to a .data.txt file
-                            (which is a textual representation of the data) and then ZIP it into a .trace.zip file PerfView
-                            knows how to decode either the uncompressed .data.txt file or the zipped .trace.zip file and
-                            display it as a stack view.   Thus you can now do linux  performance investigations with PerfView.
-                        </li>
-                    </ul>
+                    Added support doing performance investigations with Linux Perf Events data.   Basically if
+                    collect data with the bash script https://raw.githubusercontent.com/dotnet/corefx-tools/master/src/performance/perfcollect/perfcollect
+                    it will runt the Linux 'perf' tool that will collect CPU samples, convert them to a .data.txt file
+                    (which is a textual representation of the data) and then ZIP it into a .trace.zip file PerfView
+                    knows how to decode either the uncompressed .data.txt file or the zipped .trace.zip file and
+                    display it as a stack view.   Thus you can now do linux  performance investigations with PerfView.
                 </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.25 2/2/16
+            <ul>
                 <li>
-                    Version 1.8.25 2/2/16
-                    <ul>
-                        <li>
-                            Improvements in Start-Stop time.   UNKNOWN_ASYNC displayed more often, some AWAIT time shown more often.
-                        </li>
-                    </ul>
+                    Improvements in Start-Stop time.   UNKNOWN_ASYNC displayed more often, some AWAIT time shown more often.
                 </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.24 1/27/16
+            <ul>
                 <li>
-                    Version 1.8.24 1/27/16
-                    <ul>
-                        <li>
-                            When opening 'Drill Into' windows, the columns are not in the order of the parent window in the ByName view.
-                            Fixed this.
-                        </li>
-                    </ul>
+                    When opening 'Drill Into' windows, the columns are not in the order of the parent window in the ByName view.
+                    Fixed this.
                 </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.23 1/26/16
+            <ul>
                 <li>
-                    Version 1.8.23 1/26/16
-                    <ul>
-                        <li>
-                            Merging failed on Win7 and Win2k8 systems in PerfView Version 1.8.  This means you could still analyze on
-                            the machine where you collected, but symbols would fail to look up if you took the trace off the system.
-                            Fixed by including an old version of KernelTraceControl.dll an used it on Win7 systems.
-                        </li>
-                    </ul>
+                    Merging failed on Win7 and Win2k8 systems in PerfView Version 1.8.  This means you could still analyze on
+                    the machine where you collected, but symbols would fail to look up if you took the trace off the system.
+                    Fixed by including an old version of KernelTraceControl.dll an used it on Win7 systems.
                 </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.22 1/23/16
+            <ul>
                 <li>
-                    Version 1.8.22 1/23/16
-                    <ul>
-                        <li>
-                            Fixed ArgumentOutOfRange exceptions thrown in EventView for some events (strings with length prefixes)
-                        </li>
-                        <li>Don't crash if regular expressions are incorrect in Events view. </li>
-                    </ul>
+                    Fixed ArgumentOutOfRange exceptions thrown in EventView for some events (strings with length prefixes)
                 </li>
+                <li>Don't crash if regular expressions are incorrect in Events view. </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.21 1/18/16
+            <ul>
                 <li>
-                    Version 1.8.21 1/18/16
-                    <ul>
-                        <li>
-                            Extended perfView.xml file format so that it can more easily consume 'ad hoc' creation of stacks.
-                            It still accepts the 'interned' scheme where you give IDs to each frame and stack and use those
-                            to create samples, but now you can specify the samples inline with the sample like this
-                            <pre>
+                    Extended perfView.xml file format so that it can more easily consume 'ad hoc' creation of stacks.
+                    It still accepts the 'interned' scheme where you give IDs to each frame and stack and use those
+                    to create samples, but now you can specify the samples inline with the sample like this
+                    <pre>
 &lt;StackWindow&gt;
     &lt;StackSource&gt;
         &lt;Samples&gt;
@@ -9238,230 +9246,234 @@
     &lt;/StackSource&gt; 
 &lt;/StackWindow&gt;
                     </pre>
-                            While this format is inefficient (you repeat many strings in many stacks), it is sometimes
-                            convenient, and it is easy enough to support.   There are more details which I will blog about in
-                            the near future.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.20 1/13/16
-                    <ul>
-                        <li>
-                            Improved the robustness of the UserCommand 'Listen' command in the face of bad events.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.19 1/7/16
-                    <ul>
-                        <li>
-                            Significantly improved the Thread Time with Start-Stop Activities.  The goal here is
-                            that this view replaces the ASP.NET and Service Request view, and we are probably most of
-                            the way there now.   I need to validate this more and then probably obsolete the other views.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.15 12/4/15
-                    <ul>
-                        <li>
-                            Fixed a fairly serious bug associated with the Events Viewer where you don't see some CLR events
-                            (They appear in the left pane, but you never see them in the right pane even though there are
-                            instances of them in the file).   Note that version 1.8.0 does not have this bug, it was introduced
-                            relatively recently.
-                        </li>
-                        <li>
-                            Added ActivityInfo and StartStopActivity fields to Events View.   ActivityInfo will show you the
-                            creation and start time (and the raw ID) of the System.Threading.Tasks.Task that logged  the event.
-                            StartStopActivity shows you the name of the start-stop activity that
-                            is logged the event.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.15 12/4/15
-                    <ul>
-                        <li>
-                            Fixed a fairly serious bug associated with the Events Viewer where you don't see some CLR events
-                            (They appear in the left pane, but you never see them in the right pane even though there are
-                            instances of them in the file).   Note that version 1.8.0 does not have this bug, it was introduced
-                            relatively recently.
-                        </li>
-                        <li>
-                            Added ActivityInfo and StartStopActivity fields to Events View.   ActivityInfo will show you the
-                            creation and start time (and the raw ID) of the System.Threading.Tasks.Task that logged  the event.
-                            StartStopActivity shows you the name of the start-stop activity that
-                            is logged the event.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.11 11/16/15
-                    <ul>
-                        <li>
-                            Fix excessive warnings when converting ETL files.   Might also fix some StartStop Activity issues.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.10 11/12/15
-                    <ul>
-                        <li>
-                            Significant improvement in how activity tracking works.  Hopefully the stacks associated with 'with Tasks' views
-                            will be better.
-                        </li>
-                        <li>
-                            Added JIT Inlining feature that enables viewing all successful and failed inlining attempts, including the
-                            JIT-supplied reason for why inlining wasn't performed in the failure cases.
-                        </li>
-                        <li>
-                            Added finalization feature that tracks finalized objects and provides a table of each type with a finalized object
-                            and the associated number of times an object of that type was finalized.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.9 11/1/15
-                    <ul>
-                        <li>
-                            There is a bug in RC candidates of V4.6.1 where NGEN createPdb only works if the path of the NGEN image
-                            is in the Native Image Cache (NIC), but V4.6.1 uses hard links for NGEN images that come from the install itself.
-                            The result is that you don't get symbols for mscorlib, system, and system.core.   This adds a work-around
-                            for this (normally all paths to the NIC path before calling NGEN CreatePdb), until the runtime is fixed.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.8 10/31/15
-                    <ul>
-                        <li>
-                            Added support for .NET V4.6.2 convention for NGEN PDB line numbers.   This means that if data is collected on
-                            a V4.6.2 then the lack of access IL PDBS are not available at data collection time is not longer an
-                            impediment to getting line number information (that is access to the corresponding IL pdb with line number
-                            information is no longer needed to create an NGEN pdb that has line number information).
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.7 10/22/15
-                    <ul>
-                        <li>
-                            Integrated changes that allow DyanamicTraceEventParser to do everything that RegisteredTraceEventParser can do.
-                            Removed the calls to RegisteredTraceEventParser.   This could break things but should not.   So far things look
-                            OK.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.6 10/12/15
-                    <ul>
-                        <li>
-                            Integrated Lee's update of CLRMD that should make PerfView able to extract heap dumps from debugger dumps of
-                            .NET Native processes.
-                        </li>
-                        <li>Added the DotNet (Telemetry) event ETW provider by default. </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.5 10/6/15
-                    <ul>
-                        <li>
-                            Made 'Any Stacks (with StartStop Activities)' and 'Any StartStopTree' public.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.3 9/23/15
-                    <ul>
-                        <li>
-                            Turned off System.Threading.Tasks.Task events that are verbose and only needed for debugging.  This was
-                            useful before so that any traces I get have detailed information for debugging, but are now impacting
-                            the cost of using PerfView in production when Tasks are used heavily.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.2 9/13/15
-                    <ul>
-                        <li> /InMemoryCircularBuffer option was broken (Would throw a file not found exception in SetFileName).  Fixed this. </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.8.1 9/3/15
-                    <ul>
-                        <li>
-                            Fixed issue where Debug versions were asserting that two stacks were attached to the same event
-                            because kernel and user mode stacks were not being stitched together properly (mostly in rare cases
-                            where thread-starts were happening)
-                        </li>
-                    </ul>
-                </li>
-
-                <li>
-                    Version 1.8.0 8/30/15
-                    <ul>
-                        <li> Release to Web. </li>
-                    </ul>
-                </li>
-                <li>
-                    Version 1.7.31 8/19/15
-                    <ul>
-                        <li>
-                            Update code that does merging so it works properly on Win10.  It does not have an effect if you look
-                            at the events with PerfView, but on Win10 until this change, data collected with PerfView would not
-                            parse EventSource events properly in WPA.
-                        </li>
-                    </ul>
+                    While this format is inefficient (you repeat many strings in many stacks), it is sometimes
+                    convenient, and it is easy enough to support.   There are more details which I will blog about in
+                    the near future.
                 </li>
             </ul>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-            <p>
-                &nbsp;
-            </p>
-</body>
+        </li>
+        <li>
+            Version 1.8.20 1/13/16
+            <ul>
+                <li>
+                    Improved the robustness of the UserCommand 'Listen' command in the face of bad events.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.19 1/7/16
+            <ul>
+                <li>
+                    Significantly improved the Thread Time with Start-Stop Activities.  The goal here is
+                    that this view replaces the ASP.NET and Service Request view, and we are probably most of
+                    the way there now.   I need to validate this more and then probably obsolete the other views.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.15 12/4/15
+            <ul>
+                <li>
+                    Fixed a fairly serious bug associated with the Events Viewer where you don't see some CLR events
+                    (They appear in the left pane, but you never see them in the right pane even though there are
+                    instances of them in the file).   Note that version 1.8.0 does not have this bug, it was introduced
+                    relatively recently.
+                </li>
+                <li>
+                    Added ActivityInfo and StartStopActivity fields to Events View.   ActivityInfo will show you the
+                    creation and start time (and the raw ID) of the System.Threading.Tasks.Task that logged  the event.
+                    StartStopActivity shows you the name of the start-stop activity that
+                    is logged the event.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.15 12/4/15
+            <ul>
+                <li>
+                    Fixed a fairly serious bug associated with the Events Viewer where you don't see some CLR events
+                    (They appear in the left pane, but you never see them in the right pane even though there are
+                    instances of them in the file).   Note that version 1.8.0 does not have this bug, it was introduced
+                    relatively recently.
+                </li>
+                <li>
+                    Added ActivityInfo and StartStopActivity fields to Events View.   ActivityInfo will show you the
+                    creation and start time (and the raw ID) of the System.Threading.Tasks.Task that logged  the event.
+                    StartStopActivity shows you the name of the start-stop activity that
+                    is logged the event.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.11 11/16/15
+            <ul>
+                <li>
+                    Fix excessive warnings when converting ETL files.   Might also fix some StartStop Activity issues.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.10 11/12/15
+            <ul>
+                <li>
+                    Significant improvement in how activity tracking works.  Hopefully the stacks associated with 'with Tasks' views
+                    will be better.
+                </li>
+                <li>
+                    Added JIT Inlining feature that enables viewing all successful and failed inlining attempts, including the
+                    JIT-supplied reason for why inlining wasn't performed in the failure cases.
+                </li>
+                <li>
+                    Added finalization feature that tracks finalized objects and provides a table of each type with a finalized object
+                    and the associated number of times an object of that type was finalized.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.9 11/1/15
+            <ul>
+                <li>
+                    There is a bug in RC candidates of V4.6.1 where NGEN createPdb only works if the path of the NGEN image
+                    is in the Native Image Cache (NIC), but V4.6.1 uses hard links for NGEN images that come from the install itself.
+                    The result is that you don't get symbols for mscorlib, system, and system.core.   This adds a work-around
+                    for this (normally all paths to the NIC path before calling NGEN CreatePdb), until the runtime is fixed.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.8 10/31/15
+            <ul>
+                <li>
+                    Added support for .NET V4.6.2 convention for NGEN PDB line numbers.   This means that if data is collected on
+                    a V4.6.2 then the lack of access IL PDBS are not available at data collection time is not longer an
+                    impediment to getting line number information (that is access to the corresponding IL pdb with line number
+                    information is no longer needed to create an NGEN pdb that has line number information).
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.7 10/22/15
+            <ul>
+                <li>
+                    Integrated changes that allow DyanamicTraceEventParser to do everything that RegisteredTraceEventParser can do.
+                    Removed the calls to RegisteredTraceEventParser.   This could break things but should not.   So far things look
+                    OK.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.6 10/12/15
+            <ul>
+                <li>
+                    Integrated Lee's update of CLRMD that should make PerfView able to extract heap dumps from debugger dumps of
+                    .NET Native processes.
+                </li>
+                <li>Added the DotNet (Telemetry) event ETW provider by default. </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.5 10/6/15
+            <ul>
+                <li>
+                    Made 'Any Stacks (with StartStop Activities)' and 'Any StartStopTree' public.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.3 9/23/15
+            <ul>
+                <li>
+                    Turned off System.Threading.Tasks.Task events that are verbose and only needed for debugging.  This was
+                    useful before so that any traces I get have detailed information for debugging, but are now impacting
+                    the cost of using PerfView in production when Tasks are used heavily.
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.2 9/13/15
+            <ul>
+                <li> /InMemoryCircularBuffer option was broken (Would throw a file not found exception in SetFileName).  Fixed this. </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.1 9/3/15
+            <ul>
+                <li>
+                    Fixed issue where Debug versions were asserting that two stacks were attached to the same event
+                    because kernel and user mode stacks were not being stitched together properly (mostly in rare cases
+                    where thread-starts were happening)
+                </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.8.0 8/30/15
+            <ul>
+                <li> Release to Web. </li>
+            </ul>
+        </li>
+        <li>
+            Version 1.7.31 8/19/15
+            <ul>
+                <li>
+                    Update code that does merging so it works properly on Win10.  It does not have an effect if you look
+                    at the events with PerfView, but on Win10 until this change, data collected with PerfView would not
+                    parse EventSource events properly in WPA.
+                </li>
+            </ul>
+        </li>
+    </ul>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <p>
+        &nbsp;
+    </p>
+    <script>
+      // Set theme based on user preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+    </script>
+  </body>
 </html>

--- a/src/PerfView/Themes/DarkTheme.xaml
+++ b/src/PerfView/Themes/DarkTheme.xaml
@@ -63,6 +63,10 @@ SOFTWARE.
     <SolidColorBrush x:Key="AlternateRowBackground" Color="#FF424124" />
     <SolidColorBrush x:Key="HelpRibbonBackground" Color="#FF323838" />
 
+    <SolidColorBrush x:Key="ScrollBarBackground" Color="#2e2e2e" />
+    <SolidColorBrush x:Key="ScrollBarControlForground" Color="#4d4d4d" />
+    <SolidColorBrush x:Key="ScrollBarControlMouseOver" Color="#999999" />
+
     <!-- Colourful theme  Colours -->
     <SolidColorBrush x:Key="ControlPrimaryColourBackground" Color="#FF2084E8" />
     <SolidColorBrush x:Key="ControlPrimaryColourBorderBrush" Color="#FF3294E8" />
@@ -2624,17 +2628,23 @@ SOFTWARE.
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
                     <Grid Height="{TemplateBinding Height}" Width="{TemplateBinding Width}">
-                        <Rectangle x:Name="rectangle" Fill="{TemplateBinding Background}" SnapsToDevicePixels="True" />
+                        <Border x:Name="border"
+                            BorderThickness="3,0,3,0"
+                            BorderBrush="{StaticResource ControlDefaultBorderBrush}">
+                            <Rectangle x:Name="rectangle"
+                                  Fill="{StaticResource ScrollBarControlForground}"
+                                  SnapsToDevicePixels="True" />
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ControlMouseOverBackground}" />
-                            <Setter Property="BorderBrush" Value="{StaticResource ControlMouseOverBorderBrush}" />
+                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ScrollBarControlMouseOver}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource ScrollBarControlMouseOver}" />
                         </Trigger>
                         <Trigger Property="IsDragging" Value="true">
-                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ControlBrightDefaultBackground}" />
-                            <Setter Property="BorderBrush" Value="{StaticResource ControlBrightDefaultBackground}" />
-                            <Setter Property="Foreground" Value="{StaticResource ControlBrightDefaultBorderBrush}" />
+                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ScrollBarControlMouseOver}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource ScrollBarControlMouseOver}" />
+                            <Setter Property="Foreground" Value="{StaticResource ScrollBarControlMouseOver}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2651,18 +2661,23 @@ SOFTWARE.
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
                     <Grid Height="{TemplateBinding Height}" Width="{TemplateBinding Width}">
-                        <Rectangle x:Name="rectangle" Fill="{TemplateBinding Background}" SnapsToDevicePixels="True" />
-
+                        <Border x:Name="border"
+                           BorderThickness="0,3,0,3"
+                           BorderBrush="{StaticResource ControlDefaultBorderBrush}">
+                            <Rectangle x:Name="rectangle"
+                                 Fill="{StaticResource ScrollBarControlForground}"
+                                 SnapsToDevicePixels="True" />
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ControlMouseOverBackground}" />
-                            <Setter Property="BorderBrush" Value="{StaticResource ControlMouseOverBorderBrush}" />
+                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ScrollBarControlMouseOver}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource ScrollBarControlMouseOver}" />
                         </Trigger>
                         <Trigger Property="IsDragging" Value="true">
-                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ControlBrightDefaultBackground}" />
-                            <Setter Property="BorderBrush" Value="{StaticResource ControlBrightDefaultBackground}" />
-                            <Setter Property="Foreground" Value="{StaticResource ControlBrightDefaultBorderBrush}" />
+                            <Setter Property="Fill" TargetName="rectangle" Value="{StaticResource ScrollBarControlMouseOver}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource ScrollBarControlMouseOver}" />
+                            <Setter Property="Foreground" Value="{StaticResource ScrollBarControlMouseOver}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -4069,7 +4084,7 @@ SOFTWARE.
         <Setter Property="WindowChrome.WindowChrome">
             <Setter.Value>
                 <WindowChrome CaptionHeight="26"
-                              ResizeBorderThickness="6"
+                              ResizeBorderThickness="8"
                               CornerRadius="0"
                               GlassFrameThickness="1"
                               NonClientFrameEdges="None"

--- a/src/PerfView/app.manifest
+++ b/src/PerfView/app.manifest
@@ -13,4 +13,14 @@
         />
     </dependentAssembly>
   </dependency>
+  <!-- DPI Awareness Settings -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Windows 10, version 1703 and later -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+
+      <!-- Windows 10, version 1607 and later -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+    </windowsSettings>
+  </application>
 </assembly>


### PR DESCRIPTION
- Update manifest to opt into PMV2 scaling (eliminates blurring on high DPI)
- Tweak dark mode scroll bars to be more visible
- Update to C# 11
- Update most packages to latest (updating Azure packages cause runtime failures)
- Add Packages.props to the solution folder for simplicity
- Hook various XAML files to pick up the theme
- Set the WebView2 control preferred color scheme to match
- Remove outdated Internet Explorer related <meta> tag
- Change html sources to indicate that they support light and dark themes
- Generate html with theme specific code

I generally used two root entries `:root[data-theme="light"]` as it enables doing things like letting you flip the theme with a button (say to print). I didn't put that in this PR as I'm not super clear on the value.

For future reference, here is how you would do that:

```html
  <style>
@media print {
  .no-print {
    display: none !important;
  }
  </style>

<button type="button" class="no-print" onclick="toggleTheme()">🌗 Toggle Theme</button>

  <script>
    // Simple theme toggle script: switches the data-theme attribute on <html>
    function toggleTheme() {
      const root = document.documentElement;
      const newTheme = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
      root.setAttribute('data-theme', newTheme);
    }
  </script>
```

I gave up on updating the Azure packages as they cause PerfView to fail at runtime. Would require a bit more time.