### PR TITLE
Strip .il and .ni suffixes from TraceModuleFile.Name

### DIFF
--- a/src/TraceEvent/AutomatedAnalysis/StackView.cs
+++ b/src/TraceEvent/AutomatedAnalysis/StackView.cs
@@ -297,8 +297,8 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
 
             // Allow the found name to be of equivalent or greater length than the requested length.
             // Example:
-            //  Requested: System.Private.CoreLib.il!System.String.Concat
-            //  Found:     System.Private.CoreLib.il!System.String.Concat(class System.String,class System.String)
+            //  Requested: System.Private.CoreLib!System.String.Concat
+            //  Found:     System.Private.CoreLib!System.String.Concat(class System.String,class System.String)
             if (foundName.Length < requestedName.Length)
             {
                 return false;


### PR DESCRIPTION
Fix dotnet/diagnostics#3102: EventPipe module names have unexpected .il suffix.

TraceLog.ManagedModuleLoadOrUnload creates synthetic .il.dll paths for ReadyToRun assemblies to maintain separate IL and native PDB entries. This is an internal implementation detail that was leaking into the user-visible Name property, causing tools like dotnet-stack, PerfView, and WPA to display module names like 'System.Private.CoreLib.il' instead of 'System.Private.CoreLib'.

Strip the .il and .ni suffixes in TraceModuleFile.Name, matching the same logic already used in GetSourceLine() for source resolution.