### PR TITLE
Optimize nettrace-to-TraceLog Conversion

### DIFF
--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             // Merge events in timestamp order using the min-heap.
             while (_heap.Count > 0)
             {
-                Queue<EventMarker> minQueue = _heap.PeekQueue;
+                Queue<EventMarker> minQueue = _heap.PeekValue;
                 EventMarker eventMarker = minQueue.Dequeue();
                 OnEvent?.Invoke(ref eventMarker.Header);
 
@@ -227,20 +227,20 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         #region Min-heap Implementation
 
         /// <summary>
-        /// A min-heap that orders entries by timestamp. Used to efficiently merge events
-        /// from multiple thread queues in timestamp order during SortAndDispatch.
+        /// A min-heap that pairs a long key with a value of type <typeparamref name="TValue"/>.
+        /// Entries are ordered by key so the minimum key is always at the root.
         /// </summary>
-        private class MinHeap
+        internal class MinHeap<TValue>
         {
             private struct Entry
             {
-                public long Timestamp;
-                public Queue<EventMarker> Queue;
+                public long Key;
+                public TValue Value;
 
-                public Entry(long timestamp, Queue<EventMarker> queue)
+                public Entry(long key, TValue value)
                 {
-                    Timestamp = timestamp;
-                    Queue = queue;
+                    Key = key;
+                    Value = value;
                 }
             }
 
@@ -248,21 +248,28 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
 
             public int Count => _entries.Count;
 
-            public Queue<EventMarker> PeekQueue => _entries[0].Queue;
+            public TValue PeekValue => _entries[0].Value;
 
             public void Clear() => _entries.Clear();
 
-            public void Add(long timestamp, Queue<EventMarker> queue)
+            public void Add(long key, TValue value)
             {
-                _entries.Add(new Entry(timestamp, queue));
+                _entries.Add(new Entry(key, value));
             }
 
             /// <summary>
             /// Establishes the heap property over all entries. Call once after adding all
             /// entries via Add, before extracting from the heap.
             /// </summary>
+            /// <remarks>
+            /// Starts from the last non-leaf node (_entries.Count / 2 - 1) and sifts each
+            /// node down to its correct position. Leaves (the second half of the array) are
+            /// already trivially valid heaps of size 1, so they are skipped.
+            /// </remarks>
             public void Build()
             {
+                // Start from the last non-leaf node and work backwards to the root.
+                // Nodes at indices [Count/2 .. Count-1] are leaves that need no adjustment.
                 for (int i = _entries.Count / 2 - 1; i >= 0; i--)
                 {
                     SiftDown(i);
@@ -270,12 +277,12 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
             }
 
             /// <summary>
-            /// Replaces the root entry with a new timestamp for the same queue and restores
-            /// the heap property. Use when the root queue still has events to dispatch.
+            /// Replaces the root entry with a new key/value pair and restores the heap property.
+            /// Use when the root element has been consumed but its source still has more items.
             /// </summary>
-            public void ReplaceRoot(long newTimestamp, Queue<EventMarker> queue)
+            public void ReplaceRoot(long newKey, TValue value)
             {
-                _entries[0] = new Entry(newTimestamp, queue);
+                _entries[0] = new Entry(newKey, value);
                 SiftDown(0);
             }
 
@@ -313,11 +320,11 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                     int left = 2 * i + 1;
                     int right = 2 * i + 2;
 
-                    if (left < count && _entries[left].Timestamp < _entries[smallest].Timestamp)
+                    if (left < count && _entries[left].Key < _entries[smallest].Key)
                     {
                         smallest = left;
                     }
-                    if (right < count && _entries[right].Timestamp < _entries[smallest].Timestamp)
+                    if (right < count && _entries[right].Key < _entries[smallest].Key)
                     {
                         smallest = right;
                     }
@@ -402,7 +409,7 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         EventPipeEventSource _source;
         ThreadCache _threads;
         Queue<EventBlockBuffer> _buffers = new Queue<EventBlockBuffer>();
-        MinHeap _heap = new MinHeap();
+        MinHeap<Queue<EventMarker>> _heap = new MinHeap<Queue<EventMarker>>();
         HashSet<Queue<EventMarker>> _activeThreadQueues = new HashSet<Queue<EventMarker>>();
     }
 

--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -67,6 +67,10 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                 }
                 else
                 {
+                    if (thread.Events.Count == 0)
+                    {
+                        _activeThreadQueues.Add(thread.Events);
+                    }
                     thread.Events.Enqueue(eventMarker);
                 }
 
@@ -164,13 +168,14 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
 
         private unsafe void SortAndDispatch(long stopTimestamp)
         {
-            // Build a min-heap from non-empty thread queues whose front event is before stopTimestamp.
-            // This gives O(N * log(T)) merge performance instead of O(N * T) where N is the number
-            // of events and T is the number of threads.
+            // Build a min-heap from active thread queues (those with pending events) whose
+            // front event is before stopTimestamp. Using _activeThreadQueues avoids iterating
+            // all threads in the dictionary — only threads that have had events enqueued are checked.
+            // This gives O(N * log(T)) merge performance where N is the number of events and
+            // T is the number of active threads.
             _heap.Clear();
-            foreach (EventPipeThread thread in _threads.Values)
+            foreach (Queue<EventMarker> q in _activeThreadQueues)
             {
-                Queue<EventMarker> q = thread.Events;
                 if (q.Count > 0)
                 {
                     long ts = q.Peek().Header.TimeStamp;
@@ -212,8 +217,9 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                 else
                 {
                     HeapRemoveRoot();
-                    // Free internal storage for empty queues to prevent unbounded memory growth
-                    // when the application creates and destroys threads over time.
+                    // Remove from active set and free internal storage to prevent unbounded
+                    // memory growth when the application creates and destroys threads.
+                    _activeThreadQueues.Remove(min.Queue);
                     min.Queue.TrimExcess();
                 }
             }
@@ -355,6 +361,7 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         ThreadCache _threads;
         Queue<EventBlockBuffer> _buffers = new Queue<EventBlockBuffer>();
         List<HeapEntry> _heap = new List<HeapEntry>();
+        HashSet<Queue<EventMarker>> _activeThreadQueues = new HashSet<Queue<EventMarker>>();
     }
 
     internal class EventMarker

--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Tracing.EventPipe
@@ -165,48 +164,126 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
 
         private unsafe void SortAndDispatch(long stopTimestamp)
         {
-            // This sort could be made faster by using a min-heap but this is a simple place to start
-            List<Queue<EventMarker>> threadQueues = new List<Queue<EventMarker>>(_threads.Values.Select(t => t.Events));
-            while(true)
+            // Build a min-heap from non-empty thread queues whose front event is before stopTimestamp.
+            // This gives O(N * log(T)) merge performance instead of O(N * T) where N is the number
+            // of events and T is the number of threads.
+            _heap.Clear();
+            foreach (EventPipeThread thread in _threads.Values)
             {
-                long lowestTimestamp = stopTimestamp;
-                Queue<EventMarker> oldestEventQueue = null;
-                foreach(Queue<EventMarker> threadQueue in threadQueues)
+                Queue<EventMarker> q = thread.Events;
+                if (q.Count > 0)
                 {
-                    if(threadQueue.Count == 0)
+                    long ts = q.Peek().Header.TimeStamp;
+                    if (ts < stopTimestamp)
                     {
-                        continue;
+                        _heap.Add(new HeapEntry(ts, q));
                     }
-                    long eventTimestamp = threadQueue.Peek().Header.TimeStamp;
-                    if (eventTimestamp < lowestTimestamp)
-                    {
-                        oldestEventQueue = threadQueue;
-                        lowestTimestamp = eventTimestamp;
-                    }
-                }
-                if(oldestEventQueue == null)
-                {
-                    break;
-                }
-                else
-                {
-                    EventMarker eventMarker = oldestEventQueue.Dequeue();
-                    OnEvent?.Invoke(ref eventMarker.Header);
                 }
             }
 
-            // If the app creates and destroys threads over time we need to flush old threads
-            // from the cache or memory usage will grow unbounded. AddThread handles the
-            // the thread objects but the storage for the queue elements also does not shrink
-            // below the high water mark unless we free it explicitly.
-            foreach (Queue<EventMarker> q in threadQueues)
+            if (_heap.Count == 0)
             {
-                if(q.Count == 0)
+                return;
+            }
+
+            HeapBuild();
+
+            // Merge events in timestamp order using the min-heap.
+            while (_heap.Count > 0)
+            {
+                HeapEntry min = _heap[0];
+                EventMarker eventMarker = min.Queue.Dequeue();
+                OnEvent?.Invoke(ref eventMarker.Header);
+
+                if (min.Queue.Count > 0)
                 {
-                    q.TrimExcess();
+                    long nextTs = min.Queue.Peek().Header.TimeStamp;
+                    if (nextTs < stopTimestamp)
+                    {
+                        // Update the root with the next timestamp and restore the heap property.
+                        _heap[0] = new HeapEntry(nextTs, min.Queue);
+                        HeapSiftDown(0);
+                    }
+                    else
+                    {
+                        HeapRemoveRoot();
+                    }
+                }
+                else
+                {
+                    HeapRemoveRoot();
+                    // Free internal storage for empty queues to prevent unbounded memory growth
+                    // when the application creates and destroys threads over time.
+                    min.Queue.TrimExcess();
                 }
             }
         }
+
+        #region Min-heap helpers for SortAndDispatch
+
+        private struct HeapEntry
+        {
+            public long Timestamp;
+            public Queue<EventMarker> Queue;
+
+            public HeapEntry(long timestamp, Queue<EventMarker> queue)
+            {
+                Timestamp = timestamp;
+                Queue = queue;
+            }
+        }
+
+        private void HeapBuild()
+        {
+            for (int i = _heap.Count / 2 - 1; i >= 0; i--)
+            {
+                HeapSiftDown(i);
+            }
+        }
+
+        private void HeapSiftDown(int i)
+        {
+            int count = _heap.Count;
+            while (true)
+            {
+                int smallest = i;
+                int left = 2 * i + 1;
+                int right = 2 * i + 2;
+                if (left < count && _heap[left].Timestamp < _heap[smallest].Timestamp)
+                {
+                    smallest = left;
+                }
+                if (right < count && _heap[right].Timestamp < _heap[smallest].Timestamp)
+                {
+                    smallest = right;
+                }
+                if (smallest == i)
+                {
+                    break;
+                }
+                HeapEntry temp = _heap[i];
+                _heap[i] = _heap[smallest];
+                _heap[smallest] = temp;
+                i = smallest;
+            }
+        }
+
+        private void HeapRemoveRoot()
+        {
+            int lastIndex = _heap.Count - 1;
+            if (lastIndex == 0)
+            {
+                _heap.Clear();
+            }
+            else
+            {
+                _heap[0] = _heap[lastIndex];
+                _heap.RemoveAt(lastIndex);
+                HeapSiftDown(0);
+            }
+        }
+
+        #endregion
 
         private void FreeOldEventBuffers(long stopTimestamp)
         {
@@ -277,6 +354,7 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         EventPipeEventSource _source;
         ThreadCache _threads;
         Queue<EventBlockBuffer> _buffers = new Queue<EventBlockBuffer>();
+        List<HeapEntry> _heap = new List<HeapEntry>();
     }
 
     internal class EventMarker

--- a/src/TraceEvent/EventPipe/EventCache.cs
+++ b/src/TraceEvent/EventPipe/EventCache.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                     long ts = q.Peek().Header.TimeStamp;
                     if (ts < stopTimestamp)
                     {
-                        _heap.Add(new HeapEntry(ts, q));
+                        _heap.Add(ts, q);
                     }
                 }
             }
@@ -191,101 +191,143 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
                 return;
             }
 
-            HeapBuild();
+            _heap.Build();
 
             // Merge events in timestamp order using the min-heap.
             while (_heap.Count > 0)
             {
-                HeapEntry min = _heap[0];
-                EventMarker eventMarker = min.Queue.Dequeue();
+                Queue<EventMarker> minQueue = _heap.PeekQueue;
+                EventMarker eventMarker = minQueue.Dequeue();
                 OnEvent?.Invoke(ref eventMarker.Header);
 
-                if (min.Queue.Count > 0)
+                if (minQueue.Count > 0)
                 {
-                    long nextTs = min.Queue.Peek().Header.TimeStamp;
+                    long nextTs = minQueue.Peek().Header.TimeStamp;
                     if (nextTs < stopTimestamp)
                     {
                         // Update the root with the next timestamp and restore the heap property.
-                        _heap[0] = new HeapEntry(nextTs, min.Queue);
-                        HeapSiftDown(0);
+                        _heap.ReplaceRoot(nextTs, minQueue);
                     }
                     else
                     {
-                        HeapRemoveRoot();
+                        _heap.RemoveRoot();
                     }
                 }
                 else
                 {
-                    HeapRemoveRoot();
+                    _heap.RemoveRoot();
                     // Remove from active set and free internal storage to prevent unbounded
                     // memory growth when the application creates and destroys threads.
-                    _activeThreadQueues.Remove(min.Queue);
-                    min.Queue.TrimExcess();
+                    _activeThreadQueues.Remove(minQueue);
+                    minQueue.TrimExcess();
                 }
             }
         }
 
-        #region Min-heap helpers for SortAndDispatch
+        #region Min-heap Implementation
 
-        private struct HeapEntry
+        /// <summary>
+        /// A min-heap that orders entries by timestamp. Used to efficiently merge events
+        /// from multiple thread queues in timestamp order during SortAndDispatch.
+        /// </summary>
+        private class MinHeap
         {
-            public long Timestamp;
-            public Queue<EventMarker> Queue;
-
-            public HeapEntry(long timestamp, Queue<EventMarker> queue)
+            private struct Entry
             {
-                Timestamp = timestamp;
-                Queue = queue;
-            }
-        }
+                public long Timestamp;
+                public Queue<EventMarker> Queue;
 
-        private void HeapBuild()
-        {
-            for (int i = _heap.Count / 2 - 1; i >= 0; i--)
-            {
-                HeapSiftDown(i);
-            }
-        }
-
-        private void HeapSiftDown(int i)
-        {
-            int count = _heap.Count;
-            while (true)
-            {
-                int smallest = i;
-                int left = 2 * i + 1;
-                int right = 2 * i + 2;
-                if (left < count && _heap[left].Timestamp < _heap[smallest].Timestamp)
+                public Entry(long timestamp, Queue<EventMarker> queue)
                 {
-                    smallest = left;
+                    Timestamp = timestamp;
+                    Queue = queue;
                 }
-                if (right < count && _heap[right].Timestamp < _heap[smallest].Timestamp)
-                {
-                    smallest = right;
-                }
-                if (smallest == i)
-                {
-                    break;
-                }
-                HeapEntry temp = _heap[i];
-                _heap[i] = _heap[smallest];
-                _heap[smallest] = temp;
-                i = smallest;
             }
-        }
 
-        private void HeapRemoveRoot()
-        {
-            int lastIndex = _heap.Count - 1;
-            if (lastIndex == 0)
+            private readonly List<Entry> _entries = new List<Entry>();
+
+            public int Count => _entries.Count;
+
+            public Queue<EventMarker> PeekQueue => _entries[0].Queue;
+
+            public void Clear() => _entries.Clear();
+
+            public void Add(long timestamp, Queue<EventMarker> queue)
             {
-                _heap.Clear();
+                _entries.Add(new Entry(timestamp, queue));
             }
-            else
+
+            /// <summary>
+            /// Establishes the heap property over all entries. Call once after adding all
+            /// entries via Add, before extracting from the heap.
+            /// </summary>
+            public void Build()
             {
-                _heap[0] = _heap[lastIndex];
-                _heap.RemoveAt(lastIndex);
-                HeapSiftDown(0);
+                for (int i = _entries.Count / 2 - 1; i >= 0; i--)
+                {
+                    SiftDown(i);
+                }
+            }
+
+            /// <summary>
+            /// Replaces the root entry with a new timestamp for the same queue and restores
+            /// the heap property. Use when the root queue still has events to dispatch.
+            /// </summary>
+            public void ReplaceRoot(long newTimestamp, Queue<EventMarker> queue)
+            {
+                _entries[0] = new Entry(newTimestamp, queue);
+                SiftDown(0);
+            }
+
+            /// <summary>
+            /// Removes the root (minimum) entry from the heap and restores the heap property.
+            /// </summary>
+            public void RemoveRoot()
+            {
+                int lastIndex = _entries.Count - 1;
+                if (lastIndex == 0)
+                {
+                    _entries.Clear();
+                }
+                else
+                {
+                    _entries[0] = _entries[lastIndex];
+                    _entries.RemoveAt(lastIndex);
+                    SiftDown(0);
+                }
+            }
+
+            /// <summary>
+            /// Restores the min-heap property by moving the element at index i down the tree
+            /// until it is smaller than both children or reaches a leaf position.
+            /// </summary>
+            private void SiftDown(int i)
+            {
+                int count = _entries.Count;
+                while (true)
+                {
+                    int smallest = i;
+
+                    // In a binary heap stored as an array, the children of node i are at
+                    // indices 2i+1 (left) and 2i+2 (right).
+                    int left = 2 * i + 1;
+                    int right = 2 * i + 2;
+
+                    if (left < count && _entries[left].Timestamp < _entries[smallest].Timestamp)
+                    {
+                        smallest = left;
+                    }
+                    if (right < count && _entries[right].Timestamp < _entries[smallest].Timestamp)
+                    {
+                        smallest = right;
+                    }
+                    if (smallest == i)
+                    {
+                        break;
+                    }
+                    (_entries[i], _entries[smallest]) = (_entries[smallest], _entries[i]);
+                    i = smallest;
+                }
             }
         }
 
@@ -360,7 +402,7 @@ namespace Microsoft.Diagnostics.Tracing.EventPipe
         EventPipeEventSource _source;
         ThreadCache _threads;
         Queue<EventBlockBuffer> _buffers = new Queue<EventBlockBuffer>();
-        List<HeapEntry> _heap = new List<HeapEntry>();
+        MinHeap _heap = new MinHeap();
         HashSet<Queue<EventMarker>> _activeThreadQueues = new HashSet<Queue<EventMarker>>();
     }
 

--- a/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
@@ -385,6 +385,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
             Action(this);
         }
 
+        public override unsafe TraceEvent Clone()
+        {
+            var clone = (ProcessMappingMetadataTraceData)base.Clone();
+            clone._parsedSymbolMetadata = _parsedSymbolMetadata;
+            clone._parsedSymbolMetadataCached = _parsedSymbolMetadataCached;
+            return clone;
+        }
+
         protected internal override Delegate Target
         {
             get { return Action; }

--- a/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
@@ -380,6 +380,8 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
         }
         protected internal override void Dispatch()
         {
+            _parsedSymbolMetadataCached = false;
+            _parsedSymbolMetadata = null;
             Action(this);
         }
 

--- a/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/UniversalSystemTraceEventParser.cs
@@ -355,7 +355,20 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Universal.Events
 
         public string SymbolMetadata {get { return GetShortUTF8StringAt(SkipVarInt(0)); } }
 
-        internal ProcessMappingSymbolMetadata ParsedSymbolMetadata { get { return ProcessMappingSymbolMetadataParser.TryParse(SymbolMetadata); } }
+        internal ProcessMappingSymbolMetadata ParsedSymbolMetadata
+        {
+            get
+            {
+                if (!_parsedSymbolMetadataCached)
+                {
+                    _parsedSymbolMetadata = ProcessMappingSymbolMetadataParser.TryParse(SymbolMetadata);
+                    _parsedSymbolMetadataCached = true;
+                }
+                return _parsedSymbolMetadata;
+            }
+        }
+        private ProcessMappingSymbolMetadata _parsedSymbolMetadata;
+        private bool _parsedSymbolMetadataCached;
 
         public string VersionMetadata {get {return GetShortUTF8StringAt(SkipShortUTF8String(SkipVarInt(0))); } }
 

--- a/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
+++ b/src/TraceEvent/SourceConverters/NettraceUniversalConverter.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Diagnostics.Tracing.SourceConverters
                 }
                 processes.Add(process);
 
-                if (!string.IsNullOrEmpty(data.FileName) && data.FileName.StartsWith(DotnetJittedCodeMappingName, StringComparison.Ordinal))
+                string fileName = data.FileName;
+                if (!string.IsNullOrEmpty(fileName) && fileName.StartsWith(DotnetJittedCodeMappingName, StringComparison.Ordinal))
                 {
                     // Don't create a module for jitted code.
                     // These will be created for each jitted code symbol.
@@ -70,7 +71,7 @@ namespace Microsoft.Diagnostics.Tracing.SourceConverters
                 }
 
                 _mappingMetadata.TryGetValue(data.MetadataId, out ProcessMappingMetadataTraceData metadata);
-                TraceModuleFile moduleFile = process.LoadedModules.UniversalMapping(data, metadata);
+                TraceModuleFile moduleFile = process.LoadedModules.UniversalMapping(fileName, data.StartAddress, data.EndAddress, data.TimeStampQPC, metadata);
             };
             universalSystemParser.ProcessMappingMetadata += delegate (ProcessMappingMetadataTraceData data)
             {

--- a/src/TraceEvent/TraceEvent.Tests/Cache/MinHeapTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Cache/MinHeapTests.cs
@@ -1,0 +1,230 @@
+using Microsoft.Diagnostics.Tracing.EventPipe;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class MinHeapTests
+    {
+        [Fact]
+        public void EmptyHeap_CountIsZero()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            Assert.Equal(0, heap.Count);
+        }
+
+        [Fact]
+        public void SingleElement_PeekReturnsIt()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(42, "only");
+            heap.Build();
+
+            Assert.Equal(1, heap.Count);
+            Assert.Equal("only", heap.PeekValue);
+        }
+
+        [Fact]
+        public void Build_EstablishesMinOrder()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(30, "thirty");
+            heap.Add(10, "ten");
+            heap.Add(20, "twenty");
+            heap.Build();
+
+            Assert.Equal("ten", heap.PeekValue);
+        }
+
+        [Fact]
+        public void RemoveRoot_YieldsAscendingOrder()
+        {
+            var heap = new EventCache.MinHeap<int>();
+            heap.Add(50, 50);
+            heap.Add(30, 30);
+            heap.Add(40, 40);
+            heap.Add(10, 10);
+            heap.Add(20, 20);
+            heap.Build();
+
+            var result = new List<int>();
+            while (heap.Count > 0)
+            {
+                result.Add(heap.PeekValue);
+                heap.RemoveRoot();
+            }
+
+            Assert.Equal(new[] { 10, 20, 30, 40, 50 }, result);
+        }
+
+        [Fact]
+        public void RemoveRoot_SingleElement_EmptiesHeap()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(1, "a");
+            heap.Build();
+
+            heap.RemoveRoot();
+            Assert.Equal(0, heap.Count);
+        }
+
+        [Fact]
+        public void ReplaceRoot_MaintainsHeapOrder()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(10, "ten");
+            heap.Add(20, "twenty");
+            heap.Add(30, "thirty");
+            heap.Build();
+
+            Assert.Equal("ten", heap.PeekValue);
+
+            // Replace root (10) with a larger key (25) — "twenty" (20) should become new root.
+            heap.ReplaceRoot(25, "twenty-five");
+            Assert.Equal("twenty", heap.PeekValue);
+        }
+
+        [Fact]
+        public void ReplaceRoot_WithSmallestKey_KeepsItAtRoot()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(10, "ten");
+            heap.Add(20, "twenty");
+            heap.Add(30, "thirty");
+            heap.Build();
+
+            // Replace root with an even smaller key — it should remain the root.
+            heap.ReplaceRoot(5, "five");
+            Assert.Equal("five", heap.PeekValue);
+        }
+
+        [Fact]
+        public void Clear_ResetsHeap()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(1, "a");
+            heap.Add(2, "b");
+            heap.Build();
+
+            heap.Clear();
+            Assert.Equal(0, heap.Count);
+        }
+
+        [Fact]
+        public void DuplicateKeys_AllElementsPreserved()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(10, "a");
+            heap.Add(10, "b");
+            heap.Add(10, "c");
+            heap.Build();
+
+            var result = new List<string>();
+            while (heap.Count > 0)
+            {
+                result.Add(heap.PeekValue);
+                heap.RemoveRoot();
+            }
+
+            Assert.Equal(3, result.Count);
+            result.Sort();
+            Assert.Equal(new[] { "a", "b", "c" }, result);
+        }
+
+        [Fact]
+        public void LargeHeap_ExtractsInOrder()
+        {
+            var heap = new EventCache.MinHeap<int>();
+            var rng = new Random(12345);
+            var expected = new List<int>();
+
+            for (int i = 0; i < 1000; i++)
+            {
+                int val = rng.Next(0, 100000);
+                heap.Add(val, val);
+                expected.Add(val);
+            }
+
+            heap.Build();
+            expected.Sort();
+
+            var result = new List<int>();
+            while (heap.Count > 0)
+            {
+                result.Add(heap.PeekValue);
+                heap.RemoveRoot();
+            }
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void AlreadySorted_ExtractsInOrder()
+        {
+            var heap = new EventCache.MinHeap<int>();
+            for (int i = 1; i <= 10; i++)
+            {
+                heap.Add(i, i);
+            }
+            heap.Build();
+
+            var result = new List<int>();
+            while (heap.Count > 0)
+            {
+                result.Add(heap.PeekValue);
+                heap.RemoveRoot();
+            }
+
+            Assert.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, result);
+        }
+
+        [Fact]
+        public void ReverseSorted_ExtractsInOrder()
+        {
+            var heap = new EventCache.MinHeap<int>();
+            for (int i = 10; i >= 1; i--)
+            {
+                heap.Add(i, i);
+            }
+            heap.Build();
+
+            var result = new List<int>();
+            while (heap.Count > 0)
+            {
+                result.Add(heap.PeekValue);
+                heap.RemoveRoot();
+            }
+
+            Assert.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, result);
+        }
+
+        [Fact]
+        public void MixedOperations_RemoveAndReplace()
+        {
+            var heap = new EventCache.MinHeap<string>();
+            heap.Add(10, "ten");
+            heap.Add(20, "twenty");
+            heap.Add(30, "thirty");
+            heap.Add(40, "forty");
+            heap.Build();
+
+            // Extract min (10), then replace root with 25.
+            Assert.Equal("ten", heap.PeekValue);
+            heap.RemoveRoot();
+            Assert.Equal("twenty", heap.PeekValue);
+            heap.ReplaceRoot(25, "twenty-five");
+
+            // Now heap has: 25, 30, 40. Min should be 25.
+            Assert.Equal("twenty-five", heap.PeekValue);
+
+            var result = new List<string>();
+            while (heap.Count > 0)
+            {
+                result.Add(heap.PeekValue);
+                heap.RemoveRoot();
+            }
+            Assert.Equal(new[] { "twenty-five", "thirty", "forty" }, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Optimizes the nettrace-to-TraceLog/ETLX conversion pipeline, reducing conversion time for a 1.68 GB nettrace file from **~22 minutes to ~40 seconds** (34x speedup).

## Problem

Converting large nettrace files (e.g., from OneCollect Linux traces with many threads) to TraceLog/ETLX format was extremely slow. Profiling revealed three bottlenecks:

1. **`EventCache.SortAndDispatch`** consumed ~75% of CPU — O(N×T) linear scan over all thread queues per event block, plus per-call LINQ `List` allocations.
2. **`ParsedSymbolMetadata`** consumed ~10% of CPU — JSON deserialization repeated on every property access.
3. **`FileName` string allocations** consumed ~12% of CPU — `GetShortUTF8StringAt()` called 3 times per mapping event.

## Changes

### EventCache min-heap (`EventCache.cs`)
- Replaced the O(N×T) linear scan in `SortAndDispatch` with an O(N×log T) min-heap merge.
- Introduced a generic `MinHeap<TValue>` class with full unit test coverage (13 tests).
- Added `_activeThreadQueues` HashSet to track only threads with pending events, avoiding iteration over the full thread dictionary.

### Cache ParsedSymbolMetadata (`UniversalSystemTraceEventParser.cs`)
- Cached the result of `ProcessMappingSymbolMetadataParser.TryParse()` to avoid repeated JSON deserialization.
- Reset cache in `Dispatch()` to prevent stale data when TraceEvent objects are reused.
- Added `Clone()` override to preserve cached values in cloned events.

### Reduce FileName allocations (`NettraceUniversalConverter.cs`)
- Read `data.FileName` once into a local variable instead of accessing the property 3 times (each access allocates a new string via `GetShortUTF8StringAt`).
- Call `UniversalMapping(string, ...)` overload directly, passing the cached string.

## Performance Results

Measured with a 1.68 GB nettrace file (8.6M events, 11.5K processes) using Release builds:

| Metric | Before | After |
|---|---|---|
| **Conversion time** | **22:26 (1346s)** | **00:40 (40s)** |
| **Speedup** | — | **34×** |
| Events | 8,583,800 | 8,583,800 ✓ |
| Processes | 11,509 | 11,509 ✓ |
| Unique code addresses | 174,476 | 174,476 ✓ |
| Unique stacks | 206,467 | 206,467 ✓ |
| ETLX file size | 3,051,574,460 | 3,051,574,460 ✓ |

All semantic statistics match. ETLX files are the same size but not byte-identical due to different tie-breaking order for same-timestamp events (min-heap vs linear scan).

## Testing

- All existing tests pass (2,274 on net8.0 + 2,289 on net462).
- 13 new MinHeap unit tests added.