### PR TITLE
Support embedded portable PDBs for managed symbol resolution

### DIFF
--- a/PerfView.sln
+++ b/PerfView.sln
@@ -91,6 +91,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraceParserGen.Tests", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraceEvent.Benchmarks", "src\TraceEvent\TraceEvent.Benchmarks\TraceEvent.Benchmarks.csproj", "{F2FBDEF0-4C45-44B2-8B92-9C5763BD2E69}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TraceEvent", "TraceEvent", "{F2AE6042-2485-6774-F42B-98E120E28306}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TraceEvent.Tests", "TraceEvent.Tests", "{282B72FF-D1CF-1C67-705A-D384E1729A5D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmbeddedPdbTestApp", "src\TraceEvent\TraceEvent.Tests\EmbeddedPdbTestApp\EmbeddedPdbTestApp.csproj", "{1CE6D3C2-5E27-4296-89FD-5177387F0B15}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -445,9 +453,26 @@ Global
 		{F2FBDEF0-4C45-44B2-8B92-9C5763BD2E69}.Release|x64.Build.0 = Release|Any CPU
 		{F2FBDEF0-4C45-44B2-8B92-9C5763BD2E69}.Release|x86.ActiveCfg = Release|Any CPU
 		{F2FBDEF0-4C45-44B2-8B92-9C5763BD2E69}.Release|x86.Build.0 = Release|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Debug|x64.Build.0 = Debug|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Debug|x86.Build.0 = Debug|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Release|x64.ActiveCfg = Release|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Release|x64.Build.0 = Release|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Release|x86.ActiveCfg = Release|Any CPU
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F2AE6042-2485-6774-F42B-98E120E28306} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{282B72FF-D1CF-1C67-705A-D384E1729A5D} = {F2AE6042-2485-6774-F42B-98E120E28306}
+		{1CE6D3C2-5E27-4296-89FD-5177387F0B15} = {282B72FF-D1CF-1C67-705A-D384E1729A5D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F85A2A3-E0DF-4826-9BBA-4DFFA0F17150}

--- a/src/TraceEvent/Symbols/PortableSymbolModule.cs
+++ b/src/TraceEvent/Symbols/PortableSymbolModule.cs
@@ -19,6 +19,19 @@ namespace Microsoft.Diagnostics.Symbols
             _metaData = _provider.GetMetadataReader();
         }
 
+        /// <summary>
+        /// Creates a PortableSymbolModule from a MetadataReaderProvider that has already been
+        /// opened (e.g. an embedded portable PDB read out of a PE image via
+        /// PEReader.ReadEmbeddedPortablePdbDebugDirectoryData).   The provider owns its own backing
+        /// memory, so it remains valid after the PEReader it came from has been disposed.   This
+        /// PortableSymbolModule takes ownership of 'provider' and disposes it when disposed.
+        /// </summary>
+        internal PortableSymbolModule(SymbolReader reader, MetadataReaderProvider provider, string pdbFileName = "") : base(reader, pdbFileName)
+        {
+            _provider = provider;
+            _metaData = _provider.GetMetadataReader();
+        }
+
         public void Dispose() => _provider.Dispose();
 
         public override Guid PdbGuid

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
@@ -709,6 +711,115 @@ namespace Microsoft.Diagnostics.Symbols
         public NativeSymbolModule OpenNativeSymbolFile(string pdbFileName)
         {
             return OpenSymbolFile(pdbFileName) as NativeSymbolModule;
+        }
+
+        /// <summary>
+        /// Attempts to open a portable PDB that is embedded inside the managed module image at
+        /// <paramref name="dllFilePath"/> (modules built with &lt;DebugType&gt;embedded&lt;/DebugType&gt;).
+        /// Returns a <see cref="ManagedSymbolModule"/> (a <c>PortableSymbolModule</c>) whose data comes
+        /// straight from the module's embedded debug directory, or null if <paramref name="dllFilePath"/>
+        /// does not exist, is not a PE file, or has no embedded portable PDB.
+        ///
+        /// Because the PDB bytes are read from the same on-disk module, no separate GUID/age matching
+        /// against a standalone PDB file is needed.  This is the embedded-PDB analog of
+        /// <see cref="OpenSymbolFile(string)"/>, which opens a standalone PDB file.
+        /// </summary>
+        /// <param name="dllFilePath">The path to the managed module (.dll/.exe) that may contain an embedded portable PDB.</param>
+        /// <returns>The symbol module for the embedded PDB, or null if none is present.</returns>
+        public ManagedSymbolModule OpenEmbeddedPortablePdb(string dllFilePath)
+        {
+            // Suffix the key so it cannot collide with the standalone-PDB cache entries (which are
+            // keyed by PDB file path), even when an embedded and a standalone PDB share the same module.
+            string cacheKey = dllFilePath + "|EmbeddedPdb";
+            if (m_symbolModuleCache.TryGet(cacheKey, out ManagedSymbolModule ret))
+            {
+                return ret;
+            }
+
+            try
+            {
+                if (!File.Exists(dllFilePath))
+                {
+                    m_log.WriteLine("OpenEmbeddedPortablePdb: {0} does not exist.", dllFilePath);
+                    return null;
+                }
+
+                using (FileStream peStream = File.Open(dllFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (PEReader peReader = new PEReader(peStream))
+                {
+                    foreach (DebugDirectoryEntry entry in peReader.ReadDebugDirectory())
+                    {
+                        if (entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb)
+                        {
+                            // The returned provider owns its own (decompressed) backing memory, so it
+                            // remains valid after the PEReader and FileStream are disposed below.
+                            MetadataReaderProvider provider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
+                            ret = new PortableSymbolModule(this, provider, dllFilePath);
+                            m_log.WriteLine("OpenEmbeddedPortablePdb: Found embedded portable PDB in {0}", dllFilePath);
+                            break;
+                        }
+                    }
+
+                    if (ret == null)
+                    {
+                        m_log.WriteLine("OpenEmbeddedPortablePdb: {0} has no embedded portable PDB.", dllFilePath);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                m_log.WriteLine("OpenEmbeddedPortablePdb: Failure reading {0}: {1}", dllFilePath, e.Message);
+                ret = null;
+            }
+
+            m_symbolModuleCache.Add(cacheKey, ret);
+            return ret;
+        }
+
+        /// <summary>
+        /// Opens the symbols for a managed/native module given only the path to the module itself
+        /// (a .dll/.exe), without the caller having to know where the PDB lives.   This is the magic,
+        /// module-oriented entry point: normal usage of <see cref="SymbolReader"/> points at a module,
+        /// not at a symbol file.
+        ///
+        /// Resolution order:
+        ///   1. A standalone PDB found via <see cref="FindSymbolFilePathForModule(string, bool)"/>
+        ///      (probing next to the module and along the symbol path / symbol servers), opened with
+        ///      <see cref="OpenSymbolFile(string)"/>.
+        ///   2. Failing that, a portable PDB embedded inside the module image itself
+        ///      (modules built with &lt;DebugType&gt;embedded&lt;/DebugType&gt;), via
+        ///      <see cref="OpenEmbeddedPortablePdb(string)"/>.
+        ///
+        /// Returns null if no symbols can be found for the module.
+        /// </summary>
+        /// <param name="moduleFilePath">The path to the managed/native module (.dll/.exe) to resolve symbols for.</param>
+        /// <returns>The symbol module for the given module, or null if none could be found.</returns>
+        public ManagedSymbolModule OpenSymbolFileForModuleFile(string moduleFilePath)
+        {
+            // 1. Standalone PDB (next to the module, symbol path, symbol servers, NGEN, ...).
+            string pdbFilePath = FindSymbolFilePathForModule(moduleFilePath);
+            if (pdbFilePath != null)
+            {
+                ManagedSymbolModule standalone = OpenSymbolFile(pdbFilePath);
+                if (standalone != null)
+                {
+                    if (string.IsNullOrEmpty(standalone.ExePath))
+                    {
+                        standalone.ExePath = moduleFilePath;
+                    }
+
+                    return standalone;
+                }
+            }
+
+            // 2. Portable PDB embedded inside the module image itself.
+            ManagedSymbolModule embedded = OpenEmbeddedPortablePdb(moduleFilePath);
+            if (embedded != null && string.IsNullOrEmpty(embedded.ExePath))
+            {
+                embedded.ExePath = moduleFilePath;
+            }
+
+            return embedded;
         }
 
         internal R2RPerfMapSymbolModule OpenR2RPerfMapSymbolFile(string filePath, uint loadedLayoutTextOffset)

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -776,52 +776,6 @@ namespace Microsoft.Diagnostics.Symbols
             return ret;
         }
 
-        /// <summary>
-        /// Opens the symbols for a managed/native module given only the path to the module itself
-        /// (a .dll/.exe), without the caller having to know where the PDB lives.   This is the magic,
-        /// module-oriented entry point: normal usage of <see cref="SymbolReader"/> points at a module,
-        /// not at a symbol file.
-        ///
-        /// Resolution order:
-        ///   1. A standalone PDB found via <see cref="FindSymbolFilePathForModule(string, bool)"/>
-        ///      (probing next to the module and along the symbol path / symbol servers), opened with
-        ///      <see cref="OpenSymbolFile(string)"/>.
-        ///   2. Failing that, a portable PDB embedded inside the module image itself
-        ///      (modules built with &lt;DebugType&gt;embedded&lt;/DebugType&gt;), via
-        ///      <see cref="OpenEmbeddedPortablePdb(string)"/>.
-        ///
-        /// Returns null if no symbols can be found for the module.
-        /// </summary>
-        /// <param name="moduleFilePath">The path to the managed/native module (.dll/.exe) to resolve symbols for.</param>
-        /// <returns>The symbol module for the given module, or null if none could be found.</returns>
-        public ManagedSymbolModule OpenSymbolFileForModuleFile(string moduleFilePath)
-        {
-            // 1. Standalone PDB (next to the module, symbol path, symbol servers, NGEN, ...).
-            string pdbFilePath = FindSymbolFilePathForModule(moduleFilePath);
-            if (pdbFilePath != null)
-            {
-                ManagedSymbolModule standalone = OpenSymbolFile(pdbFilePath);
-                if (standalone != null)
-                {
-                    if (string.IsNullOrEmpty(standalone.ExePath))
-                    {
-                        standalone.ExePath = moduleFilePath;
-                    }
-
-                    return standalone;
-                }
-            }
-
-            // 2. Portable PDB embedded inside the module image itself.
-            ManagedSymbolModule embedded = OpenEmbeddedPortablePdb(moduleFilePath);
-            if (embedded != null && string.IsNullOrEmpty(embedded.ExePath))
-            {
-                embedded.ExePath = moduleFilePath;
-            }
-
-            return embedded;
-        }
-
         internal R2RPerfMapSymbolModule OpenR2RPerfMapSymbolFile(string filePath, uint loadedLayoutTextOffset)
         {
             return new R2RPerfMapSymbolModule(filePath, loadedLayoutTextOffset);

--- a/src/TraceEvent/TraceEvent.Tests/EmbeddedPdbTestApp/EmbeddedPdbTestApp.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/EmbeddedPdbTestApp/EmbeddedPdbTestApp.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Test fixture for SymbolReader embedded-portable-PDB resolution.
+
+    This assembly is intentionally built with <DebugType>embedded</DebugType> so that its
+    portable PDB lives inside the PE image (there is no standalone .pdb next to the DLL).
+    SymbolReaderTests opens the produced DLL via SymbolReader.OpenEmbeddedPortablePdb and
+    verifies that managed source lines resolve straight out of the embedded PDB.
+
+    Keep this assembly tiny and deterministic: EmbeddedTarget is a static class with a single
+    method whose metadata token the test resolves via reflection.
+  -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>EmbeddedPdbTestApp</AssemblyName>
+    <RootNamespace>EmbeddedPdbTestApp</RootNamespace>
+    <!-- The whole point of this fixture: embed the portable PDB in the PE image. -->
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <Deterministic>true</Deterministic>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <!-- Public-sign with the same key as the test assembly.  The (strong-named) test assembly
+       references this fixture, and .NET Framework refuses to load an unsigned assembly from a
+       strong-named one, so this fixture must be strong-named too. -->
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition="'$(SIGNING_BUILD)' != 'true'">true</PublicSign>
+    <DelaySign Condition="'$(SIGNING_BUILD)' == 'true'">true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\MSFT.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+</Project>

--- a/src/TraceEvent/TraceEvent.Tests/EmbeddedPdbTestApp/EmbeddedPdbTestApp.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/EmbeddedPdbTestApp/EmbeddedPdbTestApp.csproj
@@ -20,6 +20,12 @@
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <Deterministic>true</Deterministic>
+    <!-- Always build unoptimized, even when the solution is built Release.  The tests assert an
+         exact source line for EmbeddedTarget.Add's first sequence point; with optimization on, the
+         compiler collapses the method body and that sequence point shifts (e.g. to the 'return'
+         line), which made the tests fail in Release.  Pinning Optimize=false keeps the emitted
+         sequence points stable regardless of the build configuration. -->
+    <Optimize>false</Optimize>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/src/TraceEvent/TraceEvent.Tests/EmbeddedPdbTestApp/EmbeddedTarget.cs
+++ b/src/TraceEvent/TraceEvent.Tests/EmbeddedPdbTestApp/EmbeddedTarget.cs
@@ -1,0 +1,20 @@
+namespace EmbeddedPdbTestApp
+{
+    /// <summary>
+    /// Minimal target type for the embedded-portable-PDB SymbolReader test.   The test resolves the
+    /// metadata token of <see cref="Add"/> via reflection (do not rely on a fixed token, since the
+    /// netstandard2.0 build synthesizes attribute-type constructors ahead of it in the MethodDef table).
+    ///
+    /// IMPORTANT: SymbolReaderTests asserts the source line of the first sequence point of
+    /// <see cref="Add"/> (IL offset 0, the first statement).   If you move the body below,
+    /// update the expected line number in the test.
+    /// </summary>
+    public static class EmbeddedTarget
+    {
+        public static int Add(int a, int b)
+        {
+            int sum = a + b; // first sequence point (IL offset 0) is on this line
+            return sum;
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
@@ -227,68 +227,6 @@ namespace TraceEventTests
         }
 
         [Fact]
-        public void OpenSymbolFileForModuleFileResolvesEmbeddedPdb()
-        {
-            // The magic, module-oriented entry point: hand it the module path (not a PDB path) and it
-            // should transparently fall back to the module's embedded portable PDB.
-            uint addToken = (uint)typeof(EmbeddedPdbTestApp.EmbeddedTarget)
-                .GetMethod(nameof(EmbeddedPdbTestApp.EmbeddedTarget.Add)).MetadataToken;
-
-            ManagedSymbolModule pdbFile = _symbolReader.OpenSymbolFileForModuleFile(EmbeddedPdbTestAppPath);
-            using (pdbFile as IDisposable)
-            {
-                Assert.NotNull(pdbFile);
-                Assert.IsType<PortableSymbolModule>(pdbFile);
-
-                // The module-oriented entry point stamps ExePath with the module it resolved symbols for.
-                Assert.Equal(EmbeddedPdbTestAppPath, pdbFile.ExePath);
-
-                SourceLocation sourceLocation = pdbFile.SourceLocationForManagedCode(addToken, ilOffset: 0);
-                Assert.NotNull(sourceLocation);
-                Assert.EndsWith("EmbeddedTarget.cs", sourceLocation.SourceFile.BuildTimeFilePath, StringComparison.OrdinalIgnoreCase);
-                Assert.Equal(15, sourceLocation.LineNumber);
-            }
-        }
-
-        [Fact]
-        public void OpenSymbolFileForModuleFileResolvesStandalonePdb()
-        {
-            // Covers the first resolution branch of the module-oriented entry point: a standalone PDB
-            // found next to the module (here, the test assembly's own portable PDB) takes precedence
-            // over the embedded-PDB fallback.
-            string moduleWithStandalonePdb = typeof(SymbolReaderTests).Assembly.Location;
-            Assert.True(File.Exists(moduleWithStandalonePdb));
-
-            uint methodToken = (uint)typeof(SymbolReaderTests)
-                .GetMethod(nameof(OpenSymbolFileForModuleFileResolvesStandalonePdb)).MetadataToken;
-
-            // The PDB sits next to the DLL, which SymbolReader treats as an "unsafe" location; opt in
-            // to trusting it (as a real consumer would for a known-good build output directory).
-            _symbolReader.SecurityCheck = _ => true;
-
-            ManagedSymbolModule pdbFile = _symbolReader.OpenSymbolFileForModuleFile(moduleWithStandalonePdb);
-            using (pdbFile as IDisposable)
-            {
-                Assert.NotNull(pdbFile);
-                Assert.IsType<PortableSymbolModule>(pdbFile);
-                Assert.Equal(moduleWithStandalonePdb, pdbFile.ExePath);
-
-                // The standalone PDB resolves this very test method back to this source file.
-                SourceLocation sourceLocation = pdbFile.SourceLocationForManagedCode(methodToken, ilOffset: 0);
-                Assert.NotNull(sourceLocation);
-                Assert.EndsWith("SymbolReaderTests.cs", sourceLocation.SourceFile.BuildTimeFilePath, StringComparison.OrdinalIgnoreCase);
-            }
-        }
-
-        [Fact]
-        public void OpenSymbolFileForModuleFileReturnsNullForMissingFile()
-        {
-            string missing = Path.Combine(Path.GetTempPath(), "DoesNotExist_" + Guid.NewGuid().ToString("N") + ".dll");
-            ManagedSymbolModule pdbFile = _symbolReader.OpenSymbolFileForModuleFile(missing);
-            Assert.Null(pdbFile);
-        }
-
-        [Fact]
         public void TraceLogOpenPdbForModuleFileResolvesEmbeddedPdb()
         {
             // Exercises the trace symbol-resolution path end-to-end: TraceCodeAddresses.OpenPdbForModuleFile,

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
@@ -1,4 +1,8 @@
+using FastSerialization;
 using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.EventPipe;
 using PerfView.TestUtilities;
 using System;
 using System.Collections.Generic;
@@ -132,6 +136,207 @@ namespace TraceEventTests
                 Assert.Equal("CsPortablePdb1/Program.cs", relativePath);
 
                 Assert.Equal(9, sourceLocation.LineNumber);
+            }
+        }
+
+        [Fact]
+        public void EmbeddedPortablePdbResolvesSourceLine()
+        {
+            string dllPath = EmbeddedPdbTestAppPath;
+
+            ManagedSymbolModule pdbFile = _symbolReader.OpenEmbeddedPortablePdb(dllPath);
+            using (pdbFile as IDisposable)
+            {
+                Assert.NotNull(pdbFile);
+                Assert.IsType<PortableSymbolModule>(pdbFile);
+
+                // Resolve the metadata token for EmbeddedTarget.Add from the referenced fixture assembly
+                // rather than hard-coding it: on netstandard2.0 the compiler synthesizes attribute types
+                // (e.g. EmbeddedAttribute, RefSafetyRulesAttribute) whose constructors occupy the first
+                // MethodDef rows, so Add is not token 0x06000001.
+                uint addToken = (uint)typeof(EmbeddedPdbTestApp.EmbeddedTarget)
+                    .GetMethod(nameof(EmbeddedPdbTestApp.EmbeddedTarget.Add)).MetadataToken;
+
+                // Resolve the source location of the method's first sequence point (the one covering
+                // IL offset 0).
+                SourceLocation sourceLocation = pdbFile.SourceLocationForManagedCode(addToken, ilOffset: 0);
+                Assert.NotNull(sourceLocation);
+
+                SourceFile sourceFile = sourceLocation.SourceFile;
+                Assert.NotNull(sourceFile);
+                Assert.EndsWith("EmbeddedTarget.cs", sourceFile.BuildTimeFilePath, StringComparison.OrdinalIgnoreCase);
+
+                // The first sequence point of Add() (IL offset 0) maps to its first statement,
+                // "int sum = a + b;", on this line of EmbeddedTarget.cs.  If the fixture source moves,
+                // update this expectation.
+                Assert.Equal(15, sourceLocation.LineNumber);
+            }
+        }
+
+        [Fact]
+        public void EmbeddedPortablePdbReadableAfterPEReaderDisposed()
+        {
+            // OpenEmbeddedPortablePdb disposes the PEReader/FileStream it used before returning, so a
+            // successful source-line lookup here proves the MetadataReaderProvider owns its own backing
+            // memory and survives that disposal.  (Note: the SymbolReader still owns the returned module;
+            // disposing the SymbolReader itself would clear its cache and dispose this module.)
+            uint addToken = (uint)typeof(EmbeddedPdbTestApp.EmbeddedTarget)
+                .GetMethod(nameof(EmbeddedPdbTestApp.EmbeddedTarget.Add)).MetadataToken;
+
+            ManagedSymbolModule pdbFile = _symbolReader.OpenEmbeddedPortablePdb(EmbeddedPdbTestAppPath);
+            using (pdbFile as IDisposable)
+            {
+                Assert.NotNull(pdbFile);
+                SourceLocation sourceLocation = pdbFile.SourceLocationForManagedCode(addToken, ilOffset: 0);
+                Assert.NotNull(sourceLocation);
+                Assert.NotNull(sourceLocation.SourceFile);
+            }
+        }
+
+        [Fact]
+        public void OpenEmbeddedPortablePdbCachesResult()
+        {
+            // A second open of the same module must return the cached instance (the embedded-PDB cache
+            // key cannot collide with a standalone-PDB path).  Do not dispose between calls: the
+            // SymbolReader owns the cached module's lifetime.
+            ManagedSymbolModule first = _symbolReader.OpenEmbeddedPortablePdb(EmbeddedPdbTestAppPath);
+            ManagedSymbolModule second = _symbolReader.OpenEmbeddedPortablePdb(EmbeddedPdbTestAppPath);
+
+            Assert.NotNull(first);
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void OpenEmbeddedPortablePdbReturnsNullWhenNotEmbedded()
+        {
+            // The test assembly itself is built with a standalone (portable) PDB, not an embedded one,
+            // so there is no EmbeddedPortablePdb debug-directory entry to read.
+            string dllWithoutEmbeddedPdb = typeof(SymbolReaderTests).Assembly.Location;
+            Assert.True(File.Exists(dllWithoutEmbeddedPdb));
+
+            ManagedSymbolModule pdbFile = _symbolReader.OpenEmbeddedPortablePdb(dllWithoutEmbeddedPdb);
+            Assert.Null(pdbFile);
+        }
+
+        [Fact]
+        public void OpenEmbeddedPortablePdbReturnsNullForMissingFile()
+        {
+            string missing = Path.Combine(Path.GetTempPath(), "DoesNotExist_" + Guid.NewGuid().ToString("N") + ".dll");
+            ManagedSymbolModule pdbFile = _symbolReader.OpenEmbeddedPortablePdb(missing);
+            Assert.Null(pdbFile);
+        }
+
+        [Fact]
+        public void OpenSymbolFileForModuleFileResolvesEmbeddedPdb()
+        {
+            // The magic, module-oriented entry point: hand it the module path (not a PDB path) and it
+            // should transparently fall back to the module's embedded portable PDB.
+            uint addToken = (uint)typeof(EmbeddedPdbTestApp.EmbeddedTarget)
+                .GetMethod(nameof(EmbeddedPdbTestApp.EmbeddedTarget.Add)).MetadataToken;
+
+            ManagedSymbolModule pdbFile = _symbolReader.OpenSymbolFileForModuleFile(EmbeddedPdbTestAppPath);
+            using (pdbFile as IDisposable)
+            {
+                Assert.NotNull(pdbFile);
+                Assert.IsType<PortableSymbolModule>(pdbFile);
+
+                // The module-oriented entry point stamps ExePath with the module it resolved symbols for.
+                Assert.Equal(EmbeddedPdbTestAppPath, pdbFile.ExePath);
+
+                SourceLocation sourceLocation = pdbFile.SourceLocationForManagedCode(addToken, ilOffset: 0);
+                Assert.NotNull(sourceLocation);
+                Assert.EndsWith("EmbeddedTarget.cs", sourceLocation.SourceFile.BuildTimeFilePath, StringComparison.OrdinalIgnoreCase);
+                Assert.Equal(15, sourceLocation.LineNumber);
+            }
+        }
+
+        [Fact]
+        public void OpenSymbolFileForModuleFileResolvesStandalonePdb()
+        {
+            // Covers the first resolution branch of the module-oriented entry point: a standalone PDB
+            // found next to the module (here, the test assembly's own portable PDB) takes precedence
+            // over the embedded-PDB fallback.
+            string moduleWithStandalonePdb = typeof(SymbolReaderTests).Assembly.Location;
+            Assert.True(File.Exists(moduleWithStandalonePdb));
+
+            uint methodToken = (uint)typeof(SymbolReaderTests)
+                .GetMethod(nameof(OpenSymbolFileForModuleFileResolvesStandalonePdb)).MetadataToken;
+
+            // The PDB sits next to the DLL, which SymbolReader treats as an "unsafe" location; opt in
+            // to trusting it (as a real consumer would for a known-good build output directory).
+            _symbolReader.SecurityCheck = _ => true;
+
+            ManagedSymbolModule pdbFile = _symbolReader.OpenSymbolFileForModuleFile(moduleWithStandalonePdb);
+            using (pdbFile as IDisposable)
+            {
+                Assert.NotNull(pdbFile);
+                Assert.IsType<PortableSymbolModule>(pdbFile);
+                Assert.Equal(moduleWithStandalonePdb, pdbFile.ExePath);
+
+                // The standalone PDB resolves this very test method back to this source file.
+                SourceLocation sourceLocation = pdbFile.SourceLocationForManagedCode(methodToken, ilOffset: 0);
+                Assert.NotNull(sourceLocation);
+                Assert.EndsWith("SymbolReaderTests.cs", sourceLocation.SourceFile.BuildTimeFilePath, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void OpenSymbolFileForModuleFileReturnsNullForMissingFile()
+        {
+            string missing = Path.Combine(Path.GetTempPath(), "DoesNotExist_" + Guid.NewGuid().ToString("N") + ".dll");
+            ManagedSymbolModule pdbFile = _symbolReader.OpenSymbolFileForModuleFile(missing);
+            Assert.Null(pdbFile);
+        }
+
+        [Fact]
+        public void TraceLogOpenPdbForModuleFileResolvesEmbeddedPdb()
+        {
+            // Exercises the trace symbol-resolution path end-to-end: TraceCodeAddresses.OpenPdbForModuleFile,
+            // given a managed module that (a) carries no PDB identity in the trace, (b) whose on-disk copy
+            // matches the trace (checksum + timestamp), and (c) has no standalone PDB next to it, must fall
+            // back to the module's embedded portable PDB.  This is the only consumer of
+            // SymbolReader.OpenEmbeddedPortablePdb that the SymbolReaderTests above do not reach directly.
+            string dllPath = EmbeddedPdbTestAppPath;
+
+            // Read the real PE checksum/timestamp from the fixture DLL so the TraceModuleUnchanged gate
+            // inside OpenPdbForModuleFile passes regardless of how/when the fixture was (re)built.
+            int imageChecksum;
+            int timeDateStamp;
+            using (var peFile = new PEFile.PEFile(dllPath))
+            {
+                imageChecksum = (int)peFile.Header.CheckSum;
+                timeDateStamp = peFile.Header.TimeDateStampSec;
+            }
+
+            uint addToken = (uint)typeof(EmbeddedPdbTestApp.EmbeddedTarget)
+                .GetMethod(nameof(EmbeddedPdbTestApp.EmbeddedTarget.Add)).MetadataToken;
+
+            using (TraceLog traceLog = CreateEmptyInMemoryTraceLog())
+            {
+                // Build a managed TraceModuleFile that points at the fixture DLL on disk.  The internal
+                // constructor lower-cases the path, so restore the real-cased path afterwards because
+                // File.Exists (inside TraceModuleUnchanged) is case-sensitive on non-Windows.
+                TraceModuleFile moduleFile = new TraceModuleFile(dllPath, 0x10000, (ModuleFileIndex)0);
+                moduleFile.fileName = dllPath;
+                moduleFile.imageChecksum = imageChecksum;
+                moduleFile.timeDateStamp = timeDateStamp;
+                // Leave symbolInfo null so PdbSignature == Guid.Empty: with no recorded PDB identity,
+                // OpenPdbForModuleFile is forced down the on-disk-match -> embedded-PDB branch.
+
+                ManagedSymbolModule pdbFile = traceLog.CodeAddresses.OpenPdbForModuleFile(_symbolReader, moduleFile);
+                using (pdbFile as IDisposable)
+                {
+                    Assert.NotNull(pdbFile);
+                    Assert.IsType<PortableSymbolModule>(pdbFile);
+
+                    // OpenPdbForModuleFile stamps ExePath with the module it resolved symbols for.
+                    Assert.Equal(dllPath, pdbFile.ExePath);
+
+                    SourceLocation sourceLocation = pdbFile.SourceLocationForManagedCode(addToken, ilOffset: 0);
+                    Assert.NotNull(sourceLocation);
+                    Assert.EndsWith("EmbeddedTarget.cs", sourceLocation.SourceFile.BuildTimeFilePath, StringComparison.OrdinalIgnoreCase);
+                    Assert.Equal(15, sourceLocation.LineNumber);
+                }
             }
         }
 
@@ -1401,6 +1606,45 @@ namespace TraceEventTests
         }
 
         protected string UnzippedSymbolReaderTestInputDir => Path.Combine(UnZippedDataDir, SymbolReaderTestInput);
+
+        /// <summary>
+        /// Path to the EmbeddedPdbTestApp fixture DLL (built with &lt;DebugType&gt;embedded&lt;/DebugType&gt;)
+        /// that the TraceEvent.Tests project copies next to the test assembly.
+        /// </summary>
+        protected static string EmbeddedPdbTestAppPath
+        {
+            get
+            {
+                string path = Path.Combine(AppContext.BaseDirectory, "EmbeddedPdbTestApp.dll");
+                Assert.True(File.Exists(path), "EmbeddedPdbTestApp.dll was not found next to the test assembly: " + path);
+                return path;
+            }
+        }
+
+        /// <summary>
+        /// Builds a minimal, valid, empty <see cref="TraceLog"/> entirely in memory (no ETW capture, so
+        /// it works cross-platform).  Callers can then hand-populate <see cref="TraceModuleFile"/>s and
+        /// drive <see cref="TraceCodeAddresses"/> symbol-resolution APIs directly.
+        /// </summary>
+        private static TraceLog CreateEmptyInMemoryTraceLog()
+        {
+            // Generate a minimal in-memory nettrace stream with just enough metadata to be valid.
+            var writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "Microsoft-Windows-DotNETRuntime", "EventSource", 0));
+            writer.WriteThreadBlock(w => w.WriteThreadEntry(1, 0, 0));
+            writer.WriteEventBlock(w => w.WriteEventBlob(1, 1, 1, new byte[0]));
+            writer.WriteEndBlock();
+
+            using MemoryStream nettraceStream = new MemoryStream(writer.ToArray());
+            TraceEventDispatcher eventSource = new EventPipeEventSource(nettraceStream);
+
+            // Convert to in-memory ETLX and open it as a TraceLog (the caller owns disposal).
+            MemoryStream etlxStream = new MemoryStream();
+            TraceLog.CreateFromEventPipeEventSources(eventSource, new IOStreamStreamWriter(etlxStream, SerializationSettings.Default, leaveOpen: true), null);
+            etlxStream.Position = 0;
+            return new TraceLog(etlxStream);
+        }
 
         /// <summary>
         /// A handler for the <see cref="HttpClient"/> in <see cref="SymbolReader"/> that

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -32,6 +32,19 @@
   <ItemGroup>
     <ProjectReference Include="..\..\PerfView.TestUtilities\PerfView.TestUtilities.csproj" />
     <ProjectReference Include="..\TraceEvent.csproj" />
+    <!-- Built with <DebugType>embedded</DebugType>; consumed as an on-disk DLL (with its portable
+         PDB embedded in the PE image) by the embedded-PDB SymbolReader tests.  A normal project
+         reference ensures EmbeddedPdbTestApp.dll is copied to the test output directory. -->
+    <ProjectReference Include="EmbeddedPdbTestApp\EmbeddedPdbTestApp.csproj" />
+  </ItemGroup>
+
+  <!-- EmbeddedPdbTestApp is a separate project nested under this one.  Stop the default SDK globs
+       from pulling its sources (and generated obj\ files) into this test assembly's compilation. -->
+  <ItemGroup>
+    <Compile Remove="EmbeddedPdbTestApp\**\*.cs" />
+    <EmbeddedResource Remove="EmbeddedPdbTestApp\**\*" />
+    <None Remove="EmbeddedPdbTestApp\**\*" />
+    <Content Remove="EmbeddedPdbTestApp\**\*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -9111,7 +9111,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// <summary>
         /// Look up the SymbolModule (open PDB) for a given moduleFile.   Will generate NGEN pdbs as needed.
         /// </summary>
-        private unsafe ManagedSymbolModule OpenPdbForModuleFile(SymbolReader symReader, TraceModuleFile moduleFile)
+        internal unsafe ManagedSymbolModule OpenPdbForModuleFile(SymbolReader symReader, TraceModuleFile moduleFile)
         {
             string pdbFileName = null;
             // If we have a signature, use it
@@ -9131,6 +9131,21 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 if (TraceModuleUnchanged(moduleFile, symReader.m_log))
                 {
                     pdbFileName = symReader.FindSymbolFilePathForModule(moduleFile.FilePath);
+
+                    // No standalone PDB found, but the on-disk module matches the trace.  See if the
+                    // module carries an embedded portable PDB (<DebugType>embedded</DebugType>) and use
+                    // it directly.  Because the bytes come from the matched-on-disk module, no GUID/age
+                    // re-validation is required, so we return the module immediately.
+                    if (pdbFileName == null)
+                    {
+                        ManagedSymbolModule embeddedSymbolModule = symReader.OpenEmbeddedPortablePdb(moduleFile.FilePath);
+                        if (embeddedSymbolModule != null)
+                        {
+                            embeddedSymbolModule.ExePath = moduleFile.FilePath;
+                            symReader.m_log.WriteLine("Opened embedded portable PDB for {0}", moduleFile.FilePath);
+                            return embeddedSymbolModule;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Managed assemblies built with `<DebugType>embedded</DebugType>` carry their portable PDB inside the PE image rather than in a standalone `.pdb` file. Previously `SymbolReader` could not read these, so source/line lookup failed for such modules. This PR adds the ability to read embedded portable PDBs.

## Changes

- **`SymbolReader.OpenEmbeddedPortablePdb`** — reads the `EmbeddedPortablePdb` debug-directory entry from a module and returns a `PortableSymbolModule`. Results are cached under a key suffixed so they cannot collide with standalone-PDB cache entries.
- **`PortableSymbolModule`** — gains a constructor that takes a `MetadataReaderProvider` (which owns its own backing memory, so the module survives disposal of the `PEReader`/`FileStream` used to open it).
- **`TraceLog.OpenPdbForModuleFile`** — falls back to the module's embedded portable PDB when the on-disk module matches the trace and no standalone PDB exists.

## Tests

Adds an `EmbeddedPdbTestApp` fixture (built with `<DebugType>embedded</DebugType>`) and covers:

- the happy path (source/line resolution),
- readability after the `PEReader` is disposed,
- caching,
- not-embedded and missing-file cases,
- the end-to-end `TraceLog` fallback path.

All tests run cross-platform on **net462** and **net8.0** in Debug.
