### PR TITLE
Binary symbol-server lookup 404s for /Brepro builds with leading-zero

### DIFF
--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -615,7 +615,16 @@ namespace Microsoft.Diagnostics.Symbols
                 {
                     if (exeIndexPath == null)
                     {
-                        exeIndexPath = fileName + @"\" + buildTimestamp.ToString("x") + sizeOfImage.ToString("x") + @"\" + fileName;
+                        // Symbol-server convention (matched by symsrv.dll/symchk) is
+                        // <TimeDateStamp:X8><SizeOfImage:X> — TimeDateStamp zero-padded
+                        // to 8 hex digits, SizeOfImage variable-width with no padding.
+                        // Using "x" without width drops the leading hex zero when the
+                        // value is < 0x10000000, producing a malformed key that 404s
+                        // even when the binary is indexed on the server. This hits real
+                        // binaries built with /Brepro (deterministic builds), where the
+                        // PE TimeDateStamp is a hash that can have leading zeros (e.g.
+                        // SystemSettings.dll on recent Windows: TS=0x0D9F641E).
+                        exeIndexPath = fileName + @"\" + buildTimestamp.ToString("x8") + sizeOfImage.ToString("x") + @"\" + fileName;
                     }
 
                     string cache = element.Cache;


### PR DESCRIPTION
Binary symbol-server lookup 404s for /Brepro builds with leading-zero

  SymbolReader.FindExecutableFilePath built the symbol-server key with
  buildTimestamp.ToString("x"), which drops the leading hex zero when the
  value is < 0x10000000. The symbol-server convention (matched by symsrv
  and symchk) requires TimeDateStamp zero-padded to 8 hex digits and
  SizeOfImage variable-width — so the produced URL is one digit short and
  404s even when the binary is indexed.

  This affects PE binaries built with /Brepro (deterministic builds),
  whose hash-based TimeDateStamp can legitimately have leading hex zeros.
  Concrete repro: SystemSettings.dll on recent Windows builds with
  TS=0x0D9F641E, SizeOfImage=0x599000 — server has key 0d9f641e599000,
  TraceEvent emitted d9f641e599000.

  Fix: use "x8" for TimeDateStamp. SizeOfImage stays "x" since the
  convention is variable-width there.

  PDB lookup (line 245) is unaffected: the GUID component uses "N" which
  always emits 32 chars regardless of value, and Age is variable-width on
  both client and server by convention.
  
  Fixes #2416 