### PR TITLE
Fix the PlatformToolsetVersion Variable in C++ Build

### DIFF
--- a/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PlatformToolset>v143</PlatformToolset>
-    <PlatformToolsetVersion>v142</PlatformToolsetVersion>
+    <PlatformToolsetVersion>143</PlatformToolsetVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PlatformToolset>v143</PlatformToolset>
-    <PlatformToolsetVersion>v142</PlatformToolsetVersion>
+    <PlatformToolsetVersion>143</PlatformToolsetVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Some pipeline builds are failing because they do not expect a 'v' character in the PlatformToolsetVersion variable.  Remove the 'v' and match the version in the PlatformToolset variable.