### PR TITLE
Remove Test Workaround

### DIFF
--- a/src/TraceEvent/TraceEvent.Tests/Parsing/GeneralParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/GeneralParsing.cs
@@ -193,13 +193,6 @@ namespace TraceEventTests
                 var expectedistogramLine = baselineFile.ReadLine();
                 lineNum++;
 
-                // This is a hack.  These seem to have different counts on different machines.
-                // Need to figure out why, but for now it is tracked by issue https://github.com/Microsoft/perfview/issues/643
-                if (keyValue.Key.Contains("GC/AllocationTick") || keyValue.Key.Contains("Kernel/DiskIO/Read"))
-                {
-                    continue;
-                }
-
                 if (etlFileName.Contains("net.4.0") && (keyValue.Key.Contains("HeapStats") || keyValue.Key.Contains("Kernel/PerfInfo/Sample")))
                 {
                     continue;


### PR DESCRIPTION
This workaround is for a test failure that sometimes occurs in the CI. Since this is from 2018, let's start by removing it and see if the failure shows up again.