### PR TITLE
Fix Debug.Assert failures in SpeedScope tests and DynamicTraceEventParser

### DIFF
--- a/src/PerfView.TestUtilities/DebugAssertionTests.cs
+++ b/src/PerfView.TestUtilities/DebugAssertionTests.cs
@@ -11,6 +11,9 @@
     /// <remarks>
     /// <para>This file can be linked into any project which needs to validate that assertions are behaving correctly
     /// for the purpose of unit testing.</para>
+    /// <para>On .NET Framework, assertion failures throw via <see cref="ThrowingTraceListener"/> registered in
+    /// app.config. On .NET 5+, the DefaultTraceListener already throws on assertion failures, so no
+    /// additional listener configuration is needed.</para>
     /// </remarks>
     public class DebugAssertionTests
     {

--- a/src/PerfView.TestUtilities/ThrowingTraceListener.cs
+++ b/src/PerfView.TestUtilities/ThrowingTraceListener.cs
@@ -5,7 +5,10 @@ using System.Diagnostics;
 
 namespace PerfView.TestUtilities
 {
-    // To enable this for a process, add the following to the app.config for the project:
+    // This listener converts Debug.Assert/Trace.Assert failures into xUnit test failures
+    // by throwing from the Fail() method.
+    //
+    // On .NET Framework (net462), this must be registered via app.config <system.diagnostics>:
     //
     // <configuration>
     //  <system.diagnostics>
@@ -17,6 +20,13 @@ namespace PerfView.TestUtilities
     //    </trace>
     //  </system.diagnostics>
     //</configuration>
+    //
+    // On .NET 5+, the app.config <system.diagnostics> section is NOT
+    // processed, so this listener is never registered. However, the DefaultTraceListener
+    // on .NET 5+ already throws on assert failures, so no additional configuration is
+    // needed — Debug.Assert and Trace.Assert will throw without this listener.
+    // Should this behavior change, the ThrowingTraceListener tests will fail, which will tell us we
+    // need to do something to re-enable this listener.
     public sealed class ThrowingTraceListener : TraceListener
     {
         public override void Fail(string message, string detailMessage)

--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -279,8 +279,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             // also enumerate any events from the registeredParser.  
             registeredParser.EnumerateTemplates(eventsToObserve, callback);
 
-            // also enumerate any events from the eventPipeTraceEventParser
-            eventPipeTraceEventParser.EnumerateTemplates(eventsToObserve, callback);
+            // also enumerate any events from the eventPipeTraceEventParser.
+            // Filter out any duplicates that the registeredParser already knows about,
+            // similar to how manifest-based templates are filtered above.
+            eventPipeTraceEventParser.EnumerateTemplates(eventsToObserve, delegate (TraceEvent template)
+            {
+                if (!registeredParser.HasDefinitionForTemplate(template))
+                {
+                    callback(template);
+                }
+            });
         }
 
         private class PartialManifestInfo

--- a/src/TraceEvent/TraceEvent.Tests/Speedscope/SpeedScopeExporterTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Speedscope/SpeedScopeExporterTests.cs
@@ -4,20 +4,12 @@ using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.Stacks;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using Xunit;
 
 using static Microsoft.Diagnostics.Tracing.Stacks.StackSourceWriterHelper;
-
-// For Debug.Listeners
-#if NETCOREAPP3_0_OR_GREATER
-using Trace = System.Diagnostics.Trace;
-#else
-using Trace = System.Diagnostics.Debug;
-#endif
 
 namespace TraceEventTests
 {
@@ -343,10 +335,6 @@ namespace TraceEventTests
         [InlineData("only_managed_samples.nettrace.zip")]
         public void CanConvertProvidedTraceFiles(string zippedTraceFileName)
         {
-            var debugListenersCopy = new TraceListener[Trace.Listeners.Count];
-            Trace.Listeners.CopyTo(debugListenersCopy, index: 0);
-            Trace.Listeners.Clear();
-
             string fileToUnzip = Path.Combine("inputs", "speedscope", zippedTraceFileName);
             string unzippedFile = Path.ChangeExtension(fileToUnzip, string.Empty);
 
@@ -401,10 +389,6 @@ namespace TraceEventTests
                 if (File.Exists(unzippedFile))
                 {
                     File.Delete(unzippedFile);
-                }
-                if (debugListenersCopy.Length > 0)
-                {
-                    Trace.Listeners.AddRange(debugListenersCopy);
                 }
             }
         }

--- a/src/TraceEvent/TraceEvent.cs
+++ b/src/TraceEvent/TraceEvent.cs
@@ -2882,7 +2882,12 @@ namespace Microsoft.Diagnostics.Tracing
             }
 
 #if DEBUG
-            if (GetProviderName() != null && !m_ConfirmedAllEventsAreInEnumeration && !(this is PredefinedDynamicTraceEventParser))
+            // ApplicationServerTraceEventParser is auto-generated and has many events sharing the same
+            // task name, producing duplicate computed event names that ConfirmAllEventsAreInEnumeration
+            // cannot handle.
+            if (GetProviderName() != null && !m_ConfirmedAllEventsAreInEnumeration &&
+                !(this is PredefinedDynamicTraceEventParser) &&
+                !(this is Parsers.ApplicationServerTraceEventParser))
             {
                 ConfirmAllEventsAreInEnumeration();
                 m_ConfirmedAllEventsAreInEnumeration = true;


### PR DESCRIPTION
The SpeedScope `CanConvertProvidedTraceFiles` tests were clearing `Trace.Listeners` to suppress `Debug.Assert` failures that fired during trace parsing. This masked two real bugs:

## Fix 1: Duplicate template enumeration in DynamicTraceEventParser

`DynamicTraceEventParser.EnumerateTemplates` enumerates templates from three sources (manifest-based, `registeredParser`, and `eventPipeTraceEventParser`) but only deduplicated between manifest-based templates and `registeredParser`. When both `registeredParser` and `eventPipeTraceEventParser` knew about the same event, the template was enumerated twice, causing `Subscribe` to assert on the duplicate with `mayHaveExistedBefore=false`.

**Fix:** Filter `eventPipeTraceEventParser` templates against `registeredParser`, matching the existing dedup pattern for manifest-based templates.

## Fix 2: Skip ConfirmAllEventsAreInEnumeration for ApplicationServerTraceEventParser

`ApplicationServerTraceEventParser` is auto-generated and has many events that share the same task name and opcode, producing duplicate computed event names (100+ duplicates). The `ConfirmAllEventsAreInEnumeration` DEBUG validation cannot handle this pattern.

**Fix:** Skip this parser from the validation, similar to how `PredefinedDynamicTraceEventParser` is already excluded.

## Cleanup

- Remove the listener-clearing hack from SpeedScope tests (no longer needed since the underlying asserts are fixed).
- Add documentation to `ThrowingTraceListener` and `DebugAssertionTests` explaining that on .NET 5+, the `DefaultTraceListener` already throws on assert failures, so no additional listener configuration is needed.