### PR TITLE
Special-Case BitMask Parsing

### DIFF
--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -533,9 +533,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                     // input=Array of ulong
                     // output=Array of IntPtr
                     // This is common for bitmasks.  To address this, we special case it here.
-                    if (value is ulong && elementType == typeof(IntPtr))
+                    if (elementType == typeof(IntPtr) && value is ulong uintVal)
                     {
-                        ulong uintVal = (ulong)value;
                         value = new IntPtr(unchecked((long)uintVal));
                     }
                     else if (value.GetType() != elementType)


### PR DESCRIPTION
When an event contains a bitmask, it is sometimes described in metadata as an array of pointers.  ETW differentiates between input and output types, and so there is a possibility for metadata to specify the input type as an array of UInt64 and the output type as an array of IntPtr. Existing code can't handle this properly, so we must special case it.

The MSNT_SystemTrace/SystemConfig/ProcessorGroup event is an example of one such event.