### PR TITLE
Replace individual code owners with microsoft/perfview-reviewers group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-* @brianrob @cincuranet @leculver @mconnew @marklio @StephenMolloy
+* @microsoft/perfview-reviewers


### PR DESCRIPTION
Replace the six individual code owners with the @microsoft/perfview-reviewers team group for simpler maintainability.