### PR TITLE
Fix PDB Symbol Resolution for Unmerged Windows Traces

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <ReleaseVersion>3.2.1</ReleaseVersion>
+    <ReleaseVersion>3.2.2</ReleaseVersion>
     <FastSerializationVersion>$(ReleaseVersion)</FastSerializationVersion>
     <HeapDumpDllVersion>$(ReleaseVersion)</HeapDumpDllVersion>
     <MemoryGraphVersion>$(ReleaseVersion)</MemoryGraphVersion>

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -8970,10 +8970,34 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                     }
                     break;
 
+                case ModuleBinaryFormat.Unspecified:
+                    {
+                        // For unmerged Windows traces, symbolInfo is null because the ETL
+                        // didn't contain RSDS events with PDB identity info.
+                        // Fall back to PDB lookup on Windows, which handles missing signatures
+                        // gracefully and returns null if the file isn't a PE binary.
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            reader.m_log.WriteLine("LookupSymbolsForModule: Binary format unspecified for {0}, looking up PDB info from local file.", moduleFile.FilePath);
+                            NativeSymbolModule moduleReader = OpenPdbForModuleFile(reader, moduleFile) as NativeSymbolModule;
+                            if (moduleReader != null)
+                            {
+                                symbolLookup = moduleReader;
+                            }
+                            // Standard PE RVA computation.
+                            computeRva = (address) => (uint)(address - moduleFile.ImageBase);
+                        }
+                        else
+                        {
+                            reader.m_log.WriteLine("LookupSymbolsForModule: Binary format unspecified for {0}, skipping.", moduleFile.FilePath);
+                        }
+                    }
+                    break;
+
                 default:
                     {
-                        Debug.Assert(false, "LookupSymbolsForModule: unknown binary format " + moduleFile.BinaryFormat);
-                        reader.m_log.WriteLine("LookupSymbolsForModule: Unknown binary format {0} for {1}, skipping.", moduleFile.BinaryFormat, moduleFile.FilePath);
+                        Debug.Assert(false, "LookupSymbolsForModule: unrecognized binary format " + moduleFile.BinaryFormat);
+                        reader.m_log.WriteLine("LookupSymbolsForModule: Unrecognized binary format {0} for {1}, skipping.", moduleFile.BinaryFormat, moduleFile.FilePath);
                     }
                     break;
             }
@@ -10568,7 +10592,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// <summary>
         /// The binary format of this module file (PE, ELF, or Unknown).
         /// </summary>
-        public ModuleBinaryFormat BinaryFormat { get { return symbolInfo?.Format ?? ModuleBinaryFormat.Unknown; } }
+        public ModuleBinaryFormat BinaryFormat { get { return symbolInfo?.Format ?? ModuleBinaryFormat.Unspecified; } }
 
         /// <summary>
         /// PE-specific symbol info (PDB identity + R2R). Null if this is not a PE module.
@@ -10780,7 +10804,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             serializer.WriteAddress(imageBase);
 
             // Write symbol info with format discriminator
-            byte format = (byte)(symbolInfo?.Format ?? ModuleBinaryFormat.Unknown);
+            byte format = (byte)(symbolInfo?.Format ?? ModuleBinaryFormat.Unspecified);
             serializer.Write(format);
             if (symbolInfo != null)
             {
@@ -10836,8 +10860,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
     /// </summary>
     public enum ModuleBinaryFormat : byte
     {
-        /// <summary>The module format is unknown.</summary>
-        Unknown = 0,
+        /// <summary>The module format was not specified in the trace.</summary>
+        Unspecified = 0,
         /// <summary>Windows Portable Executable format.</summary>
         PE = 1,
         /// <summary>Linux ELF (Executable and Linkable Format).</summary>


### PR DESCRIPTION
The ELF symbol work introduced a switch on `BinaryFormat` in `LookupSymbolsForModule` that only handled `PE` and `ELF` cases. For unmerged Windows traces, `symbolInfo` is null because the ETL doesn't contain RSDS events with PDB identity info. This caused `BinaryFormat` to return `Unspecified` (formerly `Unknown`), hitting the default case which skipped symbol resolution entirely.

**Symptoms:**
```
[Loading symbols for c:\windows\system32\ntoskrnl.exe]
LookupSymbolsForModule: Unknown binary format Unknown for c:\windows\system32\ntoskrnl.exe, skipping.
Could not find symbols.
```

**Fix:**
- Add a `case ModuleBinaryFormat.Unspecified` that falls back to PDB lookup when running on Windows. `OpenPdbForModuleFile` already handles missing PDB signatures gracefully by checking the local file on disk.
- Rename `ModuleBinaryFormat.Unknown` to `Unspecified` to better reflect that the format was not specified in the trace data rather than being truly unknown.