### PR TITLE
Bump version to 3.2.3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <ReleaseVersion>3.2.2</ReleaseVersion>
+    <ReleaseVersion>3.2.3</ReleaseVersion>
     <FastSerializationVersion>$(ReleaseVersion)</FastSerializationVersion>
     <HeapDumpDllVersion>$(ReleaseVersion)</HeapDumpDllVersion>
     <MemoryGraphVersion>$(ReleaseVersion)</MemoryGraphVersion>


### PR DESCRIPTION
Updates `<ReleaseVersion>` in `src/Directory.Build.props` from 3.2.2 to 3.2.3 in preparation for the 3.2.3 release.