### PR TITLE
C entrypoint fixes

### DIFF
--- a/src/TraceEvent/TraceEventStacks.cs
+++ b/src/TraceEvent/TraceEventStacks.cs
@@ -673,6 +673,14 @@ namespace Microsoft.Diagnostics.Tracing.Stacks
                     return true;
                 }
 
+                // On Linux, <processName>!_start is an ELF entry point for C programs.
+                string processName = m_log.Threads[threadIndex].Process.Name;
+                if (string.Compare(moduleFileName, processName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    m_goodTopModuleIndex = moduleFileIndex;
+                    return true;
+                }
+
                 // The special processes 4 (System) and 0 (Kernel) can stay in the kernel without being broken.  
                 if (moduleFile.FilePath.EndsWith("ntoskrnl.exe", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -8570,10 +8570,12 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             Debug.Assert(process != null);
 
+            // EndAddress is inclusive, so add one to get the exclusive length.
+            long symbolLength = (long)(data.EndAddress - data.StartAddress + 1);
+
             // Skip symbols with invalid address ranges. The length parameter to ForAllUnresolvedCodeAddressesInRange
             // is a signed long, so ranges whose unsigned size exceeds long.MaxValue (e.g., [0x0, 0xFFFFFFFFFFFFFFFF)
             // from zeroed /proc/kallsyms on Linux without root) would overflow to a negative value and must be rejected.
-            long symbolLength = (long)(data.EndAddress - data.StartAddress);
             if (symbolLength <= 0)
             {
                 return;


### PR DESCRIPTION
A couple fixes related to https://github.com/microsoft/one-collect/pull/268:

- Recognize `<module>!_start` as a valid top frame
- Bump symbol length by one for dynamic symbols to catch addresses on the symbol end boundary. `_start` seems to be a pathological case

With the one-collect change and these fixes we get a complete stack:

```
+ Process32 workload (140228) Args: workload
 + Thread (140228) CPU=19984ms
  + workload!_start
  |+ libc.so.6!__libc_start_main
  | + libc.so.6!__libc_start_call_main
  |  + workload!main
  |   + workload!run_workload
  |    + workload!hot_loop
  |    + workload!warm_loop
  |    + workload!cold_loop
```