### PR TITLE
Embed missing System.Text.Json transitive dependencies in PerfView

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -36,6 +36,8 @@
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
+    <PackageVersion Include="System.IO.Pipelines" Version="9.0.8" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.8" />
     <PackageVersion Include="System.Text.Json" Version="9.0.8" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -106,6 +106,8 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" GeneratePathProperty="true" />
     <PackageReference Include="System.Memory" GeneratePathProperty="true" />
     <PackageReference Include="System.Numerics.Vectors" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Pipelines" GeneratePathProperty="true" />
     <PackageReference Include="System.Text.Encodings.Web" GeneratePathProperty="true" />
     <PackageReference Include="System.Text.Json" GeneratePathProperty="true" />
     <PackageReference Include="System.Threading.Tasks.Extensions" GeneratePathProperty="true" />
@@ -631,6 +633,20 @@
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Security.Cryptography.ProtectedData.dll</LogicalName>
       <Link>System.Security.Cryptography.ProtectedData.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgMicrosoft_Bcl_AsyncInterfaces)\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\Microsoft.Bcl.AsyncInterfaces.dll</LogicalName>
+      <Link>Microsoft.Bcl.AsyncInterfaces.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgSystem_IO_Pipelines)\lib\net462\System.IO.Pipelines.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\System.IO.Pipelines.dll</LogicalName>
+      <Link>System.IO.Pipelines.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
     <EmbeddedResource Include="$(PkgSystem_Text_Encodings_Web)\lib\net462\System.Text.Encodings.Web.dll">


### PR DESCRIPTION
## Summary

The self-extracting PerfView EXE is missing two transitive dependencies of **System.Text.Json 9.0.8**:
- `System.IO.Pipelines.dll`
- `Microsoft.Bcl.AsyncInterfaces.dll`

Without these DLLs, System.Text.Json silently fails when parsing `ProcessMappingMetadata.SymbolMetadata` JSON strings during nettrace-to-ETLX conversion. This causes `ParsedSymbolMetadata` to return null, so `MatchOrInitElf()`/`MatchOrInitPE()` are never called, `symbolInfo` stays null, and `BinaryFormat` returns `Unknown` — breaking ELF symbol resolution for Linux .nettrace traces.

## Root Cause

PerfView embeds DLLs as `EmbeddedResource` items in `PerfView.csproj`. System.Text.Json and its direct dependency System.Text.Encodings.Web were already embedded, but the transitive dependencies System.IO.Pipelines and Microsoft.Bcl.AsyncInterfaces were not. Local builds work because the output directory contains all transitive NuGet dependencies, but the official self-extracting EXE only includes explicitly listed resources.

## Verification

| Configuration | ELF Modules | PE Modules |
|---|---|---|
| Official 3.2.0 (missing deps) | 0 | 0 |
| Official + 2 missing DLLs added | 83 | 34 |
| Local build (all deps present) | 83 | 34 |

## Changes

- **`src/Directory.Packages.props`**: Added `System.IO.Pipelines` and `Microsoft.Bcl.AsyncInterfaces` v9.0.8
- **`src/PerfView/PerfView.csproj`**: Added `PackageReference` with `GeneratePathProperty="true"` and `EmbeddedResource` entries for both DLLs

## Testing

- Full build succeeds
- All 4565 TraceEvent tests pass (2271 net8.0 + 2288 net462 + 6 skipped)
- Standalone ETLX conversion test confirms correct module binary format detection
- End-to-end validation: isolated self-extracting PerfView.exe correctly extracts both DLLs and produces ETLX with 166 ElfSymbolInfo + 68 PESymbolInfo objects