### PR TITLE
Dispose WebView2 controls before Environment.Exit to prevent finalizer crash

### DIFF
--- a/src/PerfView/MainWindow.xaml.cs
+++ b/src/PerfView/MainWindow.xaml.cs
@@ -1070,6 +1070,17 @@ namespace PerfView
             // DO NOT call Environment.Exit(0) under tests, it will kill the test runner, and tests won't complete.
             if (!_testing)
             {
+                // Dispose all WebView2 browser controls before exiting. Environment.Exit triggers
+                // finalizers, and the WebView2 finalizer crashes if the underlying COM objects have
+                // already been torn down during process shutdown.
+                foreach (Window window in Application.Current.Windows)
+                {
+                    if (window is WebBrowserWindow browserWindow)
+                    {
+                        browserWindow.Browser?.Dispose();
+                    }
+                }
+
                 Environment.Exit(0);
             }
         }


### PR DESCRIPTION
When PerfView's main window closes, Environment.Exit(0) triggers finalizers. The WebView2 HwndHost finalizer attempts to access COM objects that have already been torn down during process shutdown, causing an InvalidCastException on ICoreWebView2Controller.

Fix: explicitly dispose all WebBrowserWindow WebView2 controls before calling Environment.Exit(0) so the finalizer has nothing to clean up.