### PR TITLE
Fix Perfcollect CI Job

### DIFF
--- a/.pipelines/perfcollect-job.yml
+++ b/.pipelines/perfcollect-job.yml
@@ -1,6 +1,9 @@
 steps:
-- task: DockerInstaller@0
-  displayName: 'Install Docker'
+- task: Bash@3
+  displayName: 'Get Docker Version'
+  inputs:
+    targetType: inline
+    script: 'docker --version'
 
 - task: Bash@3
   displayName: 'Build Containers'


### PR DESCRIPTION
Removes the docker client installation, which is installing an old version of the docker client, and replaces it with a task that prints the current docker version to help with future troubleshooting.