### PR TITLE
Revise V2 field definitions in NetTraceFormat_v5.md

### DIFF
--- a/src/TraceEvent/EventPipe/NetTraceFormat_v5.md
+++ b/src/TraceEvent/EventPipe/NetTraceFormat_v5.md
@@ -290,14 +290,16 @@ If TagKind=V2Params the payload consists of
 
 Followed by V2FieldCount number of field definitions
 
-    int V2TypeCode;      // In V2 this can be EventPipeTypeCodeArray==19
-    int ArrayTypeCode;   // This optional field only appears when V2TypeCode==EventPipeTypeCodeArray
+    int Size                    // the number of bytes used to encode the field, inclusive of the 4 bytes in this Size field
+    int V2TypeCode;             // In V2 TypeCodeArray=19 is also permitted, in addition to all typecodes allowed in V1
+    int ArrayElementTypeCode;   // This optional field only appears when V2TypeCode==EventPipeTypeCodeArray
     <PAYLOAD_DESCRIPTION>
     string FieldName
+    optional padding            // as many padding bytes as needed so that the total size of the field definition = Size
 
 If the metadata event specifies a V2Params tag, the event must have an empty V1 parameter FieldCount and no field definitions.
 
-For primitive types and strings <PAYLOAD_DESCRIPTION> is not present, however if TypeCode == Object (1) then <PAYLOAD_DESCRIPTION> another payload
+For primitive types and strings <PAYLOAD_DESCRIPTION> is not present, however if TypeCode == Object (1) then <PAYLOAD_DESCRIPTION> is another payload
 description (that is a field count, followed by a list of field definitions).   These can be nested to arbitrary depth.  
 
 No attempt is made to be sophisticated about serializing the payload fields for event blobs in an EventBlock.   Each primitive type is serialized in little endian format.  Strings 

--- a/src/TraceEvent/EventPipe/NetTraceFormat_v5.md
+++ b/src/TraceEvent/EventPipe/NetTraceFormat_v5.md
@@ -291,10 +291,10 @@ If TagKind=V2Params the payload consists of
 Followed by V2FieldCount number of field definitions
 
     int Size                    // the number of bytes used to encode the field, inclusive of the 4 bytes in this Size field
+    string FieldName            // The 2 byte Unicode, null terminated string representing the Name of the Field
     int V2TypeCode;             // In V2 EventPipeTypeCodeArray=19 is also permitted, in addition to all typecodes allowed in V1
     int ArrayElementTypeCode;   // This optional field only appears when V2TypeCode==EventPipeTypeCodeArray
     <PAYLOAD_DESCRIPTION>
-    string FieldName
     optional padding            // as many padding bytes as needed so that the total size of the field definition = Size
 
 If the metadata event specifies a V2Params tag, the event must have an empty V1 parameter FieldCount and no field definitions.

--- a/src/TraceEvent/EventPipe/NetTraceFormat_v5.md
+++ b/src/TraceEvent/EventPipe/NetTraceFormat_v5.md
@@ -291,7 +291,7 @@ If TagKind=V2Params the payload consists of
 Followed by V2FieldCount number of field definitions
 
     int Size                    // the number of bytes used to encode the field, inclusive of the 4 bytes in this Size field
-    int V2TypeCode;             // In V2 TypeCodeArray=19 is also permitted, in addition to all typecodes allowed in V1
+    int V2TypeCode;             // In V2 EventPipeTypeCodeArray=19 is also permitted, in addition to all typecodes allowed in V1
     int ArrayElementTypeCode;   // This optional field only appears when V2TypeCode==EventPipeTypeCodeArray
     <PAYLOAD_DESCRIPTION>
     string FieldName


### PR DESCRIPTION
The spec didn't accurately describe the encoding of field definitions inside the V2 Params area of NetTrace V5 metadata. I am updating the doc to align it with what the CLR generates and what TraceEvent parses.
Reference source for the parser:
https://github.com/microsoft/perfview/blob/0691921c6cc22eacaff2b41efa5b4d38ef1ffd20/src/TraceEvent/EventPipe/EventPipeMetadata.cs#L397-L404