### PR TITLE
Only Dispose Non-Null Handles in ETWTraceEventSource

### DIFF
--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -879,7 +879,10 @@ namespace Microsoft.Diagnostics.Tracing
                 {
                     foreach (TraceEventNativeMethods.SafeTraceHandle handle in handles)
                     {
-                        handle?.Dispose();
+                        if(handle != null && handle.IsValid)
+                        {
+                            handle.Dispose();
+                        }
                     }
 
                     handles = null;

--- a/src/TraceEvent/ETWTraceEventSource.cs
+++ b/src/TraceEvent/ETWTraceEventSource.cs
@@ -879,7 +879,7 @@ namespace Microsoft.Diagnostics.Tracing
                 {
                     foreach (TraceEventNativeMethods.SafeTraceHandle handle in handles)
                     {
-                        handle.Dispose();
+                        handle?.Dispose();
                     }
 
                     handles = null;


### PR DESCRIPTION
If an ETL file is malformed, it's possible to end up with a null handle in `ETWTraceEventSource.handles`.  Ensure that we only dispose of non-null handles.