### PR TITLE
Remove Use of VisualStudioCredential

### DIFF
--- a/src/HeapDump/Program.cs
+++ b/src/HeapDump/Program.cs
@@ -60,9 +60,10 @@ internal class Program
             string inputSpec = null;
             int minSecForTrigger = -1;
 
-            ChainedTokenCredential symbolsTokenCredential = new ChainedTokenCredential(
-                new VisualStudioCredential(),
-                new InteractiveBrowserCredential());
+            // We tried using a ChainedTokenCredential with a VisualStudioCredential, but this resulted in
+            // silent failures in the log if the VisualStudioCredential timed out.  For now, let's just use
+            // an interactive browser credential, which will always prompt the user.
+            TokenCredential symbolsTokenCredential = new InteractiveBrowserCredential();
 
             var dumper = new GCHeapDumper(Console.Out, symbolsTokenCredential);
 

--- a/src/PerfView/Authentication.cs
+++ b/src/PerfView/Authentication.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
+using Azure.Core;
 using Azure.Identity;
 using Microsoft.Diagnostics.Symbols.Authentication;
 using Utilities;
@@ -295,11 +296,12 @@ namespace PerfView
         public static SymbolReaderAuthenticationHandler AddBasicHttpAuthentication(this SymbolReaderAuthenticationHandler httpHandler, TextWriter log, Window mainWindow)
             => httpHandler.AddHandler(new BasicHttpAuthHandler(log));
 
-        private static ChainedTokenCredential CreateTokenCredential()
+        private static TokenCredential CreateTokenCredential()
         {
-            return new ChainedTokenCredential(
-                new VisualStudioCredential(),
-                new InteractiveBrowserCredential());
+            // We tried using a ChainedTokenCredential with a VisualStudioCredential, but this resulted in
+            // silent failures in the log if the VisualStudioCredential timed out.  For now, let's just use
+            // an interactive browser credential, which will always prompt the user.
+            return new InteractiveBrowserCredential();
         }
 
         /// <summary>


### PR DESCRIPTION
Addresses failures where the `VisualStudioCredential` requires re-authentication.  This gets hidden in in the exception text in the log and isn't presented to the user.  Instead, we'll go ahead and interactively prompt the user once per session.

```
SymwebAuth: [Exception getting token. Azure.Identity.AuthenticationFailedException: The ChainedTokenCredential failed due to an unhandled exception: VisualStudioCredential authentication failed: One or more errors occurred. ---> Azure.Identity.AuthenticationFailedException: VisualStudioCredential authentication failed: One or more errors occurred. ---> System.AggregateException: One or more errors occurred. ---> Azure.Identity.AuthenticationFailedException: Process "D:\VisualStudio\Dev18\main\Enterprise\Common7\IDE\CommonExtensions\Microsoft\Asal\TokenService\Microsoft.Asal.TokenService.exe" has failed with unexpected error: TS003: Error, TS001: This account '<redacted>' needs re-authentication. Please open Visual Studio, go to Tools->Options->Azure Services Authentication, and re-authenticate the account you want to use.. ---> System.InvalidOperationException: TS003: Error, TS001: This account '<redacted>' needs re-authentication. Please open Visual Studio, go to Tools->Options->Azure Services Authentication, and re-authenticate the account you want to use.
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Azure.Identity.VisualStudioCredential.<RunProcessesAsync>d__29.MoveNext()
   --- End of inner exception stack trace ---
   --- End of inner exception stack trace ---
   at Azure.Identity.VisualStudioCredential.<RunProcessesAsync>d__29.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Azure.Identity.VisualStudioCredential.<GetTokenImplAsync>d__27.MoveNext()
   --- End of inner exception stack trace ---
   at Azure.Identity.CredentialDiagnosticScope.FailWrapAndThrow(Exception ex, String additionalMessage, Boolean isCredentialUnavailable)
   at Azure.Identity.VisualStudioCredential.<GetTokenImplAsync>d__27.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Azure.Identity.VisualStudioCredential.<GetTokenAsync>d__25.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Azure.Identity.ChainedTokenCredential.<GetTokenImplAsync>d__7.MoveNext()
   --- End of inner exception stack trace ---
   at Azure.Identity.ChainedTokenCredential.<GetTokenImplAsync>d__7.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Azure.Identity.ChainedTokenCredential.<GetTokenAsync>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Diagnostics.Symbols.Authentication.SymwebHandler.<GetTokenAsync>d__8.MoveNext()]
```