### PR TITLE
NetTrace LabelList metadata overrides and metadata flushing

### DIFF
--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -102,7 +102,8 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
 
         enum SequencePointFlags : uint
         {
-            FlushThreads = 1
+            FlushThreads = 1,
+            FlushMetadata = 2
         }
 
         public void ProcessSequencePointBlockV6OrGreater(Block block)
@@ -123,6 +124,11 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             if((flags & (uint)SequencePointFlags.FlushThreads) != 0)
             {
                 _threads.Flush();
+            }
+
+            if((flags & (uint)SequencePointFlags.FlushMetadata) != 0)
+            {
+                _source.FlushMetadataCache();
             }
         }
 

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -614,8 +614,7 @@ namespace Microsoft.Diagnostics.Tracing
             }
 
             if (header.MetaDataId != 0 &&
-                StackCache.TryGetStack(header.StackId, out int stackBytesSize, out IntPtr stackBytes) &&
-                stackBytesSize != 0 && stackBytes != IntPtr.Zero) // Sometimes the values in the StackCache are zeros.
+                header.StackBytesSize != 0 && header.StackBytes != IntPtr.Zero)
             {
                 // .NET Core emits stacks for some events that we don't need and so they are excised out before we get here.
                 if (_eventMetadataDictionary.TryGetValue(header.MetaDataId, out EventPipeMetadata metadataHeader) &&

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -642,7 +642,6 @@ namespace Microsoft.Diagnostics.Tracing
         {
             int opcode = metadata.Opcode ?? 0;
             DynamicTraceEventData template = new DynamicTraceEventData(null, metadata.EventId, 0, metadata.EventName, Guid.Empty, opcode, null, metadata.ProviderId, metadata.ProviderName);
-            template.opcode = (TraceEventOpcode)opcode;
             template.opcodeName = template.opcode.ToString();
             template.payloadNames = metadata.ParameterNames;
             template.payloadFetches = metadata.ParameterTypes;

--- a/src/TraceEvent/EventPipe/EventPipeMetadata.cs
+++ b/src/TraceEvent/EventPipe/EventPipeMetadata.cs
@@ -166,14 +166,10 @@ namespace Microsoft.Diagnostics.Tracing
             // Now we only have to copy over the fields that are specific to particular event.
 
             // these events usually come from metadata, but they can be overridden by the label list
-            _eventRecord->EventHeader.Opcode = 
-                eventData.OpCodeOverride.HasValue ? eventData.OpCodeOverride.Value : Opcode;
-            _eventRecord->EventHeader.Level = 
-                eventData.LevelOverride.HasValue ? eventData.LevelOverride.Value : Level;
-            _eventRecord->EventHeader.Keyword = 
-                eventData.KeywordsOverride.HasValue ? eventData.KeywordsOverride.Value : Keywords;
-            _eventRecord->EventHeader.Version = 
-                eventData.VersionOverride.HasValue ? eventData.VersionOverride.Value : EventVersion;
+            _eventRecord->EventHeader.Opcode = eventData.OpCodeOverride ?? Opcode ?? 0;
+            _eventRecord->EventHeader.Level = eventData.LevelOverride ?? Level;
+            _eventRecord->EventHeader.Keyword = eventData.KeywordsOverride ?? Keywords;
+            _eventRecord->EventHeader.Version = eventData.VersionOverride ?? EventVersion;
 
             // Note: ThreadId isn't 32 bit on all of our platforms but ETW EVENT_RECORD* only has room for a 32 bit
             // ID. We'll need to refactor up the stack if we want to expose a bigger ID.
@@ -270,7 +266,7 @@ namespace Microsoft.Diagnostics.Tracing
         public byte EventVersion { get; private set; }
         public ulong Keywords { get; private set; }
         public byte Level { get; private set; }
-        public byte Opcode { get; private set; }
+        public byte? Opcode { get; private set; }
 
         public DynamicTraceEventData.PayloadFetch[] ParameterTypes { get; internal set; }
         public string[] ParameterNames { get; internal set; }
@@ -794,6 +790,8 @@ namespace Microsoft.Diagnostics.Tracing
         }
 
         // After metadata has been read we do a set of baked in transforms.
+        // None of these transforms are part of the NetTrace file format, rather they are a combination of TraceEvent/EventSource specific conventions
+        // and workarounds for well known events in historic scenarios where data was missing.
         public void ApplyTransforms()
         {
             //TraceEvent expects empty name to be canonicalized as null rather than ""
@@ -815,7 +813,7 @@ namespace Microsoft.Diagnostics.Tracing
                 PopulateWellKnownEventParameters();
             }
             
-            if (Opcode == 0)
+            if (!Opcode.HasValue)
             {
                 ExtractImpliedOpcode();
             }

--- a/src/TraceEvent/EventPipe/LabelListCache.cs
+++ b/src/TraceEvent/EventPipe/LabelListCache.cs
@@ -13,7 +13,11 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         TraceId = 3,
         SpanId = 4,
         KeyValueString = 5,
-        KeyValueVarInt = 6
+        KeyValueVarInt = 6,
+        OpCode = 7,
+        Keywords = 8,
+        Level = 9,
+        Version = 10
     }
 
     struct LabelList
@@ -59,6 +63,18 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                         }
                         otherLabels.Add(new KeyValuePair<string, object>(key, varInt));
                         break;
+                    case LabelKind.OpCode:
+                        result.OpCode = reader.ReadUInt8();
+                        break;
+                    case LabelKind.Keywords:
+                        result.Keywords = reader.ReadUInt64();
+                        break;
+                    case LabelKind.Level:
+                        result.Level = reader.ReadUInt8();
+                        break;
+                    case LabelKind.Version:
+                        result.Version = reader.ReadUInt8();
+                        break;
                     default:
                         throw new FormatException($"Unknown label kind {kind} in label list");
                 }
@@ -76,6 +92,10 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         public Guid? TraceId { get; private set; }
         public ulong? SpanId { get; private set; }
         public KeyValuePair<string, object>[] OtherLabels { get; private set; }
+        public byte? OpCode { get; private set; }
+        public ulong? Keywords { get; private set; }
+        public byte? Level { get; private set; }
+        public byte? Version { get; private set; }
 
         public IEnumerable<KeyValuePair<string, object>> AllLabels
         {
@@ -103,6 +123,22 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                     {
                         yield return label;
                     }
+                }
+                if (OpCode.HasValue)
+                {
+                    yield return new KeyValuePair<string, object>("OpCode", OpCode.Value);
+                }
+                if (Keywords.HasValue)
+                {
+                    yield return new KeyValuePair<string, object>("Keywords", Keywords.Value);
+                }
+                if (Level.HasValue)
+                {
+                    yield return new KeyValuePair<string, object>("Level", Level.Value);
+                }
+                if (Version.HasValue)
+                {
+                    yield return new KeyValuePair<string, object>("Version", Version.Value);
                 }
             }
         }

--- a/src/TraceEvent/EventPipe/NetTraceFormat.md
+++ b/src/TraceEvent/EventPipe/NetTraceFormat.md
@@ -392,6 +392,7 @@ A SequencePointBlock payload is encoded:
   - SequenceNumber - varuint32
 
 If Flags & 1 == 1 then the sequence point also flushes the thread cache. Logically the flush occurs after doing any thread sequence number checks so the reader can still detect dropped events.
+If Flags & 2 == 2 then the sequence point also flushes the metadata cache.
 
 ## EndOfStreamBlock
 
@@ -465,13 +466,24 @@ The content of a LabelListBlock is:
     - if(Kind & 0x7F == 6)
       - Key - string
       - Value - varint64
+    - if(Kind & 0x7F == 7)
+      - OpCode - uint8
+    - if(Kind & 0x7F == 8)
+      - Keywords - uint64
+    - if(Kind & 0x7F == 9)
+      - Level - uint8
+    - if(Kind & 0x7F == 10)
+      - Version - uint8
 
 If the high bit of the Kind field is set that demarcates that this is the last label in a label list and the next label is part of the next list.
 
 Similar to StackBlock, references to a row in the LabelListBlock are only valid in the file after the LabelListBlock that defines it and before the next SequencePoint block.
 This prevents the reader from needing a lookup table that grows indefinitely with file length or requiring the reader to search the entire file to resolve a given label list index.
 
-An empty LabelList can't be explicitly encoded in the LabelListBlock, but implicitly the LabelList index 0 refers to an empty LabelList. 
+An empty LabelList can't be explicitly encoded in the LabelListBlock, but implicitly the LabelList index 0 refers to an empty LabelList.
+
+The OpCode, Keywords, Level, and Version fields are considered to override any value found in the metadata for the event. The trace writer is free to provide these values in either metadata
+or in a LabelList, but for the common scenario where they are the same across all events of a given type metadata is probably the more space efficient option.
 
 ## Changes relative to older file format versions
 

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -1910,18 +1910,18 @@ namespace TraceEventTests
             });
             writer.WriteLabelListBlock(99, 2, w =>
             {
-                w.WriteV6LabelListActivityIdLabel(activityId1);
-                w.WriteV6LabelListRelatedActivityIdLabel(relatedActivityId1, isLastLabel: true);
-                w.WriteV6LabelListNameValueStringLabel("Key1", "Value1");
-                w.WriteV6LabelListNameValueVarIntLabel("Key2", 123, isLastLabel: true);
+                w.WriteActivityIdLabel(activityId1);
+                w.WriteRelatedActivityIdLabel(relatedActivityId1, isLastLabel: true);
+                w.WriteNameValueStringLabel("Key1", "Value1");
+                w.WriteNameValueVarIntLabel("Key2", 123, isLastLabel: true);
             });
             writer.WriteLabelListBlock(7, 2, w =>
             {
-                w.WriteV6LabelListNameValueStringLabel("Key3", "Value3");
-                w.WriteV6LabelListActivityIdLabel(activityId2);
-                w.WriteV6LabelListRelatedActivityIdLabel(relatedActivityId2, isLastLabel: true);
-                w.WriteV6LabelListTraceIdLabel(traceId.ToByteArray());
-                w.WriteV6LabelListSpanIdLabel(spanId, isLastLabel: true);
+                w.WriteNameValueStringLabel("Key3", "Value3");
+                w.WriteActivityIdLabel(activityId2);
+                w.WriteRelatedActivityIdLabel(relatedActivityId2, isLastLabel: true);
+                w.WriteTraceIdLabel(traceId.ToByteArray());
+                w.WriteSpanIdLabel(spanId, isLastLabel: true);
             });
             writer.WriteEventBlock(useCompressedEventHeaders, w =>
             {
@@ -2005,6 +2005,73 @@ namespace TraceEventTests
             Assert.Equal(6, eventCount);
         }
 
+        [Fact] //V6
+        public void V6LabelListCanOverrideMetadata()
+        {
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, threadId: 12, processId: 84);
+            });
+            writer.WriteLabelListBlock(7, 2, w =>
+            {
+                w.WriteOpCodeLabel(8);
+                w.WriteKeywordsLabel(0x123456789abcef);
+                w.WriteLevelLabel(19);
+                w.WriteVersionLabel(4, isLastLabel:true);
+                w.WriteOpCodeLabel(18);
+                w.WriteKeywordsLabel(0x234);
+                w.WriteLevelLabel(2);
+                w.WriteVersionLabel(3, isLastLabel: true);
+            });
+            writer.WriteEventBlock(w =>
+            {
+                w.WriteEventBlob(new WriteEventOptions() { MetadataId = 1, SequenceNumber = 1, ThreadIndexOrId = 999, CaptureThreadIndexOrId = 999, LabelListId = 7 }, p => { });
+                w.WriteEventBlob(new WriteEventOptions() { MetadataId = 1, SequenceNumber = 2, ThreadIndexOrId = 999, CaptureThreadIndexOrId = 999, LabelListId = 8 }, p => { });
+                w.WriteEventBlob(new WriteEventOptions() { MetadataId = 1, SequenceNumber = 1, ThreadIndexOrId = 999, CaptureThreadIndexOrId = 999, LabelListId = 0 }, p => { });
+            });
+            writer.WriteEndBlock();
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            EventPipeEventSource source = new EventPipeEventSource(stream);
+            int eventCount = 0;
+            source.Dynamic.All += e =>
+            {
+                eventCount++;
+                if (eventCount == 1)
+                {
+                    // Suspend is opcode 8
+                    Assert.Equal("TestEvent1/Suspend", e.EventName);
+                    Assert.Equal("TestProvider", e.ProviderName);
+                    Assert.Equal(8, (int)e.Opcode);
+                    Assert.Equal(0x123456789abcefUL, (ulong)e.Keywords);
+                    Assert.Equal(19, (int)e.Level);
+                    Assert.Equal(4, e.Version);
+                }
+                else if (eventCount == 2)
+                {
+                    Assert.Equal("TestEvent1/Opcode(18)", e.EventName);
+                    Assert.Equal("TestProvider", e.ProviderName);
+                    Assert.Equal(18, (int)e.Opcode);
+                    Assert.Equal(0x234UL, (ulong)e.Keywords);
+                    Assert.Equal(2, (int)e.Level);
+                    Assert.Equal(3, e.Version);
+                }
+                else if (eventCount == 3)
+                {
+                    Assert.Equal("TestEvent1", e.EventName);
+                    Assert.Equal("TestProvider", e.ProviderName);
+                    Assert.Equal(0, (int)e.Opcode);
+                    Assert.Equal(0UL, (ulong)e.Keywords);
+                    Assert.Equal(0, (int)e.Level);
+                    Assert.Equal(0, e.Version);
+                }
+            };
+            source.Process();
+            Assert.Equal(3, eventCount);
+        }
+
 
         [Fact] //V6
         public void ParseV6CompressedEventHeaders()
@@ -2025,8 +2092,8 @@ namespace TraceEventTests
             });
             writer.WriteLabelListBlock(99, 2, w =>
             {
-                w.WriteV6LabelListActivityIdLabel(activityId1, isLastLabel: true);
-                w.WriteV6LabelListActivityIdLabel(activityId2, isLastLabel: true);
+                w.WriteActivityIdLabel(activityId1, isLastLabel: true);
+                w.WriteActivityIdLabel(activityId2, isLastLabel: true);
             });
             writer.WriteEventBlock(true, w =>
             {
@@ -2112,7 +2179,7 @@ namespace TraceEventTests
             {
                 w.WriteThreadEntry(999, threadId: 12, processId: 84);
             });
-            writer.WriteSequencePointBlock(0, resetThreadIndicies: false);
+            writer.WriteSequencePointBlock(0, resetThreadIndicies: false, resetMetadataIndices: false);
             writer.WriteEventBlock(true, w =>
             {
                 w.WriteEventBlob(1, 999, 1, p => { });
@@ -2142,7 +2209,7 @@ namespace TraceEventTests
             {
                 w.WriteThreadEntry(999, threadId: 12, processId: 84);
             });
-            writer.WriteSequencePointBlock(0, resetThreadIndicies: false);
+            writer.WriteSequencePointBlock(0, resetThreadIndicies: false, resetMetadataIndices: false);
             writer.WriteThreadBlock(w =>
             {
                 w.WriteThreadEntry(999, threadId: 15, processId: 84);
@@ -2164,7 +2231,7 @@ namespace TraceEventTests
             {
                 w.WriteThreadEntry(999, threadId: 12, processId: 84);
             });
-            writer.WriteSequencePointBlock(0, resetThreadIndicies: true);
+            writer.WriteSequencePointBlock(0, resetThreadIndicies: true, resetMetadataIndices: false);
             writer.WriteThreadBlock(w =>
             {
                 w.WriteThreadEntry(999, threadId: 15, processId: 84);
@@ -2189,6 +2256,81 @@ namespace TraceEventTests
         }
 
         [Fact] //V6
+        public void V6SequencePointDoesNotFlushMetadataByDefault()
+        {
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, threadId: 12, processId: 84);
+            });
+            writer.WriteSequencePointBlock(0, resetThreadIndicies: false, resetMetadataIndices: false);
+            writer.WriteEventBlock(true, w =>
+            {
+                w.WriteEventBlob(1, 999, 1, p => { });
+            });
+            writer.WriteEndBlock();
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            EventPipeEventSource source = new EventPipeEventSource(stream);
+
+            int eventCount = 0;
+            source.Dynamic.All += e =>
+            {
+                eventCount++;
+                Assert.Equal("TestEvent1", e.EventName);
+                Assert.Equal(12, e.ThreadID);
+            };
+            source.Process();
+            Assert.Equal(1, eventCount);
+        }
+
+        [Fact] //V6
+        public void V6RedefinedMetadataIndexThrowsFormatException()
+        {
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15));
+            writer.WriteSequencePointBlock(0, resetThreadIndicies: false, resetMetadataIndices: false);
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent2", 19));
+            writer.WriteEndBlock();
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            EventPipeEventSource source = new EventPipeEventSource(stream);
+
+            Assert.Throws<FormatException>(() => source.Process());
+        }
+
+        [Fact] //V6
+        public void V6SequencePointCanFlushMetadataOnDemand()
+        {
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, threadId: 12, processId: 84);
+            });
+            writer.WriteSequencePointBlock(0, resetThreadIndicies: false, resetMetadataIndices: true);
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent2", 19));
+            writer.WriteEventBlock(true, w =>
+            {
+                w.WriteEventBlob(1, 999, 1, p => { });
+            });
+            writer.WriteEndBlock();
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            EventPipeEventSource source = new EventPipeEventSource(stream);
+
+            int eventCount = 0;
+            source.Dynamic.All += e =>
+            {
+                eventCount++;
+                Assert.Equal("TestEvent2", e.EventName);
+            };
+            source.Process();
+            Assert.Equal(1, eventCount);
+        }
+
+        [Fact] //V6
         public void V6SequencePointDetectsDroppedEvents()
         {
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -2198,7 +2340,7 @@ namespace TraceEventTests
             {
                 w.WriteThreadEntry(999, threadId: 12, processId: 84);
             });
-            writer.WriteSequencePointBlock(0, resetThreadIndicies: true, new V6ThreadSequencePoint(999, 5));
+            writer.WriteSequencePointBlock(0, resetThreadIndicies: true, resetMetadataIndices: false, new V6ThreadSequencePoint(999, 5));
             writer.WriteEndBlock();
             MemoryStream stream = new MemoryStream(writer.ToArray());
             EventPipeEventSource source = new EventPipeEventSource(stream);
@@ -2649,12 +2791,22 @@ namespace TraceEventTests
             _writer.WriteRemoveThreadBlock(writeThreadEntries);
         }
 
-        public void WriteSequencePointBlock(long timestamp, bool resetThreadIndicies, params V6ThreadSequencePoint[] sequencePoints)
+        public void WriteSequencePointBlock(long timestamp, bool resetThreadIndicies, bool resetMetadataIndices, params V6ThreadSequencePoint[] sequencePoints)
         {
             WriteBlock(4 /* BlockKind.SequencePoint */, w =>
             {
                 w.Write(timestamp);
-                w.Write((int)(resetThreadIndicies ? 1 : 0));
+                int flags = 0;
+                if (resetThreadIndicies)
+                {
+                    flags |= 1;
+                }
+                if (resetMetadataIndices)
+                {
+                    flags |= 2;
+                }
+                
+                w.Write(flags);
                 w.Write(sequencePoints.Length);
                 foreach (var sequencePoint in sequencePoints)
                 {
@@ -2664,7 +2816,7 @@ namespace TraceEventTests
             });
         }
 
-        public void WriteLabelListBlock(int firstIndex, int count, Action<BinaryWriter> writeLabelListEntries)
+        public void WriteLabelListBlock(int firstIndex, int count, Action<V6LabelListBlockWriter> writeLabelListEntries)
         {
             _writer.WriteV6LabelListBlock(firstIndex, count, writeLabelListEntries);
         }
@@ -3208,82 +3360,16 @@ namespace TraceEventTests
             });
         }
 
-        public static void WriteV6LabelListActivityIdLabel(this BinaryWriter writer, Guid activityId, bool isLastLabel = false)
-        {
-            byte kind = 1; // ActivityId
-            if (isLastLabel)
-            {
-                kind |= 0x80;
-            }
-            writer.Write(kind);
-            writer.Write(activityId);
-        }
 
-        public static void WriteV6LabelListRelatedActivityIdLabel(this BinaryWriter writer, Guid relatedActivityId, bool isLastLabel = false)
-        {
-            byte kind = 2; // RelatedActivityId
-            if (isLastLabel)
-            {
-                kind |= 0x80;
-            }
-            writer.Write(kind);
-            writer.Write(relatedActivityId);
-        }
 
-        public static void WriteV6LabelListTraceIdLabel(this BinaryWriter writer, byte[] traceId, bool isLastLabel = false)
-        {
-            Debug.Assert(traceId.Length == 16);
-            byte kind = 3; // TraceId
-            if (isLastLabel)
-            {
-                kind |= 0x80;
-            }
-            writer.Write(kind);
-            writer.Write(traceId);
-        }
-
-        public static void WriteV6LabelListSpanIdLabel(this BinaryWriter writer, ulong spanId, bool isLastLabel = false)
-        {
-            byte kind = 4; // SpanId
-            if (isLastLabel)
-            {
-                kind |= 0x80;
-            }
-            writer.Write(kind);
-            writer.Write(spanId);
-        }
-
-        public static void WriteV6LabelListNameValueStringLabel(this BinaryWriter writer, string name, string value, bool isLastLabel = false)
-        {
-            byte kind = 5; // NameValueString
-            if (isLastLabel)
-            {
-                kind |= 0x80;
-            }
-            writer.Write(kind);
-            writer.WriteVarUIntPrefixedUTF8String(name);
-            writer.WriteVarUIntPrefixedUTF8String(value);
-        }
-
-        public static void WriteV6LabelListNameValueVarIntLabel(this BinaryWriter writer, string name, long value, bool isLastLabel = false)
-        {
-            byte kind = 6; // NameValueVarint
-            if (isLastLabel)
-            {
-                kind |= 0x80;
-            }
-            writer.Write(kind);
-            writer.WriteVarUIntPrefixedUTF8String(name);
-            writer.WriteVarInt(value);
-        }
-
-        public static void WriteV6LabelListBlock(this BinaryWriter writer, int firstIndex, int count, Action<BinaryWriter> writeLabelLists)
+        public static void WriteV6LabelListBlock(this BinaryWriter writer, int firstIndex, int count, Action<V6LabelListBlockWriter> writeLabelLists)
         {
             WriteBlockV6OrGreater(writer, 8 /* BlockKind.LabelList */, w =>
             {
                 w.Write(firstIndex);
                 w.Write(count);
-                writeLabelLists(w);
+                V6LabelListBlockWriter labelListWriter = new V6LabelListBlockWriter(w);
+                writeLabelLists(labelListWriter);
             });
         }
 
@@ -3403,6 +3489,129 @@ namespace TraceEventTests
         public static void WriteEndObject(this BinaryWriter writer)
         {
             writer.Write(1); // null tag
+        }
+    }
+
+    public class V6LabelListBlockWriter
+    {
+        BinaryWriter _writer;
+
+        public V6LabelListBlockWriter(BinaryWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public void WriteActivityIdLabel(Guid activityId, bool isLastLabel = false)
+        {
+            byte kind = 1; // ActivityId
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(activityId);
+        }
+
+        public void WriteRelatedActivityIdLabel(Guid relatedActivityId, bool isLastLabel = false)
+        {
+            byte kind = 2; // RelatedActivityId
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(relatedActivityId);
+        }
+
+        public void WriteTraceIdLabel(byte[] traceId, bool isLastLabel = false)
+        {
+            Debug.Assert(traceId.Length == 16);
+            byte kind = 3; // TraceId
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(traceId);
+        }
+
+        public void WriteSpanIdLabel(ulong spanId, bool isLastLabel = false)
+        {
+            byte kind = 4; // SpanId
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(spanId);
+        }
+
+        public void WriteNameValueStringLabel(string name, string value, bool isLastLabel = false)
+        {
+            byte kind = 5; // NameValueString
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.WriteVarUIntPrefixedUTF8String(name);
+            _writer.WriteVarUIntPrefixedUTF8String(value);
+        }
+
+        public void WriteNameValueVarIntLabel(string name, long value, bool isLastLabel = false)
+        {
+            byte kind = 6; // NameValueVarint
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.WriteVarUIntPrefixedUTF8String(name);
+            _writer.WriteVarInt(value);
+        }
+
+        public void WriteOpCodeLabel(byte opcode, bool isLastLabel = false)
+        {
+            byte kind = 7; // OpCode
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(opcode);
+        }
+
+        public void WriteKeywordsLabel(ulong keywords, bool isLastLabel = false)
+        {
+            byte kind = 8; // Keyword
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(keywords);
+        }
+
+        public void WriteLevelLabel(byte level, bool isLastLabel = false)
+        {
+            byte kind = 9; // Level
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(level);
+        }
+
+        public void WriteVersionLabel(byte version, bool isLastLabel = false)
+        {
+            byte kind = 10; // Version
+            if (isLastLabel)
+            {
+                kind |= 0x80;
+            }
+            _writer.Write(kind);
+            _writer.Write(version);
         }
     }
 


### PR DESCRIPTION
This adds two new features to NetTrace V6 format:
- The LabelList now has explicit encodings for OpCode, Level, Keywords, and Version. These labels can be used to override the values stored in metadata allowing the fields to vary on a per-event basis. It also provides writers more flexibility on how to store the data regardless whether the values are varying. Using metadata is still expected to be the more the compact encoding in most scenarios but writers may need to weigh other implementation concerns beyond file size.
- The SequencePointBlock now supports a flag to flush all metadata entries. This eliminates the final place in the format where writers were forced to maintain a cache of potentially unbounded size to write an unbounded number of events. If the writer's metadata cache grows past some implementation defined limit it can emit a sequence point and flush the cache.

This PR updates the specification, implements the parser, and adds tests of the new functionality.