### PR TITLE
Add support for showing stacks from selected events

### DIFF
--- a/src/PerfView.Tests/EventViewer/EventWindowTests.cs
+++ b/src/PerfView.Tests/EventViewer/EventWindowTests.cs
@@ -1,0 +1,311 @@
+using EventSources;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Stacks;
+using Microsoft.VisualStudio.Threading;
+using PerfView;
+using PerfView.TestUtilities;
+using PerfViewTests.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PerfViewTests.EventViewer
+{
+    public class EventWindowTests : PerfViewTestBase
+    {
+        public EventWindowTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForOneSelectedCellAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.OneCell);
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForTwoSelectedCellsAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.TwoCells);
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForThreeSelectedCellsAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.ThreeCells);
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForSelectedTimeRangeAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.TimeRange);
+        }
+
+        private Task TestOpenStacksAsync(SelectedCellScenario scenario)
+        {
+            Func<Task<EventWindow>> setupAsync = async () =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                var eventData = new PerfViewEventSource(new SelectedStacksFile());
+                var opened = new TaskCompletionSource<bool>();
+                eventData.Open(GuiApp.MainWindow, GuiApp.MainWindow.StatusBar, () => opened.SetResult(true));
+                await opened.Task.ConfigureAwait(true);
+
+                var eventWindow = eventData.Viewer;
+                eventWindow.EventTypes.SelectAll();
+                eventWindow.Update();
+                await eventWindow.StatusBar.WaitForWorkCompleteAsync().ConfigureAwait(true);
+                return eventWindow;
+            };
+
+            Func<EventWindow, Task> cleanupAsync = async eventWindow =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                foreach (var stackWindow in StackWindow.StackWindows.ToArray())
+                {
+                    stackWindow.Close();
+                }
+
+                eventWindow.Close();
+            };
+
+            Func<EventWindow, Task> testDriverAsync = async eventWindow =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                var selectedCells = eventWindow.Grid.SelectedCells;
+                if (scenario == SelectedCellScenario.TimeRange)
+                {
+                    var timeColumn = eventWindow.Grid.Columns.Single(column => Equals(column.Header, "Time MSec"));
+                    selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[1], timeColumn));
+                    selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[2], timeColumn));
+                }
+                else
+                {
+                    selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[1], eventWindow.Grid.Columns[0]));
+                    if (scenario == SelectedCellScenario.TwoCells)
+                    {
+                        selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[2], eventWindow.Grid.Columns[0]));
+                    }
+                    else if (scenario == SelectedCellScenario.ThreeCells)
+                    {
+                        // Select two cells from the first event to verify that rows are de-duplicated.
+                        selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[1], eventWindow.Grid.Columns[1]));
+                        selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[2], eventWindow.Grid.Columns[0]));
+                    }
+                }
+
+                EventWindow.OpenCpuStacksCommand.Execute(null, eventWindow.Grid);
+                await eventWindow.StatusBar.WaitForWorkCompleteAsync().ConfigureAwait(true);
+                await WaitForUIAsync(eventWindow.Dispatcher, CancellationToken.None);
+
+                var stackWindow = Assert.Single(StackWindow.StackWindows);
+                await stackWindow.StatusBar.WaitForWorkCompleteAsync().ConfigureAwait(true);
+                Assert.Equal("20.000", stackWindow.StartTextBox.Text);
+                if (scenario == SelectedCellScenario.OneCell)
+                {
+                    Assert.Equal("20.000", stackWindow.EndTextBox.Text);
+                    Assert.Equal(new[] { 20.0 }, GetSampleTimes(stackWindow.StackSource));
+                }
+                else if (scenario == SelectedCellScenario.TimeRange)
+                {
+                    Assert.Equal("30.000", stackWindow.EndTextBox.Text);
+                    Assert.Equal(new[] { 20.0, 25.0, 30.0, 30.0 }, GetSampleTimes(stackWindow.StackSource));
+                }
+                else
+                {
+                    Assert.Equal("30.000", stackWindow.EndTextBox.Text);
+                    Assert.Equal(new[] { 20.0, 30.0 }, GetSampleTimes(stackWindow.StackSource));
+                }
+            };
+
+            return RunUITestAsync(setupAsync, testDriverAsync, cleanupAsync);
+        }
+
+        private enum SelectedCellScenario
+        {
+            OneCell,
+            TwoCells,
+            ThreeCells,
+            TimeRange,
+        }
+
+        private static double[] GetSampleTimes(StackSource stackSource)
+        {
+            var times = new List<double>();
+            stackSource.ForEach(sample => times.Add(sample.TimeRelativeMSec));
+            return times.ToArray();
+        }
+
+        private sealed class SelectedStacksFile : PerfViewFile
+        {
+            private readonly PerfViewStackSource m_stackSource;
+
+            public SelectedStacksFile()
+            {
+                m_stackSource = new PerfViewStackSource(this, "CPU");
+                Title = FormatName = nameof(SelectedStacksFile);
+            }
+
+            public override string Title { get; }
+            public override string FormatName { get; }
+            public override string[] FileExtensions { get; } = new[] { "Selected Stacks Test" };
+            public override PerfViewStackSource GetStackSource(string sourceName = null) => m_stackSource;
+
+            protected internal override EventSource OpenEventSourceImpl(TextWriter log) => new SelectedStacksEventSource();
+
+            protected internal override StackSource OpenStackSourceImpl(
+                string streamName,
+                TextWriter log,
+                double startRelativeMSec = 0,
+                double endRelativeMSec = double.PositiveInfinity,
+                Predicate<TraceEvent> predicate = null)
+            {
+                return new SelectedStacksStackSource(startRelativeMSec, endRelativeMSec, predicate);
+            }
+        }
+
+        private sealed class SelectedStacksEventSource : EventSource
+        {
+            private readonly List<TestEtwEventRecord> m_events;
+
+            public override ICollection<string> EventNames { get; } = new[] { "Test/Event" };
+
+            public SelectedStacksEventSource()
+            {
+                MaxEventTimeRelativeMsec = 30;
+                var recordSource = CreateRecordSource();
+                m_events = new List<TestEtwEventRecord>
+                {
+                    new TestEtwEventRecord(recordSource, 10, (EventIndex)1),
+                    new TestEtwEventRecord(recordSource, 20, (EventIndex)2),
+                    new TestEtwEventRecord(recordSource, 30, (EventIndex)4),
+                };
+            }
+
+            public override EventSource Clone() => new SelectedStacksEventSource();
+            public override void SetEventFilter(List<string> eventNames) { }
+
+            public override void ForEach(Func<EventRecord, bool> callback)
+            {
+                foreach (var eventRecord in m_events.Where(e => e.TimeStampRelatveMSec >= StartTimeRelativeMSec && e.TimeStampRelatveMSec <= EndTimeRelativeMSec))
+                {
+                    if (!callback(eventRecord))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            private static ETWEventSource CreateRecordSource()
+            {
+#pragma warning disable SYSLIB0050 // Formatter-based initialization is used only for this lightweight test double.
+                var source = (ETWEventSource)FormatterServices.GetUninitializedObject(typeof(ETWEventSource));
+#pragma warning restore SYSLIB0050
+                typeof(ETWEventSource)
+                    .GetField("<SessionStartTime>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(source, new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+                typeof(ETWEventSource)
+                    .GetField("<OriginTimeZone>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(source, TimeZoneInfo.Utc);
+                return source;
+            }
+        }
+
+        private sealed class TestEtwEventRecord : ETWEventSource.ETWEventRecord
+        {
+            private readonly double m_time;
+
+            public TestEtwEventRecord(ETWEventSource source, double time, EventIndex index)
+                : base(source)
+            {
+                m_time = time;
+                m_displayFields = new string[12];
+                typeof(ETWEventSource.ETWEventRecord)
+                    .GetField("m_idx", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(this, index);
+            }
+
+            public override string EventName => "Test/Event";
+            public override string ProcessName => "test";
+            public override double TimeStampRelatveMSec => m_time;
+            public override string Rest { get => string.Empty; set { } }
+            public override List<Payload> Payloads { get; } = new List<Payload>();
+        }
+
+        private sealed class SelectedStacksStackSource : StackSource
+        {
+            private readonly List<StackSourceSample> m_samples = new List<StackSourceSample>();
+
+            public SelectedStacksStackSource(double startTime, double endTime, Predicate<TraceEvent> predicate)
+            {
+                var candidates = new[]
+                {
+                    new { Time = 10.0, Index = (EventIndex)1 },
+                    new { Time = 20.0, Index = (EventIndex)2 },
+                    new { Time = 25.0, Index = (EventIndex)3 },
+                    new { Time = 30.0, Index = (EventIndex)4 },
+                    new { Time = 30.0, Index = (EventIndex)5 },
+                };
+
+                foreach (var candidate in candidates)
+                {
+                    if (candidate.Time >= startTime &&
+                        candidate.Time <= endTime &&
+                        (predicate == null || predicate(new TestTraceEvent(candidate.Index))))
+                    {
+                        m_samples.Add(new StackSourceSample(this)
+                        {
+                            SampleIndex = (StackSourceSampleIndex)m_samples.Count,
+                            StackIndex = StackSourceCallStackIndex.Start,
+                            Metric = 1,
+                            TimeRelativeMSec = candidate.Time,
+                        });
+                    }
+                }
+            }
+
+            public override int CallStackIndexLimit => (int)StackSourceCallStackIndex.Start + 1;
+            public override int CallFrameIndexLimit => (int)StackSourceFrameIndex.Start + 1;
+            public override int SampleIndexLimit => m_samples.Count;
+            public override double SampleTimeRelativeMSecLimit => m_samples.LastOrDefault()?.TimeRelativeMSec ?? 0;
+            public override void ForEach(Action<StackSourceSample> callback) => m_samples.ForEach(callback);
+            public override StackSourceSample GetSampleByIndex(StackSourceSampleIndex sampleIndex) => m_samples[(int)sampleIndex];
+            public override StackSourceCallStackIndex GetCallerIndex(StackSourceCallStackIndex callStackIndex) => StackSourceCallStackIndex.Invalid;
+            public override StackSourceFrameIndex GetFrameIndex(StackSourceCallStackIndex callStackIndex) => StackSourceFrameIndex.Start;
+            public override string GetFrameName(StackSourceFrameIndex frameIndex, bool verboseName) => "Selected event stack";
+        }
+
+        private sealed class TestTraceEvent : TraceEvent
+        {
+            private static readonly FieldInfo EventIndexField = typeof(TraceEvent)
+                .GetField("eventIndex", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            public TestTraceEvent(EventIndex index)
+                : base(0, 0, "Test", Guid.Empty, 0, "Info", Guid.Empty, "Test")
+            {
+                EventIndexField.SetValue(this, index);
+            }
+
+            public override string[] PayloadNames { get; } = Array.Empty<string>();
+            public override object PayloadValue(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+            protected override Delegate Target { get; set; }
+        }
+    }
+}

--- a/src/PerfView.Tests/EventViewer/EventWindowTests.cs
+++ b/src/PerfView.Tests/EventViewer/EventWindowTests.cs
@@ -1,7 +1,8 @@
 using EventSources;
 using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using Microsoft.Diagnostics.Tracing.Stacks;
-using Microsoft.VisualStudio.Threading;
 using PerfView;
 using PerfView.TestUtilities;
 using PerfViewTests.Utilities;
@@ -9,11 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
 using Xunit;
 using Xunit.Abstractions;
@@ -60,8 +58,11 @@ namespace PerfViewTests.EventViewer
             Func<Task<EventWindow>> setupAsync = async () =>
             {
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
+                var tracePath = Path.Combine(AppContext.BaseDirectory, "EventViewer", "inputs", "net.4.5.2.x86.etl.zip");
+                var etlFile = Assert.IsType<ETLPerfViewData>(PerfViewFile.Get(tracePath));
+                var perfViewFile = new SampledProfileFile(etlFile);
 
-                var eventData = new PerfViewEventSource(new SelectedStacksFile());
+                var eventData = new PerfViewEventSource(perfViewFile);
                 var opened = new TaskCompletionSource<bool>();
                 eventData.Open(GuiApp.MainWindow, GuiApp.MainWindow.StatusBar, () => opened.SetResult(true));
                 await opened.Task.ConfigureAwait(true);
@@ -83,6 +84,7 @@ namespace PerfViewTests.EventViewer
                 }
 
                 eventWindow.Close();
+                eventWindow.DataSource.DataFile.Close();
             };
 
             Func<EventWindow, Task> testDriverAsync = async eventWindow =>
@@ -90,24 +92,27 @@ namespace PerfViewTests.EventViewer
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var selectedCells = eventWindow.Grid.SelectedCells;
+                var sampledProfileRows = GetSampledProfileRows(
+                    eventWindow,
+                    scenario == SelectedCellScenario.OneCell ? 1 : 2);
                 if (scenario == SelectedCellScenario.TimeRange)
                 {
                     var timeColumn = eventWindow.Grid.Columns.Single(column => Equals(column.Header, "Time MSec"));
-                    selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[1], timeColumn));
-                    selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[2], timeColumn));
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], timeColumn));
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], timeColumn));
                 }
                 else
                 {
-                    selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[1], eventWindow.Grid.Columns[0]));
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[0]));
                     if (scenario == SelectedCellScenario.TwoCells)
                     {
-                        selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[2], eventWindow.Grid.Columns[0]));
+                        selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
                     }
                     else if (scenario == SelectedCellScenario.ThreeCells)
                     {
                         // Select two cells from the first event to verify that rows are de-duplicated.
-                        selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[1], eventWindow.Grid.Columns[1]));
-                        selectedCells.Add(new DataGridCellInfo(eventWindow.Grid.Items[2], eventWindow.Grid.Columns[0]));
+                        selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[1]));
+                        selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
                     }
                 }
 
@@ -117,21 +122,27 @@ namespace PerfViewTests.EventViewer
 
                 var stackWindow = Assert.Single(StackWindow.StackWindows);
                 await stackWindow.StatusBar.WaitForWorkCompleteAsync().ConfigureAwait(true);
-                Assert.Equal("20.000", stackWindow.StartTextBox.Text);
+                var selectedTimes = scenario == SelectedCellScenario.OneCell
+                    ? new[] { sampledProfileRows[0].TimeStampRelatveMSec }
+                    : new[] { sampledProfileRows[0].TimeStampRelatveMSec, sampledProfileRows[1].TimeStampRelatveMSec };
+                var expectedStart = selectedTimes.Min();
+                var expectedEnd = selectedTimes.Max();
+
+                Assert.Equal(expectedStart.ToString("n3"), stackWindow.StartTextBox.Text);
                 if (scenario == SelectedCellScenario.OneCell)
                 {
-                    Assert.Equal("20.000", stackWindow.EndTextBox.Text);
-                    Assert.Equal(new[] { 20.0 }, GetSampleTimes(stackWindow.StackSource));
+                    Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
+                    Assert.Equal(selectedTimes, GetSampleTimes(stackWindow.StackSource));
                 }
                 else if (scenario == SelectedCellScenario.TimeRange)
                 {
-                    Assert.Equal("30.000", stackWindow.EndTextBox.Text);
-                    Assert.Equal(new[] { 20.0, 25.0, 30.0, 30.0 }, GetSampleTimes(stackWindow.StackSource));
+                    Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
+                    Assert.NotEmpty(GetSampleTimes(stackWindow.StackSource));
                 }
                 else
                 {
-                    Assert.Equal("30.000", stackWindow.EndTextBox.Text);
-                    Assert.Equal(new[] { 20.0, 30.0 }, GetSampleTimes(stackWindow.StackSource));
+                    Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
+                    Assert.Equal(selectedTimes.OrderBy(time => time), GetSampleTimes(stackWindow.StackSource).OrderBy(time => time));
                 }
             };
 
@@ -153,22 +164,50 @@ namespace PerfViewTests.EventViewer
             return times.ToArray();
         }
 
-        private sealed class SelectedStacksFile : PerfViewFile
+        private static ETWEventSource.ETWEventRecord[] GetSampledProfileRows(EventWindow eventWindow, int count)
         {
-            private readonly PerfViewStackSource m_stackSource;
+            var file = Assert.IsType<SampledProfileFile>(eventWindow.DataSource.DataFile);
+            var rows = eventWindow.Grid.Items
+                .OfType<ETWEventSource.ETWEventRecord>()
+                .Where(row => file.IsSampledProfileWithStack(row, eventWindow.StatusBar.LogWriter))
+                .Take(count)
+                .ToArray();
 
-            public SelectedStacksFile()
+            Assert.Equal(count, rows.Length);
+            return rows;
+        }
+
+        /// <summary>
+        /// Exposes the real ETL event and CPU-stack sources without running the Event Window's
+        /// unrelated cached-symbol lookup, which depends on a PerfView executable host.
+        /// </summary>
+        private sealed class SampledProfileFile : PerfViewFile
+        {
+            private readonly ETLPerfViewData m_file;
+            private readonly PerfViewStackSource m_cpuStacks;
+
+            public SampledProfileFile(ETLPerfViewData file)
             {
-                m_stackSource = new PerfViewStackSource(this, "CPU");
-                Title = FormatName = nameof(SelectedStacksFile);
+                m_file = file;
+                m_cpuStacks = new PerfViewStackSource(this, "CPU");
+                Title = file.Title;
             }
 
             public override string Title { get; }
-            public override string FormatName { get; }
-            public override string[] FileExtensions { get; } = new[] { "Selected Stacks Test" };
-            public override PerfViewStackSource GetStackSource(string sourceName = null) => m_stackSource;
+            public override string FormatName => m_file.FormatName;
+            public override string[] FileExtensions => m_file.FileExtensions;
+            public override string FilePath => m_file.FilePath;
+            public override PerfViewStackSource GetStackSource(string sourceName = null) => m_cpuStacks;
 
-            protected internal override EventSource OpenEventSourceImpl(TextWriter log) => new SelectedStacksEventSource();
+            protected internal override EventSource OpenEventSourceImpl(TextWriter log) => m_file.OpenEventSourceImpl(log);
+
+            public bool IsSampledProfileWithStack(ETWEventSource.ETWEventRecord row, TextWriter log)
+            {
+                var traceEvent = m_file.GetTraceLog(log).GetEvent(row.Index);
+                return traceEvent is SampledProfileTraceData &&
+                    traceEvent.ProcessID != 0 &&
+                    traceEvent.CallStackIndex() != CallStackIndex.Invalid;
+            }
 
             protected internal override StackSource OpenStackSourceImpl(
                 string streamName,
@@ -177,135 +216,10 @@ namespace PerfViewTests.EventViewer
                 double endRelativeMSec = double.PositiveInfinity,
                 Predicate<TraceEvent> predicate = null)
             {
-                return new SelectedStacksStackSource(startRelativeMSec, endRelativeMSec, predicate);
-            }
-        }
-
-        private sealed class SelectedStacksEventSource : EventSource
-        {
-            private readonly List<TestEtwEventRecord> m_events;
-
-            public override ICollection<string> EventNames { get; } = new[] { "Test/Event" };
-
-            public SelectedStacksEventSource()
-            {
-                MaxEventTimeRelativeMsec = 30;
-                var recordSource = CreateRecordSource();
-                m_events = new List<TestEtwEventRecord>
-                {
-                    new TestEtwEventRecord(recordSource, 10, (EventIndex)1),
-                    new TestEtwEventRecord(recordSource, 20, (EventIndex)2),
-                    new TestEtwEventRecord(recordSource, 30, (EventIndex)4),
-                };
+                return m_file.OpenStackSourceImpl(streamName, log, startRelativeMSec, endRelativeMSec, predicate);
             }
 
-            public override EventSource Clone() => new SelectedStacksEventSource();
-            public override void SetEventFilter(List<string> eventNames) { }
-
-            public override void ForEach(Func<EventRecord, bool> callback)
-            {
-                foreach (var eventRecord in m_events.Where(e => e.TimeStampRelatveMSec >= StartTimeRelativeMSec && e.TimeStampRelatveMSec <= EndTimeRelativeMSec))
-                {
-                    if (!callback(eventRecord))
-                    {
-                        break;
-                    }
-                }
-            }
-
-            private static ETWEventSource CreateRecordSource()
-            {
-#pragma warning disable SYSLIB0050 // Formatter-based initialization is used only for this lightweight test double.
-                var source = (ETWEventSource)FormatterServices.GetUninitializedObject(typeof(ETWEventSource));
-#pragma warning restore SYSLIB0050
-                typeof(ETWEventSource)
-                    .GetField("<SessionStartTime>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .SetValue(source, new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
-                typeof(ETWEventSource)
-                    .GetField("<OriginTimeZone>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .SetValue(source, TimeZoneInfo.Utc);
-                return source;
-            }
-        }
-
-        private sealed class TestEtwEventRecord : ETWEventSource.ETWEventRecord
-        {
-            private readonly double m_time;
-
-            public TestEtwEventRecord(ETWEventSource source, double time, EventIndex index)
-                : base(source)
-            {
-                m_time = time;
-                m_displayFields = new string[12];
-                typeof(ETWEventSource.ETWEventRecord)
-                    .GetField("m_idx", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .SetValue(this, index);
-            }
-
-            public override string EventName => "Test/Event";
-            public override string ProcessName => "test";
-            public override double TimeStampRelatveMSec => m_time;
-            public override string Rest { get => string.Empty; set { } }
-            public override List<Payload> Payloads { get; } = new List<Payload>();
-        }
-
-        private sealed class SelectedStacksStackSource : StackSource
-        {
-            private readonly List<StackSourceSample> m_samples = new List<StackSourceSample>();
-
-            public SelectedStacksStackSource(double startTime, double endTime, Predicate<TraceEvent> predicate)
-            {
-                var candidates = new[]
-                {
-                    new { Time = 10.0, Index = (EventIndex)1 },
-                    new { Time = 20.0, Index = (EventIndex)2 },
-                    new { Time = 25.0, Index = (EventIndex)3 },
-                    new { Time = 30.0, Index = (EventIndex)4 },
-                    new { Time = 30.0, Index = (EventIndex)5 },
-                };
-
-                foreach (var candidate in candidates)
-                {
-                    if (candidate.Time >= startTime &&
-                        candidate.Time <= endTime &&
-                        (predicate == null || predicate(new TestTraceEvent(candidate.Index))))
-                    {
-                        m_samples.Add(new StackSourceSample(this)
-                        {
-                            SampleIndex = (StackSourceSampleIndex)m_samples.Count,
-                            StackIndex = StackSourceCallStackIndex.Start,
-                            Metric = 1,
-                            TimeRelativeMSec = candidate.Time,
-                        });
-                    }
-                }
-            }
-
-            public override int CallStackIndexLimit => (int)StackSourceCallStackIndex.Start + 1;
-            public override int CallFrameIndexLimit => (int)StackSourceFrameIndex.Start + 1;
-            public override int SampleIndexLimit => m_samples.Count;
-            public override double SampleTimeRelativeMSecLimit => m_samples.LastOrDefault()?.TimeRelativeMSec ?? 0;
-            public override void ForEach(Action<StackSourceSample> callback) => m_samples.ForEach(callback);
-            public override StackSourceSample GetSampleByIndex(StackSourceSampleIndex sampleIndex) => m_samples[(int)sampleIndex];
-            public override StackSourceCallStackIndex GetCallerIndex(StackSourceCallStackIndex callStackIndex) => StackSourceCallStackIndex.Invalid;
-            public override StackSourceFrameIndex GetFrameIndex(StackSourceCallStackIndex callStackIndex) => StackSourceFrameIndex.Start;
-            public override string GetFrameName(StackSourceFrameIndex frameIndex, bool verboseName) => "Selected event stack";
-        }
-
-        private sealed class TestTraceEvent : TraceEvent
-        {
-            private static readonly FieldInfo EventIndexField = typeof(TraceEvent)
-                .GetField("eventIndex", BindingFlags.Instance | BindingFlags.NonPublic);
-
-            public TestTraceEvent(EventIndex index)
-                : base(0, 0, "Test", Guid.Empty, 0, "Info", Guid.Empty, "Test")
-            {
-                EventIndexField.SetValue(this, index);
-            }
-
-            public override string[] PayloadNames { get; } = Array.Empty<string>();
-            public override object PayloadValue(int index) => throw new ArgumentOutOfRangeException(nameof(index));
-            protected override Delegate Target { get; set; }
+            public override void Close() => m_file.Close();
         }
     }
 }

--- a/src/PerfView.Tests/EventViewer/EventWindowTests.cs
+++ b/src/PerfView.Tests/EventViewer/EventWindowTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
@@ -58,7 +59,8 @@ namespace PerfViewTests.EventViewer
             Func<Task<EventWindow>> setupAsync = async () =>
             {
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
-                var tracePath = Path.Combine(AppContext.BaseDirectory, "EventViewer", "inputs", "net.4.5.2.x86.etl.zip");
+
+                var tracePath = GetExtractedTracePath();
                 var etlFile = Assert.IsType<ETLPerfViewData>(PerfViewFile.Get(tracePath));
                 var perfViewFile = new SampledProfileFile(etlFile);
 
@@ -162,6 +164,29 @@ namespace PerfViewTests.EventViewer
             var times = new List<double>();
             stackSource.ForEach(sample => times.Add(sample.TimeRelativeMSec));
             return times.ToArray();
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        private static string GetExtractedTracePath()
+        {
+            var inputDirectory = Path.Combine(AppContext.BaseDirectory, "EventViewer", "inputs");
+            var zipPath = Path.Combine(inputDirectory, "net.4.5.2.x86.etl.zip");
+            var extractedDirectory = Path.Combine(AppContext.BaseDirectory, "EventViewer", "unzipped");
+            var etlPath = Path.Combine(extractedDirectory, Path.GetFileNameWithoutExtension(zipPath));
+
+            Directory.CreateDirectory(extractedDirectory);
+            if (!File.Exists(etlPath) || File.GetLastWriteTimeUtc(etlPath) < File.GetLastWriteTimeUtc(zipPath))
+            {
+                var zipReader = new ZippedETLReader(zipPath)
+                {
+                    EtlFileName = etlPath,
+                    SymbolDirectory = Path.Combine(extractedDirectory, "Symbols"),
+                };
+                zipReader.UnpackArchive();
+            }
+
+            Assert.True(File.Exists(etlPath));
+            return etlPath;
         }
 
         private static ETWEventSource.ETWEventRecord[] GetSampledProfileRows(EventWindow eventWindow, int count)

--- a/src/PerfView.Tests/EventViewer/EventWindowTests.cs
+++ b/src/PerfView.Tests/EventViewer/EventWindowTests.cs
@@ -21,6 +21,8 @@ namespace PerfViewTests.EventViewer
 {
     public class EventWindowTests : PerfViewTestBase
     {
+        private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(2);
+
         public EventWindowTests(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)
         {
@@ -58,72 +60,109 @@ namespace PerfViewTests.EventViewer
         {
             Func<Task<EventWindow>> setupAsync = async () =>
             {
+                var tracePath = await WithTimeoutAsync(
+                    Task.Run(() => GetExtractedTracePath()),
+                    "extracting the ETL fixture").ConfigureAwait(false);
+
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                var tracePath = GetExtractedTracePath();
                 var etlFile = Assert.IsType<ETLPerfViewData>(PerfViewFile.Get(tracePath));
-                var perfViewFile = new SampledProfileFile(etlFile);
+                try
+                {
+                    var perfViewFile = new SampledProfileFile(etlFile);
+                    var eventData = new PerfViewEventSource(perfViewFile);
+                    var opened = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    eventData.Open(GuiApp.MainWindow, GuiApp.MainWindow.StatusBar, () => opened.TrySetResult(true));
+                    await WithTimeoutAsync(opened.Task, "opening the Event Window").ConfigureAwait(true);
 
-                var eventData = new PerfViewEventSource(perfViewFile);
-                var opened = new TaskCompletionSource<bool>();
-                eventData.Open(GuiApp.MainWindow, GuiApp.MainWindow.StatusBar, () => opened.SetResult(true));
-                await opened.Task.ConfigureAwait(true);
-
-                var eventWindow = eventData.Viewer;
-                eventWindow.EventTypes.SelectAll();
-                eventWindow.Update();
-                await eventWindow.StatusBar.WaitForWorkCompleteAsync().ConfigureAwait(true);
-                return eventWindow;
+                    var eventWindow = eventData.Viewer;
+                    eventWindow.EventTypes.SelectAll();
+                    eventWindow.Update();
+                    await WithTimeoutAsync(
+                        eventWindow.StatusBar.WaitForWorkCompleteAsync(),
+                        "loading events from the ETL fixture").ConfigureAwait(true);
+                    return eventWindow;
+                }
+                catch
+                {
+                    etlFile.Close();
+                    throw;
+                }
             };
 
             Func<EventWindow, Task> cleanupAsync = async eventWindow =>
             {
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                foreach (var stackWindow in StackWindow.StackWindows.ToArray())
+                try
                 {
-                    stackWindow.Close();
-                }
+                    foreach (var stackWindow in StackWindow.StackWindows.ToArray())
+                    {
+                        stackWindow.Close();
+                    }
 
-                eventWindow.Close();
-                eventWindow.DataSource.DataFile.Close();
+                    eventWindow.Close();
+                }
+                finally
+                {
+                    eventWindow.DataSource.DataFile.Close();
+                }
             };
 
             Func<EventWindow, Task> testDriverAsync = async eventWindow =>
             {
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                var selectedCells = eventWindow.Grid.SelectedCells;
-                var sampledProfileRows = GetSampledProfileRows(
-                    eventWindow,
-                    scenario == SelectedCellScenario.OneCell ? 1 : 2);
-                if (scenario == SelectedCellScenario.TimeRange)
-                {
-                    var timeColumn = eventWindow.Grid.Columns.Single(column => Equals(column.Header, "Time MSec"));
-                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], timeColumn));
-                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], timeColumn));
-                }
-                else
-                {
-                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[0]));
-                    if (scenario == SelectedCellScenario.TwoCells)
-                    {
-                        selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
-                    }
-                    else if (scenario == SelectedCellScenario.ThreeCells)
-                    {
-                        // Select two cells from the first event to verify that rows are de-duplicated.
-                        selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[1]));
-                        selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
-                    }
-                }
+                await VerifyScenarioAsync(eventWindow, scenario).ConfigureAwait(true);
+            };
 
-                EventWindow.OpenCpuStacksCommand.Execute(null, eventWindow.Grid);
-                await eventWindow.StatusBar.WaitForWorkCompleteAsync().ConfigureAwait(true);
-                await WaitForUIAsync(eventWindow.Dispatcher, CancellationToken.None);
+            return RunUITestAsync(setupAsync, testDriverAsync, cleanupAsync);
+        }
 
-                var stackWindow = Assert.Single(StackWindow.StackWindows);
-                await stackWindow.StatusBar.WaitForWorkCompleteAsync().ConfigureAwait(true);
+        private async Task VerifyScenarioAsync(EventWindow eventWindow, SelectedCellScenario scenario)
+        {
+            Assert.Same(eventWindow.Dispatcher.Thread, Thread.CurrentThread);
+
+            var selectedCells = eventWindow.Grid.SelectedCells;
+            selectedCells.Clear();
+            var sampledProfileRows = GetSampledProfileRows(
+                eventWindow,
+                scenario == SelectedCellScenario.OneCell ? 1 : 2);
+            if (scenario == SelectedCellScenario.TimeRange)
+            {
+                var timeColumn = eventWindow.Grid.Columns.Single(column => Equals(column.Header, "Time MSec"));
+                selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], timeColumn));
+                selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], timeColumn));
+            }
+            else
+            {
+                selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[0]));
+                if (scenario == SelectedCellScenario.TwoCells)
+                {
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
+                }
+                else if (scenario == SelectedCellScenario.ThreeCells)
+                {
+                    // Select two cells from the first event to verify that rows are de-duplicated.
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[1]));
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
+                }
+            }
+
+            EventWindow.OpenCpuStacksCommand.Execute(null, eventWindow.Grid);
+            await WithTimeoutAsync(
+                eventWindow.StatusBar.WaitForWorkCompleteAsync(),
+                $"opening CPU stacks for {scenario}").ConfigureAwait(true);
+            await WithTimeoutAsync(
+                WaitForUIAsync(eventWindow.Dispatcher, CancellationToken.None),
+                $"dispatching the stack window for {scenario}").ConfigureAwait(true);
+
+            var stackWindow = Assert.Single(StackWindow.StackWindows);
+            try
+            {
+                await WithTimeoutAsync(
+                    stackWindow.StatusBar.WaitForWorkCompleteAsync(),
+                    $"computing the stack view for {scenario}").ConfigureAwait(true);
                 var selectedTimes = scenario == SelectedCellScenario.OneCell
                     ? new[] { sampledProfileRows[0].TimeStampRelatveMSec }
                     : new[] { sampledProfileRows[0].TimeStampRelatveMSec, sampledProfileRows[1].TimeStampRelatveMSec };
@@ -131,24 +170,48 @@ namespace PerfViewTests.EventViewer
                 var expectedEnd = selectedTimes.Max();
 
                 Assert.Equal(expectedStart.ToString("n3"), stackWindow.StartTextBox.Text);
-                if (scenario == SelectedCellScenario.OneCell)
+                Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
+                if (scenario == SelectedCellScenario.TimeRange)
                 {
-                    Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
-                    Assert.Equal(selectedTimes, GetSampleTimes(stackWindow.StackSource));
-                }
-                else if (scenario == SelectedCellScenario.TimeRange)
-                {
-                    Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
                     Assert.NotEmpty(GetSampleTimes(stackWindow.StackSource));
                 }
                 else
                 {
-                    Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
-                    Assert.Equal(selectedTimes.OrderBy(time => time), GetSampleTimes(stackWindow.StackSource).OrderBy(time => time));
+                    Assert.Equal(
+                        selectedTimes.OrderBy(time => time),
+                        GetSampleTimes(stackWindow.StackSource).OrderBy(time => time));
                 }
-            };
+            }
+            finally
+            {
+                stackWindow.Close();
+            }
+        }
 
-            return RunUITestAsync(setupAsync, testDriverAsync, cleanupAsync);
+        private static async Task<T> WithTimeoutAsync<T>(Task<T> task, string operation)
+        {
+            var timeoutTask = Task.Delay(TestTimeout);
+#pragma warning disable VSTHRD003 // Deliberately bound an externally-created operation in test code.
+            if (await Task.WhenAny(task, timeoutTask).ConfigureAwait(true) != task)
+            {
+                throw new TimeoutException($"Timed out after {TestTimeout} while {operation}.");
+            }
+
+            return await task.ConfigureAwait(true);
+#pragma warning restore VSTHRD003
+        }
+
+        private static async Task WithTimeoutAsync(Task task, string operation)
+        {
+            var timeoutTask = Task.Delay(TestTimeout);
+#pragma warning disable VSTHRD003 // Deliberately bound an externally-created operation in test code.
+            if (await Task.WhenAny(task, timeoutTask).ConfigureAwait(true) != task)
+            {
+                throw new TimeoutException($"Timed out after {TestTimeout} while {operation}.");
+            }
+
+            await task.ConfigureAwait(true);
+#pragma warning restore VSTHRD003
         }
 
         private enum SelectedCellScenario

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -14,6 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\TraceEvent\TraceEvent.Tests\inputs\net.4.5.2.x86.etl.zip">
+      <Link>EventViewer\inputs\net.4.5.2.x86.etl.zip</Link>
+      <TargetPath>EventViewer\inputs\net.4.5.2.x86.etl.zip</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -1,6 +1,9 @@
-﻿using EventSources;
+﻿using Diagnostics.Tracing.StackSources;
+using EventSources;
 using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Stacks;
 using Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression;
 using Microsoft.Diagnostics.Utilities;
 using Microsoft.IdentityModel.Tokens;
@@ -459,41 +462,38 @@ namespace PerfView
                 var startTimeRelativeMSec = m_source.StartTimeRelativeMSec;
                 var endTimeRelativeMSec = m_source.EndTimeRelativeMSec;
                 var selectedCells = Grid.SelectedCells;
-                if (selectedCells.Count == 1 || selectedCells.Count == 2)
+                if (selectedCells.Count == 2)
                 {
                     string start = GetCellStringValue(selectedCells[0]);
                     double parsedStart;
                     if (!double.TryParse(start, out parsedStart))
                     {
-                        if (selectedCells.Count != 1)
-                        {
                             StatusBar.LogError("Could not parse " + start + " as a number.");
+                            OpenSelectedStacks(stackSourceName, selectedCells);
                             return;
-                        }
-                        StatusBar.Log("Assuming total current time range");
                     }
-                    else
-                    {
-                        startTimeRelativeMSec = parsedStart;
-                        endTimeRelativeMSec = parsedStart;
-                        if (selectedCells.Count == 2)
-                        {
-                            string end = GetCellStringValue(selectedCells[1]);
-                            if (!double.TryParse(end, out endTimeRelativeMSec))
-                            {
-                                StatusBar.LogError("Could not parse " + end + " as a number.");
-                                return;
-                            }
-                        }
 
-                        // Make sure that start < end
-                        if (endTimeRelativeMSec < startTimeRelativeMSec)
-                        {
-                            var tmp = startTimeRelativeMSec;
-                            startTimeRelativeMSec = endTimeRelativeMSec;
-                            endTimeRelativeMSec = tmp;
-                        }
+                    startTimeRelativeMSec = parsedStart;
+                    string end = this.GetCellStringValue(selectedCells[1]);
+                    if (!double.TryParse(end, out endTimeRelativeMSec))
+                    {
+                        this.StatusBar.LogError("Could not parse " + end + " as a number.");
+                        this.OpenSelectedStacks(stackSourceName, selectedCells);
+                        return;
                     }
+
+                    // Make sure that start < end
+                    if (endTimeRelativeMSec < startTimeRelativeMSec)
+                    {
+                        var tmp = startTimeRelativeMSec;
+                        startTimeRelativeMSec = endTimeRelativeMSec;
+                        endTimeRelativeMSec = tmp;
+                    }
+                }
+                else if (selectedCells.Count != 2)
+                {
+                    OpenSelectedStacks(stackSourceName, selectedCells);
+                    return;
                 }
 
                 // TODO FIX NOW: this should call a routine that does the opening of the stack view
@@ -557,6 +557,125 @@ namespace PerfView
                 });
             }
         }
+
+        private void OpenSelectedStacks(string stackSourceName, IList<DataGridCellInfo> selectedCells)
+        {
+            if (selectedCells == null || selectedCells.Count == 0)
+            {
+                StatusBar.LogError("No events selected.");
+                return;
+            }
+
+            StatusBar.StartWork("Reading " + DataSource.Name, delegate ()
+            {
+                PerfViewStackSource dataSource = null;
+                var dataFile = DataSource.DataFile;
+                if (dataFile != null)
+                {
+                    if (stackSourceName == null)
+                    {
+                        stackSourceName = dataFile.DefaultStackSourceName;
+                    }
+
+                    dataSource = dataFile.GetStackSource(stackSourceName);
+                }
+
+                if (dataSource == null)
+                {
+                    throw new ApplicationException("Could not find stack source " + stackSourceName);
+                }
+
+                // Collect unique event records (a row may have multiple selected cells).
+                var uniqueRecords = selectedCells
+                    .Select(c => c.Item as EventRecord)
+                    .Where(r => r != null)
+                    .Distinct()
+                    .ToList();
+
+                if (uniqueRecords.Count == 0)
+                {
+                    StatusBar.EndWork(delegate ()
+                    {
+                        StatusBar.LogError("No event records found in selection.");
+                    });
+                    return;
+                }
+
+                StackSource aggregateSource;
+
+                // For ETW sources, filter by exact EventIndex so concurrent events on other
+                // threads at the same timestamp are excluded.
+                var etwRecords = uniqueRecords.OfType<ETWEventSource.ETWEventRecord>().ToList();
+                var startTimeRelativeMSec = etwRecords.Min(r => r.TimeStampRelatveMSec);
+                var endTimeRelativeMSec = etwRecords.Max(r => r.TimeStampRelatveMSec);
+                if (etwRecords.Count == uniqueRecords.Count)
+                {
+                    var selectedIndices = new HashSet<EventIndex>(etwRecords.Select(r => r.Index));
+                    aggregateSource = dataSource.GetStackSource(
+                        StatusBar.LogWriter,
+                        startTimeRelativeMSec - .001,
+                        endTimeRelativeMSec + .001,
+                        data => selectedIndices.Contains(data.EventIndex));
+                }
+                else
+                {
+                        // Fall back to per-event time windows for non-ETW sources.
+                        var sources = new List<StackSource>();
+                        foreach (var record in uniqueRecords)
+                        {
+                            sources.Add(dataSource.GetStackSource(
+                                StatusBar.LogWriter,
+                                record.TimeStampRelatveMSec - .001,
+                                record.TimeStampRelatveMSec + .001));
+                        }
+                        aggregateSource = InternStackSource.Merge(sources);
+                }
+
+                if (aggregateSource == null)
+                {
+                    StatusBar.EndWork(delegate ()
+                    {
+                        StatusBar.LogError("Could not open stacks for selected events.");
+                    });
+                    return;
+                }
+
+                if (!m_lookedUpCachedSymbolsForETLData)
+                {
+                    m_lookedUpCachedSymbolsForETLData = true;
+                    StatusBar.Log("Quick Looking up symbols from PDB cache.");
+                    var etlDataFile = dataFile as ETLPerfViewData;
+                    if (etlDataFile != null)
+                    {
+                        var traceLog = etlDataFile.GetTraceLog(StatusBar.LogWriter);
+                        using (var reader = etlDataFile.GetSymbolReader(StatusBar.LogWriter,
+                                   SymbolReaderOptions.CacheOnly | SymbolReaderOptions.NoNGenSymbolCreation))
+                        {
+                            var moduleFiles = ETLPerfViewData.GetInterestingModuleFiles(etlDataFile, 5.0, StatusBar.LogWriter, null);
+                            foreach (var moduleFile in moduleFiles)
+                            {
+                                traceLog.CodeAddresses.LookupSymbolsForModule(reader, moduleFile);
+                            }
+                        }
+                    }
+                    StatusBar.Log("Quick Done looking up symbols from PDB cache.");
+                }
+
+                StatusBar.EndWork(delegate ()
+                {
+                    App.CommandProcessor.NoExitOnElevate = true;
+
+                    var stackWindow = new PerfView.StackWindow(this, dataSource);
+                    stackWindow.StatusBar.Log("Read " + DataSource.Name);
+                    dataSource.ConfigureStackWindow(stackWindow);
+                    stackWindow.StartTextBox.Text = startTimeRelativeMSec.ToString();
+                    stackWindow.EndTextBox.Text = endTimeRelativeMSec.ToString();
+                    stackWindow.Show();
+                    stackWindow.SetStackSource(aggregateSource);
+                });
+            });
+        }
+
         private void DoProcessFilter(object sender, ExecutedRoutedEventArgs e)
         {
             var selectedCells = Grid.SelectedCells;

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -461,7 +461,7 @@ namespace PerfView
                 // If we have selected exactly two items, use that as the time limits, otherwise use what is the my dialog.
                 var startTimeRelativeMSec = m_source.StartTimeRelativeMSec;
                 var endTimeRelativeMSec = m_source.EndTimeRelativeMSec;
-                var selectedCells = Grid.SelectedCells;
+                var selectedCells = Grid.SelectedCells.ToList();
                 if (selectedCells.Count == 2)
                 {
                     string start = GetCellStringValue(selectedCells[0]);
@@ -490,7 +490,7 @@ namespace PerfView
                         endTimeRelativeMSec = tmp;
                     }
                 }
-                else if (selectedCells.Count != 2)
+                else if (selectedCells.Count > 0)
                 {
                     OpenSelectedStacks(stackSourceName, selectedCells);
                     return;
@@ -606,10 +606,13 @@ namespace PerfView
                 // For ETW sources, filter by exact EventIndex so concurrent events on other
                 // threads at the same timestamp are excluded.
                 var etwRecords = uniqueRecords.OfType<ETWEventSource.ETWEventRecord>().ToList();
-                var startTimeRelativeMSec = etwRecords.Min(r => r.TimeStampRelatveMSec);
-                var endTimeRelativeMSec = etwRecords.Max(r => r.TimeStampRelatveMSec);
+                double startTimeRelativeMSec;
+                double endTimeRelativeMSec;
                 if (etwRecords.Count == uniqueRecords.Count)
                 {
+                    startTimeRelativeMSec = etwRecords.Min(r => r.TimeStampRelatveMSec);
+                    endTimeRelativeMSec = etwRecords.Max(r => r.TimeStampRelatveMSec);
+
                     var selectedIndices = new HashSet<EventIndex>(etwRecords.Select(r => r.Index));
                     aggregateSource = dataSource.GetStackSource(
                         StatusBar.LogWriter,
@@ -619,16 +622,14 @@ namespace PerfView
                 }
                 else
                 {
-                        // Fall back to per-event time windows for non-ETW sources.
-                        var sources = new List<StackSource>();
-                        foreach (var record in uniqueRecords)
-                        {
-                            sources.Add(dataSource.GetStackSource(
-                                StatusBar.LogWriter,
-                                record.TimeStampRelatveMSec - .001,
-                                record.TimeStampRelatveMSec + .001));
-                        }
-                        aggregateSource = InternStackSource.Merge(sources);
+                    // Non-ETW records have no EventIndex for an exact event filter.
+                    // Use one stack source covering the selected records' time range.
+                    startTimeRelativeMSec = uniqueRecords.Min(r => r.TimeStampRelatveMSec);
+                    endTimeRelativeMSec = uniqueRecords.Max(r => r.TimeStampRelatveMSec);
+                    aggregateSource = dataSource.GetStackSource(
+                        StatusBar.LogWriter,
+                        startTimeRelativeMSec - .001,
+                        endTimeRelativeMSec + .001);
                 }
 
                 if (aggregateSource == null)

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4571,7 +4571,24 @@ namespace PerfView
             return ret;
         }
 
-        // TODO not clear I want this method 
+        public virtual StackSource GetStackSource(TextWriter log, double startRelativeMSec, double endRelativeMSec, Predicate<TraceEvent> predicate)
+        {
+            StackSource ret = DataFile.OpenStackSourceImpl(SourceName, log, startRelativeMSec, endRelativeMSec, predicate);
+            if (ret == null)
+            {
+                // Fall back to implementation without predicate
+                ret = DataFile.OpenStackSourceImpl(SourceName, log, startRelativeMSec, endRelativeMSec);
+            }
+
+            if (ret == null)
+            {
+                throw new ApplicationException("Not a file type that supports the StackView.");
+            }
+
+            return ret;
+        }
+
+        // TODO not clear I want this method
         protected virtual StackSource OpenStackSource(
             string streamName, TextWriter log, double startRelativeMSec = 0, double endRelativeMSec = double.PositiveInfinity, Predicate<TraceEvent> predicate = null)
         {

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4574,11 +4574,6 @@ namespace PerfView
         public virtual StackSource GetStackSource(TextWriter log, double startRelativeMSec, double endRelativeMSec, Predicate<TraceEvent> predicate)
         {
             StackSource ret = DataFile.OpenStackSourceImpl(SourceName, log, startRelativeMSec, endRelativeMSec, predicate);
-            if (ret == null)
-            {
-                // Fall back to implementation without predicate
-                ret = DataFile.OpenStackSourceImpl(SourceName, log, startRelativeMSec, endRelativeMSec);
-            }
 
             if (ret == null)
             {

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4577,7 +4577,7 @@ namespace PerfView
 
             if (ret == null)
             {
-                throw new ApplicationException("Not a file type that supports the StackView.");
+                throw new ApplicationException($"The {SourceName} does not support filtering by selected events.");
             }
 
             return ret;

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -3641,10 +3641,27 @@
             (lower right corner).&nbsp;&nbsp;
         </li>
         <li>
-            <strong>Viewing Stacks</strong> If an event has a stack trace associated with it
-            the 'HasStack' field will be true. By selecting the time of that event and hitting
-            Alt-S you can see the stack for that time (which will include that events). You
-            can also select two times, and that region will be shown in the AnyStack view.
+            <strong>Viewing Stacks</strong> - An event has a stack when its 'HasStack' value is
+            true. To view it, click a cell in that event's row, then right click and choose
+            'Open Any Stacks', or press Alt-S. To view stacks for several events together, hold
+            Ctrl and click a cell in each row before opening the stacks.
+            <ul>
+                <li>
+                    Selecting more than one cell in the same row still includes that event only once.
+                </li>
+                <li>
+                    If you select exactly two cells containing numbers, PerfView tries to use the numbers
+                    as the start and end times and opens all stacks in that time range.
+                </li>
+                <li>
+                    If no cells are selected, PerfView opens the stacks for the time range currently
+                    shown in the Event Viewer.
+                </li>
+                <li>
+                    Some file types cannot identify stacks for individual events. For these files,
+                    PerfView opens all stacks between the first and last selected events.
+                </li>
+            </ul>
         </li>
         <li>
             <strong>Selecting columns </strong>- hitting the &#39;cols&#39; dropdown allows

--- a/src/TraceEvent/Stacks/Stacks.cs
+++ b/src/TraceEvent/Stacks/Stacks.cs
@@ -738,6 +738,30 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
+        /// Merge multiple stack sources into a single unified source by re-interning all frames by name.
+        /// Frames with the same name across sources (e.g. the same process frame) are automatically merged.
+        /// </summary>
+        public static InternStackSource Merge(IEnumerable<StackSource> sources)
+        {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            var ret = new InternStackSource();
+            foreach (var source in sources)
+            {
+                if (source == null)
+                {
+                    continue;
+                }
+                ret.ReadAllSamples(source, source, 1.0F);
+            }
+            ret.Interner.DoneInterning();
+            return ret;
+        }
+
+        /// <summary>
         /// Create a new InternStackSource
         /// </summary>
         public InternStackSource()

--- a/src/TraceEvent/Stacks/Stacks.cs
+++ b/src/TraceEvent/Stacks/Stacks.cs
@@ -738,30 +738,6 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
         }
 
         /// <summary>
-        /// Merge multiple stack sources into a single unified source by re-interning all frames by name.
-        /// Frames with the same name across sources (e.g. the same process frame) are automatically merged.
-        /// </summary>
-        public static InternStackSource Merge(IEnumerable<StackSource> sources)
-        {
-            if (sources == null)
-            {
-                throw new ArgumentNullException(nameof(sources));
-            }
-
-            var ret = new InternStackSource();
-            foreach (var source in sources)
-            {
-                if (source == null)
-                {
-                    continue;
-                }
-                ret.ReadAllSamples(source, source, 1.0F);
-            }
-            ret.Interner.DoneInterning();
-            return ret;
-        }
-
-        /// <summary>
         /// Create a new InternStackSource
         /// </summary>
         public InternStackSource()


### PR DESCRIPTION
This pull request introduces the ability to show stacks for selected events with the 'Open Any Stacks' function, regardless of the column of the event selected. Previously, stacks were only accessible for either a single time or a time range and defaulted to the everything when some other selection happened. With this update:
- Stacks are now filtered by event ID in addition to time.
- Selecting any number of events and viewing their stacks is possible.
- Behavior for selecting time ranges remains unchanged.

Issue #2394