### PR TITLE
Stop lowercasing module file names sometimes

### DIFF
--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -10769,11 +10769,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         #region Private
         internal TraceModuleFile(string fileName, Address imageBase, ModuleFileIndex moduleFileIndex)
         {
-            if (fileName != null)
-            {
-                this.fileName = fileName.ToLowerInvariant();        // Normalize to lower case.
-            }
-
+            this.fileName = fileName;
             this.imageBase = imageBase;
             this.moduleFileIndex = moduleFileIndex;
             fileVersion = "";


### PR DESCRIPTION
This is a suggestion for how to fix https://github.com/dotnet/diagnostics/issues/5835.

I don't understand the codebase in depth so I'm really not sure this is the correct fix. But what I do know is that speedscope casing is now consistent. Empirically, it looks like this constructor where the module name is lowercases is used some portion of the time, and then other times the correctly case module name is used via some other codepath. But that's just a guess.


 Here's a random example before. Unfortunately, the speedscope files are too big, so screenshots of speedscope.app is all I can easily provide:

Old behavior. Notably, *most* of the modules are correctly cased, but not all:
<img width="1916" height="293" alt="image" src="https://github.com/user-attachments/assets/364e0bdb-c4ed-404e-9f43-66dfb24dead3" />
<img width="1910" height="314" alt="image" src="https://github.com/user-attachments/assets/e2c3b0f4-3f39-4208-b251-0d9bf02521ff" />

Behavior with this patch (modules consistently case, speedscope can correctly group calls together, color consistently, etc)

<img width="1839" height="289" alt="image" src="https://github.com/user-attachments/assets/eef6b448-d10e-42fc-ad00-39f0ed49091a" />


<img width="1739" height="313" alt="image" src="https://github.com/user-attachments/assets/89b8e06e-d0c8-4d81-b885-49e2ace3289a" />


