### PR TITLE
Handle provider names that start with a numeric digit.

### DIFF
--- a/src/TraceParserGen.Tests/ParserGenerationTests.cs
+++ b/src/TraceParserGen.Tests/ParserGenerationTests.cs
@@ -911,5 +911,19 @@ class Program
         }
 
         #endregion
+
+        #region Leading digit provider name tests
+
+        [Fact]
+        public void LeadingDigitProvider_ClassNamePrefixedWithUnderscore()
+        {
+            string content = GenerateParserFromManifest("LeadingDigitProvider.manifest.xml");
+
+            // Provider "3Scale-ETW-Provider" → ToCSharpName → "_3ScaleETWProvider"
+            // C# identifiers cannot start with a digit, so an underscore is prepended.
+            Assert.Contains("public sealed class _3ScaleETWProviderTraceEventParser : TraceEventParser", content);
+        }
+
+        #endregion
     }
 }

--- a/src/TraceParserGen.Tests/inputs/LeadingDigitProvider.manifest.xml
+++ b/src/TraceParserGen.Tests/inputs/LeadingDigitProvider.manifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<instrumentationManifest xmlns="http://schemas.microsoft.com/win/2004/08/events">
+  <instrumentation xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events">
+
+    <events xmlns="http://schemas.microsoft.com/win/2004/08/events">
+      <!-- Provider name starts with a digit to test ToCSharpName leading-digit fix -->
+      <provider name="3Scale-ETW-Provider"
+                guid="{DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF}"
+                symbol="THREE_SCALE_ETW_PROVIDER"
+                messageFileName="3Scale.dll"
+                resourceFileName="3Scale.dll">
+
+        <tasks>
+          <task name="Request" value="1" />
+        </tasks>
+
+        <templates>
+          <template tid="RequestArgs">
+            <data name="Url" inType="win:UnicodeString" />
+          </template>
+        </templates>
+
+        <events>
+          <event value="1"
+                 symbol="Request"
+                 task="Request"
+                 template="RequestArgs"
+                 level="win:Informational" />
+        </events>
+
+      </provider>
+    </events>
+  </instrumentation>
+</instrumentationManifest>

--- a/src/TraceParserGen/TraceParserGen.cs
+++ b/src/TraceParserGen/TraceParserGen.cs
@@ -1006,6 +1006,13 @@ internal class TraceParserGen
 
             validName.Append(c);
         }
+
+        // C# identifiers cannot start with a digit - prefix with underscore if needed.
+        if (validName.Length > 0 && Char.IsDigit(validName[0]))
+        {
+            validName.Insert(0, '_');
+        }
+
         return validName.ToString();
     }
 


### PR DESCRIPTION
C# names can't start with numeric digits, so if a provider name starts with a numeric digit, prepend a '_' character onto the class name.  This is an indication that the user should adjust the name appropriately, while at the same time, allowing the code to compile and run.

Fixes #1804 