### PR TITLE
Enable Spectre mitigations and linker optimizations for EtwClrProfiler

### DIFF
--- a/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
@@ -69,6 +69,7 @@
       <SDLCheck>true</SDLCheck>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/Gs %(AdditionalOptions)</AdditionalOptions>
+      <SpectreM>Spectre</SpectreM>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -92,6 +93,8 @@
       <AdditionalOptions>/Gs %(AdditionalOptions)</AdditionalOptions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <SDLCheck>true</SDLCheck>
+      <SpectreM>Spectre</SpectreM>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -101,6 +104,9 @@
       <CETCompat>true</CETCompat>
       <AdditionalOptions>/HIGHENTROPYVA %(AdditionalOptions)</AdditionalOptions>
       <LargeAddressAware>true</LargeAddressAware>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
@@ -69,6 +69,7 @@
       <AdditionalOptions>/Gs %(AdditionalOptions)</AdditionalOptions>
       <SDLCheck>true</SDLCheck>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SpectreM>Spectre</SpectreM>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -91,6 +92,8 @@
       <AdditionalOptions>/Gs %(AdditionalOptions)</AdditionalOptions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <SDLCheck>true</SDLCheck>
+      <SpectreM>Spectre</SpectreM>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -98,6 +101,9 @@
       <ModuleDefinitionFile>.\ETWClrProfiler.def</ModuleDefinitionFile>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <CETCompat>true</CETCompat>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Add build hardening flags to resolve BinSkim findings now that EtwClrProfiler is included in the official scan (PR 727750).

**Untested** and not suggesting you should take any of these (AFAIK none are required by SDL currently). Feel free to pick any all or none.

Both x86 and x64 vcxproj:
- BA2024: Enable Spectre mitigations (/Qspectre) in Debug and Release
- BA6004: Enable COMDAT folding (/OPT:ICF) in Release
- BA6005: Enable Optimize References (/OPT:REF) in Release
- BA6006: Enable Link-Time Code Generation (/LTCG + /GL) in Release