### PR TITLE
Bring v3.2.4 security and reliability fixes into main

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <ReleaseVersion>3.2.3</ReleaseVersion>
+    <ReleaseVersion>3.2.4</ReleaseVersion>
     <FastSerializationVersion>$(ReleaseVersion)</FastSerializationVersion>
     <HeapDumpDllVersion>$(ReleaseVersion)</HeapDumpDllVersion>
     <MemoryGraphVersion>$(ReleaseVersion)</MemoryGraphVersion>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.8" />
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.8" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.1" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.8" />

--- a/src/PerfView.Tests/DiagSessionPerfViewFileTests.cs
+++ b/src/PerfView.Tests/DiagSessionPerfViewFileTests.cs
@@ -1,0 +1,46 @@
+using PerfView;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace PerfViewTests
+{
+    public class DiagSessionPerfViewFileTests
+    {
+        [Theory]
+        [InlineData(@"..\..\victim", "victim")]
+        [InlineData(@"\..\..\Startup", "Startup")]
+        [InlineData(@"C:\temp\symbols", "symbols")]
+        [InlineData("symbols/cache", "cache")]
+        [InlineData("symbols\\cache", "cache")]
+        [InlineData("foo.bar", "foo")]
+        [InlineData("plain", "plain")]
+        [InlineData("C:relative", "relative")]
+        [InlineData("foo:bar", "bar")]
+        public void GetSafeDiagSessionResourceDirectoryName_StripsPathComponents(string resourceName, string expected)
+        {
+            string safeName = DiagSessionPerfViewFile.GetSafeDiagSessionResourceDirectoryName(resourceName);
+
+            Assert.Equal(expected, safeName);
+            Assert.DoesNotContain(Path.DirectorySeparatorChar, safeName);
+            Assert.DoesNotContain(Path.AltDirectorySeparatorChar, safeName);
+            Assert.DoesNotContain(safeName, c => Path.GetInvalidFileNameChars().Contains(c));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(".")]
+        [InlineData("..")]
+        [InlineData(@"\")]
+        [InlineData("/")]
+        [InlineData(@"foo\..")]
+        [InlineData(@"foo\.")]
+        public void GetSafeDiagSessionResourceDirectoryName_RejectsUnsafeNames(string resourceName)
+        {
+            string safeName = DiagSessionPerfViewFile.GetSafeDiagSessionResourceDirectoryName(resourceName);
+
+            Assert.Null(safeName);
+        }
+    }
+}

--- a/src/PerfView.Tests/Memory/PathUtilitiesTests.cs
+++ b/src/PerfView.Tests/Memory/PathUtilitiesTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.Diagnostics.Utilities;
+using Xunit;
+
+namespace PerfViewTests.Memory
+{
+    public class PathUtilitiesTests
+    {
+        [Theory]
+        [InlineData(@"\\server\share\module.dll")]
+        [InlineData(@"\\?\UNC\server\share\module.dll")]
+        [InlineData(@"\\?\unc\server\share\module.dll")]
+        [InlineData(@"\\.\UNC\server\share\module.dll")]
+        [InlineData(@"\\?\GLOBALROOT\Device\Mup\server\share\module.dll")]
+        [InlineData(@"\\?\GLOBALROOT\Device\LanmanRedirector\server\share\module.dll")]
+        [InlineData(@"\??\UNC\server\share\module.dll")]
+        [InlineData(@"\??\unc\server\share\module.dll")]
+        [InlineData("https://server/share/module.dll")]
+        [InlineData("http://server/share/module.dll")]
+        [InlineData("ftp://server/module.dll")]
+        public void IsRemotePathDetectsRemotePaths(string modulePath)
+        {
+            Assert.True(PathUtilities.IsRemotePath(modulePath));
+        }
+
+        [Theory]
+        [InlineData(@"C:\Symbols\foo.pdb\01234567890123456789012345678901FFFFFFFF\foo.pdb")]
+        [InlineData(@"C:\Users\dev\src\bin\foo.dll")]
+        [InlineData(@"module.dll")]
+        [InlineData(@"subdir\module.dll")]
+        [InlineData(@"..\module.dll")]
+        [InlineData(@"D:\drive\path.dll")]
+        [InlineData(@"\\?\C:\Windows\notepad.exe")]
+        [InlineData(@"\\.\C:\Windows\notepad.exe")]
+        [InlineData(@"\\?\Volume{12345678-1234-1234-1234-1234567890ab}\foo.dll")]
+        public void IsRemotePathAcceptsLocalPaths(string modulePath)
+        {
+            Assert.False(PathUtilities.IsRemotePath(modulePath));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void IsRemotePathHandlesEmptyInputWithoutThrowing(string modulePath)
+        {
+            // Empty/null inputs are not remote (they will be caught elsewhere).
+            Assert.False(PathUtilities.IsRemotePath(modulePath));
+        }
+    }
+}

--- a/src/PerfView.Tests/Memory/PathUtilitiesTests.cs
+++ b/src/PerfView.Tests/Memory/PathUtilitiesTests.cs
@@ -45,5 +45,91 @@ namespace PerfViewTests.Memory
             // Empty/null inputs are not remote (they will be caught elsewhere).
             Assert.False(PathUtilities.IsRemotePath(modulePath));
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(".")]
+        [InlineData("..")]
+        public void SanitizeFileName_ReturnsNullForRejectedInput(string input)
+        {
+            // null / empty / "." / ".." all return null so callers can choose how to
+            // handle the missing name (skip the resource, substitute a placeholder,
+            // etc.) instead of being forced to accept an arbitrary string.
+            Assert.Null(PathUtilities.SanitizeFileName(input));
+        }
+
+        [Theory]
+        [InlineData(@"..\outside", ".._outside")]
+        [InlineData(@"..\..\..\Startup\x", ".._.._.._Startup_x")]
+        [InlineData("../forward/slash", ".._forward_slash")]
+        [InlineData(@"C:\Windows\System32\evil", "C__Windows_System32_evil")]
+        [InlineData(@"\\server\share\evil", "__server_share_evil")]
+        [InlineData(@"with:colons", "with_colons")]
+        [InlineData("with|pipes?and*wildcards", "with_pipes_and_wildcards")]
+        public void SanitizeFileName_ReplacesInvalidCharactersAndSeparators(string input, string expected)
+        {
+            // Every path separator, volume separator, and Path.GetInvalidFileNameChars
+            // character is replaced with '_'.  Control characters are also replaced.
+            Assert.Equal(expected, PathUtilities.SanitizeFileName(input));
+        }
+
+        [Theory]
+        [InlineData("CON", "_CON")]
+        [InlineData("nul", "_nul")]
+        [InlineData("PRN", "_PRN")]
+        [InlineData("AUX", "_AUX")]
+        [InlineData("COM1", "_COM1")]
+        [InlineData("LPT9", "_LPT9")]
+        [InlineData("CLOCK$", "_CLOCK$")]
+        [InlineData("CONIN$", "_CONIN$")]
+        [InlineData("conout$", "_conout$")]
+        [InlineData("CONIN$.log", "_CONIN$.log")]
+        [InlineData("NUL.", "_NUL")]
+        [InlineData("NUL ", "_NUL")]
+        [InlineData("NUL. . ", "_NUL")]
+        [InlineData("NUL.evil", "_NUL.evil")]
+        [InlineData("CON.foo.bar", "_CON.foo.bar")]
+        [InlineData("com1.data", "_com1.data")]
+        [InlineData("LPT5.tar.gz", "_LPT5.tar.gz")]
+        public void SanitizeFileName_RewritesReservedDosDeviceNames(string input, string expected)
+        {
+            // Win32 matches a reserved device name on the stem before the first '.'
+            // in the basename, so "NUL.evil" or "COM1.data" still open the device.
+            // The sanitizer prefixes such names with '_' to make them safe.
+            Assert.Equal(expected, PathUtilities.SanitizeFileName(input));
+        }
+
+        [Theory]
+        [InlineData("Trailing.", "Trailing")]
+        [InlineData("Trailing ", "Trailing")]
+        [InlineData("Trailing.. .", "Trailing")]
+        public void SanitizeFileName_StripsTrailingDotsAndSpaces(string input, string expected)
+        {
+            // Windows silently trims trailing '.' and ' ' from file names; stripping
+            // them ourselves prevents two distinct names colliding on disk and
+            // closes the "NUL." device-name evasion.
+            Assert.Equal(expected, PathUtilities.SanitizeFileName(input));
+        }
+
+        [Theory]
+        [InlineData("...")]
+        [InlineData("   ")]
+        public void SanitizeFileName_ReturnsNullWhenAllCharactersAreStripped(string input)
+        {
+            // Inputs that consist entirely of trailing-trim characters (or sanitize
+            // to nothing) return null rather than the empty string.
+            Assert.Null(PathUtilities.SanitizeFileName(input));
+        }
+
+        [Theory]
+        [InlineData("Contoso.Provider-Valid_1", "Contoso.Provider-Valid_1")]
+        [InlineData("My Provider", "My Provider")]
+        [InlineData("provider.with.dots", "provider.with.dots")]
+        public void SanitizeFileName_PreservesValidNames(string input, string expected)
+        {
+            Assert.Equal(expected, PathUtilities.SanitizeFileName(input));
+        }
     }
 }
+

--- a/src/PerfView.Tests/Memory/PdbScopeMemoryGraphTests.cs
+++ b/src/PerfView.Tests/Memory/PdbScopeMemoryGraphTests.cs
@@ -1,0 +1,106 @@
+using PerfView;
+using System;
+using System.IO;
+using Xunit;
+
+namespace PerfViewTests.Memory
+{
+    public class PdbScopeMemoryGraphTests : IDisposable
+    {
+        private readonly string m_testDirectory;
+
+        public PdbScopeMemoryGraphTests()
+        {
+            m_testDirectory = Path.Combine(Path.GetTempPath(), "PdbScopeMemoryGraphTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(m_testDirectory);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(m_testDirectory))
+            {
+                Directory.Delete(m_testDirectory, recursive: true);
+            }
+        }
+
+        [Theory]
+        [InlineData(@"\\server\share\module.dll")]
+        [InlineData(@"\\?\UNC\server\share\module.dll")]
+        [InlineData("https://server/share/module.dll")]
+        public void TryResolveTrustedFilePathRejectsRemotePaths(string modulePath)
+        {
+            string pdbScopeFilePath = GetPdbScopeFilePath();
+
+            Assert.False(PdbScopeMemoryGraph.TryResolveTrustedFilePath(modulePath, pdbScopeFilePath, out string trustedFilePath));
+            Assert.Null(trustedFilePath);
+        }
+
+        [Fact]
+        public void TryResolveTrustedFilePathRejectsRootedPathsOutsidePdbScopeDirectory()
+        {
+            string pdbScopeFilePath = GetPdbScopeFilePath();
+            string outsideDirectory = Path.Combine(Path.GetPathRoot(m_testDirectory), "PdbScopeMemoryGraphTestsOutside");
+            string outsideModulePath = Path.Combine(outsideDirectory, "module.dll");
+
+            Assert.False(PdbScopeMemoryGraph.TryResolveTrustedFilePath(outsideModulePath, pdbScopeFilePath, out string trustedFilePath));
+            Assert.Null(trustedFilePath);
+        }
+
+        [Theory]
+        [InlineData("module.dll")]
+        [InlineData(@"subdirectory\module.dll")]
+        public void TryResolveTrustedFilePathAllowsRelativePathsUnderPdbScopeDirectory(string modulePath)
+        {
+            string pdbScopeFilePath = GetPdbScopeFilePath();
+
+            Assert.True(PdbScopeMemoryGraph.TryResolveTrustedFilePath(modulePath, pdbScopeFilePath, out string trustedFilePath));
+            Assert.Equal(Path.GetFullPath(Path.Combine(m_testDirectory, modulePath)), trustedFilePath);
+        }
+
+        [Fact]
+        public void TryResolveTrustedFilePathAllowsRootedPathsUnderPdbScopeDirectory()
+        {
+            string pdbScopeFilePath = GetPdbScopeFilePath();
+            string modulePath = Path.Combine(m_testDirectory, "module.dll");
+
+            Assert.True(PdbScopeMemoryGraph.TryResolveTrustedFilePath(modulePath, pdbScopeFilePath, out string trustedFilePath));
+            Assert.Equal(modulePath, trustedFilePath);
+        }
+
+        [Theory]
+        [InlineData(@"..\module.dll")]
+        [InlineData(@"subdirectory\..\..\module.dll")]
+        public void TryResolveTrustedFilePathRejectsRelativePathsEscapingPdbScopeDirectory(string modulePath)
+        {
+            string pdbScopeFilePath = GetPdbScopeFilePath();
+
+            Assert.False(PdbScopeMemoryGraph.TryResolveTrustedFilePath(modulePath, pdbScopeFilePath, out string trustedFilePath));
+            Assert.Null(trustedFilePath);
+        }
+
+        [Fact]
+        public void PdbScopeXmlWithRemoteModuleFilePathDoesNotThrow()
+        {
+            CommandProcessor originalCommandProcessor = App.CommandProcessor;
+            string pdbScopeFilePath = GetPdbScopeFilePath();
+            try
+            {
+                App.CommandProcessor = new CommandProcessor() { LogFile = TextWriter.Null };
+                File.WriteAllText(
+                    pdbScopeFilePath,
+                    @"<PdbscopeReport><Section Start=""8192"" Size=""16"" Name="".text"" /><Module Base=""4096"" FilePath=""\\server\share\module.dll"" /><Symbol addr=""2000"" size=""16"" name=""Main"" tag=""code"" /></PdbscopeReport>");
+
+                new PdbScopeMemoryGraph(pdbScopeFilePath);
+            }
+            finally
+            {
+                App.CommandProcessor = originalCommandProcessor;
+            }
+        }
+
+        private string GetPdbScopeFilePath()
+        {
+            return Path.Combine(m_testDirectory, "test.imageSize.xml");
+        }
+    }
+}

--- a/src/PerfView/App.cs
+++ b/src/PerfView/App.cs
@@ -904,11 +904,33 @@ namespace PerfView
 
                     return result == System.Windows.MessageBoxResult.Yes;
                 };
+
+                ret.AuthorizeSourceServerCommand = request =>
+                {
+                    var result = XamlMessageBox.Show(
+                        request.Command + "\n\n" +
+                        "This command was derived from PDB-supplied data.  Do you want to run it?",
+                        "Source Server Command",
+                        System.Windows.MessageBoxButton.YesNo);
+
+                    bool allowed = result == System.Windows.MessageBoxResult.Yes;
+                    log.WriteLine("Source Server command authorization {0} by user: {1}", allowed ? "GRANTED" : "DENIED", request.Command);
+                    return allowed;
+                };
             }
             else
 #endif
             {
                 ret.SecurityCheck = (pdbFile => true);
+                ret.AuthorizeSourceServerCommand = request =>
+                {
+#if PERFVIEW_COLLECT
+                    log.WriteLine("Source Server command auto-approved in PerfViewCollect: {0}", request.Command);
+#else
+                    log.WriteLine("Source Server command auto-approved because /TrustPdbs is set: {0}", request.Command);
+#endif
+                    return true;
+                };
             }
             ret.SourceCacheDirectory = Path.Combine(CacheFiles.CacheDir, "src");
             if (localSymDir != null)

--- a/src/PerfView/Extensibility.cs
+++ b/src/PerfView/Extensibility.cs
@@ -708,7 +708,12 @@ namespace PerfViewExtensibility
                             log.WriteLine("Putting symbols in {0}", dirForPdbs);
                         }
 
-                        var pdbTargetPath = Path.Combine(dirForPdbs, pdbRelativePath);
+                        if (!SymbolCachePathUtilities.TryGetPdbTargetPath(dirForPdbs, pdbRelativePath, out var pdbTargetPath))
+                        {
+                            log.WriteLine("WARNING: found PDB file with invalid path {0}, skipping extraction", pdbRelativePath);
+                            continue;
+                        }
+
                         var pdbTargetName = Path.GetFileName(pdbTargetPath);
                         if (!File.Exists(pdbTargetPath) || (new System.IO.FileInfo(pdbTargetPath).Length != entry.Length))
                         {

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -103,6 +103,7 @@
     <PackageReference Include="PerfView.SupportFiles" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" GeneratePathProperty="true" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Hashing" GeneratePathProperty="true" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" GeneratePathProperty="true" />
     <PackageReference Include="System.Memory" GeneratePathProperty="true" />
     <PackageReference Include="System.Numerics.Vectors" GeneratePathProperty="true" />
@@ -612,6 +613,13 @@
       <WithCulture>false</WithCulture>
       <LogicalName>.\System.Diagnostics.DiagnosticSource.dll</LogicalName>
       <Link>System.Diagnostics.DiagnosticSource.dll</Link>
+      <Visible>False</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(PkgSystem_IO_Hashing)\lib\net462\System.IO.Hashing.dll">
+      <Type>Non-Resx</Type>
+      <WithCulture>false</WithCulture>
+      <LogicalName>.\System.IO.Hashing.dll</LogicalName>
+      <Link>System.IO.Hashing.dll</Link>
       <Visible>False</Visible>
     </EmbeddedResource>
     <EmbeddedResource Include="$(PkgSystem_Memory)\lib\net462\System.Memory.dll">

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -180,6 +180,9 @@
     <Compile Include="..\Utilities\FileUtilities.cs">
       <Link>Utilities\FileUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\Utilities\PathUtilities.cs">
+      <Link>Utilities\PathUtilities.cs</Link>
+    </Compile>
     <Compile Include="..\Utilities\StringUtilities.cs">
       <Link>Utilities\StringUtilities.cs</Link>
     </Compile>

--- a/src/PerfView/PerfView.csproj
+++ b/src/PerfView/PerfView.csproj
@@ -183,6 +183,9 @@
     <Compile Include="..\Utilities\StringUtilities.cs">
       <Link>Utilities\StringUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\Utilities\SymbolCachePathUtilities.cs">
+      <Link>Utilities\SymbolCachePathUtilities.cs</Link>
+    </Compile>
     <Compile Include="..\Utilities\SymbolsAuthenticationUtilities.cs">
       <Link>Utilities\SymbolsAuthenticationUtilities.cs</Link>
     </Compile>

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -10996,7 +10996,12 @@ namespace PerfView
         /// <returns>The full local path to the resource</returns>
         private static string GetLocalDirPath(string packageFilePath, DhPackage package, ResourceInfo resource)
         {
-            string localDirName = resource.Name;
+            string localDirName = GetSafeDiagSessionResourceDirectoryName(resource.Name);
+            if (localDirName == null)
+            {
+                return null;
+            }
+
             string localDirPath = CacheFiles.FindFile(packageFilePath, "_" + localDirName);
 
             if (!Directory.Exists(localDirPath))
@@ -11005,6 +11010,31 @@ namespace PerfView
             }
 
             return localDirPath;
+        }
+
+        /// <summary>
+        /// Sanitizes an attacker-controlled .diagsession resource name into a safe directory-name fragment.
+        /// Mirrors the sibling <see cref="GetLocalFilePath"/> which uses <see cref="Path.GetFileNameWithoutExtension"/>
+        /// to strip any path components from the metadata before it is concatenated into a cache path.
+        /// Returns null if the sanitized name is empty, ".", or ".." so the caller can skip the resource
+        /// rather than create an oddly-named cache entry.
+        /// </summary>
+        internal static string GetSafeDiagSessionResourceDirectoryName(string resourceName)
+        {
+            string sanitized = Path.GetFileNameWithoutExtension(resourceName ?? string.Empty);
+            if (string.IsNullOrEmpty(sanitized) || sanitized == "." || sanitized == "..")
+            {
+                return null;
+            }
+
+            // Reject any character that the OS would consider invalid in a file name
+            // (e.g. ':' which on NTFS would create an Alternate Data Stream).
+            if (sanitized.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                return null;
+            }
+
+            return sanitized;
         }
 
         /// <summary>
@@ -11045,6 +11075,11 @@ namespace PerfView
                 foreach (var resource in resources)
                 {
                     string localDirPath = GetLocalDirPath(FilePath, dhPackage, resource);
+                    if (localDirPath == null)
+                    {
+                        worker.Log("Skipping symbol cache resource '" + resource.ResourceId + "' with unsafe name '" + resource.Name + "'.");
+                        continue;
+                    }
 
                     worker.Log("Found '" + resource.ResourceId + "' resource '" + resource.Name + "'. Loading ...");
 

--- a/src/PerfView/memory/PdbScopeMemoryGraph.cs
+++ b/src/PerfView/memory/PdbScopeMemoryGraph.cs
@@ -1,5 +1,6 @@
 ﻿using Graphs;
 using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -220,38 +221,52 @@ public class PdbScopeMemoryGraph : MemoryGraph
     {
         try
         {
-            string pdbFilePath = null;
+            string originalDllFilePath = dllFilePath;
             DebugWriteLine("Module being analyzed: " + dllFilePath);
+
+            // PdbScope XML is user-controlled and the FilePath attribute can name an
+            // arbitrary path (including UNC) that would otherwise reach File.Exists /
+            // SymbolReader and leak NTLM credentials.  Only trust paths that normalize
+            // to a real file under the XML file's own directory.  If validation fails
+            // we simply skip the module -- no "next to the binary" fallback, because a
+            // malicious PdbScope file should not be able to coerce us into resolving
+            // anything outside what the XML explicitly and safely references.
+            if (!TryResolveTrustedFilePath(dllFilePath, pdbScopeFilePath, out dllFilePath))
+            {
+                DebugWriteLine("Ignoring untrusted module path from PdbScope XML: " + originalDllFilePath);
+                return;
+            }
+
             if (!File.Exists(dllFilePath))
             {
-                DebugWriteLine("DLL not found in original location: " + dllFilePath + ".");
-                dllFilePath = Path.Combine(Path.GetDirectoryName(pdbScopeFilePath), Path.GetFileName(dllFilePath));
-                if (!File.Exists(dllFilePath))
-                {
-                    DebugWriteLine("Error: The DLL not found next to pdbScopeFile " + pdbScopeFilePath + ".");
-                    pdbFilePath = Path.Combine(Path.GetDirectoryName(pdbScopeFilePath), Path.GetFileNameWithoutExtension(dllFilePath) + ".pdb");
-                    if (!File.Exists(pdbFilePath))
-                    {
-                        DebugWriteLine("Error: The PDB not found next to pdbScopeFile " + pdbScopeFilePath + ".");
-                        return;
-                    }
-                }
+                DebugWriteLine("Error: The DLL not found at " + dllFilePath + ".");
+                return;
             }
 
             DebugWriteLine("Found DLL/EXE file " + dllFilePath);
             using (var symReader = new SymbolReader(PerfView.App.CommandProcessor.LogFile))
             {
-                symReader.SecurityCheck = name => true;         // Disable security checks.  
+                // TryResolveTrustedFilePath has already validated that dllFilePath is a
+                // real local file under the PdbScope XML's own directory, so the DLL
+                // itself is trusted.  SymbolReader will derive additional probe paths
+                // from that DLL (PDB next to the DLL, the PE debug directory's embedded
+                // pdbFileName, the user's symbol cache, configured symbol servers); the
+                // PE-embedded path in particular could be an arbitrary string baked into
+                // the DLL at build time.  Allow any probe path that is not obviously
+                // remote so legitimate local lookups succeed while still refusing UNC /
+                // URI / NT-namespace paths that would trigger an SMB authentication
+                // probe and leak NTLM credentials.  (The default behavior when
+                // SecurityCheck is null is to reject every probe -- we have to set
+                // something for symbol resolution to work at all.)
+                symReader.SecurityCheck = name => !PathUtilities.IsRemotePath(name);
 
+                string pdbFilePath = symReader.FindSymbolFilePathForModule(dllFilePath);
                 if (pdbFilePath == null)
                 {
-                    pdbFilePath = symReader.FindSymbolFilePathForModule(dllFilePath);
-                    if (pdbFilePath == null)
-                    {
-                        DebugWriteLine("Error: The PDB for DLL: " + dllFilePath + " not found.");
-                        return;
-                    }
+                    DebugWriteLine("Error: The PDB for DLL: " + dllFilePath + " not found.");
+                    return;
                 }
+
                 DebugWriteLine("Found pdb file " + pdbFilePath);
                 var module = symReader.OpenNativeSymbolFile(pdbFilePath);
                 m_moduleMap = module.GetMergedAssembliesMap();
@@ -260,6 +275,46 @@ public class PdbScopeMemoryGraph : MemoryGraph
         catch (Exception e)
         {
             DebugWriteLine("Error: reading PDB file " + e.Message);
+        }
+    }
+
+    internal static bool TryResolveTrustedFilePath(string filePath, string pdbScopeFilePath, out string trustedFilePath)
+    {
+        trustedFilePath = null;
+
+        if (string.IsNullOrWhiteSpace(filePath) || string.IsNullOrWhiteSpace(pdbScopeFilePath) || PathUtilities.IsRemotePath(filePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            string pdbScopeDirectory = Path.GetDirectoryName(Path.GetFullPath(pdbScopeFilePath));
+
+            // PdbScope XML is user-controlled. Only trust paths that normalize under the XML file's directory.
+            string fullFilePath = Path.IsPathRooted(filePath)
+                ? Path.GetFullPath(filePath)
+                : Path.GetFullPath(Path.Combine(pdbScopeDirectory, filePath));
+
+            if (PathUtilities.IsRemotePath(fullFilePath) || !PathUtilities.IsPathWithinDirectory(fullFilePath, pdbScopeDirectory))
+            {
+                return false;
+            }
+
+            trustedFilePath = fullFilePath;
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+        catch (PathTooLongException)
+        {
+            return false;
         }
     }
 

--- a/src/PerfViewCollect/PerfViewCollect.csproj
+++ b/src/PerfViewCollect/PerfViewCollect.csproj
@@ -33,6 +33,7 @@
     <Compile Include="..\Utilities\FileUtilities.cs" />
     <Compile Include="..\Utilities\DirectoryUtilities.cs" />
     <Compile Include="..\Utilities\StringUtilities.cs" />
+    <Compile Include="..\Utilities\SymbolCachePathUtilities.cs" />
     <Compile Include="..\Utilities\XmlUtilities.cs" />
     <Compile Include="..\Utilities\SymbolsAuthenticationUtilities.cs" />
     <Compile Include="..\PerfView\Utilities\ExceptionMessage.cs" />

--- a/src/TraceEvent/BPerf/BPerfEventSource.cs
+++ b/src/TraceEvent/BPerf/BPerfEventSource.cs
@@ -630,7 +630,7 @@ namespace Microsoft.Diagnostics.Tracing
         /// The delegate function to decompress by using ULZ777 algorithm
         /// </summary>
         /// <returns></returns>
-        private unsafe static int ULZ777Decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputLength)
+        internal unsafe static int ULZ777Decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputLength)
         {
             fixed (byte* uncompressedBufferPtr = &output[0])
             fixed (byte* compressedBufferPtr = &input[inputOffset])
@@ -660,11 +660,15 @@ namespace Microsoft.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void WildCopy(byte* d, byte* s, int n)
         {
-            *(ulong*)d = *(ulong*)s;
-
-            for (int i = 8; i < n; i += 8)
+            int i = 0;
+            for (; i <= n - 8; i += 8)
             {
                 *(ulong*)(d + i) = *(ulong*)(s + i);
+            }
+
+            for (; i < n; i++)
+            {
+                d[i] = s[i];
             }
         }
 

--- a/src/TraceEvent/BPerf/BPerfEventSource.cs
+++ b/src/TraceEvent/BPerf/BPerfEventSource.cs
@@ -383,28 +383,35 @@ namespace Microsoft.Diagnostics.Tracing
             return false;
         }
 
-        private unsafe TraceEventNativeMethods.EVENT_RECORD* DeserializeEventRecord(byte* buffer, ref int retVal)
+        private unsafe TraceEventNativeMethods.EVENT_RECORD* DeserializeEventRecord(byte* buffer, int remainingBufferInBytes, ref int retVal)
         {
-            int bufferOffset = OffsetToExtendedData + 24; // store space for 3 8-byte pointers regardless of arch
+            // Walk the record once, validating that each section fits in the remaining buffer
+            // before constructing pointers into it. Advance throws if the next section, or its
+            // alignment, would extend past remainingBufferInBytes.
+            int bufferOffset = 0;
+            Advance(ref bufferOffset, OffsetToExtendedData + 24, alignTo: 1, remainingBufferInBytes); // store space for 3 8-byte pointers regardless of arch
+
             var eventRecord = (TraceEventNativeMethods.EVENT_RECORD*)buffer;
 
-            eventRecord->UserData = new IntPtr(buffer + bufferOffset);
+            int userDataOffset = bufferOffset;
+            Advance(ref bufferOffset, eventRecord->UserDataLength, alignTo: 8, remainingBufferInBytes);
 
-            bufferOffset += eventRecord->UserDataLength;
-            bufferOffset = AlignUp(bufferOffset, 8);
+            int extendedDataOffset = bufferOffset;
+            int extendedDataSize = sizeof(TraceEventNativeMethods.EVENT_HEADER_EXTENDED_DATA_ITEM) * eventRecord->ExtendedDataCount;
+            Advance(ref bufferOffset, extendedDataSize, alignTo: 1, remainingBufferInBytes);
 
-            eventRecord->ExtendedData = eventRecord->ExtendedDataCount > 0 ? (TraceEventNativeMethods.EVENT_HEADER_EXTENDED_DATA_ITEM*)(buffer + bufferOffset) : (TraceEventNativeMethods.EVENT_HEADER_EXTENDED_DATA_ITEM*)0;
-            bufferOffset += sizeof(TraceEventNativeMethods.EVENT_HEADER_EXTENDED_DATA_ITEM) * eventRecord->ExtendedDataCount;
+            eventRecord->UserData = new IntPtr(buffer + userDataOffset);
+            eventRecord->ExtendedData = eventRecord->ExtendedDataCount > 0
+                ? (TraceEventNativeMethods.EVENT_HEADER_EXTENDED_DATA_ITEM*)(buffer + extendedDataOffset)
+                : (TraceEventNativeMethods.EVENT_HEADER_EXTENDED_DATA_ITEM*)0;
 
             for (ushort i = 0; i < eventRecord->ExtendedDataCount; ++i)
             {
                 eventRecord->ExtendedData[i].DataPtr = (ulong)(buffer + bufferOffset);
-
-                bufferOffset += eventRecord->ExtendedData[i].DataSize;
-                bufferOffset = AlignUp(bufferOffset, 8);
+                Advance(ref bufferOffset, eventRecord->ExtendedData[i].DataSize, alignTo: 8, remainingBufferInBytes);
             }
 
-            bufferOffset = AlignUp(bufferOffset, 16);
+            Advance(ref bufferOffset, 0, alignTo: 16, remainingBufferInBytes);
             retVal += bufferOffset;
 
             return eventRecord;
@@ -546,7 +553,7 @@ namespace Microsoft.Diagnostics.Tracing
                     int bufferOffset = 0;
                     while (bufferOffset < finalUncompressedSize && !this.stopProcessing)
                     {
-                        var eventRecord = this.DeserializeEventRecord(uncompressedBufferPtr + bufferOffset, ref bufferOffset);
+                        var eventRecord = this.DeserializeEventRecord(uncompressedBufferPtr + bufferOffset, finalUncompressedSize - bufferOffset, ref bufferOffset);
 
                         if (this.sessionStartTimeQPC == 0)
                         {
@@ -574,6 +581,34 @@ namespace Microsoft.Diagnostics.Tracing
         private static int AlignUp(int num, int align)
         {
             return (num + (align - 1)) & ~(align - 1);
+        }
+
+        /// <summary>
+        /// Advances <paramref name="bufferOffset"/> by <paramref name="bytesToAdvance"/> bytes (then aligns
+        /// the result up to <paramref name="alignTo"/>) while requiring that the section, and the
+        /// alignment slack, fit inside <paramref name="remainingBufferInBytes"/> bytes. Throws
+        /// <see cref="InvalidDataException"/> for any malformed input, including negative sizes
+        /// and arithmetic overflow.
+        /// </summary>
+        private static void Advance(ref int bufferOffset, int bytesToAdvance, int alignTo, int remainingBufferInBytes)
+        {
+            if (alignTo <= 0 ||
+                bytesToAdvance < 0 ||
+                bufferOffset < 0 ||
+                bufferOffset > remainingBufferInBytes ||
+                bytesToAdvance > remainingBufferInBytes - bufferOffset)
+            {
+                throw new InvalidDataException("Malformed BPerf event record: section extends past the decompressed buffer.");
+            }
+
+            int next = bufferOffset + bytesToAdvance;
+            int aligned = AlignUp(next, alignTo);
+            if (aligned < next || aligned > remainingBufferInBytes)
+            {
+                throw new InvalidDataException("Malformed BPerf event record: section extends past the decompressed buffer.");
+            }
+
+            bufferOffset = aligned;
         }
 
         private static long GetOffset(string indexFile, DateTime requestTimestamp, out long sessionStartQPC, out long ts)

--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -605,6 +605,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                             else if (IsCountedSize(size))
                             {
                                 bool unicodeByteCountString = !isAnsi && (size & ELEM_COUNT) == 0;
+                                // The length-prefix bytes are read from the payload via GetInt16At / GetInt32At,
+                                // which do not bounds check.  Validate that the prefix itself is inside the payload
+                                // before reading it, so a crafted offset near EventDataLength cannot pull bytes
+                                // from adjacent native memory into 'size'.
+                                int prefixBytes = ((size & BIT_32) != 0) ? 4 : 2;
+                                if (offset < 0 || EventDataLength - offset < prefixBytes)
+                                {
+                                    throw new ArgumentOutOfRangeException(nameof(size));
+                                }
                                 if (((size & BIT_32) != 0))
                                 {
                                     size = (ushort)GetInt32At(offset);
@@ -629,6 +638,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                         {
                             size -= 0x8000;
                             isAnsi = true;
+                        }
+                        // Bounds-check before reading the fixed/counted string.  For counted strings 'size' was just
+                        // read from the payload bytes, so we must ensure the read stays inside EventDataLength to
+                        // avoid an out-of-bounds read of native heap memory.  ANSI strings use 'size' bytes; Unicode
+                        // strings use 'size * 2' bytes.  We compute the required byte count using long arithmetic to
+                        // avoid any chance of overflow before the comparison.
+                        long bytesNeeded = isAnsi ? (long)size : (long)size * 2;
+                        if (offset < 0 || EventDataLength - offset < bytesNeeded)
+                        {
+                            throw new ArgumentOutOfRangeException(nameof(size));
                         }
                         if (isAnsi)
                         {
@@ -1140,6 +1159,15 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 Debug.Assert(IsCountedSize(payloadFetch.Size));
 
                 // Length prefixed arrays have a 2 or 4 byte length field.
+                int lengthFieldSize = ((payloadFetch.Size & DynamicTraceEventData.BIT_32) != 0) ? 4 : 2;
+                // GetInt16At / GetInt32At are raw memory reads that do not bounds check, so
+                // validate the length-field bytes are inside EventDataLength before reading them.
+                // Without this, a payload with fewer than 'lengthFieldSize' bytes at 'offset' would
+                // surface adjacent native heap bytes as the array count.
+                if (offset < 0 || EventDataLength - offset < lengthFieldSize)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(offset));
+                }
                 if (((payloadFetch.Size & DynamicTraceEventData.BIT_32) != 0))
                 {
                     arrayCount = GetInt32At(offset);
@@ -1150,20 +1178,25 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                     arrayCount = GetInt16At(offset);
                     offset += 2;
                 }
+
+                // The length field is read directly from the payload bytes,
+                // so validate it against EventDataLength before the caller uses it to read array elements.
+                // For fixed-size elements we can compute the exact byte cost; for variable-sized elements
+                // we use a per-element minimum derived from the element encoding (e.g. 2 bytes for UTF-16
+                // null-terminated strings) which still gives a useful upper bound that prevents OOB reads.
+                ValidateArrayCount(arrayInfo, offset, arrayCount);
             }
             else if (arrayInfo.Kind == ArrayKind.RelLoc)
             {
                 Debug.Assert(arrayInfo.Element.IsFixedSize);
 
-                arrayCount = GetInt16At(offset + 2) / arrayInfo.Element.Size;
-                offset = GetInt16At(offset) + offset + 4; // RelLoc offset is relative to the end of the field.
+                (offset, arrayCount) = GetArrayDataOffsetAndCount(arrayInfo, offset, isRelLoc: true);
             }
             else if (arrayInfo.Kind == ArrayKind.DataLoc)
             {
                 Debug.Assert(arrayInfo.Element.IsFixedSize);
 
-                arrayCount = GetInt16At(offset + 2) / arrayInfo.Element.Size;
-                offset = GetInt16At(offset); // DataLoc offset is absolute in the buffer
+                (offset, arrayCount) = GetArrayDataOffsetAndCount(arrayInfo, offset, isRelLoc: false);
             }
             else
             {
@@ -1172,6 +1205,98 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
 
             return arrayCount;
+        }
+
+        private (int dataOffset, int arrayCount) GetArrayDataOffsetAndCount(PayloadFetchArrayInfo arrayInfo, int offset, bool isRelLoc)
+        {
+            const int locDescriptorSize = 4;
+
+            if (offset < 0 || EventDataLength - locDescriptorSize < offset)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+
+            int arrayOffset = (ushort)GetInt16At(offset);
+            int arrayByteLength = (ushort)GetInt16At(offset + 2);
+            int elementSize = arrayInfo.Element.Size;
+            if (elementSize <= 0 || arrayByteLength % elementSize != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayByteLength));
+            }
+
+            int dataOffset = arrayOffset;
+            if (isRelLoc)
+            {
+                int relativeOffsetBase = offset + locDescriptorSize;
+                if (relativeOffsetBase < offset || int.MaxValue - relativeOffsetBase < arrayOffset)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(offset));
+                }
+
+                dataOffset = relativeOffsetBase + arrayOffset; // RelLoc offset is relative to the end of the RelLoc field itself.
+            }
+
+            if (dataOffset < 0 || EventDataLength - dataOffset < arrayByteLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayByteLength));
+            }
+
+            return (dataOffset, arrayByteLength / elementSize);
+        }
+
+        // Validates that 'arrayCount' (just read from payload bytes for a length-prefixed
+        // array) does not point past the end of the event payload.  For fixed-size elements we use the actual
+        // element size; for variable-sized elements we use a per-element minimum derived from the element
+        // encoding (e.g. 2 bytes for UTF-16 null-terminated strings) so that callers that fast-path byte /
+        // char arrays via GetByteArrayAt or GetFixed*StringAt cannot be tricked into an OOB read.
+        private void ValidateArrayCount(PayloadFetchArrayInfo arrayInfo, int offset, int arrayCount)
+        {
+            if (arrayCount < 0 || offset < 0 || offset > EventDataLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayCount));
+            }
+
+            int remaining = EventDataLength - offset;
+            long minBytesNeeded;
+            if (arrayInfo.Element.IsFixedSize)
+            {
+                int elementSize = arrayInfo.Element.Size;
+                if (elementSize <= 0)
+                {
+                    // Defensive: a zero-sized element with an unbounded count makes no sense.
+                    throw new ArgumentOutOfRangeException(nameof(arrayCount));
+                }
+                minBytesNeeded = (long)arrayCount * elementSize;
+            }
+            else
+            {
+                // Variable-sized elements still have a minimum byte footprint per element.
+                // For strings, the minimum depends on encoding:
+                //   - null-terminated Unicode strings need at least 2 bytes (the terminator),
+                //   - counted strings need at least the size prefix (2 or 4 bytes),
+                //   - null-terminated ANSI strings need at least 1 byte (the terminator).
+                // For any other variable-sized element kind we conservatively assume 1 byte.
+                int minBytesPerElement = 1;
+                if (arrayInfo.Element.Type == typeof(string))
+                {
+                    ushort elementSize = arrayInfo.Element.Size;
+                    if (IsNullTerminated(elementSize))
+                    {
+                        bool isAnsi = (elementSize & IS_ANSI) != 0;
+                        minBytesPerElement = isAnsi ? 1 : 2;
+                    }
+                    else if (IsCountedSize(elementSize))
+                    {
+                        minBytesPerElement = ((elementSize & BIT_32) != 0) ? 4 : 2;
+                    }
+                }
+                minBytesNeeded = (long)arrayCount * minBytesPerElement;
+            }
+
+            if (minBytesNeeded > remaining)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayCount));
+            }
         }
 
         internal int OffsetOfNextField(ref PayloadFetch payloadFetch, int offset, int payloadLength)

--- a/src/TraceEvent/DynamicTraceEventParser.cs
+++ b/src/TraceEvent/DynamicTraceEventParser.cs
@@ -114,14 +114,40 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         /// </summary>
         public void WriteAllManifests(string directoryPath)
         {
-            Directory.CreateDirectory(directoryPath);
+            string fullDirectoryPath = Path.GetFullPath(directoryPath);
+            Directory.CreateDirectory(fullDirectoryPath);
             foreach (var providerManifest in DynamicProviders)
             {
-                
-                var filePath = Path.Combine(directoryPath, providerManifest.Name + ".manifest.xml");
+                // Provider names come from <provider name="..."> attributes in untrusted
+                // manifest XML embedded in trace data.  Sanitize the name into a safe
+                // file-name component; if the sanitizer rejects the input outright,
+                // fall back to the provider's GUID (which is always well-formed for a
+                // non-Guid.Empty value) so distinct providers still get distinct
+                // manifest files.  Use "_" only as a last resort when neither the
+                // name nor the GUID is usable.
+                string sanitizedName = PathUtilities.SanitizeFileName(providerManifest.Name);
+                if (sanitizedName == null)
+                {
+                    sanitizedName = providerManifest.Guid != Guid.Empty
+                        ? providerManifest.Guid.ToString("N")
+                        : "_";
+                }
+                string fileName = sanitizedName + ".manifest.xml";
+                string filePath = Path.GetFullPath(Path.Combine(fullDirectoryPath, fileName));
+
+                // SanitizeFileName strips every path separator and other invalid
+                // file-name character, so the combined path cannot escape the requested
+                // directory.  Verify that invariant defensively in case the sanitizer
+                // ever regresses or Path.Combine behaves unexpectedly on a new runtime.
+                if (!PathUtilities.IsPathWithinDirectory(filePath, fullDirectoryPath))
+                {
+                    throw new InvalidOperationException("Manifest output path must remain within the requested directory.");
+                }
+
                 providerManifest.WriteToFile(filePath);
             }
         }
+
 
         /// <summary>
         /// Utility method that read all the manifests the directory 'directoryPath' into the parser.   

--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -1093,6 +1093,26 @@ namespace Microsoft.Diagnostics.Tracing
         public static void ReadFromFormatV3(ref SpanReader reader, ref EventPipeEventHeader header)
         {
             ref readonly LayoutV3 layout = ref reader.ReadRef<LayoutV3>();
+            int totalSize;
+            try
+            {
+                totalSize = checked(layout.EventSize + sizeof(int));
+            }
+            catch (OverflowException ex)
+            {
+                throw new FormatException("Invalid EventPipe V3 event size", ex);
+            }
+
+            header.HeaderSize = sizeof(LayoutV3);
+            header.TotalNonHeaderSize = totalSize - header.HeaderSize;
+            if (totalSize < header.HeaderSize ||
+                header.TotalNonHeaderSize > reader.RemainingBytes.Length ||
+                layout.PayloadSize < 0 ||
+                layout.PayloadSize > header.TotalNonHeaderSize)
+            {
+                throw new FormatException("Invalid EventPipe V3 event payload size");
+            }
+
             header.EventSize = layout.EventSize;
             header.MetaDataId = layout.MetaDataId;
             header.ThreadIndexOrId = header.ThreadId = layout.ThreadId;
@@ -1109,11 +1129,30 @@ namespace Microsoft.Diagnostics.Tracing
             // we want to peak ahead and read some data in the stack part of the event without advancing the reader's cursor
             SpanReader eventReader = reader;
             eventReader.ReadBytes(layout.PayloadSize);
-            header.StackBytesSize = eventReader.ReadInt32();
+            int remainingStackBytes = header.TotalNonHeaderSize - layout.PayloadSize;
+            if (remainingStackBytes < sizeof(int))
+            {
+                throw new FormatException("Invalid EventPipe V3 event stack size");
+            }
+
+            int stackBytesSize = eventReader.ReadInt32();
+            remainingStackBytes -= sizeof(int);
+            if (stackBytesSize < 0 || stackBytesSize > remainingStackBytes)
+            {
+                throw new FormatException("Invalid EventPipe V3 event stack size");
+            }
+
+            // Defense-in-depth: EventPipeMetadata.GetEventRecordForEventData stores the stack-extended-data length
+            // in a ushort field (DataSize = (ushort)(stackBytesSize + sizeof(ulong))). If stackBytesSize is larger
+            // than ushort.MaxValue - sizeof(ulong), the cast truncates and TraceLog.ProcessExtendedData then
+            // computes a negative addressesCount, producing another out-of-bounds read. Reject those sizes here.
+            if (stackBytesSize > ushort.MaxValue - sizeof(ulong))
+            {
+                throw new FormatException("Invalid EventPipe V3 event stack size");
+            }
+
+            header.StackBytesSize = stackBytesSize;
             header.StackBytes = (IntPtr)Unsafe.AsPointer<byte>(ref MemoryMarshal.GetReference(eventReader.RemainingBytes));
-            header.HeaderSize = sizeof(LayoutV3);
-            int totalSize = header.EventSize + 4;
-            header.TotalNonHeaderSize = totalSize - header.HeaderSize;
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/src/TraceEvent/Parsers/GCDynamicTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/GCDynamicTraceEventParser.cs
@@ -127,21 +127,39 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
         }
 
         /// <summary>
-        /// These are the raw payload fields of the underlying event.
+        /// These are the raw payload fields of the underlying event.  They read through
+        /// the cached <see cref="_payload"/> that <see cref="FixupData"/> populates per
+        /// event; when the payload didn't pass the bounds check (i.e. <c>_payload</c>
+        /// is <c>null</c>) the accessors return type-appropriate safe defaults rather
+        /// than throwing, so the dispatch hot path stays exception-safe.
         /// </summary>
-        internal string Name { get { return GetUnicodeStringAt(0); } }
-        internal Int32 DataSize { get { return GetInt32At(SkipUnicodeString(0)); } }
-        internal byte[] Data { get { return GetByteArrayAt(offset: SkipUnicodeString(0) + 4, DataSize); } }
-        internal int ClrInstanceID { get { return GetInt16At(SkipUnicodeString(0) + 4 + DataSize); } }
+        internal string Name { get { return _payload?.Name ?? string.Empty; } }
+        internal Int32 DataSize { get { return _payload?.DataSize ?? 0; } }
+        internal byte[] Data { get { return _payload.HasValue ? GetByteArrayAt(offset: _payload.Value.DataOffset, _payload.Value.DataSize) : Array.Empty<byte>(); } }
+        internal int ClrInstanceID { get { return _payload.HasValue ? GetInt16At(_payload.Value.ClrInstanceIDOffset) : 0; } }
 
         /// <summary>
         /// This gets run before each event is dispatched.  It is responsible for detecting the event type
         /// and selecting the correct event template (derived from GCDynamicEvent).
+        ///
+        /// The single <see cref="GCDynamicTraceEventImpl"/> instance is reused for every
+        /// GCDynamic event the source produces, so the per-event payload validation
+        /// must run here (not once at construction) -- it refreshes <see cref="_payload"/>
+        /// for the event that's about to dispatch.  Centralising the bounds check here
+        /// lets all downstream payload accessors (Name / DataSize / Data / ClrInstanceID,
+        /// the typed CommittedUsage fixed-offset reads, PayloadValue / PayloadValues,
+        /// ToXml) trust the cached layout without re-validating, and prevents an
+        /// attacker-controlled DataSize from triggering an OOB read or an unhandled
+        /// exception on the dispatch hot path.
         /// </summary>
         internal override void FixupData()
         {
             // Delete any per-event user data because we may mutate the event identity.
             EventTypeUserData = null;
+
+            // Validate the payload layout for THIS event (instance is shared across all
+            // GCDynamic events, so we must re-validate each time, not just the first).
+            _payload = ReadPayloadLayout();
 
             // Set the event identity.
             SelectEventMetadata();
@@ -193,7 +211,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
         public override StringBuilder ToXml(StringBuilder sb)
         {
             Prefix(sb);
-
             foreach (KeyValuePair<string, object> pair in EventPayload.PayloadValues)
             {
                 XmlAttrib(sb, pair.Key, pair.Value);
@@ -205,11 +222,75 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
 
         private event Action<GCDynamicTraceEventImpl> Action;
 
+        // Per-event scratch state populated by FixupData.  null means the bound event's
+        // payload failed the bounds check; accessors above return safe defaults in
+        // that case.  The cache lifetime is exactly one dispatch -- FixupData
+        // overwrites it before each event is delivered.
+        private PayloadLayout? _payload;
+
+        /// <summary>
+        /// Bounds-checks the current event's payload against <see cref="TraceEvent.EventDataLength"/>
+        /// and returns the validated layout (including the eagerly read Name string)
+        /// on success, or <c>null</c> on failure.  Safe to call on attacker-controlled
+        /// payloads: every read goes through bounds-aware primitives
+        /// (<see cref="TraceEvent.GetUnicodeStringAt"/>, <see cref="TraceEvent.GetInt32At"/>)
+        /// and the byte array is not materialised -- only its range is validated.
+        /// </summary>
+        private PayloadLayout? ReadPayloadLayout()
+        {
+            int eventDataLength = EventDataLength;
+
+            // GetUnicodeStringAt requires at least one byte; a malformed event with
+            // an empty payload trivially has nowhere to put the GCDynamic fields.
+            if (eventDataLength < sizeof(char))
+            {
+                return null;
+            }
+
+            // GetUnicodeStringAt's read is bounded by EventDataLength.  If the buffer
+            // contains no Unicode null terminator the returned string saturates at
+            // the buffer end and the nameEndOffset computed below exceeds
+            // eventDataLength, which the next range check rejects.
+            string name = GetUnicodeStringAt(0);
+
+            // Account for the Unicode null terminator after the name string.
+            int nameEndOffset = (name.Length + 1) * sizeof(char);
+            if (eventDataLength - nameEndOffset < sizeof(int))
+            {
+                return null;
+            }
+
+            int dataSize = GetInt32At(nameEndOffset);
+            if (dataSize < 0)
+            {
+                return null;
+            }
+
+            int dataOffset = nameEndOffset + sizeof(int);
+            int remainingBytesBeforeClrInstanceID = eventDataLength - dataOffset - sizeof(short);
+            if (remainingBytesBeforeClrInstanceID < 0 || dataSize > remainingBytesBeforeClrInstanceID)
+            {
+                return null;
+            }
+
+            return new PayloadLayout(name, dataSize, dataOffset, dataOffset + dataSize);
+        }
+
         private void SelectEventMetadata()
         {
+            // Default to the generic template -- its accessors fall back to safe
+            // placeholder values when _payload is null.
             GCDynamicEventBase eventTemplate = GCDynamicEventBase.GCDynamicTemplate;
 
-            if (Name.Equals(GCDynamicEventBase.CommittedUsageTemplate.OpcodeName, StringComparison.InvariantCultureIgnoreCase))
+            // Only select the CommittedUsage template when the payload validated AND
+            // is large enough to satisfy CommittedUsageTraceEvent's fixed-offset
+            // reads (Version through TotalBookkeepingCommitted occupy bytes 0..41).
+            // A spoofed event named "CommittedUsage" with a shorter DataSize would
+            // otherwise let BitConverter throw ArgumentException during PayloadValue
+            // / ToXml on the dispatch hot path.
+            if (_payload.HasValue
+                && _payload.Value.Name.Equals(GCDynamicEventBase.CommittedUsageTemplate.OpcodeName, StringComparison.InvariantCultureIgnoreCase)
+                && _payload.Value.DataSize >= CommittedUsageTraceEvent.MinimumDataSize)
             {
                 eventTemplate = GCDynamicEventBase.CommittedUsageTemplate;
             }
@@ -224,6 +305,22 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
             taskName = eventTemplate.TaskName;
             opcodeName = eventTemplate.OpcodeName;
             eventName = eventTemplate.EventName;
+        }
+
+        private struct PayloadLayout
+        {
+            public PayloadLayout(string name, int dataSize, int dataOffset, int clrInstanceIDOffset)
+            {
+                Name = name;
+                DataSize = dataSize;
+                DataOffset = dataOffset;
+                ClrInstanceIDOffset = clrInstanceIDOffset;
+            }
+
+            public readonly string Name;
+            public readonly int DataSize;
+            public readonly int DataOffset;
+            public readonly int ClrInstanceIDOffset;
         }
     }
 
@@ -331,6 +428,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.GCDynamic
 
     public sealed class CommittedUsageTraceEvent : GCDynamicEventBase
     {
+        /// <summary>
+        /// The minimum number of bytes the Data payload must contain in order for
+        /// all CommittedUsage fields (Version through TotalBookkeepingCommitted)
+        /// to be readable.  Used by the GCDynamic dispatcher to reject spoofed
+        /// "CommittedUsage" events whose DataSize is too small, which would
+        /// otherwise cause BitConverter to throw ArgumentException during
+        /// PayloadValue / ToXml and abort trace processing.
+        /// </summary>
+        internal const int MinimumDataSize = 42;
+
         public short Version { get { return BitConverter.ToInt16(DataField, 0); } }
         public long TotalCommittedInUse { get { return BitConverter.ToInt64(DataField, 2); } }
         public long TotalCommittedInGlobalDecommit { get { return BitConverter.ToInt64(DataField, 10); } }

--- a/src/TraceEvent/RegisteredTraceEventParser.cs
+++ b/src/TraceEvent/RegisteredTraceEventParser.cs
@@ -32,13 +32,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
             symbolSource.MetaDataEventInfo += delegate (EmptyTraceData data)
             {
-                DynamicTraceEventData template = (new RegisteredTraceEventParser.TdhEventParser((byte*)data.userData, null, MapTable)).ParseEventMetaData();
+                DynamicTraceEventData template = (new RegisteredTraceEventParser.TdhEventParser((byte*)data.userData, data.EventDataLength, null, MapTable)).ParseEventMetaData();
 
                 // Uncomment this if you want to see the template in the debugger at this point
                 // template.source = data.source;
                 // template.eventRecord = data.eventRecord;
                 // template.userData = data.userData;  
-                m_state.m_templates[template] = template;
+                if (template != null)
+                {
+                    m_state.m_templates[template] = template;
+                }
             };
 
             // Try to parse bitmap and value map information.  
@@ -46,14 +49,18 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             {
                 try
                 {
-                    Guid providerID = *((Guid*)data.userData);
-                    byte* eventInfoBuffer = (byte*)(data.userData + sizeof(Guid));
-                    RegisteredTraceEventParser.EVENT_MAP_INFO* eventInfo = (RegisteredTraceEventParser.EVENT_MAP_INFO*)eventInfoBuffer;
-                    IDictionary<long, string> map = RegisteredTraceEventParser.TdhEventParser.ParseMap(eventInfo, eventInfoBuffer);
-                    if (eventInfo->NameOffset < data.EventDataLength - 16)
+                    if (data.EventDataLength >= sizeof(Guid))
                     {
-                        string mapName = new string((char*)(&eventInfoBuffer[eventInfo->NameOffset]));
-                        MapTable.Add(new MapKey(providerID, mapName), map);
+                        Guid providerID = *((Guid*)data.userData);
+                        byte* eventInfoBuffer = (byte*)(data.userData + sizeof(Guid));
+                        int eventInfoBufferLength = data.EventDataLength - sizeof(Guid);
+                        RegisteredTraceEventParser.EVENT_MAP_INFO* eventInfo = (RegisteredTraceEventParser.EVENT_MAP_INFO*)eventInfoBuffer;
+                        IDictionary<long, string> map = RegisteredTraceEventParser.TdhEventParser.ParseMap(eventInfo, eventInfoBuffer, eventInfoBufferLength);
+                        string mapName;
+                        if (map != null && RegisteredTraceEventParser.TdhEventParser.TryReadMapName(eventInfo, eventInfoBuffer, eventInfoBufferLength, out mapName))
+                        {
+                            MapTable.Add(new MapKey(providerID, mapName), map);
+                        }
                     }
                 }
                 catch (Exception) { };
@@ -792,8 +799,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
                 if (status == 0)
                 {
-                    ret = (new TdhEventParser(buffer, unknownEvent.eventRecord, mapTable)).ParseEventMetaData();
-                    ret.containsSelfDescribingMetadata = hasETWEventInformation;
+                    ret = (new TdhEventParser(buffer, buffSize, unknownEvent.eventRecord, mapTable)).ParseEventMetaData();
+                    if (ret != null)
+                    {
+                        ret.containsSelfDescribingMetadata = hasETWEventInformation;
+                    }
                 }
 
                 System.Runtime.InteropServices.Marshal.FreeHGlobal((IntPtr)buffer);
@@ -811,14 +821,17 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
         internal class TdhEventParser
         {
             /// <summary>
-            /// Creates a new parser from the TRACE_EVENT_INFO held in 'buffer'.  Use
+            /// Creates a new parser from the TRACE_EVENT_INFO held in 'eventInfo'.  Use
             /// ParseEventMetaData to then parse it into a DynamicTraceEventData structure.
-            ///  EventRecord can be null and mapTable if present allow the parser to resolve maps (enums), and can be null.  
+            /// eventInfoLength is the length in bytes of the buffer pointed to by 'eventInfo'; every offset and array
+            /// extent contained in the TRACE_EVENT_INFO is bounds-checked against this length before being dereferenced.
+            /// eventRecord can be null and mapTable if present allow the parser to resolve maps (enums), and can be null.
             /// </summary>
-            public TdhEventParser(byte* eventInfo, TraceEventNativeMethods.EVENT_RECORD* eventRecord, Dictionary<MapKey, IDictionary<long, string>> mapTable)
+            public TdhEventParser(byte* eventInfo, int eventInfoLength, TraceEventNativeMethods.EVENT_RECORD* eventRecord, Dictionary<MapKey, IDictionary<long, string>> mapTable)
             {
                 eventBuffer = eventInfo;
                 this.eventInfo = (TRACE_EVENT_INFO*)eventInfo;
+                this.eventInfoLength = eventInfoLength;
                 propertyInfos = &this.eventInfo->EventPropertyInfoArray;
                 this.eventRecord = eventRecord;
                 this.mapTable = mapTable;
@@ -830,29 +843,41 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             /// <returns></returns>
             public DynamicTraceEventData ParseEventMetaData()
             {
+                if (!ValidateEventInfo())
+                {
+                    return null;
+                }
+
                 EVENT_PROPERTY_INFO* propertyInfos = &eventInfo->EventPropertyInfoArray;
                 string taskName = null;
                 if (eventInfo->TaskNameOffset != 0)
                 {
-                    taskName = MakeLegalIdentifier(new string((char*)(&eventBuffer[eventInfo->TaskNameOffset])));
+                    taskName = ReadString(eventInfo->TaskNameOffset);
+                    if (taskName != null)
+                    {
+                        taskName = MakeLegalIdentifier(taskName);
+                    }
                 }
 
                 string opcodeName = null;
                 if (eventInfo->OpcodeNameOffset != 0)
                 {
-                    opcodeName = new string((char*)(&eventBuffer[eventInfo->OpcodeNameOffset]));
-                    if (opcodeName.StartsWith("win:"))
+                    opcodeName = ReadString(eventInfo->OpcodeNameOffset);
+                    if (opcodeName != null)
                     {
-                        opcodeName = opcodeName.Substring(4);
-                    }
+                        if (opcodeName.StartsWith("win:"))
+                        {
+                            opcodeName = opcodeName.Substring(4);
+                        }
 
-                    opcodeName = MakeLegalIdentifier(opcodeName);
+                        opcodeName = MakeLegalIdentifier(opcodeName);
+                    }
                 }
 
                 string providerName = "UnknownProvider";
                 if (eventInfo->ProviderNameOffset != 0)
                 {
-                    providerName = new string((char*)(&eventBuffer[eventInfo->ProviderNameOffset]));
+                    providerName = ReadString(eventInfo->ProviderNameOffset) ?? providerName;
                 }
 
                 var eventID = eventInfo->EventDescriptor.Id;
@@ -875,11 +900,16 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
 
                 if (eventInfo->EventMessageOffset != 0)
                 {
-                    newTemplate.MessageFormat = new string((char*)(&eventBuffer[eventInfo->EventMessageOffset]));
+                    newTemplate.MessageFormat = ReadString(eventInfo->EventMessageOffset);
                 }
 
                 Debug.WriteLine("In TdhEventParser for event" + providerName + "/" + taskName + "/" + opcodeName + " with " + eventInfo->TopLevelPropertyCount + " fields");
                 DynamicTraceEventData.PayloadFetchClassInfo fields = ParseFields(0, eventInfo->TopLevelPropertyCount);
+                if (fields == null)
+                {
+                    return null;
+                }
+
                 newTemplate.payloadNames = fields.FieldNames;
                 newTemplate.payloadFetches = fields.FieldFetches;
 
@@ -893,15 +923,37 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
             /// </summary>
             private DynamicTraceEventData.PayloadFetchClassInfo ParseFields(int startField, int numFields)
             {
+                _totalFieldsParsed = 0;
+                return ParseFields(startField, numFields, 0);
+            }
+
+            private DynamicTraceEventData.PayloadFetchClassInfo ParseFields(int startField, int numFields, int recursionDepth)
+            {
+                if (!ValidateFieldRange(startField, numFields) || recursionDepth > MaxParseFieldRecursionDepth)
+                {
+                    return null;
+                }
+
                 ushort fieldOffset = 0;
                 var fieldNames = new List<string>(numFields);
                 var fieldFetches = new List<DynamicTraceEventData.PayloadFetch>(numFields);
 
                 for (int curField = 0; curField < numFields; curField++)
                 {
+                    // Bound the *total* number of fields parsed across all recursion frames.  In well-formed
+                    // metadata struct membership partitions the property array, so every property is parsed
+                    // exactly once and the cumulative count never exceeds PropertyCount.  A crafted blob whose
+                    // structs reference overlapping/shared ranges would otherwise re-parse properties and blow
+                    // up exponentially (the depth cap below bounds depth, not total work).  Exceeding
+                    // PropertyCount therefore proves the metadata is malformed, so reject the whole template.
+                    if (++_totalFieldsParsed > eventInfo->PropertyCount)
+                    {
+                        return null;
+                    }
+
                     DynamicTraceEventData.PayloadFetch propertyFetch = new DynamicTraceEventData.PayloadFetch();
                     var propertyInfo = &propertyInfos[curField + startField];
-                    var propertyName = new string((char*)(&eventBuffer[propertyInfo->NameOffset]));
+                    var propertyName = ReadString(propertyInfo->NameOffset) ?? string.Empty;
                     // Remove anything that does not look like an ID (.e.g space)
                     propertyName = Regex.Replace(propertyName, "[^A-Za-z0-9_]", "");
 
@@ -920,11 +972,11 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                     {
                         int numStructFields = propertyInfo->NumOfStructMembers;
                         Debug.WriteLine("   " + propertyName + " Is a nested type with " + numStructFields + " fields {");
-                        DynamicTraceEventData.PayloadFetchClassInfo classInfo = ParseFields(propertyInfo->StructStartIndex, numStructFields);
+                        DynamicTraceEventData.PayloadFetchClassInfo classInfo = ParseFields(propertyInfo->StructStartIndex, numStructFields, recursionDepth + 1);
                         if (classInfo == null)
                         {
                             Debug.WriteLine("    Failure parsing nested struct.");
-                            goto Exit;
+                            return null;
                         }
                         Debug.WriteLine(" } " + propertyName + " Nested struct completes.");
                         propertyFetch = DynamicTraceEventData.PayloadFetch.StructPayloadFetch(fieldOffset, classInfo);
@@ -941,42 +993,47 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                         // Deal with any maps (bit fields or enumerations)
                         if (propertyInfo->MapNameOffset != 0)
                         {
-                            string mapName = new string((char*)(&eventBuffer[propertyInfo->MapNameOffset]));
+                            string mapName = ReadString(propertyInfo->MapNameOffset);
 
-                            // Normal case, you can look up the enum information immediately. 
-                            if (eventRecord != null)
+                            // If the map name is out of range we simply skip the map and parse the field
+                            // as its underlying integer type rather than rejecting the whole event.
+                            if (mapName != null)
                             {
-                                int buffSize = 84000;  // TODO this is inefficient (and incorrect for very large enums).  
-                                byte* enumBuffer = (byte*)System.Runtime.InteropServices.Marshal.AllocHGlobal(buffSize);
-
-                                EVENT_MAP_INFO* enumInfo = (EVENT_MAP_INFO*)enumBuffer;
-                                var hr = TdhGetEventMapInformation(eventRecord, mapName, enumInfo, ref buffSize);
-                                if (hr == 0)
+                                // Normal case, you can look up the enum information immediately. 
+                                if (eventRecord != null)
                                 {
-                                    propertyFetch.Map = ParseMap(enumInfo, enumBuffer);
-                                }
+                                    int buffSize = 84000;  // TODO this is inefficient (and incorrect for very large enums).  
+                                    byte* enumBuffer = (byte*)System.Runtime.InteropServices.Marshal.AllocHGlobal(buffSize);
 
-                                System.Runtime.InteropServices.Marshal.FreeHGlobal((IntPtr)enumBuffer);
-                            }
-                            else
-                            {
-                                // This is the kernelTraceControl case,  the map information will be provided
-                                // later, so we have to set up a LAZY map which will be evaluated when we need the
-                                // enum (giving time for the enum definition to be processed. 
-                                var mapKey = new MapKey(eventInfo->ProviderGuid, mapName);
-
-                                // Set the map to be a lazyMap, which is a Func that returns a map.  
-                                Func<IDictionary<long, string>> lazyMap = delegate ()
-                                {
-                                    IDictionary<long, string> map = null;
-                                    if (mapTable != null)
+                                    EVENT_MAP_INFO* enumInfo = (EVENT_MAP_INFO*)enumBuffer;
+                                    var hr = TdhGetEventMapInformation(eventRecord, mapName, enumInfo, ref buffSize);
+                                    if (hr == 0)
                                     {
-                                        mapTable.TryGetValue(mapKey, out map);
+                                        propertyFetch.Map = ParseMap(enumInfo, enumBuffer, buffSize);
                                     }
 
-                                    return map;
-                                };
-                                propertyFetch.LazyMap = lazyMap;
+                                    System.Runtime.InteropServices.Marshal.FreeHGlobal((IntPtr)enumBuffer);
+                                }
+                                else
+                                {
+                                    // This is the kernelTraceControl case,  the map information will be provided
+                                    // later, so we have to set up a LAZY map which will be evaluated when we need the
+                                    // enum (giving time for the enum definition to be processed. 
+                                    var mapKey = new MapKey(eventInfo->ProviderGuid, mapName);
+
+                                    // Set the map to be a lazyMap, which is a Func that returns a map.  
+                                    Func<IDictionary<long, string>> lazyMap = delegate ()
+                                    {
+                                        IDictionary<long, string> map = null;
+                                        if (mapTable != null)
+                                        {
+                                            mapTable.TryGetValue(mapKey, out map);
+                                        }
+
+                                        return map;
+                                    };
+                                    propertyFetch.LazyMap = lazyMap;
+                                }
                             }
                         }
                     }
@@ -1007,6 +1064,14 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                             if (countOrCountIndex == startField + curField - 1)
                             {
                                 var lastFieldIdx = fieldFetches.Count - 1;
+                                if (lastFieldIdx < 0)
+                                {
+                                    // Malformed metadata: the count index points before the current (nested) parse
+                                    // frame, so there is no preceding field in this frame to consume as the prefix.
+                                    // Reject the template rather than indexing fieldFetches[-1] on the untrusted path.
+                                    return null;
+                                }
+
                                 arraySize = DynamicTraceEventData.COUNTED_SIZE + DynamicTraceEventData.CONSUMES_FIELD + DynamicTraceEventData.ELEM_COUNT;
                                 if (fieldFetches[lastFieldIdx].Size == 4)
                                 {
@@ -1084,44 +1149,146 @@ namespace Microsoft.Diagnostics.Tracing.Parsers
                 return ret; ;
             }
 
-            // Parses a EVENT_MAP_INFO into a Dictionary for a Value map or a SortedDictionary for a Bitmap
-            // returns null if it does not know how to parse it.  
-            internal static unsafe IDictionary<long, string> ParseMap(EVENT_MAP_INFO* enumInfo, byte* enumBuffer)
+            // Parses a EVENT_MAP_INFO into a Dictionary for a Value map or a SortedDictionary for a Bitmap.
+            // 'enumBufferLength' is the length in bytes of the buffer pointed to by 'enumBuffer'; every offset and array
+            // extent contained in the EVENT_MAP_INFO is bounds-checked against this length before being dereferenced.
+            // Returns null if it does not know how to parse it or if the metadata fails validation.
+            internal static unsafe IDictionary<long, string> ParseMap(EVENT_MAP_INFO* enumInfo, byte* enumBuffer, int enumBufferLength)
             {
-                IDictionary<long, string> map = null;
-                // We only support manifest enums for now.  
-                if (enumInfo->Flag == MAP_FLAGS.EVENTMAP_INFO_FLAG_MANIFEST_VALUEMAP ||
-                    enumInfo->Flag == MAP_FLAGS.EVENTMAP_INFO_FLAG_MANIFEST_BITMAP)
+                if (enumInfo == null || !ValidateRange(enumBufferLength, 0, EventMapInfoEntryArrayOffset))
                 {
-                    StringWriter enumWriter = new StringWriter();
-                    string enumName = new string((char*)(&enumBuffer[enumInfo->NameOffset]));
-
-                    if (enumInfo->Flag == MAP_FLAGS.EVENTMAP_INFO_FLAG_MANIFEST_VALUEMAP)
-                    {
-                        map = new Dictionary<long, string>();
-                    }
-                    else
-                    {
-                        map = new SortedDictionary<long, string>();
-                    }
-
-                    EVENT_MAP_ENTRY* mapEntries = &enumInfo->MapEntryArray;
-                    for (int k = 0; k < enumInfo->EntryCount; k++)
-                    {
-                        int value = mapEntries[k].Value;
-                        string valueName = new string((char*)(&enumBuffer[mapEntries[k].NameOffset])).Trim();
-                        map[value] = valueName;
-                    }
+                    return null;
                 }
+
+                // We only support manifest enums for now.
+                if (enumInfo->Flag != MAP_FLAGS.EVENTMAP_INFO_FLAG_MANIFEST_VALUEMAP &&
+                    enumInfo->Flag != MAP_FLAGS.EVENTMAP_INFO_FLAG_MANIFEST_BITMAP)
+                {
+                    return null;
+                }
+
+                // The entry array must fit within the buffer before we can index into it below.
+                if (enumInfo->EntryCount < 0 ||
+                    !ValidateRange(enumBufferLength, EventMapInfoEntryArrayOffset, (long)enumInfo->EntryCount * EventMapEntrySize))
+                {
+                    return null;
+                }
+
+                IDictionary<long, string> map = (enumInfo->Flag == MAP_FLAGS.EVENTMAP_INFO_FLAG_MANIFEST_VALUEMAP)
+                    ? (IDictionary<long, string>)new Dictionary<long, string>()
+                    : new SortedDictionary<long, string>();
+
+                EVENT_MAP_ENTRY* mapEntries = &enumInfo->MapEntryArray;
+                for (int k = 0; k < enumInfo->EntryCount; k++)
+                {
+                    string valueName;
+                    if (!TryReadUnicodeString(enumBuffer, mapEntries[k].NameOffset, enumBufferLength, out valueName) || valueName == null)
+                    {
+                        return null;
+                    }
+
+                    map[mapEntries[k].Value] = valueName.Trim();
+                }
+
                 return map;
             }
 
+            // Reads the map's name (EVENT_MAP_INFO.NameOffset) from 'enumBuffer', bounds-checked against
+            // 'enumBufferLength'.  Returns false if the name offset is missing or out of range.
+            internal static unsafe bool TryReadMapName(EVENT_MAP_INFO* enumInfo, byte* enumBuffer, int enumBufferLength, out string mapName)
+            {
+                mapName = null;
+                return enumInfo != null &&
+                    ValidateRange(enumBufferLength, 0, EventMapInfoEntryArrayOffset) &&
+                    enumInfo->NameOffset != 0 &&
+                    TryReadUnicodeString(enumBuffer, enumInfo->NameOffset, enumBufferLength, out mapName);
+            }
+
+            // Validates the fixed-size TRACE_EVENT_INFO header and that the declared property array fits within
+            // the buffer.  This is the minimum required before ParseFields can safely index into the property
+            // array; individual string offsets and field ranges are bounds-checked at the point they are read.
+            private bool ValidateEventInfo()
+            {
+                if (eventInfo == null || !ValidateRange(eventInfoLength, 0, TraceEventInfoPropertyArrayOffset))
+                {
+                    return false;
+                }
+
+                if (eventInfo->PropertyCount < 0 ||
+                    eventInfo->TopLevelPropertyCount < 0 ||
+                    eventInfo->TopLevelPropertyCount > eventInfo->PropertyCount)
+                {
+                    return false;
+                }
+
+                return ValidateRange(eventInfoLength, TraceEventInfoPropertyArrayOffset, (long)eventInfo->PropertyCount * EventPropertyInfoSize);
+            }
+
+            private bool ValidateFieldRange(int startField, int numFields)
+            {
+                return startField >= 0 &&
+                    numFields >= 0 &&
+                    startField <= eventInfo->PropertyCount &&
+                    numFields <= eventInfo->PropertyCount - startField;
+            }
+
+            private string ReadString(int offset)
+            {
+                string value;
+                return TryReadUnicodeString(eventBuffer, offset, eventInfoLength, out value) ? value : null;
+            }
+
+            // Returns true if [offset, offset + size) lies entirely within a buffer of 'bufferLength' bytes.
+            private static bool ValidateRange(int bufferLength, int offset, long size)
+            {
+                return bufferLength >= 0 &&
+                    offset >= 0 &&
+                    size >= 0 &&
+                    offset <= bufferLength &&
+                    size <= bufferLength - offset;
+            }
+
+            // Reads a null-terminated Unicode string starting at 'offset' in 'buffer', refusing to read past
+            // 'bufferLength'.  An offset of 0 means the string is absent (returns true with a null value); any
+            // other offset that is out of range or lacks a terminator within the buffer returns false.
+            private static unsafe bool TryReadUnicodeString(byte* buffer, int offset, int bufferLength, out string value)
+            {
+                value = null;
+                if (offset == 0)
+                {
+                    return true;
+                }
+
+                if (!ValidateRange(bufferLength, offset, sizeof(char)))
+                {
+                    return false;
+                }
+
+                for (int i = offset; i <= bufferLength - sizeof(char); i += sizeof(char))
+                {
+                    if (buffer[i] == 0 && buffer[i + 1] == 0)
+                    {
+                        value = new string((char*)(&buffer[offset]));
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             #region private
+            private const int MaxParseFieldRecursionDepth = 32;
+            private int _totalFieldsParsed;          // cumulative fields parsed across all ParseFields frames; bounds total work
+            private static readonly int TraceEventInfoPropertyArrayOffset = (int)Marshal.OffsetOf(typeof(TRACE_EVENT_INFO), "EventPropertyInfoArray");
+            private static readonly int EventPropertyInfoSize = Marshal.SizeOf(typeof(EVENT_PROPERTY_INFO));
+            private static readonly int EventMapInfoEntryArrayOffset = (int)Marshal.OffsetOf(typeof(EVENT_MAP_INFO), "MapEntryArray");
+            private static readonly int EventMapEntrySize = Marshal.SizeOf(typeof(EVENT_MAP_ENTRY));
             private TRACE_EVENT_INFO* eventInfo;
             private TraceEventNativeMethods.EVENT_RECORD* eventRecord;
             private Dictionary<MapKey, IDictionary<long, string>> mapTable;     // table of enums that have defined. 
             private EVENT_PROPERTY_INFO* propertyInfos;
             private byte* eventBuffer;                           // points at the eventInfo, but in increments of bytes 
+            private int eventInfoLength;
             #endregion // private
         }
 

--- a/src/TraceEvent/Symbols/NativeSymbolModule.cs
+++ b/src/TraceEvent/Symbols/NativeSymbolModule.cs
@@ -518,7 +518,7 @@ namespace Microsoft.Diagnostics.Symbols
             /// </summary>
             protected override string GetSourceFromSrcServer()
             {
-                // Try getting the source from the source server using SourceLink information.  
+                // Try getting the source from the source server using SourceLink information.
                 var ret = base.GetSourceFromSrcServer();
                 if (ret != null)
                 {
@@ -527,116 +527,681 @@ namespace Microsoft.Diagnostics.Symbols
 
                 var cacheDir = _symbolModule.SymbolReader.SourceCacheDirectory;
 
-                string target, fetchCmdStr;
-                GetSourceServerTargetAndCommand(out target, out fetchCmdStr, cacheDir);
+                GetSourceServerTargetAndCommand(out string target, out string fetchCmdStr, cacheDir);
 
-                if (target != null)
+                if (target == null)
                 {
-                    if (!target.StartsWith(cacheDir, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // if target is not in cache dir, it means it's from a remote server.
-                        Uri uri = null;
-                        if (Uri.TryCreate(target, UriKind.Absolute, out uri))
-                        {
-                            target = null;
-                            var newTarget = Path.Combine(cacheDir, uri.AbsolutePath.TrimStart('/').Replace('/', '\\'));
-                            if (_symbolModule.SymbolReader.GetPhysicalFileFromServer(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped), uri.AbsolutePath, newTarget))
-                            {
-                                target = newTarget;
-                            }
+                    _log.WriteLine("Did not find source file in the set of source files in the PDB.");
+                    return null;
+                }
 
-                            if (target == null)
-                            {
-                                _log.WriteLine("Could not fetch {0} from web", uri.AbsoluteUri);
-                                return null;
-                            }
-                        }
-                        else
-                        {
-                            _log.WriteLine("Source Server string {0} is targeting an unsafe location.  Giving up.", target);
-                            return null;
-                        }
+                // Synthesize a path under cacheDir that is structurally impossible to escape, no matter what
+                // the PDB-supplied 'target' looks like.  The shape is <cacheDir>\<hash(target)>\<file name>.
+                if (!TryGetSafeSourceCachePath(cacheDir, target, out string safeCachePath))
+                {
+                    _log.WriteLine("Source Server target {0} cannot be mapped to a safe cache path. Giving up.", target);
+                    return null;
+                }
+
+                // If the file already exists in the safe cache path, return it without re-fetching.
+                // This is also what suppresses repeat authorization prompts when the user opens the same source
+                // file more than once: the second open finds the cached file and never reaches the prompt below.
+                if (File.Exists(safeCachePath))
+                {
+                    if (new FileInfo(safeCachePath).Length > 0)
+                    {
+                        _log.WriteLine("Found an existing source server file {0}.", safeCachePath);
+                        return safeCachePath;
                     }
 
-                    if (!File.Exists(target) && fetchCmdStr != null)
+                    if (!FileUtilities.TryDelete(safeCachePath))
                     {
-                        _log.WriteLine("Trying to generate the file {0}.", target);
-                        var toolsDir = Path.GetDirectoryName(typeof(SourceFile).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName);
-                        var archToolsDir = Path.Combine(toolsDir, NativeDlls.ProcessArchitectureDirectory);
+                        _log.WriteLine("Found an existing empty source server file that could not be deleted: {0}", safeCachePath);
+                        return null;
+                    }
 
-                        // Find the EXE to do the source server fetch.  We only support TF.exe.   
-                        string addToPath = null;
-                        if (fetchCmdStr.StartsWith("tf.exe ", StringComparison.OrdinalIgnoreCase))
+                    _log.WriteLine("Found an existing empty source server file {0}. Re-fetching.", safeCachePath);
+                }
+
+                // HTTP(S) fetch path.  Non-HTTP(S) targets fall through to the source-server command branch.
+                if (Uri.TryCreate(target, UriKind.Absolute, out Uri uri)
+                    && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+                {
+                    if (!TryCreateSafeSourceCacheDirectory(safeCachePath))
+                    {
+                        return null;
+                    }
+
+                    if (_symbolModule.SymbolReader.GetPhysicalFileFromServer(
+                            uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped),
+                            uri.AbsolutePath,
+                            safeCachePath))
+                    {
+                        _log.WriteLine("Source Server command succeeded creating {0}", safeCachePath);
+                        return safeCachePath;
+                    }
+
+                    _log.WriteLine("Could not fetch {0} from web", uri.AbsoluteUri);
+                    return null;
+                }
+
+                // Source-server command-line fetch path (tf.exe view / tf.exe git view).
+                if (string.IsNullOrEmpty(fetchCmdStr))
+                {
+                    _log.WriteLine("Source Server target {0} is not an HTTP(S) URL and no fetch command was provided.  Giving up.", target);
+                    return null;
+                }
+
+                _log.WriteLine("Trying to generate the file {0}.", safeCachePath);
+
+                // Find tf.exe.  We only support tf.exe-based fetch commands (the per-tool allow-list in
+                // TryCreateSafeSourceServerCommand will reject any other executable).
+                string addToPath = null;
+                var tfExe = Command.FindOnPath("tf.exe");
+                if (tfExe == null)
+                {
+                    tfExe = FindTfExe();
+                    if (tfExe == null)
+                    {
+                        _log.WriteLine("Could not find TF.exe, place it on the PATH environment variable to fix this.");
+                        return null;
+                    }
+                    addToPath = Path.GetDirectoryName(tfExe);
+                }
+
+                // Legacy URL fixup: the original Microsoft TFS server's URL changed.  Because we no longer go
+                // through cmd /c, this is just a string rewrite on the PDB-supplied command before tokenization.
+                fetchCmdStr = fetchCmdStr.Replace(OldSourceServerUrl, NewSourceServerUrl);
+
+                // Rebuild the fetch command from validated, allow-listed tokens, with safeCachePath forced as
+                // the output destination.
+                if (!TryCreateSafeSourceServerCommand(fetchCmdStr, tfExe, safeCachePath, out string safeFetchCmdStr, out string rejectReason))
+                {
+                    _log.WriteLine("Source Server command (PDB-supplied, not executed): {0}", fetchCmdStr);
+                    _log.WriteLine("Source Server command is not recognized as safe ({0}). Failing.", rejectReason);
+                    return null;
+                }
+
+                // Ask the consumer for permission to run the safe command.  Defaults to deny when no authorizer
+                // is installed: non-PerfView consumers must opt in to executing source-server fetch commands.
+                var authorize = _symbolModule.SymbolReader.AuthorizeSourceServerCommand;
+                if (authorize == null)
+                {
+                    _log.WriteLine("Source Server command execution denied by default because no source-server command authorizer is installed.  Install SymbolReader.AuthorizeSourceServerCommand, or in PerfView run with /TrustPdbs, to allow this.  Safe rebuilt command was not executed: {0}", safeFetchCmdStr);
+                    return null;
+                }
+
+                bool authorized;
+                try
+                {
+                    authorized = authorize(new SourceServerAuthorizationRequest { Command = safeFetchCmdStr });
+                }
+                catch (Exception ex)
+                {
+                    _log.WriteLine("Source Server command authorizer threw exception.  Treating as denied.  Safe rebuilt command was not executed: {0}\r\nException: {1}", safeFetchCmdStr, ex.ToString());
+                    return null;
+                }
+
+                if (!authorized)
+                {
+                    _log.WriteLine("Source Server command execution denied by authorizer.  Safe rebuilt command was not executed: {0}", safeFetchCmdStr);
+                    return null;
+                }
+
+                _log.WriteLine("Source Server command authorized; running: {0}", safeFetchCmdStr);
+
+                if (!TryCreateSafeSourceCacheDirectory(safeCachePath))
+                {
+                    return null;
+                }
+
+                var options = new CommandOptions().AddOutputStream(_log).AddNoThrow();
+                if (addToPath != null)
+                {
+                    options = options.AddEnvironmentVariable("PATH", addToPath + ";%PATH%");
+                }
+
+                var fetchCmd = Command.Run(safeFetchCmdStr, options);
+                if (fetchCmd.ExitCode != 0)
+                {
+                    _log.WriteLine("Source Server command failed with exit code {0}", fetchCmd.ExitCode);
+                }
+
+                if (File.Exists(safeCachePath))
+                {
+                    // If the fetch command fails it might still create an empty output file.  Treat that as a failure.
+                    if (new FileInfo(safeCachePath).Length == 0)
+                    {
+                        if (!FileUtilities.TryDelete(safeCachePath))
                         {
-                            var tfExe = Command.FindOnPath("tf.exe");
-                            if (tfExe == null)
-                            {
-                                tfExe = FindTfExe();
-                                if (tfExe == null)
-                                {
-                                    _log.WriteLine("Could not find TF.exe, place it on the PATH environment variable to fix this.");
-                                    return null;
-                                }
-                                addToPath = Path.GetDirectoryName(tfExe);
-                            }
-                        }
-                        else
-                        {
-                            _log.WriteLine("Source Server command {0} is not recognized as safe (tf.exe) command. Failing.", fetchCmdStr);
-                            return null;
+                            _log.WriteLine("Source Server command produced an empty output file that could not be deleted: {0}", safeCachePath);
                         }
 
-                        // Update the source server URL if necessary.
-                        fetchCmdStr = fetchCmdStr.Replace(OldSourceServerUrl, NewSourceServerUrl);
+                        _log.WriteLine("Source Server command failed to produce the output file.");
+                        return null;
+                    }
 
-                        Directory.CreateDirectory(Path.GetDirectoryName(target));
-                        fetchCmdStr = "cmd /c " + fetchCmdStr;
-                        var options = new CommandOptions().AddOutputStream(_log).AddNoThrow();
-                        if (addToPath != null)
+                    _log.WriteLine("Source Server command succeeded creating {0}", safeCachePath);
+                    return safeCachePath;
+                }
+
+                _log.WriteLine("Source Server command failed to produce the output file.");
+                return null;
+            }
+
+            /// <summary>
+            /// Creates the cache directory for a synthesized source-server cache path.
+            /// Source-server fetches are best-effort: in locked-down environments the parent symbol cache
+            /// directory may be read-only, ACL-restricted, unavailable, or otherwise unsuitable for creating
+            /// per-source subdirectories.  Treat those filesystem failures as a source lookup miss and log the
+            /// full exception instead of allowing a malformed or untrusted PDB lookup to fail the caller.
+            /// </summary>
+            private bool TryCreateSafeSourceCacheDirectory(string safeCachePath)
+            {
+                string directory = Path.GetDirectoryName(safeCachePath);
+                try
+                {
+                    Directory.CreateDirectory(directory);
+                    return true;
+                }
+                catch (Exception ex) when (
+                    ex is IOException ||
+                    ex is UnauthorizedAccessException ||
+                    ex is ArgumentException ||
+                    ex is NotSupportedException)
+                {
+                    _log.WriteLine("Could not create Source Server cache directory {0}. {1}", directory, ex);
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// Synthesizes a structurally-safe path under <paramref name="cacheDir"/> for the PDB-supplied
+            /// source-server <paramref name="target"/>.  The returned path has the shape
+            /// <c>&lt;cacheDir&gt;\&lt;hash(target)&gt;\&lt;Path.GetFileName(target)&gt;</c>, which makes path
+            /// traversal structurally impossible: the hash subdirectory is a 32-character hexadecimal string
+            /// and the file name is a single path segment produced by <see cref="Path.GetFileName(string)"/>.
+            ///
+            /// Returns false if either input is null/empty, if the file-name component is missing, or if it
+            /// contains characters not allowed in a file name.  On failure <paramref name="safeCachePath"/>
+            /// is set to null.
+            /// </summary>
+            internal static bool TryGetSafeSourceCachePath(string cacheDir, string target, out string safeCachePath)
+            {
+                safeCachePath = null;
+
+                if (string.IsNullOrEmpty(cacheDir) || string.IsNullOrEmpty(target))
+                {
+                    return false;
+                }
+
+                // Path.GetFileName treats both '\' and '/' as separators on Windows, so it correctly extracts
+                // the trailing path segment from local paths and HTTP(S) URLs alike.
+                string fileName;
+                try
+                {
+                    fileName = Path.GetFileName(target);
+                }
+                catch (ArgumentException)
+                {
+                    return false;
+                }
+
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    return false;
+                }
+
+                // Reject "." and ".." (and the trailing-space / trailing-dot variants Windows normalizes
+                // to them).  Neither character sequence contains any character from
+                // Path.GetInvalidFileNameChars() (so the IndexOfAny check below would pass them through),
+                // but on Windows the kernel path normalizer strips trailing spaces and trailing dots from
+                // every path component before resolving '.' / '..' semantics.  Consequently ".. ", "..  ",
+                // "...", and similar all canonicalize at the OS level to ".." and would break the
+                // single-segment containment invariant -- safeCachePath = <cacheDir>\<hash>\.. resolves to
+                // <cacheDir>.  TrimEnd(' ', '.') reduces every such name to "" (and reduces "." / ".." to ""
+                // as well), giving us a single check that subsumes the literal-dot-segment cases.
+                if (fileName.TrimEnd(' ', '.').Length == 0)
+                {
+                    return false;
+                }
+
+                if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                {
+                    return false;
+                }
+
+                string canonicalCacheDir;
+                try
+                {
+                    canonicalCacheDir = Path.GetFullPath(cacheDir);
+                }
+                catch (ArgumentException)
+                {
+                    return false;
+                }
+                catch (NotSupportedException)
+                {
+                    return false;
+                }
+                catch (PathTooLongException)
+                {
+                    return false;
+                }
+                catch (System.Security.SecurityException)
+                {
+                    // Path.GetFullPath checks FileIOPermission on the resolved path on .NET Framework, and
+                    // can throw SecurityException on sandboxed hosts.  Treat as failure.
+                    return false;
+                }
+
+                string subdir = ComputeCacheSubdir(target);
+                safeCachePath = Path.Combine(canonicalCacheDir, subdir, fileName);
+                return true;
+            }
+
+            /// <summary>
+            /// Returns a 32-character hexadecimal subdirectory name derived from the XxHash128 of the UTF-8
+            /// bytes of <paramref name="value"/>.  XxHash128 is a fast non-cryptographic hash; it is used here
+            /// solely as a stable mapping from <paramref name="value"/> to a directory name so that the cache
+            /// layout is identical across processes and runtimes (unlike <see cref="string.GetHashCode"/>,
+            /// which is randomized in .NET Core).
+            /// </summary>
+            private static string ComputeCacheSubdir(string value)
+            {
+                byte[] hash = System.IO.Hashing.XxHash128.Hash(Encoding.UTF8.GetBytes(value));
+                var sb = new StringBuilder(hash.Length * 2);
+                for (int i = 0; i < hash.Length; i++)
+                {
+                    sb.Append(hash[i].ToString("x2", CultureInfo.InvariantCulture));
+                }
+                return sb.ToString();
+            }
+
+            /// <summary>
+            /// Allow-list of switches accepted by <c>tf.exe view</c> (TFVC).  All other switches cause the
+            /// command to be rejected.  The PDB-supplied output destination is always stripped and replaced
+            /// with our own <c>/output:&lt;safeCachePath&gt;</c>; <c>/login</c> is always stripped.
+            /// </summary>
+            private static readonly HashSet<string> s_tfViewAllowedSwitches = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "version",   // /version:<changeset>
+                "noprompt",  // flag
+                "server",    // /server:<TFS server URL>
+                "console",   // flag - now a no-op since we always write to /output:
+            };
+
+            /// <summary>
+            /// Allow-list of switches accepted by <c>tf.exe git view</c> (Azure DevOps Git via tf.exe).  All
+            /// other switches cause the command to be rejected.  The PDB-supplied output destination is always
+            /// stripped and replaced with our own <c>/output:&lt;safeCachePath&gt;</c>; <c>/login</c> is always
+            /// stripped.
+            /// </summary>
+            private static readonly HashSet<string> s_tfGitViewAllowedSwitches = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "collection",   // /collection:<collection URL>
+                "teamproject",  // /teamproject:<project>
+                "repository",   // /repository:<repo>
+                "commitid",     // /commitid:<sha>
+                "path",         // /path:<repo-relative path>
+                "applyfilters", // flag
+            };
+
+            /// <summary>
+            /// Validates and rebuilds <paramref name="sourceServerCommand"/> (the PDB-supplied SRCSRVCMD /
+            /// TFS_EXTRACT_CMD expansion) into a safe command line that can be executed directly via
+            /// <c>CreateProcess</c> (not through a shell).
+            ///
+            /// Three command shapes are accepted (case-insensitive): <c>tf.exe view ...</c> (TFVC),
+            /// <c>tf.exe vc view ...</c> (TFVC via the explicit vc namespace), and
+            /// <c>tf.exe git view ...</c> (Azure DevOps Git via tf.exe).  Other executables -- including
+            /// <c>cmd.exe</c>, <c>fastVstsBlob.exe</c>, <c>sd.exe</c> (Perforce), and other tf.exe sub-commands
+            /// like <c>workfold</c> -- are rejected.  Within an accepted command, only switches on the
+            /// corresponding per-tool allow-list (<see cref="s_tfViewAllowedSwitches"/> /
+            /// <see cref="s_tfGitViewAllowedSwitches"/>) are kept; any unrecognized switch causes the whole
+            /// command to be rejected and the offending token is named in <paramref name="rejectionReason"/>.
+            ///
+            /// Regardless of accept/reject, the rewriter always strips any PDB-supplied <c>/output</c> or
+            /// <c>/login</c> token (PDBs have no business carrying credentials, and we always force the output
+            /// destination to <paramref name="outputPath"/>) and stops processing at any <c>&gt;file</c>
+            /// shell-redirection token (legacy templates that ran through <c>cmd /c</c>).  The rebuilt command
+            /// always ends with a single <c>/output:&lt;outputPath&gt;</c>.
+            /// </summary>
+            internal static bool TryCreateSafeSourceServerCommand(
+                string sourceServerCommand,
+                string tfExe,
+                string outputPath,
+                out string safeCommand,
+                out string rejectionReason)
+            {
+                safeCommand = null;
+                rejectionReason = null;
+
+                if (string.IsNullOrWhiteSpace(sourceServerCommand))
+                {
+                    rejectionReason = "empty command";
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(tfExe))
+                {
+                    rejectionReason = "missing tf.exe path";
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(outputPath))
+                {
+                    rejectionReason = "missing output path";
+                    return false;
+                }
+
+                if (!TrySplitCommandLine(sourceServerCommand, out List<string> tokens, out rejectionReason))
+                {
+                    return false;
+                }
+
+                // Identify the tool: "tf.exe view ...", "tf.exe vc view ...", or "tf.exe git view ...".
+                // The starting position of the argument walk depends on which shape we saw.
+                HashSet<string> allowedSwitches;
+                List<string> safeArguments;
+                int argStart;
+
+                if (tokens.Count >= 2
+                    && string.Equals(tokens[0], "tf.exe", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(tokens[1], "view", StringComparison.OrdinalIgnoreCase))
+                {
+                    allowedSwitches = s_tfViewAllowedSwitches;
+                    safeArguments = new List<string> { "view" };
+                    argStart = 2;
+                }
+                else if (tokens.Count >= 3
+                    && string.Equals(tokens[0], "tf.exe", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(tokens[1], "vc", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(tokens[2], "view", StringComparison.OrdinalIgnoreCase))
+                {
+                    allowedSwitches = s_tfViewAllowedSwitches;
+                    safeArguments = new List<string> { "vc", "view" };
+                    argStart = 3;
+                }
+                else if (tokens.Count >= 3
+                    && string.Equals(tokens[0], "tf.exe", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(tokens[1], "git", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(tokens[2], "view", StringComparison.OrdinalIgnoreCase))
+                {
+                    allowedSwitches = s_tfGitViewAllowedSwitches;
+                    safeArguments = new List<string> { "git", "view" };
+                    argStart = 3;
+                }
+                else
+                {
+                    rejectionReason = "only 'tf.exe view', 'tf.exe vc view', and 'tf.exe git view' source-server commands are supported";
+                    return false;
+                }
+
+                // Whether we've already taken the positional depot-path argument for the TFVC view shapes.
+                // Only one such positional is allowed; further positionals are rejected as unknown.
+                bool tookTfViewPositional = false;
+
+                for (int i = argStart; i < tokens.Count; i++)
+                {
+                    string token = tokens[i];
+
+                    // Stop at legacy '>file' shell redirection.  These appear in templates that originally
+                    // ran through cmd /c; we always write via /output: instead.
+                    if (token.Length > 0 && token[0] == '>')
+                    {
+                        break;
+                    }
+
+                    // Strip any PDB-supplied output destination.  We append our own /output: at the end.
+                    if (IsTfSwitch(token, "output", out bool outputHasAttachedValue))
+                    {
+                        if (!outputHasAttachedValue && i + 1 < tokens.Count && !LooksLikeSwitchOrRedirection(tokens[i + 1]))
                         {
-                            options = options.AddEnvironmentVariable("PATH", addToPath + ";%PATH%");
+                            i++;
+                        }
+                        continue;
+                    }
+
+                    // Strip any PDB-supplied /login.  Source-server templates have no business carrying credentials.
+                    if (IsTfSwitch(token, "login", out bool loginHasAttachedValue))
+                    {
+                        if (!loginHasAttachedValue && i + 1 < tokens.Count && !LooksLikeSwitchOrRedirection(tokens[i + 1]))
+                        {
+                            i++;
+                        }
+                        continue;
+                    }
+
+                    // Switch-shaped token: must be on the per-tool allow-list.
+                    if (token.Length > 0 && (token[0] == '/' || token[0] == '-'))
+                    {
+                        string switchName = ExtractSwitchName(token);
+                        if (switchName != null && allowedSwitches.Contains(switchName))
+                        {
+                            safeArguments.Add(token);
+                            continue;
                         }
 
-                        _log.WriteLine("Source Server command {0}", fetchCmdStr);
-                        var fetchCmd = Command.Run(fetchCmdStr, options);
-                        if (fetchCmd.ExitCode != 0)
+                        rejectionReason = "unrecognized switch '" + token + "'";
+                        return false;
+                    }
+
+                    // Positional argument.  For the TFVC view shapes the legitimate templates carry exactly
+                    // one depot path (e.g. "$/team/path/file.cs").  Require the minimum plausible file shape
+                    // "$/x"; "$" and "$/" are not source-file paths.
+                    if (allowedSwitches == s_tfViewAllowedSwitches
+                        && !tookTfViewPositional
+                        && token.Length >= 3
+                        && token[0] == '$'
+                        && token[1] == '/')
+                    {
+                        safeArguments.Add(token);
+                        tookTfViewPositional = true;
+                        continue;
+                    }
+
+                    rejectionReason = "unrecognized argument '" + token + "'";
+                    return false;
+                }
+
+                safeArguments.Add("/output:" + outputPath);
+
+                var builder = new StringBuilder();
+                builder.Append(QuoteCommandLineArgument(tfExe));
+                foreach (string argument in safeArguments)
+                {
+                    builder.Append(' ');
+                    builder.Append(QuoteCommandLineArgument(argument));
+                }
+
+                safeCommand = builder.ToString();
+                return true;
+            }
+
+            /// <summary>
+            /// Returns the name portion of a tf.exe-style switch token (e.g. <c>"/server:foo"</c> -&gt;
+            /// <c>"server"</c>, <c>"/noprompt"</c> -&gt; <c>"noprompt"</c>, <c>"-applyfilters"</c> -&gt;
+            /// <c>"applyfilters"</c>).  Returns null if <paramref name="token"/> is not a switch-shaped token.
+            /// </summary>
+            private static string ExtractSwitchName(string token)
+            {
+                if (string.IsNullOrEmpty(token) || (token[0] != '/' && token[0] != '-'))
+                {
+                    return null;
+                }
+
+                int end = 1;
+                while (end < token.Length && token[end] != ':' && token[end] != '=')
+                {
+                    end++;
+                }
+
+                if (end == 1)
+                {
+                    return null;
+                }
+
+                return token.Substring(1, end - 1);
+            }
+
+            /// <summary>
+            /// Returns true if <paramref name="token"/> looks like a switch (leading '/' or '-') or a shell
+            /// redirection ('&gt;' / '&lt;').  Used when stripping a PDB-supplied <c>/output</c> or
+            /// <c>/login</c> with no attached value to decide whether the following token is the missing
+            /// value (consume it) or another switch / structural marker (leave it for the main walk to
+            /// process normally).  This keeps us from silently swallowing a legitimate allow-listed switch
+            /// when a malformed PDB emits a bare <c>/output</c> with no following value.
+            /// </summary>
+            private static bool LooksLikeSwitchOrRedirection(string token)
+            {
+                if (string.IsNullOrEmpty(token))
+                {
+                    return false;
+                }
+
+                char first = token[0];
+                return first == '/' || first == '-' || first == '>' || first == '<';
+            }
+
+            /// <summary>
+            /// Returns true if <paramref name="token"/> is a tf.exe-style switch named <paramref name="switchName"/>.
+            /// Accepts both '/' and '-' prefixes and recognizes the value-attached forms 'switch:value' and
+            /// 'switch=value'.  <paramref name="hasAttachedValue"/> is set when the token also carries the
+            /// switch's value; when false, callers that consume a value should skip the next token as well.
+            /// </summary>
+            private static bool IsTfSwitch(string token, string switchName, out bool hasAttachedValue)
+            {
+                hasAttachedValue = false;
+                if (string.IsNullOrEmpty(token))
+                {
+                    return false;
+                }
+
+                if (token[0] != '/' && token[0] != '-')
+                {
+                    return false;
+                }
+
+                if (token.Length == 1 + switchName.Length)
+                {
+                    return string.Equals(token.Substring(1), switchName, StringComparison.OrdinalIgnoreCase);
+                }
+
+                if (token.Length > 1 + switchName.Length
+                    && (token[1 + switchName.Length] == ':' || token[1 + switchName.Length] == '=')
+                    && string.Equals(token.Substring(1, switchName.Length), switchName, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasAttachedValue = true;
+                    return true;
+                }
+
+                return false;
+            }
+
+            /// <summary>
+            /// Splits <paramref name="commandLine"/> into tokens using a simple Windows-style quote-aware
+            /// tokenizer.  Double quotes can group whitespace into a single token and are stripped from the
+            /// resulting token value.
+            /// </summary>
+            private static bool TrySplitCommandLine(string commandLine, out List<string> tokens, out string rejectionReason)
+            {
+                tokens = new List<string>();
+                rejectionReason = null;
+
+                int i = 0;
+                while (i < commandLine.Length)
+                {
+                    while (i < commandLine.Length && char.IsWhiteSpace(commandLine[i]))
+                    {
+                        i++;
+                    }
+
+                    if (i >= commandLine.Length)
+                    {
+                        break;
+                    }
+
+                    var token = new StringBuilder();
+                    bool inQuotes = false;
+                    while (i < commandLine.Length && (inQuotes || !char.IsWhiteSpace(commandLine[i])))
+                    {
+                        char c = commandLine[i++];
+                        if (c == '"')
                         {
-                            _log.WriteLine("Source Server command failed with exit code {0}", fetchCmd.ExitCode);
+                            inQuotes = !inQuotes;
+                            continue;
                         }
 
-                        if (File.Exists(target))
-                        {
-                            // If TF.exe command files it might still create an empty output file.   Fix that 
-                            if (new FileInfo(target).Length == 0)
-                            {
-                                File.Delete(target);
-                                target = null;
-                            }
-                        }
-                        else
-                        {
-                            target = null;
-                        }
+                        token.Append(c);
+                    }
 
-                        if (target == null)
-                        {
-                            _log.WriteLine("Source Server command failed to produce the output file.");
-                        }
-                        else
-                        {
-                            _log.WriteLine("Source Server command succeeded creating {0}", target);
-                        }
+                    if (inQuotes)
+                    {
+                        rejectionReason = "unterminated quoted argument";
+                        return false;
+                    }
+
+                    tokens.Add(token.ToString());
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Quotes <paramref name="argument"/> for inclusion in a Windows command line consumable by
+            /// CommandLineToArgvW.  Backslashes immediately preceding a quote (or a closing quote) are doubled
+            /// per CRT rules; other characters are emitted literally.  Returns <paramref name="argument"/>
+            /// unchanged when no quoting is needed.
+            /// </summary>
+            private static string QuoteCommandLineArgument(string argument)
+            {
+                if (argument.Length == 0)
+                {
+                    return "\"\"";
+                }
+
+                bool quote = false;
+                for (int i = 0; i < argument.Length; i++)
+                {
+                    if (char.IsWhiteSpace(argument[i]) || argument[i] == '"')
+                    {
+                        quote = true;
+                        break;
+                    }
+                }
+
+                if (!quote)
+                {
+                    return argument;
+                }
+
+                var quotedArgument = new StringBuilder();
+                quotedArgument.Append('"');
+                int backslashCount = 0;
+                foreach (char c in argument)
+                {
+                    if (c == '\\')
+                    {
+                        backslashCount++;
+                    }
+                    else if (c == '"')
+                    {
+                        quotedArgument.Append('\\', backslashCount * 2 + 1);
+                        quotedArgument.Append('"');
+                        backslashCount = 0;
                     }
                     else
                     {
-                        _log.WriteLine("Found an existing source server file {0}.", target);
+                        quotedArgument.Append('\\', backslashCount);
+                        quotedArgument.Append(c);
+                        backslashCount = 0;
                     }
-
-                    return target;
                 }
 
-                _log.WriteLine("Did not find source file in the set of source files in the PDB.");
-                return null;
+                quotedArgument.Append('\\', backslashCount * 2);
+                quotedArgument.Append('"');
+                return quotedArgument.ToString();
             }
 
 

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -315,8 +315,14 @@ namespace Microsoft.Diagnostics.Symbols
             string indexPath = null;
             string perfMapPath = null;
             string symbolCacheTargetPath = null;
-            string perfMapSimpleName = Path.GetFileName(perfMapName);
-            R2RPerfMapSignature cacheKey = new R2RPerfMapSignature() { Name = perfMapName, Signature = perfMapSignature, Version = perfMapVersion };
+            string perfMapSimpleName = PathUtil.GetPlatformIndependentFileName(perfMapName ?? string.Empty);
+            if (string.IsNullOrEmpty(perfMapSimpleName) || perfMapSimpleName == "." || perfMapSimpleName == "..")
+            {
+                m_log.WriteLine("FindR2RPerfMapSymbolFilePath: *}} Invalid R2R perfmap symbol file name {0} Signature {1} Version {2}", perfMapName, perfMapSignature, perfMapVersion);
+                return null;
+            }
+
+            R2RPerfMapSignature cacheKey = new R2RPerfMapSignature() { Name = perfMapSimpleName, Signature = perfMapSignature, Version = perfMapVersion };
             if (m_r2rPerfMapPathCache.TryGet(cacheKey, out perfMapPath))
             {
                 m_log.WriteLine("FindR2RPerfMapSymbolFile: }} Hit Cache, returning {0}", perfMapPath);
@@ -340,47 +346,47 @@ namespace Microsoft.Diagnostics.Symbols
 
             if (perfMapPath == null)
             {
-            SymbolPath path = new SymbolPath(SymbolPath);
-            foreach (SymbolPathElement element in path.Elements)
-            {
-                if (element.IsSymServer)
+                SymbolPath path = new SymbolPath(SymbolPath);
+                foreach (SymbolPathElement element in path.Elements)
                 {
-                    string cache = element.Cache;
-                    if (cache == null)
+                    if (element.IsSymServer)
                     {
-                        cache = path.DefaultSymbolCache();
-                    }
-                    if (indexPath == null)
-                    {
-                        indexPath = $"/{perfMapName}/r2rmap-v{perfMapVersion}-{perfMapSignature:N}/{perfMapName}";
-                    }
-                    if (symbolCacheTargetPath == null)
-                    {
-                        symbolCacheTargetPath = Path.Combine(perfMapName,  perfMapVersion.ToString() + "-" + perfMapSignature.ToString("N"), perfMapName);
-                    }
-                    perfMapPath = GetFileFromServer(element.Target, indexPath, Path.Combine(cache, symbolCacheTargetPath));
-                    if (perfMapPath != null)
-                    {
-                        break;
-                    }
-                }
-                else
-                {
-                    string filePath = Path.Combine(element.Target, perfMapSimpleName);
-                    if ((Options & SymbolReaderOptions.CacheOnly) == 0 || !element.IsRemote)
-                    {
-                        if (R2RPerfMapMatches(filePath, perfMapSignature, perfMapVersion, checkSecurity: false))
+                        string cache = element.Cache;
+                        if (cache == null)
                         {
-                            perfMapPath = filePath;
+                            cache = path.DefaultSymbolCache();
+                        }
+                        if (indexPath == null)
+                        {
+                            indexPath = $"/{perfMapSimpleName}/r2rmap-v{perfMapVersion}-{perfMapSignature:N}/{perfMapSimpleName}";
+                        }
+                        if (symbolCacheTargetPath == null)
+                        {
+                            symbolCacheTargetPath = Path.Combine(perfMapSimpleName, perfMapVersion.ToString() + "-" + perfMapSignature.ToString("N"), perfMapSimpleName);
+                        }
+                        perfMapPath = GetFileFromServer(element.Target, indexPath, Path.Combine(cache, symbolCacheTargetPath));
+                        if (perfMapPath != null)
+                        {
                             break;
                         }
                     }
                     else
                     {
-                        m_log.WriteLine("FindR2RPerfMapSymbolFilePath: location {0} is remote and cacheOnly set, skipping.", filePath);
+                        string filePath = Path.Combine(element.Target, perfMapSimpleName);
+                        if ((Options & SymbolReaderOptions.CacheOnly) == 0 || !element.IsRemote)
+                        {
+                            if (R2RPerfMapMatches(filePath, perfMapSignature, perfMapVersion, checkSecurity: false))
+                            {
+                                perfMapPath = filePath;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            m_log.WriteLine("FindR2RPerfMapSymbolFilePath: location {0} is remote and cacheOnly set, skipping.", filePath);
+                        }
                     }
                 }
-            }
             }
 
             if (perfMapPath != null)

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -843,6 +843,19 @@ namespace Microsoft.Diagnostics.Symbols
         public Func<string, bool> SecurityCheck { get; set; }
 
         /// <summary>
+        /// We call back on this before executing a source-server fetch command (e.g. <c>tf.exe view ...</c> or
+        /// <c>tf.exe git view ...</c>) that was derived from PDB-supplied data.  The callback receives a
+        /// <see cref="SourceServerAuthorizationRequest"/> describing the exact command line that will be run, and
+        /// must return <c>true</c> to allow execution or <c>false</c> to deny it.
+        ///
+        /// If this property is <c>null</c>, source-server fetch commands are denied by default.  This protects
+        /// callers that do not explicitly opt in to running external processes on PDB data: a malicious PDB
+        /// cannot cause a fetch to occur silently.  To enable source-server fetches, set this property to either
+        /// an interactive prompt (as PerfView does) or to <c>request =&gt; true</c> for fully trusted scenarios.
+        /// </summary>
+        public Func<SourceServerAuthorizationRequest, bool> AuthorizeSourceServerCommand { get; set; }
+
+        /// <summary>
         /// If set OnSymbolFileFound will be called when a PDB file is found.  
         /// It is passed the complete local file path, the PDB Guid (may be Guid.Empty) and PDB age.
         /// </summary>
@@ -2184,6 +2197,27 @@ namespace Microsoft.Diagnostics.Symbols
         private List<Tuple<string, string, bool>> _sourceLinkMapping;      // Used by SourceLink to map build paths to URLs (path, url, isWildcard)
         private bool _sourceLinkMappingInited;                       // Lazy init flag. 
         #endregion
+    }
+
+    /// <summary>
+    /// Describes a source-server fetch command that has been validated and is about to be executed.
+    /// Passed to <see cref="SymbolReader.AuthorizeSourceServerCommand"/> so the caller can choose whether
+    /// to allow execution.
+    /// </summary>
+    /// <remarks>
+    /// This is a wrapper class so that additional context can be added in the future without breaking
+    /// the <see cref="SymbolReader.AuthorizeSourceServerCommand"/> delegate signature.
+    /// </remarks>
+    public sealed class SourceServerAuthorizationRequest
+    {
+        /// <summary>
+        /// The full command line that will be executed (e.g. <c>tf.exe view /version:1234 ...</c>).
+        /// This has already been validated against a strict per-tool allow-list, has any PDB-supplied
+        /// output destination replaced with a safe path under the source cache, and has been quoted per
+        /// CommandLineToArgvW rules.  It will be executed directly via <c>CreateProcess</c> (not through
+        /// a shell), so shell metacharacters in this string are inert.
+        /// </summary>
+        public string Command { get; set; }
     }
 
     /// <summary>

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/BPerfTest.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/BPerfTest.cs
@@ -81,6 +81,70 @@ namespace TraceEventTests
             ValidateEventStatistics(sb.ToString(0, 1024 * 1024), Path.GetFileNameWithoutExtension(bperfFileName));
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public void ULZ777Decompress_DoesNotWritePastShortLiteralRun(int literalLength)
+        {
+            byte[] compressed = Enumerable.Repeat((byte)0xCC, 16).ToArray();
+            compressed[0] = (byte)(literalLength << 5);
+            int literalOffset = 1;
+            if (literalLength == 7)
+            {
+                compressed[1] = 0;
+                literalOffset = 2;
+            }
+
+            byte[] expected = new byte[literalLength];
+            for (int i = 0; i < literalLength; i++)
+            {
+                expected[i] = (byte)('A' + i);
+                compressed[i + literalOffset] = expected[i];
+            }
+
+            byte[] output = Enumerable.Repeat((byte)0xEE, 16).ToArray();
+
+            int written = BPerfEventSource.ULZ777Decompress(compressed, 0, literalLength + literalOffset, output, literalLength);
+
+            Assert.Equal(literalLength, written);
+            Assert.Equal(expected, output.Take(literalLength).ToArray());
+            Assert.All(output.Skip(literalLength), value => Assert.Equal(0xEE, value));
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public void ULZ777Decompress_DoesNotWritePastShortMatchLength(int matchLength)
+        {
+            byte[] compressed = new byte[12];
+            compressed[0] = (byte)(0xE0 | (matchLength - 4));
+            compressed[1] = 1; // Extend the 7-literal run to 8 literals.
+            for (int i = 0; i < 8; i++)
+            {
+                compressed[i + 2] = (byte)('a' + i);
+            }
+
+            compressed[10] = 8;
+            compressed[11] = 0;
+
+            int outputLength = 8 + matchLength;
+            byte[] output = Enumerable.Repeat((byte)0xEE, 24).ToArray();
+
+            int written = BPerfEventSource.ULZ777Decompress(compressed, 0, compressed.Length, output, outputLength);
+
+            Assert.Equal(outputLength, written);
+            Assert.Equal(compressed.Skip(2).Take(8), output.Take(8));
+            Assert.Equal(output.Take(matchLength), output.Skip(8).Take(matchLength));
+            Assert.All(output.Skip(outputLength), value => Assert.Equal(0xEE, value));
+        }
+
         private void ValidateEventStatistics(string actual, string bperfFileName)
         {
             string baselineFile = Path.Combine(TestDataDir, bperfFileName + ".baseline.txt");

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/DynamicTraceEventParserTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/DynamicTraceEventParserTests.cs
@@ -1,0 +1,191 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using System;
+using System.IO;
+using System.Security;
+using System.Text;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class DynamicTraceEventParserTests
+    {
+        [Theory]
+        [InlineData(@"..\outside", ".._outside.manifest.xml")]
+        [InlineData(@"..\..\..\Startup\x", ".._.._.._Startup_x.manifest.xml")]
+        [InlineData(@"C:\Windows\System32\evil", "C__Windows_System32_evil.manifest.xml")]
+        public void WriteAllManifests_SanitizesPathTraversalProviderNames(string providerName, string expectedFileName)
+        {
+            // Integration smoke test: an attacker-controlled provider name containing
+            // path-traversal characters must produce a manifest file whose name has
+            // been sanitized AND whose final path remains inside the requested
+            // directory.  The exhaustive sanitizer-behavior tests live in
+            // PathUtilitiesTests.SanitizeFileName_*.
+            string parentDirectory = CreateTempDirectory();
+            string outputDirectory = Path.Combine(parentDirectory, "manifests");
+            try
+            {
+                using (var source = new EventPipeEventSource(new MemoryStream()))
+                {
+                    var parser = new DynamicTraceEventParser(source);
+                    parser.AddDynamicProvider(CreateProviderManifest(providerName, Guid.NewGuid()));
+
+                    parser.WriteAllManifests(outputDirectory);
+                }
+
+                string[] manifestFiles = Directory.GetFiles(outputDirectory, "*.manifest.xml");
+                string manifestPath = Assert.Single(manifestFiles);
+                Assert.Equal(expectedFileName, Path.GetFileName(manifestPath));
+                AssertPathInDirectory(manifestPath, outputDirectory);
+
+                // No files leaked outside the output directory.
+                Assert.Empty(Directory.GetFiles(parentDirectory, "*.manifest.xml", SearchOption.TopDirectoryOnly));
+            }
+            finally
+            {
+                Directory.Delete(parentDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void WriteAllManifests_FallsBackToProviderGuidForEmptyName()
+        {
+            // PathUtilities.SanitizeFileName returns null for empty input;
+            // WriteAllManifests then falls back to the provider's GUID so distinct
+            // providers still produce distinct manifest files (rather than
+            // colliding on a single "_.manifest.xml").
+            Guid providerGuid = new Guid("12345678-1234-1234-1234-1234567890ab");
+            string outputDirectory = CreateTempDirectory();
+            try
+            {
+                using (var source = new EventPipeEventSource(new MemoryStream()))
+                {
+                    var parser = new DynamicTraceEventParser(source);
+                    parser.AddDynamicProvider(CreateProviderManifest(string.Empty, providerGuid));
+
+                    parser.WriteAllManifests(outputDirectory);
+                }
+
+                string[] manifestFiles = Directory.GetFiles(outputDirectory, "*.manifest.xml");
+                string manifestPath = Assert.Single(manifestFiles);
+                Assert.Equal(providerGuid.ToString("N") + ".manifest.xml", Path.GetFileName(manifestPath));
+            }
+            finally
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void WriteAllManifests_PreservesValidProviderName()
+        {
+            string outputDirectory = CreateTempDirectory();
+            try
+            {
+                const string providerName = "Contoso.Provider-Valid_1";
+                using (var source = new EventPipeEventSource(new MemoryStream()))
+                {
+                    var parser = new DynamicTraceEventParser(source);
+                    parser.AddDynamicProvider(CreateProviderManifest(providerName, Guid.NewGuid()));
+
+                    parser.WriteAllManifests(outputDirectory);
+                }
+
+                string manifestPath = Path.Combine(outputDirectory, providerName + ".manifest.xml");
+                Assert.True(File.Exists(manifestPath));
+                Assert.Contains("name=\"" + providerName + "\"", File.ReadAllText(manifestPath));
+            }
+            finally
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void WriteAllManifests_CreatesOutputDirectory()
+        {
+            string parentDirectory = CreateTempDirectory();
+            string outputDirectory = Path.Combine(parentDirectory, "nested", "manifests");
+            try
+            {
+                using (var source = new EventPipeEventSource(new MemoryStream()))
+                {
+                    var parser = new DynamicTraceEventParser(source);
+                    parser.AddDynamicProvider(CreateProviderManifest("Contoso.Provider", Guid.NewGuid()));
+
+                    parser.WriteAllManifests(outputDirectory);
+                }
+
+                Assert.True(Directory.Exists(outputDirectory));
+                Assert.Single(Directory.GetFiles(outputDirectory, "*.manifest.xml"));
+            }
+            finally
+            {
+                Directory.Delete(parentDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void WriteAllManifests_MultipleProvidersCollidingAfterSanitizationLastWriterWins()
+        {
+            // Two distinct attacker-controlled provider names that sanitize to the
+            // same file name.  The current contract is that the second WriteToFile
+            // overwrites the first -- this test pins that behavior so it does not
+            // silently regress to e.g. throwing or corrupting the output directory.
+            string outputDirectory = CreateTempDirectory();
+            try
+            {
+                using (var source = new EventPipeEventSource(new MemoryStream()))
+                {
+                    var parser = new DynamicTraceEventParser(source);
+                    parser.AddDynamicProvider(CreateProviderManifest(@"a\b", Guid.NewGuid()));
+                    parser.AddDynamicProvider(CreateProviderManifest("a/b", Guid.NewGuid()));
+
+                    parser.WriteAllManifests(outputDirectory);
+                }
+
+                string[] manifestFiles = Directory.GetFiles(outputDirectory, "*.manifest.xml");
+                string manifestPath = Assert.Single(manifestFiles);
+                Assert.Equal("a_b.manifest.xml", Path.GetFileName(manifestPath));
+                AssertPathInDirectory(manifestPath, outputDirectory);
+            }
+            finally
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+        }
+
+        private static ProviderManifest CreateProviderManifest(string providerName, Guid providerGuid)
+        {
+            string manifest =
+                "<instrumentationManifest xmlns=\"http://schemas.microsoft.com/win/2004/08/events\">" +
+                "  <instrumentation>" +
+                "    <events>" +
+                "      <provider name=\"" + SecurityElement.Escape(providerName) + "\" guid=\"" + providerGuid + "\" />" +
+                "    </events>" +
+                "  </instrumentation>" +
+                "</instrumentationManifest>";
+
+            return new ProviderManifest(new MemoryStream(Encoding.UTF8.GetBytes(manifest)));
+        }
+
+        private static string CreateTempDirectory()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "TraceEventTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static void AssertPathInDirectory(string path, string directoryPath)
+        {
+            string fullDirectoryPath = Path.GetFullPath(directoryPath);
+            if (!fullDirectoryPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) &&
+                !fullDirectoryPath.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+            {
+                fullDirectoryPath += Path.DirectorySeparatorChar;
+            }
+
+            Assert.StartsWith(fullDirectoryPath, Path.GetFullPath(path), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -1344,6 +1344,181 @@ namespace TraceEventTests
             Assert.Equal(1, eventCount);
         }
 
+        public static IEnumerable<object[]> InvalidV6RelLocAndDataLocArrayBounds()
+        {
+            yield return new object[] { MetadataTypeCode.DataLoc, (4 << 16) | 100 };
+            yield return new object[] { MetadataTypeCode.DataLoc, (3 << 16) | 4 };
+            yield return new object[] { MetadataTypeCode.RelLoc, (4 << 16) | 100 };
+            yield return new object[] { MetadataTypeCode.RelLoc, (3 << 16) | 0 };
+        }
+
+        [Theory] //V6
+        [MemberData(nameof(InvalidV6RelLocAndDataLocArrayBounds))]
+        public void InvalidV6RelLocAndDataLocArrayBoundsReturnLookupException(MetadataTypeCode locKind, int locValue)
+        {
+            MetadataType locType = locKind == MetadataTypeCode.RelLoc ?
+                (MetadataType)new RelLocMetadataType(new MetadataType(MetadataTypeCode.Int32)) :
+                new DataLocMetadataType(new MetadataType(MetadataTypeCode.Int32));
+
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15,
+                                      new MetadataParameter("Array", locType)));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, 0, 0);
+            });
+            writer.WriteEventBlock(w =>
+            {
+                w.WriteEventBlob(1, 999, 1, p =>
+                {
+                    p.Write(locValue);
+                    p.Write(42);
+                });
+            });
+            writer.WriteEndBlock();
+
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            TraceEventDispatcher source = new EventPipeEventSource(stream);
+
+            int eventCount = 0;
+
+            source.Dynamic.All += e =>
+            {
+                eventCount++;
+                string payloadValue = Assert.IsType<string>(e.PayloadValue(0));
+                Assert.Contains("EXCEPTION_DURING_VALUE_LOOKUP", payloadValue);
+                Assert.Contains(nameof(ArgumentOutOfRangeException), payloadValue);
+            };
+
+            source.Process();
+            Assert.Equal(1, eventCount);
+        }
+
+        [Fact] //V6
+        public void V6CountedStringWithTruncatedLengthPrefixReturnsLookupException()
+        {
+            // A counted (length-prefixed) UTF8 string has a 2-byte length prefix.  Here the payload
+            // is only 1 byte, so reading the prefix via GetInt16At would read past the end of the
+            // payload into adjacent native memory.  The bounds check must reject it before the read.
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15,
+                                      new MetadataParameter("Str", new ArrayMetadataType(new MetadataType(MetadataTypeCode.UTF8CodeUnit)))));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, 0, 0);
+            });
+            writer.WriteEventBlock(w =>
+            {
+                w.WriteEventBlob(1, 999, 1, p =>
+                {
+                    p.Write((byte)1); // Only 1 byte of payload; the 2-byte length prefix does not fit.
+                });
+            });
+            writer.WriteEndBlock();
+
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            TraceEventDispatcher source = new EventPipeEventSource(stream);
+
+            int eventCount = 0;
+
+            source.Dynamic.All += e =>
+            {
+                eventCount++;
+                string payloadValue = Assert.IsType<string>(e.PayloadValue(0));
+                Assert.Contains("EXCEPTION_DURING_VALUE_LOOKUP", payloadValue);
+                Assert.Contains(nameof(ArgumentOutOfRangeException), payloadValue);
+            };
+
+            source.Process();
+            Assert.Equal(1, eventCount);
+        }
+
+        [Fact] //V6
+        public void V6LengthPrefixedArrayWithTruncatedCountReturnsLookupException()
+        {
+            // A length-prefixed array has a 2-byte element-count prefix.  Here the payload is only
+            // 1 byte, so reading the count via GetInt16At would read past the end of the payload.
+            // The bounds check must reject it before the read.
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15,
+                                      new MetadataParameter("IntArray", new ArrayMetadataType(new MetadataType(MetadataTypeCode.Int32)))));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, 0, 0);
+            });
+            writer.WriteEventBlock(w =>
+            {
+                w.WriteEventBlob(1, 999, 1, p =>
+                {
+                    p.Write((byte)1); // Only 1 byte of payload; the 2-byte count prefix does not fit.
+                });
+            });
+            writer.WriteEndBlock();
+
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            TraceEventDispatcher source = new EventPipeEventSource(stream);
+
+            int eventCount = 0;
+
+            source.Dynamic.All += e =>
+            {
+                eventCount++;
+                string payloadValue = Assert.IsType<string>(e.PayloadValue(0));
+                Assert.Contains("EXCEPTION_DURING_VALUE_LOOKUP", payloadValue);
+                Assert.Contains(nameof(ArgumentOutOfRangeException), payloadValue);
+            };
+
+            source.Process();
+            Assert.Equal(1, eventCount);
+        }
+
+        [Fact] //V6
+        public void V6StringArrayWithInsufficientBytesForElementsReturnsLookupException()
+        {
+            // A string[] whose element count claims more strings than the remaining payload can hold.
+            // Each UTF-16 counted-string element needs at least a 2-byte length prefix, so 3 elements
+            // require >= 6 bytes, but only 3 bytes follow the count.  The previous 1-byte-per-element
+            // estimate would have incorrectly passed validation and allowed an out-of-bounds read.
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(new EventMetadata(1, "TestProvider", "TestEvent1", 15,
+                                      new MetadataParameter("StringArray", new ArrayMetadataType(new ArrayMetadataType(new MetadataType(MetadataTypeCode.UTF16CodeUnit))))));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, 0, 0);
+            });
+            writer.WriteEventBlock(w =>
+            {
+                w.WriteEventBlob(1, 999, 1, p =>
+                {
+                    p.Write((ushort)3); // Claim 3 strings...
+                    p.Write((byte)0);   // ...but only provide 3 bytes of element data.
+                    p.Write((byte)0);
+                    p.Write((byte)0);
+                });
+            });
+            writer.WriteEndBlock();
+
+            MemoryStream stream = new MemoryStream(writer.ToArray());
+            TraceEventDispatcher source = new EventPipeEventSource(stream);
+
+            int eventCount = 0;
+
+            source.Dynamic.All += e =>
+            {
+                eventCount++;
+                string payloadValue = Assert.IsType<string>(e.PayloadValue(0));
+                Assert.Contains("EXCEPTION_DURING_VALUE_LOOKUP", payloadValue);
+                Assert.Contains(nameof(ArgumentOutOfRangeException), payloadValue);
+            };
+
+            source.Process();
+            Assert.Equal(1, eventCount);
+        }
+
         [Fact] //V6
         public void V6RelLocThrowsOnVariableSizedElementType()
         {

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeV3StackParsingTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeV3StackParsingTests.cs
@@ -1,0 +1,241 @@
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.EventPipe;
+using System;
+using System.IO;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public unsafe class EventPipeV3StackParsingTests
+    {
+        private const int V3HeaderSize = 56;
+
+        [Fact]
+        public void ReadFromFormatV3AcceptsStackContainedInEvent()
+        {
+            byte[] payload = new byte[] { 1, 2, 3, 4 };
+            byte[] stackBytes = new byte[] { 10, 11, 12, 13, 14, 15, 16, 17 };
+            byte[] eventBytes = CreateV3Event(payload, stackBytes.Length, stackBytes);
+
+            fixed (byte* eventBytesPtr = eventBytes)
+            {
+                SpanReader reader = CreateReader(eventBytesPtr, eventBytes.Length);
+                EventPipeEventHeader header = default;
+
+                EventPipeEventHeader.ReadFromFormatV3(ref reader, ref header);
+
+                Assert.Equal(V3HeaderSize, reader.StreamOffset);
+                Assert.Equal(V3HeaderSize, header.HeaderSize);
+                Assert.Equal(payload.Length, header.PayloadSize);
+                Assert.Equal(payload.Length + sizeof(int) + stackBytes.Length, header.TotalNonHeaderSize);
+                Assert.Equal(stackBytes.Length, header.StackBytesSize);
+                Assert.NotEqual(IntPtr.Zero, header.StackBytes);
+                Assert.Equal(stackBytes, new ReadOnlySpan<byte>((void*)header.StackBytes, header.StackBytesSize).ToArray());
+            }
+        }
+
+        [Fact]
+        public void ReadFromFormatV3RejectsStackBytesExtendingPastEvent()
+        {
+            byte[] payload = new byte[] { 1, 2, 3, 4 };
+            byte[] extraBytesAfterEvent = new byte[] { 10, 11, 12, 13, 14, 15, 16, 17 };
+            byte[] eventBytes = CreateV3Event(payload, stackBytesSize: extraBytesAfterEvent.Length, stackBytes: null, extraBytesAfterEvent: extraBytesAfterEvent);
+            EventPipeEventHeader header = CreateHeaderWithStackSentinel();
+
+            fixed (byte* eventBytesPtr = eventBytes)
+            {
+                SpanReader reader = CreateReader(eventBytesPtr, eventBytes.Length);
+
+                FormatException ex = ReadV3ExpectingFormatException(ref reader, ref header);
+
+                Assert.Contains("stack size", ex.Message);
+                Assert.Equal(V3HeaderSize, reader.StreamOffset);
+                AssertStackSentinelUnchanged(header);
+            }
+        }
+
+        [Fact]
+        public void ReadFromFormatV3RejectsNegativePayloadSize()
+        {
+            byte[] eventBytes = CreateV3Event(payloadSize: -1, eventSize: V3HeaderSize + sizeof(int) - sizeof(int));
+            EventPipeEventHeader header = CreateHeaderWithStackSentinel();
+
+            fixed (byte* eventBytesPtr = eventBytes)
+            {
+                SpanReader reader = CreateReader(eventBytesPtr, eventBytes.Length);
+
+                FormatException ex = ReadV3ExpectingFormatException(ref reader, ref header);
+
+                Assert.Contains("payload size", ex.Message);
+                Assert.Equal(V3HeaderSize, reader.StreamOffset);
+                AssertStackSentinelUnchanged(header);
+            }
+        }
+
+        [Fact]
+        public void ReadFromFormatV3RejectsNegativeStackSize()
+        {
+            byte[] eventBytes = CreateV3Event(Array.Empty<byte>(), stackBytesSize: -1, stackBytes: null);
+            EventPipeEventHeader header = CreateHeaderWithStackSentinel();
+
+            fixed (byte* eventBytesPtr = eventBytes)
+            {
+                SpanReader reader = CreateReader(eventBytesPtr, eventBytes.Length);
+
+                FormatException ex = ReadV3ExpectingFormatException(ref reader, ref header);
+
+                Assert.Contains("stack size", ex.Message);
+                Assert.Equal(V3HeaderSize, reader.StreamOffset);
+                AssertStackSentinelUnchanged(header);
+            }
+        }
+
+        [Fact]
+        public void ReadFromFormatV3RejectsStackSizeThatOverflowsExtendedDataUShort()
+        {
+            // EventPipeMetadata.GetEventRecordForEventData stores (stackBytesSize + 8) in a ushort field.
+            // Any stackBytesSize > ushort.MaxValue - 8 wraps that field and causes a downstream OOB read.
+            int overflowingStackSize = ushort.MaxValue - sizeof(ulong) + 1; // 65528
+            byte[] stackBytes = new byte[overflowingStackSize];
+            byte[] eventBytes = CreateV3Event(Array.Empty<byte>(), stackBytesSize: overflowingStackSize, stackBytes: stackBytes);
+            EventPipeEventHeader header = CreateHeaderWithStackSentinel();
+
+            fixed (byte* eventBytesPtr = eventBytes)
+            {
+                SpanReader reader = CreateReader(eventBytesPtr, eventBytes.Length);
+
+                FormatException ex = ReadV3ExpectingFormatException(ref reader, ref header);
+
+                Assert.Contains("stack size", ex.Message);
+                Assert.Equal(V3HeaderSize, reader.StreamOffset);
+                AssertStackSentinelUnchanged(header);
+            }
+        }
+
+        [Fact]
+        public void ReadFromFormatV3AcceptsMaximumStackSizeUnderUShortBoundary()
+        {
+            // ushort.MaxValue - sizeof(ulong) == 65527 is the largest stack size that fits in the
+            // downstream ExtendedData.DataSize ushort after the +8 header, and must still be accepted.
+            int maxStackSize = ushort.MaxValue - sizeof(ulong); // 65527
+            byte[] stackBytes = new byte[maxStackSize];
+            for (int i = 0; i < stackBytes.Length; i++)
+            {
+                stackBytes[i] = (byte)i;
+            }
+            byte[] eventBytes = CreateV3Event(Array.Empty<byte>(), stackBytesSize: maxStackSize, stackBytes: stackBytes);
+
+            fixed (byte* eventBytesPtr = eventBytes)
+            {
+                SpanReader reader = CreateReader(eventBytesPtr, eventBytes.Length);
+                EventPipeEventHeader header = default;
+
+                EventPipeEventHeader.ReadFromFormatV3(ref reader, ref header);
+
+                Assert.Equal(maxStackSize, header.StackBytesSize);
+            }
+        }
+
+        [Fact]
+        public void ReadFromFormatV3RejectsEventSizeOverflow()
+        {
+            byte[] eventBytes = CreateV3Event(payloadSize: 0, eventSize: int.MaxValue);
+            EventPipeEventHeader header = CreateHeaderWithStackSentinel();
+
+            fixed (byte* eventBytesPtr = eventBytes)
+            {
+                SpanReader reader = CreateReader(eventBytesPtr, eventBytes.Length);
+
+                FormatException ex = ReadV3ExpectingFormatException(ref reader, ref header);
+
+                Assert.Contains("event size", ex.Message);
+                Assert.Equal(V3HeaderSize, reader.StreamOffset);
+                AssertStackSentinelUnchanged(header);
+            }
+        }
+
+        private static SpanReader CreateReader(byte* bytes, int length)
+        {
+            return new SpanReader(new ReadOnlySpan<byte>(bytes, length), 0);
+        }
+
+        private static FormatException ReadV3ExpectingFormatException(ref SpanReader reader, ref EventPipeEventHeader header)
+        {
+            try
+            {
+                EventPipeEventHeader.ReadFromFormatV3(ref reader, ref header);
+            }
+            catch (FormatException ex)
+            {
+                return ex;
+            }
+
+            throw new Xunit.Sdk.XunitException("Expected a FormatException.");
+        }
+
+        private static EventPipeEventHeader CreateHeaderWithStackSentinel()
+        {
+            return new EventPipeEventHeader
+            {
+                StackBytesSize = 123,
+                StackBytes = new IntPtr(456)
+            };
+        }
+
+        private static void AssertStackSentinelUnchanged(EventPipeEventHeader header)
+        {
+            Assert.Equal(123, header.StackBytesSize);
+            Assert.Equal(new IntPtr(456), header.StackBytes);
+        }
+
+        private static byte[] CreateV3Event(byte[] payload, int stackBytesSize, byte[] stackBytes, byte[] extraBytesAfterEvent = null)
+        {
+            int payloadSize = payload == null ? 0 : payload.Length;
+            int stackBytesLength = stackBytes == null ? 0 : stackBytes.Length;
+            int eventSize = V3HeaderSize + payloadSize + sizeof(int) + stackBytesLength - sizeof(int);
+            return CreateV3Event(payloadSize, eventSize, payload, stackBytesSize, stackBytes, extraBytesAfterEvent);
+        }
+
+        private static byte[] CreateV3Event(int payloadSize, int eventSize)
+        {
+            return CreateV3Event(payloadSize, eventSize, payload: null, stackBytesSize: null, stackBytes: null, extraBytesAfterEvent: null);
+        }
+
+        private static byte[] CreateV3Event(int payloadSize, int eventSize, byte[] payload, int? stackBytesSize, byte[] stackBytes, byte[] extraBytesAfterEvent)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write(eventSize);
+                writer.Write(1); // MetadataId
+                writer.Write(2); // ThreadId
+                writer.Write(3L); // TimeStamp
+                writer.Write(Guid.Empty.ToByteArray());
+                writer.Write(Guid.Empty.ToByteArray());
+                writer.Write(payloadSize);
+
+                if (payload != null)
+                {
+                    writer.Write(payload);
+                }
+
+                if (stackBytesSize.HasValue)
+                {
+                    writer.Write(stackBytesSize.Value);
+                }
+
+                if (stackBytes != null)
+                {
+                    writer.Write(stackBytes);
+                }
+
+                if (extraBytesAfterEvent != null)
+                {
+                    writer.Write(extraBytesAfterEvent);
+                }
+
+                return stream.ToArray();
+            }
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/RegisteredTraceEventParserTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/RegisteredTraceEventParserTests.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Xunit;
@@ -364,6 +365,352 @@ namespace TraceEventTests
 
             Assert.Equal(normalizedLegacy, normalizedNew);
         }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_ToleratesOutOfRangeTopLevelStringOffset()
+        {
+            byte[] buffer = CreateSinglePropertyEventInfoBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->ProviderNameOffset = buffer.Length + 2;
+
+                DynamicTraceEventData template = new RegisteredTraceEventParser.TdhEventParser(eventInfoBuffer, buffer.Length, null, null).ParseEventMetaData();
+
+                // An out-of-range descriptive string offset is tolerated: the event still parses and the
+                // unreadable provider name falls back to its default rather than rejecting the event.
+                Assert.NotNull(template);
+                Assert.Equal("UnknownProvider", template.ProviderName);
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_ValidatesPropertyArrayBounds()
+        {
+            byte[] buffer = CreateSinglePropertyEventInfoBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->PropertyCount = 2;
+                eventInfo->TopLevelPropertyCount = 2;
+
+                var parser = new RegisteredTraceEventParser.TdhEventParser(eventInfoBuffer, EventInfoPropertyArrayOffset + EventPropertyInfoSize, null, null);
+
+                Assert.Null(parser.ParseEventMetaData());
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_ToleratesOutOfRangePropertyNameOffset()
+        {
+            byte[] buffer = CreateSinglePropertyEventInfoBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->EventPropertyInfoArray.NameOffset = buffer.Length + 2;
+
+                DynamicTraceEventData template = new RegisteredTraceEventParser.TdhEventParser(eventInfoBuffer, buffer.Length, null, null).ParseEventMetaData();
+
+                // An out-of-range property name offset is tolerated: the field keeps its place in the
+                // payload (with an empty name) rather than rejecting the event.
+                Assert.NotNull(template);
+                Assert.Equal(new[] { "" }, template.PayloadNames);
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_ValidatesMapOffsets()
+        {
+            byte[] buffer = CreateMapInfoBuffer();
+            fixed (byte* eventMapBuffer = buffer)
+            {
+                var eventMap = (RegisteredTraceEventParser.EVENT_MAP_INFO*)eventMapBuffer;
+                eventMap->MapEntryArray.NameOffset = buffer.Length + 2;
+
+                Assert.Null(RegisteredTraceEventParser.TdhEventParser.ParseMap(eventMap, eventMapBuffer, buffer.Length));
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_ValidatesStructRecursionDepth()
+        {
+            byte[] buffer = CreateSinglePropertyEventInfoBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->EventPropertyInfoArray.Flags = RegisteredTraceEventParser.PROPERTY_FLAGS.Struct;
+                eventInfo->EventPropertyInfoArray.InType = (RegisteredTraceEventParser.TdhInputType)0; // StructStartIndex.
+                eventInfo->EventPropertyInfoArray.OutType = 1; // NumOfStructMembers.
+
+                var parser = new RegisteredTraceEventParser.TdhEventParser(eventInfoBuffer, buffer.Length, null, null);
+
+                Assert.Null(parser.ParseEventMetaData());
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_ParsesValidLengthBoundMetadata()
+        {
+            byte[] buffer = CreateSinglePropertyEventInfoBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var parser = new RegisteredTraceEventParser.TdhEventParser(eventInfoBuffer, buffer.Length, null, null);
+
+                DynamicTraceEventData template = parser.ParseEventMetaData();
+
+                Assert.NotNull(template);
+                Assert.Equal(new[] { "Field" }, template.PayloadNames);
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_ParsesValidStructProperty()
+        {
+            // Build a TRACE_EVENT_INFO with two properties: a top-level struct property whose
+            // single member is the UInt32 property at index 1.  This exercises the happy-path
+            // recursion into ParseFields for nested struct members, and ensures that a non-zero
+            // value in the MapNameOffset union slot of the struct property (which actually
+            // overlays the struct 'padding' field in the native union) does not cause
+            // ValidateEventInfo to falsely reject the event.
+            byte[] buffer = CreateStructPropertyEventInfoBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                DynamicTraceEventData template = new RegisteredTraceEventParser.TdhEventParser(
+                    eventInfoBuffer, buffer.Length, null, null).ParseEventMetaData();
+
+                Assert.NotNull(template);
+                Assert.Equal(new[] { "Outer" }, template.PayloadNames);
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_RejectsExponentialStructDag()
+        {
+            // A crafted TRACE_EVENT_INFO whose two struct properties each declare the SAME pair of
+            // properties (indices 0 and 1) as their members forms a shared DAG.  Without a cumulative
+            // work budget, ParseFields re-parses the same properties and the work doubles at every
+            // recursion level (~2^32 invocations from a tiny blob) -> multi-hour hang + OOM.  The
+            // PropertyCount work budget must reject this quickly because a property is revisited.
+            // (Without the budget this test hangs, which is what makes it a genuine regression.)
+            byte[] buffer = CreateRecursiveStructDagEventInfoBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var parser = new RegisteredTraceEventParser.TdhEventParser(eventInfoBuffer, buffer.Length, null, null);
+
+                Assert.Null(parser.ParseEventMetaData());
+            }
+        }
+
+        [Fact]
+        public unsafe void EmbeddedTdhMetadataParser_RejectsNestedStructArrayPrefixUnderflow()
+        {
+            // A nested struct whose first (and only) member is a variable-length array whose count
+            // index points at the field immediately before the struct frame (startField - 1).  Inside
+            // the nested frame curField == 0 and no field has been added yet, so the "length/count is
+            // right before the array" prefix logic would index fieldFetches[-1].  The parser must not
+            // throw on the untrusted metadata path: it detects the prefix underflow and rejects the
+            // template (returns null) rather than crashing.
+            byte[] buffer = CreateNestedStructArrayPrefixBuffer();
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                DynamicTraceEventData template = new RegisteredTraceEventParser.TdhEventParser(
+                    eventInfoBuffer, buffer.Length, null, null).ParseEventMetaData();
+
+                Assert.Null(template);
+            }
+        }
+
+        private static unsafe byte[] CreateRecursiveStructDagEventInfoBuffer()
+        {
+            byte[] buffer = new byte[EventInfoPropertyArrayOffset + (2 * EventPropertyInfoSize) + 128];
+            int stringOffset = EventInfoPropertyArrayOffset + (2 * EventPropertyInfoSize);
+            int providerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Provider");
+            int taskNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Task");
+            int opcodeNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Opcode");
+            int aNameOffset = AppendUnicodeString(buffer, ref stringOffset, "A");
+            int bNameOffset = AppendUnicodeString(buffer, ref stringOffset, "B");
+
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->ProviderGuid = Guid.NewGuid();
+                eventInfo->EventGuid = Guid.NewGuid();
+                eventInfo->EventDescriptor.Id = 1;
+                eventInfo->ProviderNameOffset = providerNameOffset;
+                eventInfo->TaskNameOffset = taskNameOffset;
+                eventInfo->OpcodeNameOffset = opcodeNameOffset;
+                eventInfo->PropertyCount = 2;
+                eventInfo->TopLevelPropertyCount = 2;
+
+                RegisteredTraceEventParser.EVENT_PROPERTY_INFO* properties = &eventInfo->EventPropertyInfoArray;
+
+                // Both properties are structs whose members are the WHOLE property array [0, 2).
+                // StructStartIndex=0 / NumOfStructMembers=2 encoded via the InType/OutType union slots.
+                for (int i = 0; i < 2; i++)
+                {
+                    properties[i].Flags = RegisteredTraceEventParser.PROPERTY_FLAGS.Struct;
+                    properties[i].InType = (RegisteredTraceEventParser.TdhInputType)0; // StructStartIndex = 0
+                    properties[i].OutType = 2;                                          // NumOfStructMembers = 2
+                }
+                properties[0].NameOffset = aNameOffset;
+                properties[1].NameOffset = bNameOffset;
+            }
+
+            return buffer;
+        }
+
+        private static unsafe byte[] CreateNestedStructArrayPrefixBuffer()
+        {
+            byte[] buffer = new byte[EventInfoPropertyArrayOffset + (2 * EventPropertyInfoSize) + 128];
+            int stringOffset = EventInfoPropertyArrayOffset + (2 * EventPropertyInfoSize);
+            int providerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Provider");
+            int taskNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Task");
+            int opcodeNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Opcode");
+            int outerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Outer");
+            int innerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Inner");
+
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->ProviderGuid = Guid.NewGuid();
+                eventInfo->EventGuid = Guid.NewGuid();
+                eventInfo->EventDescriptor.Id = 1;
+                eventInfo->ProviderNameOffset = providerNameOffset;
+                eventInfo->TaskNameOffset = taskNameOffset;
+                eventInfo->OpcodeNameOffset = opcodeNameOffset;
+                eventInfo->PropertyCount = 2;
+                eventInfo->TopLevelPropertyCount = 1;
+
+                RegisteredTraceEventParser.EVENT_PROPERTY_INFO* properties = &eventInfo->EventPropertyInfoArray;
+
+                // Top-level struct property whose single member is property index 1.
+                properties[0].Flags = RegisteredTraceEventParser.PROPERTY_FLAGS.Struct;
+                properties[0].NameOffset = outerNameOffset;
+                properties[0].InType = (RegisteredTraceEventParser.TdhInputType)1; // StructStartIndex = 1
+                properties[0].OutType = 1;                                          // NumOfStructMembers = 1
+
+                // Nested member: a variable-length (ParamCount) array whose count index points at
+                // startField - 1 (= 0), i.e. just before this nested frame.  In the nested frame
+                // curField == 0 and fieldFetches is empty, so the prefix removal would underflow.
+                properties[1].Flags = RegisteredTraceEventParser.PROPERTY_FLAGS.ParamCount;
+                properties[1].NameOffset = innerNameOffset;
+                properties[1].InType = RegisteredTraceEventParser.TdhInputType.UInt32;
+                properties[1].CountOrCountIndex = 0; // == startField(1) + curField(0) - 1
+            }
+
+            return buffer;
+        }
+
+        private static unsafe byte[] CreateStructPropertyEventInfoBuffer()
+        {
+            byte[] buffer = new byte[EventInfoPropertyArrayOffset + (2 * EventPropertyInfoSize) + 128];
+            int stringOffset = EventInfoPropertyArrayOffset + (2 * EventPropertyInfoSize);
+            int providerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Provider");
+            int taskNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Task");
+            int opcodeNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Opcode");
+            int outerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Outer");
+            int innerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Inner");
+
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->ProviderGuid = Guid.NewGuid();
+                eventInfo->EventGuid = Guid.NewGuid();
+                eventInfo->EventDescriptor.Id = 1;
+                eventInfo->EventDescriptor.Task = 1;
+                eventInfo->EventDescriptor.Opcode = 1;
+                eventInfo->ProviderNameOffset = providerNameOffset;
+                eventInfo->TaskNameOffset = taskNameOffset;
+                eventInfo->OpcodeNameOffset = opcodeNameOffset;
+                eventInfo->PropertyCount = 2;
+                eventInfo->TopLevelPropertyCount = 1;
+
+                RegisteredTraceEventParser.EVENT_PROPERTY_INFO* properties = &eventInfo->EventPropertyInfoArray;
+
+                // Top-level struct property pointing at property index 1 as its single member.
+                // Encode StructStartIndex=1 / NumOfStructMembers=1 via the union members.
+                properties[0].Flags = RegisteredTraceEventParser.PROPERTY_FLAGS.Struct;
+                properties[0].NameOffset = outerNameOffset;
+                properties[0].InType = (RegisteredTraceEventParser.TdhInputType)1; // StructStartIndex
+                properties[0].OutType = 1;                                          // NumOfStructMembers
+                // Deliberately set the slot that overlays MapNameOffset to a non-zero garbage
+                // value to mimic real TDH output where the struct 'padding' field is not
+                // guaranteed to be zero.  ValidateEventInfo must not interpret this as a
+                // string offset for struct-typed properties.
+                properties[0].MapNameOffset = unchecked((int)0xDEADBEEF);
+
+                // The nested member.
+                properties[1].NameOffset = innerNameOffset;
+                properties[1].InType = RegisteredTraceEventParser.TdhInputType.UInt32;
+            }
+
+            return buffer;
+        }
+
+        private static unsafe byte[] CreateSinglePropertyEventInfoBuffer()
+        {
+            byte[] buffer = new byte[EventInfoPropertyArrayOffset + EventPropertyInfoSize + 128];
+            int stringOffset = EventInfoPropertyArrayOffset + EventPropertyInfoSize;
+            int providerNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Provider");
+            int taskNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Task");
+            int opcodeNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Opcode");
+            int propertyNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Field");
+
+            fixed (byte* eventInfoBuffer = buffer)
+            {
+                var eventInfo = (RegisteredTraceEventParser.TRACE_EVENT_INFO*)eventInfoBuffer;
+                eventInfo->ProviderGuid = Guid.NewGuid();
+                eventInfo->EventGuid = Guid.NewGuid();
+                eventInfo->EventDescriptor.Id = 1;
+                eventInfo->EventDescriptor.Task = 1;
+                eventInfo->EventDescriptor.Opcode = 1;
+                eventInfo->ProviderNameOffset = providerNameOffset;
+                eventInfo->TaskNameOffset = taskNameOffset;
+                eventInfo->OpcodeNameOffset = opcodeNameOffset;
+                eventInfo->PropertyCount = 1;
+                eventInfo->TopLevelPropertyCount = 1;
+
+                RegisteredTraceEventParser.EVENT_PROPERTY_INFO* propertyInfo = &eventInfo->EventPropertyInfoArray;
+                propertyInfo->NameOffset = propertyNameOffset;
+                propertyInfo->InType = RegisteredTraceEventParser.TdhInputType.UInt32;
+            }
+
+            return buffer;
+        }
+
+        private static unsafe byte[] CreateMapInfoBuffer()
+        {
+            byte[] buffer = new byte[EventMapInfoEntryArrayOffset + EventMapEntrySize + 128];
+            int stringOffset = EventMapInfoEntryArrayOffset + EventMapEntrySize;
+            int mapNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Map");
+            int entryNameOffset = AppendUnicodeString(buffer, ref stringOffset, "Entry");
+
+            fixed (byte* eventMapBuffer = buffer)
+            {
+                var eventMap = (RegisteredTraceEventParser.EVENT_MAP_INFO*)eventMapBuffer;
+                eventMap->NameOffset = mapNameOffset;
+                eventMap->Flag = RegisteredTraceEventParser.MAP_FLAGS.EVENTMAP_INFO_FLAG_MANIFEST_VALUEMAP;
+                eventMap->EntryCount = 1;
+                eventMap->MapEntryArray.NameOffset = entryNameOffset;
+                eventMap->MapEntryArray.Value = 1;
+            }
+
+            return buffer;
+        }
+
+        private static int AppendUnicodeString(byte[] buffer, ref int offset, string value)
+        {
+            byte[] bytes = Encoding.Unicode.GetBytes(value + '\0');
+            int originalOffset = offset;
+            Buffer.BlockCopy(bytes, 0, buffer, offset, bytes.Length);
+            offset += bytes.Length;
+            return originalOffset;
+        }
+
+        private static readonly int EventInfoPropertyArrayOffset = (int)Marshal.OffsetOf(typeof(RegisteredTraceEventParser.TRACE_EVENT_INFO), "EventPropertyInfoArray");
+        private static readonly int EventPropertyInfoSize = Marshal.SizeOf(typeof(RegisteredTraceEventParser.EVENT_PROPERTY_INFO));
+        private static readonly int EventMapInfoEntryArrayOffset = (int)Marshal.OffsetOf(typeof(RegisteredTraceEventParser.EVENT_MAP_INFO), "MapEntryArray");
+        private static readonly int EventMapEntrySize = Marshal.SizeOf(typeof(RegisteredTraceEventParser.EVENT_MAP_ENTRY));
 
         #region Legacy Implementation (for comparison testing only)
 

--- a/src/TraceEvent/TraceEvent.Tests/Regression/BPerfEventSourceTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Regression/BPerfEventSourceTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.Diagnostics.Tracing;
+using System;
+using System.IO;
+using Xunit;
+
+namespace TraceEventTests.Regression
+{
+    /// <summary>
+    /// Regression tests for malformed BPerf event records. Each test constructs an
+    /// uncompressed buffer that claims more space than is actually present (truncated
+    /// header, oversized UserDataLength, oversized ExtendedDataCount, oversized extended
+    /// data payload, or trailing alignment that spills past the buffer) and verifies that
+    /// BPerfEventSource rejects it with InvalidDataException instead of reading past the
+    /// end of the decompressed buffer.
+    /// </summary>
+    public class BPerfEventSourceTests
+    {
+        // Sizes and offsets within the native EVENT_RECORD layout that BPerf deserializes.
+        // Held as constants so the tests can poke specific fields without depending on
+        // PerfView's internal types.
+        private const int EventRecordSize = 112;
+        private const int ExtendedDataCountOffset = 84;
+        private const int UserDataLengthOffset = 86;
+        private const int ExtendedDataItemSize = 16;
+        private const int ExtendedDataItemDataSizeOffset = 6;
+
+        [Fact]
+        public void ProcessThrowsInvalidDataExceptionForTruncatedEventRecordHeader()
+        {
+            // Buffer is one byte shorter than the EVENT_RECORD header, so even the
+            // initial header read should fail bounds checking.
+            AssertMalformedBtlThrows(new byte[EventRecordSize - 1]);
+        }
+
+        [Fact]
+        public void ProcessThrowsInvalidDataExceptionWhenUserDataExtendsPastBuffer()
+        {
+            // Buffer is exactly the header size, but UserDataLength = 1 claims one more
+            // byte of user data that does not exist in the buffer.
+            byte[] record = new byte[EventRecordSize];
+            WriteUInt16(record, UserDataLengthOffset, 1);
+
+            AssertMalformedBtlThrows(record);
+        }
+
+        [Fact]
+        public void ProcessThrowsInvalidDataExceptionWhenExtendedDataArrayExtendsPastBuffer()
+        {
+            // Buffer is exactly the header size, but ExtendedDataCount = 1 claims a
+            // 16-byte extended-data item that does not fit in the buffer.
+            byte[] record = new byte[EventRecordSize];
+            WriteUInt16(record, ExtendedDataCountOffset, 1);
+
+            AssertMalformedBtlThrows(record);
+        }
+
+        [Fact]
+        public void ProcessThrowsInvalidDataExceptionWhenExtendedDataPayloadExtendsPastBuffer()
+        {
+            // Buffer holds the header and one extended-data item, but that item's
+            // DataSize = 1 claims a payload byte that lies past the end of the buffer.
+            byte[] record = new byte[EventRecordSize + ExtendedDataItemSize];
+            WriteUInt16(record, ExtendedDataCountOffset, 1);
+            WriteUInt16(record, EventRecordSize + ExtendedDataItemDataSizeOffset, 1);
+
+            AssertMalformedBtlThrows(record);
+        }
+
+        [Fact]
+        public void ProcessThrowsInvalidDataExceptionWhenFinalRecordAlignmentExtendsPastBuffer()
+        {
+            // Buffer is 8 bytes larger than the header and UserDataLength = 1 fits within
+            // the buffer, but the final 16-byte alignment of the record's end would push
+            // past the buffer.
+            byte[] record = new byte[EventRecordSize + 8];
+            WriteUInt16(record, UserDataLengthOffset, 1);
+
+            AssertMalformedBtlThrows(record);
+        }
+
+        /// <summary>
+        /// Wraps <paramref name="uncompressedData"/> in a minimal BTL chunk on disk, then
+        /// constructs a BPerfEventSource over it and asserts that consuming the source
+        /// throws <see cref="InvalidDataException"/>.
+        /// </summary>
+        private static void AssertMalformedBtlThrows(byte[] uncompressedData)
+        {
+            string btlPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".btl");
+
+            try
+            {
+                File.WriteAllBytes(btlPath, CreateBtlChunk(uncompressedData));
+
+                Assert.Throws<InvalidDataException>(
+                    () => new BPerfEventSource(
+                        btlPath,
+                        new TraceEventDispatcherOptions(),
+                        new byte[1024],
+                        new byte[1024],
+                        decompressDelegate: CopyDecompress));
+            }
+            finally
+            {
+                if (File.Exists(btlPath))
+                {
+                    File.Delete(btlPath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the minimal BTL chunk header that BPerfEventSource expects: a compressed
+        /// length and an uncompressed length followed by the (uncompressed) payload bytes.
+        /// Because the test uses <see cref="CopyDecompress"/>, both lengths are equal.
+        /// </summary>
+        private static byte[] CreateBtlChunk(byte[] uncompressedData)
+        {
+            byte[] btl = new byte[sizeof(int) + sizeof(int) + uncompressedData.Length];
+            BitConverter.GetBytes(uncompressedData.Length).CopyTo(btl, 0);
+            BitConverter.GetBytes(uncompressedData.Length).CopyTo(btl, sizeof(int));
+            uncompressedData.CopyTo(btl, sizeof(int) + sizeof(int));
+            return btl;
+        }
+
+        // Identity "decompression" delegate so the tests directly control the bytes that
+        // BPerf's record deserializer sees. The real ULZ777 decompressor is exercised by
+        // other tests.
+        private static int CopyDecompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputLength)
+        {
+            Array.Copy(input, inputOffset, output, 0, inputLength);
+            return inputLength;
+        }
+
+        private static void WriteUInt16(byte[] buffer, int offset, ushort value)
+        {
+            byte[] valueBytes = BitConverter.GetBytes(value);
+            valueBytes.CopyTo(buffer, offset);
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Regression/GCDynamicTraceEventParserTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Regression/GCDynamicTraceEventParserTests.cs
@@ -1,0 +1,264 @@
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.GCDynamic;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace TraceEventTests.Regression
+{
+    public class GCDynamicTraceEventParserTests
+    {
+        [Fact]
+        public void GCDynamicPayloadAllowsValidPayload()
+        {
+            byte[] data = new byte[] { 1, 2, 3 };
+            byte[] payload = CreatePayload("DynamicTraceEvent", data.Length, data, 42);
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                traceEvent.FixupData();
+
+                Assert.Equal("DynamicTraceEvent", traceEvent.Name);
+                Assert.Equal(data.Length, traceEvent.DataSize);
+                Assert.Equal(data, traceEvent.Data);
+                Assert.Equal(42, traceEvent.ClrInstanceID);
+            });
+        }
+
+        [Fact]
+        public void GCDynamicPayloadRejectsNegativeDataSize()
+        {
+            byte[] payload = CreatePayload("DynamicTraceEvent", -1, new byte[0], 42);
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                traceEvent.FixupData();
+                AssertSafeDefaultsSurfaced(traceEvent);
+            });
+        }
+
+        [Fact]
+        public void GCDynamicPayloadRejectsOversizedDataSize()
+        {
+            byte[] payload = CreatePayload("DynamicTraceEvent", 4, new byte[] { 1, 2, 3 }, 42);
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                traceEvent.FixupData();
+                AssertSafeDefaultsSurfaced(traceEvent);
+            });
+        }
+
+        [Fact]
+        public void GCDynamicPayloadRejectsNameWithoutTerminator()
+        {
+            byte[] payload = Encoding.Unicode.GetBytes("DynamicTraceEvent");
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                traceEvent.FixupData();
+                AssertSafeDefaultsSurfaced(traceEvent);
+            });
+        }
+
+        /// <summary>
+        /// Regression test for the DoS path that the bounds-check fix could
+        /// otherwise introduce.  FixupData is called from the core dispatch
+        /// loops of every trace source (ETW, EventPipe, BPerf, etc.) without
+        /// a surrounding try/catch.  A malformed payload that makes the
+        /// validated field accessors throw must NOT cause FixupData itself
+        /// to throw, or a single bad event would abort the entire trace.
+        /// </summary>
+        [Fact]
+        public void GCDynamicFixupDataDoesNotThrowOnMalformedPayload()
+        {
+            // Name has no null terminator -> TryGetPayloadLayout returns false.
+            byte[] payload = Encoding.Unicode.GetBytes("DynamicTraceEvent");
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                Exception thrown = Record.Exception(delegate { traceEvent.FixupData(); });
+                Assert.Null(thrown);
+            });
+        }
+
+        /// <summary>
+        /// Regression test ensuring that a payload that passes the basic
+        /// bounds check but is too small for the CommittedUsage layout
+        /// (DataSize &lt; 42) does NOT get dispatched as a CommittedUsage
+        /// event, because the CommittedUsage accessors read at fixed
+        /// offsets up to byte 41 via BitConverter and would otherwise throw
+        /// ArgumentException during PayloadValue / ToXml.
+        /// </summary>
+        [Fact]
+        public void GCDynamicCommittedUsageWithUndersizedDataStaysGeneric()
+        {
+            // Use the CommittedUsage opcode name but supply DataSize = 0.
+            byte[] payload = CreatePayload("CommittedUsage", 0, new byte[0], 42);
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                // FixupData must not throw and must NOT select the CommittedUsage template.
+                traceEvent.FixupData();
+                Assert.NotEqual((int)GCDynamicEventBase.CommittedUsageTemplate.ID, (int)traceEvent.ID);
+
+                // Draining PayloadValues on the generic template must also be exception-safe
+                // for this payload — Name/DataSize/Data/ClrInstanceID all read in-bounds bytes.
+                foreach (KeyValuePair<string, object> kv in traceEvent.EventPayload.PayloadValues)
+                {
+                    Assert.NotNull(kv.Key);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Positive coverage: a properly sized CommittedUsage payload IS dispatched
+        /// as a CommittedUsage event and its fields decode correctly.
+        /// </summary>
+        [Fact]
+        public void GCDynamicCommittedUsageWithValidDataIsDispatched()
+        {
+            // 42-byte data: Version(2) + 5 * Int64(40).
+            byte[] data = new byte[42];
+            BitConverter.GetBytes((short)1).CopyTo(data, 0);
+            BitConverter.GetBytes((long)100).CopyTo(data, 2);
+            BitConverter.GetBytes((long)200).CopyTo(data, 10);
+            BitConverter.GetBytes((long)300).CopyTo(data, 18);
+            BitConverter.GetBytes((long)400).CopyTo(data, 26);
+            BitConverter.GetBytes((long)500).CopyTo(data, 34);
+
+            byte[] payload = CreatePayload("CommittedUsage", data.Length, data, 7);
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                traceEvent.FixupData();
+                Assert.Equal((int)GCDynamicEventBase.CommittedUsageTemplate.ID, (int)traceEvent.ID);
+
+                CommittedUsageTraceEvent committedUsage = (CommittedUsageTraceEvent)traceEvent.EventPayload;
+                Assert.Equal(1, committedUsage.Version);
+                Assert.Equal(100, committedUsage.TotalCommittedInUse);
+                Assert.Equal(500, committedUsage.TotalBookkeepingCommitted);
+            });
+        }
+
+        /// <summary>
+        /// Regression test for the propagated-exception path through
+        /// PayloadValues on a malformed payload.  ToXml iterates
+        /// EventPayload.PayloadValues; if any yielded accessor throws, ToXml
+        /// (called from trace dump tools, the PerfView Events view, and ETW
+        /// reloggers without a try/catch) would propagate the exception and
+        /// abort the surrounding loop.  PayloadValues must therefore be
+        /// exception-safe on malformed input.
+        /// </summary>
+        [Fact]
+        public void GCDynamicPayloadValuesOnMalformedPayloadEmitsSafeDefaults()
+        {
+            // Name has no null terminator -> ReadPayloadLayout returns null.
+            byte[] payload = Encoding.Unicode.GetBytes("DynamicTraceEvent");
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                traceEvent.FixupData();
+
+                List<KeyValuePair<string, object>> values = new List<KeyValuePair<string, object>>();
+                Exception thrown = Record.Exception(delegate
+                {
+                    foreach (KeyValuePair<string, object> kv in traceEvent.EventPayload.PayloadValues)
+                    {
+                        values.Add(kv);
+                    }
+                });
+
+                Assert.Null(thrown);
+                Assert.Equal(4, values.Count);
+                Assert.Equal("Name", values[0].Key);
+                Assert.Equal(string.Empty, values[0].Value);
+                Assert.Equal("DataSize", values[1].Key);
+                Assert.Equal(0, values[1].Value);
+                Assert.Equal("Data", values[2].Key);
+                Assert.Equal(string.Empty, values[2].Value);
+                Assert.Equal("ClrInstanceID", values[3].Key);
+                Assert.Equal(0, values[3].Value);
+            });
+        }
+
+        /// <summary>
+        /// Regression test ensuring PayloadValue on the generic GCDynamic template
+        /// returns safe placeholder values rather than throwing when the payload
+        /// is malformed.  Direct PayloadValue access happens from the PerfView
+        /// Events grid and from generic event-printing utilities; an unhandled
+        /// exception there would crash the consumer.
+        /// </summary>
+        [Fact]
+        public void GCDynamicPayloadValueOnMalformedPayloadReturnsSafeDefaults()
+        {
+            byte[] payload = Encoding.Unicode.GetBytes("DynamicTraceEvent");
+
+            WithGCDynamicEvent(payload, delegate (GCDynamicTraceEventImpl traceEvent)
+            {
+                traceEvent.FixupData();
+
+                Assert.Equal(string.Empty, traceEvent.PayloadValue(0));
+                Assert.Equal(0, traceEvent.PayloadValue(1));
+                Assert.Equal(Array.Empty<byte>(), (byte[])traceEvent.PayloadValue(2));
+                Assert.Equal(0, traceEvent.PayloadValue(3));
+            });
+        }
+
+        private static void AssertSafeDefaultsSurfaced(GCDynamicTraceEventImpl traceEvent)
+        {
+            // The framework-facing accessors (PayloadValue / PayloadValues / ToXml)
+            // are the ones called on the dispatch hot path; they must always be
+            // exception-safe and surface type-appropriate safe defaults rather
+            // than throw when the underlying payload is malformed.
+            Assert.Equal(string.Empty, traceEvent.PayloadValue(0));
+            Assert.Equal(0, traceEvent.PayloadValue(1));
+            Assert.Equal(Array.Empty<byte>(), (byte[])traceEvent.PayloadValue(2));
+            Assert.Equal(0, traceEvent.PayloadValue(3));
+
+            List<KeyValuePair<string, object>> values = new List<KeyValuePair<string, object>>();
+            foreach (KeyValuePair<string, object> kv in traceEvent.EventPayload.PayloadValues)
+            {
+                values.Add(kv);
+            }
+
+            Assert.Equal(4, values.Count);
+            Assert.Equal("Name", values[0].Key);
+            Assert.Equal("DataSize", values[1].Key);
+            Assert.Equal("Data", values[2].Key);
+            Assert.Equal("ClrInstanceID", values[3].Key);
+        }
+
+        private static byte[] CreatePayload(string name, int dataSize, byte[] data, short clrInstanceID)
+        {
+            List<byte> payload = new List<byte>();
+            payload.AddRange(Encoding.Unicode.GetBytes(name));
+            payload.Add(0);
+            payload.Add(0);
+            payload.AddRange(BitConverter.GetBytes(dataSize));
+            payload.AddRange(data);
+            payload.AddRange(BitConverter.GetBytes(clrInstanceID));
+            return payload.ToArray();
+        }
+
+        private static unsafe void WithGCDynamicEvent(byte[] payload, Action<GCDynamicTraceEventImpl> action)
+        {
+            fixed (byte* payloadBytes = payload)
+            {
+                TraceEventNativeMethods.EVENT_RECORD eventRecord = new TraceEventNativeMethods.EVENT_RECORD();
+                eventRecord.EventHeader.ProviderId = GCDynamicTraceEventParser.ProviderGuid;
+                eventRecord.EventHeader.Id = 39;
+                eventRecord.UserDataLength = (ushort)payload.Length;
+                eventRecord.UserData = (IntPtr)payloadBytes;
+
+                GCDynamicTraceEventImpl traceEvent = new GCDynamicTraceEventImpl(null, 39, 1, "GC", Guid.Empty, 41, "DynamicTraceEvent", GCDynamicTraceEventParser.ProviderGuid, "Microsoft-Windows-DotNETRuntime");
+                traceEvent.eventRecord = &eventRecord;
+                traceEvent.userData = eventRecord.UserData;
+
+                action(traceEvent);
+            }
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Regression/ZippedETLTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Regression/ZippedETLTests.cs
@@ -1,0 +1,229 @@
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class ZippedETLTests
+    {
+        [Fact]
+        public void UnpackArchiveExtractsValidPdbIntoSymbolDirectory()
+        {
+            WithTempDirectory(tempDir =>
+            {
+                string zipPath = Path.Combine(tempDir, "trace.etl.zip");
+                string symbolDirectory = Path.Combine(tempDir, "symbols");
+                const string pdbRelativePath = @"valid.pdb\ABCDEF1234567890\valid.pdb";
+                const string pdbContents = "valid pdb contents";
+
+                CreateZippedEtl(
+                    zipPath,
+                    new[] { new KeyValuePair<string, string>(@"symbols\" + pdbRelativePath, pdbContents) });
+
+                var reader = new ZippedETLReader(zipPath, new StringWriter())
+                {
+                    EtlFileName = Path.Combine(tempDir, "trace.etl"),
+                    SymbolDirectory = symbolDirectory
+                };
+
+                reader.UnpackArchive();
+
+                Assert.Equal(pdbContents, File.ReadAllText(Path.Combine(symbolDirectory, pdbRelativePath)));
+            });
+        }
+
+        [Fact]
+        public void UnpackArchiveRejectsPdbTraversalAfterPrefixStripping()
+        {
+            WithTempDirectory(tempDir =>
+            {
+                string zipPath = Path.Combine(tempDir, "trace.etl.zip");
+                string symbolDirectory = Path.Combine(tempDir, "symbols");
+                var log = new StringWriter();
+
+                CreateZippedEtl(
+                    zipPath,
+                    new[]
+                    {
+                        new KeyValuePair<string, string>("symbols/../outside.pdb", "traversal"),
+                        new KeyValuePair<string, string>("payload.ngenpdbs/../prefixCollision.pdb", "prefix collision"),
+                    });
+
+                var reader = new ZippedETLReader(zipPath, log)
+                {
+                    EtlFileName = Path.Combine(tempDir, "trace.etl"),
+                    SymbolDirectory = symbolDirectory
+                };
+
+                reader.UnpackArchive();
+
+                Assert.False(File.Exists(Path.Combine(tempDir, "outside.pdb")));
+                Assert.False(File.Exists(Path.Combine(tempDir, "prefixCollision.pdb")));
+                Assert.Contains("invalid path", log.ToString());
+            });
+        }
+
+        [Fact]
+        public void UnpackArchiveDoesNotStripDiagsessionPrefixFromMiddleOfPath()
+        {
+            WithTempDirectory(tempDir =>
+            {
+                string zipPath = Path.Combine(tempDir, "trace.etl.zip");
+                string symbolDirectory = Path.Combine(tempDir, "symbols");
+                const string pdbName = "prefixCollision.pdb";
+                var log = new StringWriter();
+
+                CreateZippedEtl(
+                    zipPath,
+                    new[]
+                    {
+                        new KeyValuePair<string, string>(
+                            @"prefix\194BAE98-C4ED-470E-9204-1F9389FC9DC1\symcache\" + pdbName,
+                            "prefix collision"),
+                    });
+
+                var reader = new ZippedETLReader(zipPath, log)
+                {
+                    EtlFileName = Path.Combine(tempDir, "trace.etl"),
+                    SymbolDirectory = symbolDirectory
+                };
+
+                reader.UnpackArchive();
+
+                Assert.False(File.Exists(Path.Combine(symbolDirectory, pdbName)));
+                Assert.Contains("not in a symbol server style directory", log.ToString());
+            });
+        }
+
+        [Fact]
+        public void UnpackArchiveExtractsDiagsessionPdbFromRootPrefix()
+        {
+            WithTempDirectory(tempDir =>
+            {
+                string zipPath = Path.Combine(tempDir, "trace.etl.zip");
+                string symbolDirectory = Path.Combine(tempDir, "symbols");
+                const string pdbName = "valid.pdb";
+                const string pdbContents = "valid pdb contents";
+
+                CreateZippedEtl(
+                    zipPath,
+                    new[]
+                    {
+                        new KeyValuePair<string, string>(
+                            @"194BAE98-C4ED-470E-9204-1F9389FC9DC1\symcache\" + pdbName,
+                            pdbContents),
+                    });
+
+                var reader = new ZippedETLReader(zipPath, new StringWriter())
+                {
+                    EtlFileName = Path.Combine(tempDir, "trace.etl"),
+                    SymbolDirectory = symbolDirectory
+                };
+
+                reader.UnpackArchive();
+
+                Assert.Equal(pdbContents, File.ReadAllText(Path.Combine(symbolDirectory, pdbName)));
+            });
+        }
+
+        private static void CreateZippedEtl(string zipPath, IEnumerable<KeyValuePair<string, string>> pdbEntries)
+        {
+            using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+            {
+                ZipArchiveEntry etlEntry = archive.CreateEntry("trace.etl");
+                using (var writer = new StreamWriter(etlEntry.Open()))
+                {
+                    writer.Write("etl");
+                }
+
+                foreach (KeyValuePair<string, string> pdbEntry in pdbEntries)
+                {
+                    ZipArchiveEntry entry = archive.CreateEntry(pdbEntry.Key);
+                    using (var writer = new StreamWriter(entry.Open()))
+                    {
+                        writer.Write(pdbEntry.Value);
+                    }
+                }
+            }
+        }
+
+        private static void WithTempDirectory(Action<string> action)
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), "ZippedETLTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                action(tempDir);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    public class SymbolCachePathUtilitiesTests
+    {
+        // Paths that must be accepted.
+        [Theory]
+        [InlineData(@"module.pdb\ABCDEF1234567890ABCDEF1234567890\module.pdb")]
+        [InlineData("module.pdb/ABCDEF1234567890ABCDEF1234567890/module.pdb")]
+        [InlineData(@"sub\module.pdb\ABCDEF1234567890ABCDEF1234567890\module.pdb")]
+        public void AcceptsValidSymbolServerStylePaths(string pdbRelativePath)
+        {
+            string symbolCache = @"C:\SymbolCache";
+
+            bool ok = SymbolCachePathUtilities.TryGetPdbTargetPath(symbolCache, pdbRelativePath, out string pdbTargetPath);
+
+            Assert.True(ok, $"Expected path '{pdbRelativePath}' to be accepted.");
+            Assert.NotNull(pdbTargetPath);
+            string fullCache = Path.GetFullPath(symbolCache);
+            Assert.StartsWith(
+                fullCache + Path.DirectorySeparatorChar,
+                pdbTargetPath,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Paths that must be rejected: traversal, whitespace-padded traversal, rooted paths,
+        // and paths that escape the cache via prefix-collision or sibling-cache tricks.
+        [Theory]
+        [InlineData(@"..\outside.pdb")]
+        [InlineData(@"module.pdb\..\outside.pdb")]
+        [InlineData("module.pdb/../outside.pdb")]
+        [InlineData(@"module.pdb\.. \outside.pdb")]
+        [InlineData(@"module.pdb\ ..\outside.pdb")]
+        [InlineData(@"module.pdb\ .. \outside.pdb")]
+        [InlineData(@"\rooted\module.pdb")]
+        [InlineData(@"C:\rooted\module.pdb")]
+        [InlineData(@"C:rooted\module.pdb")]
+        [InlineData(@"module.pdb:stream\ABCDEF1234567890ABCDEF1234567890\module.pdb")]
+        [InlineData(@"module.pdb\ABCDEF1234567890ABCDEF1234567890\module.pdb:stream")]
+        [InlineData(@"..\SymbolCache2\module.pdb\ABCDEF1234567890ABCDEF1234567890\module.pdb")]
+        public void RejectsUnsafePaths(string pdbRelativePath)
+        {
+            string symbolCache = @"C:\SymbolCache";
+
+            bool ok = SymbolCachePathUtilities.TryGetPdbTargetPath(symbolCache, pdbRelativePath, out string pdbTargetPath);
+
+            Assert.False(ok, $"Expected path '{pdbRelativePath}' to be rejected.");
+            Assert.Null(pdbTargetPath);
+        }
+
+        [Theory]
+        [InlineData(null, @"module.pdb\HEX\module.pdb")]
+        [InlineData("", @"module.pdb\HEX\module.pdb")]
+        [InlineData(@"C:\SymbolCache", null)]
+        [InlineData(@"C:\SymbolCache", "")]
+        public void RejectsNullOrEmptyInputs(string symbolCache, string pdbRelativePath)
+        {
+            bool ok = SymbolCachePathUtilities.TryGetPdbTargetPath(symbolCache, pdbRelativePath, out string pdbTargetPath);
+
+            Assert.False(ok);
+            Assert.Null(pdbTargetPath);
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/NativeSymbolModuleTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/NativeSymbolModuleTests.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.IO;
+using Microsoft.Diagnostics.Symbols;
+using Xunit;
+using Xunit.Abstractions;
+
+using static Microsoft.Diagnostics.Symbols.NativeSymbolModule.MicrosoftPdbSourceFile;
+
+namespace TraceEventTests
+{
+    /// <summary>
+    /// Tests for <see cref="NativeSymbolModule.MicrosoftPdbSourceFile.TryGetSafeSourceCachePath"/>, the
+    /// helper that synthesizes a structurally-safe source-cache path under a given cache directory.  This
+    /// is the path-traversal containment: PDB-supplied SRCSRVTRG strings (which can contain '..\..\',
+    /// mixed separators, alternate roots, etc.) must not be able to cause writes outside the cache
+    /// directory.
+    /// </summary>
+    public class NativeSymbolModuleTests : TestBase
+    {
+        public NativeSymbolModuleTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string CacheDir = @"C:\cache";
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_NullCacheDir_ReturnsFalse()
+        {
+            Assert.False(TryGetSafeSourceCachePath(null, @"C:\src\Program.cs", out string safe));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_EmptyCacheDir_ReturnsFalse()
+        {
+            Assert.False(TryGetSafeSourceCachePath(string.Empty, @"C:\src\Program.cs", out string safe));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_NullTarget_ReturnsFalse()
+        {
+            Assert.False(TryGetSafeSourceCachePath(CacheDir, null, out string safe));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_EmptyTarget_ReturnsFalse()
+        {
+            Assert.False(TryGetSafeSourceCachePath(CacheDir, string.Empty, out string safe));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_TargetWithoutFileName_ReturnsFalse()
+        {
+            // Path.GetFileName(@"C:\foo\") returns string.Empty.
+            Assert.False(TryGetSafeSourceCachePath(CacheDir, @"C:\foo\", out string safe));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_FileNameWithInvalidChars_ReturnsFalse()
+        {
+            // Pipe is in Path.GetInvalidFileNameChars() on Windows.  Use a backslash-separated path so
+            // Path.GetFileName returns the offending segment unchanged on net462 / netcoreapp.
+            Assert.False(TryGetSafeSourceCachePath(CacheDir, @"C:\src\bad|name.cs", out string safe));
+            Assert.Null(safe);
+        }
+
+        [Theory]
+        [InlineData(@"C:\path\..")]
+        [InlineData(@"C:\path\.")]
+        [InlineData("https://example.com/path/..")]
+        [InlineData("https://example.com/path/.")]
+        [InlineData(@"..")]
+        [InlineData(@".")]
+        [InlineData(@".. ")]     // trailing space; Windows kernel normalizes to ".."
+        [InlineData(@". ")]      // trailing space; Windows kernel normalizes to "."
+        [InlineData(@"...")]     // trailing dot run; Windows kernel normalizes to ".."
+        [InlineData(@"..  ")]    // multiple trailing spaces
+        [InlineData(@".. .")]    // mixed trailing dots/spaces
+        [InlineData(@"   ")]     // pure whitespace -- TrimEnd reduces to empty
+        [InlineData("https://example.com/path/.. ")]
+        public void TryGetSafeSourceCachePath_DotSegmentFileName_ReturnsFalse(string target)
+        {
+            // Path.GetFileName returns "." or ".." (or a trailing-space/dot variant) for these targets,
+            // and none of those character sequences appears in Path.GetInvalidFileNameChars(), so the
+            // structural containment invariant would be broken (<cacheDir>\<hash>\.. resolves to
+            // <cacheDir>; the Windows kernel strips trailing spaces and dots so ".. " resolves identically
+            // to "..") unless we explicitly reject them.
+            Assert.False(TryGetSafeSourceCachePath(CacheDir, target, out string safe));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_HttpUrlWithPathTraversal_IsStructurallyContained()
+        {
+            // Even when the URL path contains '..' segments before the final file name, the trailing
+            // segment is what Path.GetFileName extracts -- and the structural containment must hold.
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, "https://example.com/a/../../../etc/passwd", out string safe));
+
+            string canonical = Path.GetFullPath(CacheDir);
+            string resolved = Path.GetFullPath(safe);
+            Assert.StartsWith(canonical, resolved, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("passwd", Path.GetFileName(safe));
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_HttpUrlWithQueryString_ReturnsFalse()
+        {
+            // '?' is in Path.GetInvalidFileNameChars() on Windows, so a URL whose final path segment carries
+            // a query string must be rejected rather than silently truncated.
+            Assert.False(TryGetSafeSourceCachePath(CacheDir, "https://example.com/foo.cs?evil=1", out string safe));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_BasicTarget_ProducesPathUnderCacheDir()
+        {
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, @"C:\src\Program.cs", out string safe));
+            Assert.NotNull(safe);
+
+            // The result must be under the canonical cacheDir.
+            string canonical = Path.GetFullPath(CacheDir);
+            Assert.StartsWith(canonical, safe, StringComparison.OrdinalIgnoreCase);
+
+            // The final segment is the file name from the target.
+            Assert.Equal("Program.cs", Path.GetFileName(safe));
+
+            // The middle segment is a 32-character hex hash subdirectory.
+            string subdir = Path.GetFileName(Path.GetDirectoryName(safe));
+            Assert.Equal(32, subdir.Length);
+            foreach (char c in subdir)
+            {
+                Assert.True((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'), $"unexpected hex character '{c}'");
+            }
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_PathTraversalInTarget_IsStructurallyContained()
+        {
+            // The PDB tries to escape the cache directory via '..\..\..\' traversal in SRCSRVTRG.
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, @"..\..\..\evil.exe", out string safe));
+
+            // No matter how malicious the target is, the resulting path is anchored at the canonical
+            // cache directory.  The file-name component is only ever 'evil.exe' (a single segment).
+            string canonical = Path.GetFullPath(CacheDir);
+            Assert.StartsWith(canonical, safe, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("evil.exe", Path.GetFileName(safe));
+
+            // Most importantly: Path.GetFullPath(safe) must still resolve under canonical cacheDir.  This
+            // is the structural property the rest of the system relies on.
+            string resolved = Path.GetFullPath(safe);
+            Assert.StartsWith(canonical, resolved, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_AlternateRootInTarget_IsStructurallyContained()
+        {
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, @"D:\Windows\System32\drivers\etc\hosts", out string safe));
+
+            string canonical = Path.GetFullPath(CacheDir);
+            string resolved = Path.GetFullPath(safe);
+            Assert.StartsWith(canonical, resolved, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("hosts", Path.GetFileName(safe));
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_UncRootInTarget_IsStructurallyContained()
+        {
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, @"\\evil-server\share\payload.dll", out string safe));
+
+            string canonical = Path.GetFullPath(CacheDir);
+            string resolved = Path.GetFullPath(safe);
+            Assert.StartsWith(canonical, resolved, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("payload.dll", Path.GetFileName(safe));
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_HttpUrl_ProducesContainedPath()
+        {
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, "https://example.com/team/Program.cs", out string safe));
+
+            string canonical = Path.GetFullPath(CacheDir);
+            Assert.StartsWith(canonical, safe, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("Program.cs", Path.GetFileName(safe));
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_CanonicalizesCacheDirWithDot()
+        {
+            // Path.GetFullPath should resolve '.' references and produce an absolute cache directory.
+            string relative = Path.Combine(Path.GetTempPath(), ".", "PerfViewCacheTest");
+            Assert.True(TryGetSafeSourceCachePath(relative, @"C:\src\Program.cs", out string safe));
+
+            string canonical = Path.GetFullPath(relative);
+            Assert.StartsWith(canonical, safe, StringComparison.OrdinalIgnoreCase);
+            // No literal "\.\" should remain in the safe path.
+            Assert.DoesNotContain(@"\.\", safe);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_CanonicalizesCacheDirWithTrailingSeparator()
+        {
+            Assert.True(TryGetSafeSourceCachePath(@"C:\cache\", @"C:\src\Program.cs", out string safe));
+            string canonical = Path.GetFullPath(@"C:\cache\");
+            Assert.StartsWith(canonical, safe, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_DifferentTargetsSameFileName_MapToDistinctSubdirs()
+        {
+            // 'Program.cs' from two different repos must land in different cache directories.  Otherwise
+            // a malicious PDB could collide with an existing trusted cache entry.
+            string targetA = "https://contoso.example.com/projA/Program.cs";
+            string targetB = "https://fabrikam.example.com/projB/Program.cs";
+
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, targetA, out string safeA));
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, targetB, out string safeB));
+
+            Assert.NotEqual(safeA, safeB);
+            Assert.Equal("Program.cs", Path.GetFileName(safeA));
+            Assert.Equal("Program.cs", Path.GetFileName(safeB));
+            Assert.NotEqual(Path.GetDirectoryName(safeA), Path.GetDirectoryName(safeB));
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_SameTarget_IsDeterministic()
+        {
+            // The cache path for a given (cacheDir, target) pair must be deterministic across calls in
+            // the same process (and, because the hash is XxHash128, across runs/processes too).  This is
+            // what makes the cache-hit short-circuit in GetSourceFromSrcServer work: opening the same
+            // file twice must produce the same safe path and therefore find the existing file.
+            string target = "https://example.com/team/repo/file.cs";
+
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, target, out string first));
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, target, out string second));
+
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public void TryGetSafeSourceCachePath_KnownTarget_HasStableHash()
+        {
+            // Pin the XxHash128 of a known target so that an accidental algorithm change (e.g. swapping
+            // the hash, changing encoding, changing byte ordering) is caught by this test.  If this test
+            // ever breaks legitimately because the hash is being changed on purpose, it can be updated.
+            Assert.True(TryGetSafeSourceCachePath(CacheDir, "https://example.com/source.cs", out string safe));
+
+            string subdir = Path.GetFileName(Path.GetDirectoryName(safe));
+            Assert.Equal("6ea7349872f1f7e170a97a688b999a47", subdir);
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/SourceServerCommandTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/SourceServerCommandTests.cs
@@ -1,0 +1,448 @@
+﻿using System;
+using Microsoft.Diagnostics.Symbols;
+using Xunit;
+using Xunit.Abstractions;
+
+using static Microsoft.Diagnostics.Symbols.NativeSymbolModule.MicrosoftPdbSourceFile;
+
+namespace TraceEventTests
+{
+    /// <summary>
+    /// Tests for <see cref="NativeSymbolModule.MicrosoftPdbSourceFile.TryCreateSafeSourceServerCommand"/>,
+    /// the per-tool allow-list rewriter that turns a PDB-supplied SRCSRVCMD / TFS_EXTRACT_CMD into a safe
+    /// command line we can run directly (no shell).  Malicious PDBs must not be able to embed shell
+    /// metacharacters, unknown executables, or unrecognized arguments and have them executed.
+    /// </summary>
+    public class SourceServerCommandTests : TestBase
+    {
+        public SourceServerCommandTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string TfExe = @"C:\tools\tf.exe";
+        private const string OutputPath = @"C:\cache\abcdef0123456789abcdef0123456789\file.cs";
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_NullCommand_ReturnsFalse()
+        {
+            Assert.False(TryCreateSafeSourceServerCommand(null, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_EmptyCommand_ReturnsFalse()
+        {
+            Assert.False(TryCreateSafeSourceServerCommand("   ", TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_NullTfExe_ReturnsFalse()
+        {
+            Assert.False(TryCreateSafeSourceServerCommand("tf.exe view", null, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_NullOutputPath_ReturnsFalse()
+        {
+            Assert.False(TryCreateSafeSourceServerCommand("tf.exe view", TfExe, null, out string safe, out string reason));
+            Assert.Null(safe);
+        }
+
+        // --- Modern, real-world legitimate command shapes -----------------------------------------------
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfvcModernTemplate_Accepted()
+        {
+            // This is the literal TFS_EXTRACT_CMD shape from clr.pdb after %var3% / %var4% substitution.
+            string command = "tf.exe view /version:12345 /noprompt \"$/team/path/Program.cs\" " +
+                "/server:https://tfs.example.com/tfs/DefaultCollection /output:c:\\original\\path.cs";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(reason);
+
+            // Tool prefix is preserved and quoted because TfExe has no spaces here.
+            Assert.StartsWith(TfExe, safe);
+
+            Assert.Contains(" view ", safe);
+            Assert.Contains("/version:12345", safe);
+            Assert.Contains("/noprompt", safe);
+            Assert.Contains("$/team/path/Program.cs", safe);
+            Assert.Contains("/server:https://tfs.example.com/tfs/DefaultCollection", safe);
+
+            // PDB-supplied /output was stripped; our own /output:<safeCachePath> is appended.
+            Assert.DoesNotContain("c:\\original\\path.cs", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfvcLegacyConsoleFlag_Accepted()
+        {
+            // Older TFVC templates carried /console; we accept it as a no-op because we always force
+            // /output:.  This keeps the safe rewriter from rejecting legitimate legacy PDBs.
+            string command = "tf.exe view /version:42 /noprompt /console \"$/foo/bar.cs\" /server:https://tfs.example.com";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(reason);
+            Assert.Contains("/console", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfvcNamespaceView_Accepted()
+        {
+            // tf.exe also supports the explicit 'vc' namespace for version-control commands.  Treat
+            // 'tf.exe vc view' as the same TFVC shape as 'tf.exe view' and apply the same allow-list.
+            string command = "tf.exe vc view /version:12345 /noprompt \"$/team/path/Program.cs\" " +
+                "/server:https://tfs.example.com/tfs/DefaultCollection /output:c:\\original\\path.cs";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(reason);
+
+            Assert.Contains(" vc view ", safe);
+            Assert.Contains("/version:12345", safe);
+            Assert.Contains("/noprompt", safe);
+            Assert.Contains("$/team/path/Program.cs", safe);
+            Assert.Contains("/server:https://tfs.example.com/tfs/DefaultCollection", safe);
+
+            // PDB-supplied /output was stripped; our own /output:<safeCachePath> is appended.
+            Assert.DoesNotContain("c:\\original\\path.cs", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfGitViewModernTemplate_Accepted()
+        {
+            // The literal shape from modern Windows PDBs (ntdll.pdb / ole32.pdb / fltMgr.pdb).
+            string command = "tf.exe git view " +
+                "/collection:https://dev.azure.com/microsoft " +
+                "/teamproject:os " +
+                "/repository:os.2020 " +
+                "/commitid:0123456789abcdef0123456789abcdef01234567 " +
+                "/path:src/foo/bar.cpp " +
+                "/output:c:\\anywhere.cpp " +
+                "/applyfilters";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(reason);
+
+            Assert.Contains(" git view ", safe);
+            Assert.Contains("/collection:https://dev.azure.com/microsoft", safe);
+            Assert.Contains("/teamproject:os", safe);
+            Assert.Contains("/repository:os.2020", safe);
+            Assert.Contains("/commitid:0123456789abcdef0123456789abcdef01234567", safe);
+            Assert.Contains("/path:src/foo/bar.cpp", safe);
+            Assert.Contains("/applyfilters", safe);
+
+            // PDB-supplied output was stripped; our /output: is appended at the end.
+            Assert.DoesNotContain("c:\\anywhere.cpp", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfvcWithDashSwitches_Accepted()
+        {
+            // tf.exe accepts both '/' and '-' switch prefixes; the allow-list and stripping logic must
+            // handle both equally.  This also exercises the '=' value separator on /version.
+            string command = "tf.exe view -version=99 -noprompt -server=https://tfs.example.com \"$/x/y.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(reason);
+            Assert.Contains("-version=99", safe);
+            Assert.Contains("-noprompt", safe);
+        }
+
+        // --- Output-stripping invariant -----------------------------------------------------------------
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_PdbOutputAttachedColon_IsStripped()
+        {
+            string command = "tf.exe view /version:1 /noprompt /server:https://t /output:C:\\evil.txt \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.DoesNotContain("C:\\evil.txt", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_PdbOutputAttachedEquals_IsStripped()
+        {
+            string command = "tf.exe view /version:1 /noprompt /server:https://t /output=C:\\evil.txt \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.DoesNotContain("C:\\evil.txt", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_PdbOutputSpaceSeparated_IsStripped()
+        {
+            // /output as a flag followed by the value as a separate token.  The rewriter must consume both.
+            string command = "tf.exe view /version:1 /noprompt /server:https://t /output C:\\evil.txt \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.DoesNotContain("C:\\evil.txt", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_PdbOutputDashPrefix_IsStripped()
+        {
+            string command = "tf.exe view /version:1 /noprompt /server:https://t -output:C:\\evil.txt \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.DoesNotContain("C:\\evil.txt", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_PdbLogin_IsStripped()
+        {
+            // PDB-supplied credentials are nonsense and dangerous; they must be dropped.
+            string command = "tf.exe view /version:1 /noprompt /server:https://t /login:user,secret \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.DoesNotContain("/login", safe);
+            Assert.DoesNotContain("secret", safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_BareOutputDoesNotEatFollowingSwitch()
+        {
+            // If a malformed PDB emits '/output' with no value before another allow-listed switch, the
+            // rewriter must not silently consume that switch as the (missing) value.  Otherwise the safely-
+            // rebuilt command shown to the user in the consent prompt would silently omit /server:...,
+            // /version:..., or any other legitimate switch that happened to follow.
+            string command = "tf.exe view /noprompt /output /server:https://tfs.example.com /version:42 \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Contains("/server:https://tfs.example.com", safe);
+            Assert.Contains("/version:42", safe);
+            Assert.EndsWith("/output:" + OutputPath, safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_BareLoginDoesNotEatFollowingSwitch()
+        {
+            // Same protection as for bare /output: a /login with no value must not silently consume the
+            // next allow-listed switch.
+            string command = "tf.exe view /noprompt /login /server:https://tfs.example.com /version:42 \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Contains("/server:https://tfs.example.com", safe);
+            Assert.Contains("/version:42", safe);
+            Assert.DoesNotContain("/login", safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_BareOutputBeforeRedirection_DoesNotEatRedirection()
+        {
+            // A bare /output followed by '>file' must not consume the redirection token; the main walk's
+            // '>' handling should still terminate parsing at the redirection.
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"$/a.cs\" /output >C:\\evil.txt";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.DoesNotContain("C:\\evil.txt", safe);
+            Assert.DoesNotContain(">", safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_LegacyShellRedirection_StopsParsing()
+        {
+            // Legacy SRCSRV templates that ran through cmd /c sometimes used '>file' redirection.  Anything
+            // after a '>'-prefixed token is dropped (we always write via /output:).
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"$/a.cs\" >C:\\evil.txt";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.DoesNotContain("C:\\evil.txt", safe);
+            Assert.DoesNotContain(">", safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_StdoutRedirectToStderr_Rejected()
+        {
+            // We do not run through cmd /c, so shell redirection is not interpreted.  Still, a redirection
+            // token like 1>&2 is not part of any supported source-server shape and should be rejected rather
+            // than copied into the rebuilt command line.
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"$/a.cs\" 1>&2";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+            Assert.Contains("1>&2", reason);
+        }
+
+        // --- Rejection paths ----------------------------------------------------------------------------
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_CmdExe_Rejected()
+        {
+            string command = "cmd.exe /c echo pwned > C:\\evil.txt";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_FastVstsBlob_Rejected()
+        {
+            // fastVstsBlob.exe is observed in real PDBs but we intentionally don't support it (the same
+            // PDBs declare tf.exe git view as a fallback).
+            string command = "fastVstsBlob.exe /BlobStore:https://x /blobid:abc /output:C:\\out.cs";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_SdExePerforce_Rejected()
+        {
+            string command = "sd.exe -p server:port print -o C:\\out.cs -q //depot/file.cs";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfvcWorkfold_Rejected()
+        {
+            // 'tf.exe workfold' is a real tf.exe subcommand but not 'view' / 'git view', so it must be
+            // rejected.  Otherwise an attacker could pivot the allow-list across tf.exe subcommands.
+            string command = "tf.exe workfold /map C:\\evil";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_UnknownSwitchOnTfvc_Rejected()
+        {
+            string command = "tf.exe view /version:1 /noprompt /shelve:foo \"$/a.cs\"";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+            Assert.Contains("/shelve", reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_UnknownSwitchOnTfvcNamespaceView_Rejected()
+        {
+            string command = "tf.exe vc view /version:1 /noprompt /shelve:foo \"$/a.cs\"";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+            Assert.Contains("/shelve", reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_UnknownSwitchOnGitView_Rejected()
+        {
+            string command = "tf.exe git view /collection:https://x /teamproject:p /repository:r /commitid:c /path:f /evil:bad";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+            Assert.Contains("/evil", reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfvcExtraPositional_Rejected()
+        {
+            // Only one positional ($-prefixed) argument is allowed for tf.exe view.  A second positional
+            // is a sign that the PDB is up to something unexpected, so reject it.
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"$/a.cs\" \"$/b.cs\"";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfvcNonDollarPositional_Rejected()
+        {
+            string command = "tf.exe view /version:1 /noprompt /server:https://t junk.cs";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+        }
+
+        [Theory]
+        [InlineData("$")]
+        [InlineData("$/")]
+        public void TryCreateSafeSourceServerCommand_TfvcTooShortDepotPath_Rejected(string depotPath)
+        {
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"" + depotPath + "\"";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+            Assert.Contains(depotPath, reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_GitViewPositional_Rejected()
+        {
+            // tf.exe git view templates never carry positional arguments.  Any positional means the PDB
+            // has gone off-script, so reject.
+            string command = "tf.exe git view /collection:https://x /teamproject:p /repository:r /commitid:c /path:f extraToken";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_UnterminatedQuote_Rejected()
+        {
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"$/a.cs";
+
+            Assert.False(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(safe);
+            Assert.NotNull(reason);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_ShellMetacharactersInSwitchValue_DoNotEscape()
+        {
+            // Even if a malicious PDB jams shell metacharacters into a /server: value, we no longer go
+            // through cmd /c, so the rebuilt command does not interpret them.  The token survives only
+            // as a single literal argument value to tf.exe (which will then fail in its own URL parser).
+            string command = "tf.exe view /version:1 /noprompt \"$/a.cs\" /server:https://t&calc.exe";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, OutputPath, out string safe, out string reason));
+            Assert.Null(reason);
+            // The metacharacters are preserved as part of a single argument value -- not as separate
+            // shell tokens.  Quoting may or may not be applied depending on whitespace.
+            Assert.Contains("https://t&calc.exe", safe);
+        }
+
+        // --- Quoting ------------------------------------------------------------------------------------
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_TfExePathWithSpaces_IsQuoted()
+        {
+            string tfExeWithSpaces = @"C:\Program Files\Common\tf.exe";
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, tfExeWithSpaces, OutputPath, out string safe, out string reason));
+            Assert.StartsWith("\"C:\\Program Files\\Common\\tf.exe\"", safe);
+        }
+
+        [Fact]
+        public void TryCreateSafeSourceServerCommand_OutputPathWithSpaces_IsQuoted()
+        {
+            string outputWithSpaces = @"C:\My Cache\abc\file.cs";
+            string command = "tf.exe view /version:1 /noprompt /server:https://t \"$/a.cs\"";
+
+            Assert.True(TryCreateSafeSourceServerCommand(command, TfExe, outputWithSpaces, out string safe, out string reason));
+            Assert.EndsWith("\"/output:" + outputWithSpaces + "\"", safe);
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
@@ -941,6 +941,137 @@ namespace TraceEventTests
         }
 
         [Fact]
+        public void FindR2RPerfMapSymbolFilePath_UsesSanitizedNameForSymbolServerPaths()
+        {
+            string cacheDir = Path.Combine(OutputDir, "r2r-symserver-sanitized-cache");
+            try
+            {
+                Directory.CreateDirectory(cacheDir);
+                var sig = new Guid("dddddddd-dddd-dddd-dddd-dddddddddddd");
+                int version = 1;
+                string safeName = "Unsafe.r2rmap";
+                string indexPath = $"/{safeName}/r2rmap-v{version}-{sig:N}/{safeName}";
+                var expectedUri = new Uri("https://symbols.example.test" + indexPath);
+                _handler.AddIntercept(expectedUri, HttpMethod.Get, HttpStatusCode.OK, () => new ByteArrayContent(CreateMinimalR2RPerfMap(sig, version)));
+
+                _symbolReader.SymbolPath = $"SRV*{cacheDir}*https://symbols.example.test";
+
+                string result = _symbolReader.FindR2RPerfMapSymbolFilePath(@"..\..\" + safeName, sig, version);
+
+                Assert.NotNull(result);
+                Assert.StartsWith(Path.GetFullPath(cacheDir), Path.GetFullPath(result), StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("..", result, StringComparison.Ordinal);
+                Assert.Contains(expectedUri, _handler.Requests);
+            }
+            finally
+            {
+                if (Directory.Exists(cacheDir))
+                    Directory.Delete(cacheDir, true);
+            }
+        }
+
+        [Fact]
+        public void FindR2RPerfMapSymbolFilePath_DoesNotUseRootedMetadataAsCachePath()
+        {
+            string tempDir = Path.Combine(OutputDir, "r2r-rooted-cache-path");
+            try
+            {
+                string cacheDir = Path.Combine(tempDir, "cache");
+                string outsideDir = Path.Combine(tempDir, "outside");
+                Directory.CreateDirectory(cacheDir);
+                Directory.CreateDirectory(outsideDir);
+
+                var sig = new Guid("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+                int version = 1;
+                string rootedMetadataName = Path.Combine(outsideDir, "Rooted.r2rmap");
+                File.WriteAllBytes(rootedMetadataName, CreateMinimalR2RPerfMap(sig, version));
+
+                _symbolReader.SymbolPath = $"SRV*{cacheDir}*https://symbols.example.test";
+                _symbolReader.Options = SymbolReaderOptions.CacheOnly;
+
+                string result = _symbolReader.FindR2RPerfMapSymbolFilePath(rootedMetadataName, sig, version);
+
+                Assert.Null(result);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(".")]
+        [InlineData("..")]
+        [InlineData(@"..\..")]
+        [InlineData("/")]
+        [InlineData(@"\")]
+        [InlineData(@"foo\")]
+        [InlineData(@"foo\..")]
+        public void FindR2RPerfMapSymbolFilePath_RejectsInvalidNames(string perfMapName)
+        {
+            // Configure a sym-server-only path so that, if validation were bypassed, the
+            // call would attempt an HTTP request we can detect.
+            string cacheDir = Path.Combine(OutputDir, "r2r-invalid-name-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(cacheDir);
+                _symbolReader.SymbolPath = $"SRV*{cacheDir}*https://symbols.example.test";
+
+                var sig = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+                string result = _symbolReader.FindR2RPerfMapSymbolFilePath(perfMapName, sig, 1);
+
+                Assert.Null(result);
+                Assert.Empty(_handler.Requests);
+                Assert.Empty(Directory.GetFiles(cacheDir, "*", SearchOption.AllDirectories));
+            }
+            finally
+            {
+                if (Directory.Exists(cacheDir))
+                    Directory.Delete(cacheDir, true);
+            }
+        }
+
+        [Fact]
+        public void FindR2RPerfMapSymbolFilePath_DifferentRawNamesShareSanitizedCachePath()
+        {
+            // Two raw perfMapName values that sanitize to the same simple name must
+            // resolve to the same on-disk cache file -- this is the expected behavior
+            // of the rooted-arg defense and prevents an attacker from "splitting" the
+            // cache across many entries that all alias the same simple name.
+            string cacheDir = Path.Combine(OutputDir, "r2r-cache-aliasing");
+            try
+            {
+                Directory.CreateDirectory(cacheDir);
+                var sig = new Guid("12345678-9abc-def0-1234-56789abcdef0");
+                int version = 7;
+                string safeName = "Shared.r2rmap";
+                var expectedUri = new Uri($"https://symbols.example.test/{safeName}/r2rmap-v{version}-{sig:N}/{safeName}");
+                _handler.AddIntercept(expectedUri, HttpMethod.Get, HttpStatusCode.OK, () => new ByteArrayContent(CreateMinimalR2RPerfMap(sig, version)));
+
+                _symbolReader.SymbolPath = $"SRV*{cacheDir}*https://symbols.example.test";
+
+                string fromTraversal = _symbolReader.FindR2RPerfMapSymbolFilePath(@"..\..\evil\" + safeName, sig, version);
+                string fromRooted = _symbolReader.FindR2RPerfMapSymbolFilePath(@"C:\victim\" + safeName, sig, version);
+                string fromSimple = _symbolReader.FindR2RPerfMapSymbolFilePath(safeName, sig, version);
+
+                Assert.NotNull(fromTraversal);
+                Assert.NotNull(fromRooted);
+                Assert.NotNull(fromSimple);
+                Assert.Equal(Path.GetFullPath(fromTraversal), Path.GetFullPath(fromRooted), ignoreCase: true);
+                Assert.Equal(Path.GetFullPath(fromTraversal), Path.GetFullPath(fromSimple), ignoreCase: true);
+                Assert.StartsWith(Path.GetFullPath(cacheDir), Path.GetFullPath(fromTraversal), StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                if (Directory.Exists(cacheDir))
+                    Directory.Delete(cacheDir, true);
+            }
+        }
+
+        [Fact]
         public void FindR2RPerfMapSymbolFilePath_NotFound()
         {
             string tempDir = Path.Combine(OutputDir, "r2r-empty");
@@ -1422,6 +1553,8 @@ namespace TraceEventTests
             /// </summary>
             public Dictionary<(Uri uri, HttpMethod method), (HttpStatusCode statusCode, Func<HttpContent> contentFactory)> Intercepts { get; } = new Dictionary<(Uri uri, HttpMethod method), (HttpStatusCode statusCode, Func<HttpContent> contentFactory)>();
 
+            public List<Uri> Requests { get; } = new List<Uri>();
+
             /// <summary>
             /// Convenience helper for adding an intercept for HTTP GET
             /// returning UTF-8 content with status code 200 (OK).
@@ -1437,6 +1570,8 @@ namespace TraceEventTests
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                Requests.Add(request.RequestUri);
+
                 if (Intercepts.TryGetValue((request.RequestUri, request.Method), out var response))
                 {
                     return Task.FromResult(new HttpResponseMessage(response.statusCode)

--- a/src/TraceEvent/TraceEvent.Tests/Utilities/PEFileTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Utilities/PEFileTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using PEFile;
 using Xunit;
 using Xunit.Abstractions;
@@ -374,6 +375,169 @@ namespace TraceEventTests
                 
                 Assert.Equal(numberOfSections1, numberOfSections2);
             }
+        }
+
+        [Fact]
+        public void PEFile_GetPdbSignature_BoundsUnterminatedCodeViewPdbName()
+        {
+            Guid firstGuid = new Guid("11111111-1111-1111-1111-111111111111");
+            Guid secondGuid = new Guid("22222222-2222-2222-2222-222222222222");
+
+            // Create an unterminated PDB name, then place non-zero bytes immediately after the declared SizeOfData.
+            // An unbounded PtrToStringAnsi() will read into the suffix; a bounded implementation must not.
+            byte[] shortPdbUnterminated = CreateCodeViewBlob(secondGuid, 2, "short.pdb", nulTerminate: false);
+            byte[] suffixWithTerminator = Encoding.ASCII.GetBytes("-OVERREAD\0");
+            byte[] shortPdbWithSuffix = new byte[shortPdbUnterminated.Length + suffixWithTerminator.Length];
+            Buffer.BlockCopy(shortPdbUnterminated, 0, shortPdbWithSuffix, 0, shortPdbUnterminated.Length);
+            Buffer.BlockCopy(suffixWithTerminator, 0, shortPdbWithSuffix, shortPdbUnterminated.Length, suffixWithTerminator.Length);
+
+            string peFilePath = CreatePEWithCodeViewDebugData(
+                new CodeViewDebugData(CreateCodeViewBlob(firstGuid, 1, "short.pdb-overread-data", nulTerminate: true)),
+                new CodeViewDebugData(shortPdbWithSuffix, sizeOfData: shortPdbUnterminated.Length));
+
+            try
+            {
+                using (var peFile = new PEFile.PEFile(peFilePath))
+                {
+                    Assert.True(peFile.GetPdbSignature(out string pdbName, out Guid pdbGuid, out int pdbAge));
+                    Assert.Equal("short.pdb", pdbName);
+                    Assert.Equal(secondGuid, pdbGuid);
+                    Assert.Equal(2, pdbAge);
+                }
+            }
+            finally
+            {
+                File.Delete(peFilePath);
+            }
+        }
+
+        [Fact]
+        public void PEFile_GetPdbSignature_IgnoresCodeViewBlobSmallerThanPdb70Header()
+        {
+            string peFilePath = CreatePEWithCodeViewDebugData(
+                new CodeViewDebugData(
+                    CreateCodeViewBlob(Guid.NewGuid(), 1, "ignored.pdb", nulTerminate: true),
+                    global::PEFile.CV_INFO_PDB70.FixedSize - 1));
+
+            try
+            {
+                using (var peFile = new PEFile.PEFile(peFilePath))
+                {
+                    Assert.False(peFile.GetPdbSignature(out string pdbName, out Guid pdbGuid, out int pdbAge));
+                    Assert.Null(pdbName);
+                    Assert.Equal(Guid.Empty, pdbGuid);
+                    Assert.Equal(0, pdbAge);
+                }
+            }
+            finally
+            {
+                File.Delete(peFilePath);
+            }
+        }
+
+        private static string CreatePEWithCodeViewDebugData(params CodeViewDebugData[] codeViewEntries)
+        {
+            const int peHeaderOffset = 0x80;
+            const int sizeOfOptionalHeader = 0xE0;
+            const int optionalHeaderOffset = peHeaderOffset + 24;
+            const int sectionHeaderOffset = peHeaderOffset + 24 + sizeOfOptionalHeader;
+            const int sectionRva = 0x1000;
+            const int sectionFileOffset = 0x200;
+            const int debugDirectoryOffset = sectionFileOffset;
+            const int imageDebugDirectorySize = 28;
+
+            int debugDirectorySize = codeViewEntries.Length * imageDebugDirectorySize;
+            int codeViewOffset = debugDirectoryOffset + debugDirectorySize;
+            int fileSize = codeViewOffset;
+            foreach (CodeViewDebugData entry in codeViewEntries)
+            {
+                fileSize += entry.Blob.Length;
+            }
+
+            byte[] peImage = new byte[Math.Max(0x400, fileSize)];
+            WriteUInt16(peImage, 0, 0x5A4D); // MZ
+            WriteUInt32(peImage, 0x3C, peHeaderOffset);
+
+            WriteUInt32(peImage, peHeaderOffset, 0x4550); // PE\0\0
+            WriteUInt16(peImage, peHeaderOffset + 4, 0x014C); // IMAGE_FILE_MACHINE_I386
+            WriteUInt16(peImage, peHeaderOffset + 6, 1); // NumberOfSections
+            WriteUInt16(peImage, peHeaderOffset + 20, sizeOfOptionalHeader);
+            WriteUInt16(peImage, peHeaderOffset + 22, 0x0102); // Executable image, 32-bit machine
+
+            WriteUInt16(peImage, optionalHeaderOffset, 0x10B); // PE32
+            WriteUInt32(peImage, optionalHeaderOffset + 32, sectionRva); // SectionAlignment
+            WriteUInt32(peImage, optionalHeaderOffset + 36, sectionFileOffset); // FileAlignment
+            WriteUInt32(peImage, optionalHeaderOffset + 56, 0x2000); // SizeOfImage
+            WriteUInt32(peImage, optionalHeaderOffset + 60, sectionFileOffset); // SizeOfHeaders
+            WriteUInt32(peImage, optionalHeaderOffset + 92, 16); // NumberOfRvaAndSizes
+
+            int debugDirectoryDataDirectoryOffset = optionalHeaderOffset + 96 + 6 * 8;
+            WriteUInt32(peImage, debugDirectoryDataDirectoryOffset, sectionRva);
+            WriteUInt32(peImage, debugDirectoryDataDirectoryOffset + 4, debugDirectorySize);
+
+            byte[] sectionName = Encoding.ASCII.GetBytes(".rdata");
+            Buffer.BlockCopy(sectionName, 0, peImage, sectionHeaderOffset, sectionName.Length);
+            WriteUInt32(peImage, sectionHeaderOffset + 8, 0x1000); // VirtualSize
+            WriteUInt32(peImage, sectionHeaderOffset + 12, sectionRva);
+            WriteUInt32(peImage, sectionHeaderOffset + 16, 0x1000); // SizeOfRawData
+            WriteUInt32(peImage, sectionHeaderOffset + 20, sectionFileOffset);
+
+            int currentCodeViewOffset = codeViewOffset;
+            for (int i = 0; i < codeViewEntries.Length; i++)
+            {
+                CodeViewDebugData entry = codeViewEntries[i];
+                int debugEntryOffset = debugDirectoryOffset + i * imageDebugDirectorySize;
+                int codeViewRva = sectionRva + currentCodeViewOffset - sectionFileOffset;
+
+                WriteUInt32(peImage, debugEntryOffset + 12, 2); // IMAGE_DEBUG_TYPE_CODEVIEW
+                WriteUInt32(peImage, debugEntryOffset + 16, entry.SizeOfData);
+                WriteUInt32(peImage, debugEntryOffset + 20, codeViewRva);
+                WriteUInt32(peImage, debugEntryOffset + 24, currentCodeViewOffset);
+
+                Buffer.BlockCopy(entry.Blob, 0, peImage, currentCodeViewOffset, entry.Blob.Length);
+                currentCodeViewOffset += entry.Blob.Length;
+            }
+
+            string filePath = Path.Combine(Path.GetTempPath(), "PEFileTests-" + Guid.NewGuid().ToString("N") + ".dll");
+            File.WriteAllBytes(filePath, peImage);
+            return filePath;
+        }
+
+        private static byte[] CreateCodeViewBlob(Guid signature, int age, string pdbFileName, bool nulTerminate)
+        {
+            byte[] pdbFileNameBytes = Encoding.ASCII.GetBytes(pdbFileName);
+            byte[] blob = new byte[global::PEFile.CV_INFO_PDB70.FixedSize + pdbFileNameBytes.Length + (nulTerminate ? 1 : 0)];
+
+            WriteUInt32(blob, 0, global::PEFile.CV_INFO_PDB70.PDB70CvSignature);
+            Buffer.BlockCopy(signature.ToByteArray(), 0, blob, 4, 16);
+            WriteUInt32(blob, 20, age);
+            Buffer.BlockCopy(pdbFileNameBytes, 0, blob, global::PEFile.CV_INFO_PDB70.FixedSize, pdbFileNameBytes.Length);
+
+            return blob;
+        }
+
+        private static void WriteUInt16(byte[] buffer, int offset, int value)
+        {
+            byte[] bytes = BitConverter.GetBytes((ushort)value);
+            Buffer.BlockCopy(bytes, 0, buffer, offset, bytes.Length);
+        }
+
+        private static void WriteUInt32(byte[] buffer, int offset, int value)
+        {
+            byte[] bytes = BitConverter.GetBytes((uint)value);
+            Buffer.BlockCopy(bytes, 0, buffer, offset, bytes.Length);
+        }
+
+        private struct CodeViewDebugData
+        {
+            public CodeViewDebugData(byte[] blob, int? sizeOfData = null)
+            {
+                Blob = blob;
+                SizeOfData = sizeOfData ?? blob.Length;
+            }
+
+            public byte[] Blob { get; }
+            public int SizeOfData { get; }
         }
     }
 }

--- a/src/TraceEvent/TraceEvent.Tests/Utilities/PEFileTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Utilities/PEFileTests.cs
@@ -348,6 +348,251 @@ namespace TraceEventTests
             }
         }
 
+        [Fact]
+        public unsafe void PEFile_ResourceStringNamesUseExplicitLength()
+        {
+            // Layout: a single IMAGE_RESOURCE_DIRECTORY_STRING (UInt16 length-prefixed
+            // wide string) starting at file offset 0.  The character count is 3 and
+            // the second character is an embedded NUL - the legacy code constructed
+            // strings with `new string(char*)`, which would truncate at that NUL.
+            byte[] resourceNameData =
+            {
+                3, 0,        // UTF-16 character count.
+                (byte)'A', 0,
+                0, 0,        // Embedded null character that must not terminate the name.
+                (byte)'B', 0
+            };
+
+            using (var stream = new MemoryStream(resourceNameData))
+            using (var buffer = new PEBufferedReader(stream))
+            {
+                IMAGE_RESOURCE_DIRECTORY_ENTRY entry = default;
+                int* rawEntry = (int*)&entry;
+                rawEntry[0] = unchecked((int)0x80000000); // String-name flag with offset 0.
+
+                string resourceName = entry.GetName(buffer, resourceStartFileOffset: 0, resourceDirectorySize: resourceNameData.Length);
+
+                Assert.Equal("A\0B", resourceName);
+                Assert.Equal(3, resourceName.Length);
+            }
+        }
+
+        [Fact]
+        public unsafe void PEFile_ResourceStringNameRejectsLengthBeyondDirectory()
+        {
+            // The character count (0x4000) intentionally exceeds the entire resource
+            // directory (8 bytes here).  The original PoC used exactly this trick to
+            // induce an out-of-bounds read past the pinned buffer.  GetName must
+            // refuse to read the name rather than walking past the data directory.
+            byte[] resourceNameData =
+            {
+                0x00, 0x40,  // Attacker-controlled UTF-16 character count (0x4000).
+                (byte)'A', 0,
+                (byte)'B', 0,
+                (byte)'C', 0
+            };
+
+            using (var stream = new MemoryStream(resourceNameData))
+            using (var buffer = new PEBufferedReader(stream))
+            {
+                IMAGE_RESOURCE_DIRECTORY_ENTRY entry = default;
+                int* rawEntry = (int*)&entry;
+                rawEntry[0] = unchecked((int)0x80000000);
+
+                string resourceName = entry.GetName(buffer, resourceStartFileOffset: 0, resourceDirectorySize: resourceNameData.Length);
+
+                Assert.Equal(string.Empty, resourceName);
+            }
+        }
+
+        [Fact]
+        public unsafe void PEFile_ResourceStringNameRejectsOffsetBeyondDirectory()
+        {
+            // NameOffset points outside the resource data directory.  Even reading
+            // the 2-byte length prefix would be out of bounds, so GetName must
+            // short-circuit before touching the buffer.
+            byte[] resourceNameData = new byte[16];
+
+            using (var stream = new MemoryStream(resourceNameData))
+            using (var buffer = new PEBufferedReader(stream))
+            {
+                IMAGE_RESOURCE_DIRECTORY_ENTRY entry = default;
+                int* rawEntry = (int*)&entry;
+                // String-name flag (0x80000000) with NameOffset == 0x100, well past the 16-byte directory.
+                rawEntry[0] = unchecked((int)0x80000100);
+
+                string resourceName = entry.GetName(buffer, resourceStartFileOffset: 0, resourceDirectorySize: resourceNameData.Length);
+
+                Assert.Equal(string.Empty, resourceName);
+            }
+        }
+
+        [Fact]
+        public unsafe void PEFile_ResourceStringNameRejectsNegativeOrZeroDirectorySize()
+        {
+            // IMAGE_DATA_DIRECTORY.Size is signed Int32 even though the on-disk
+            // field is unsigned, so a PE that writes a value with the high bit set
+            // delivers a negative size here.  Without an explicit non-positive
+            // guard, the subsequent unchecked subtractions would wrap and silently
+            // bypass the bounds check (e.g. int.MinValue - 2 wraps to int.MaxValue
+            // - 1, comfortably above any 31-bit NameOffset).
+            byte[] resourceNameData = new byte[16];
+
+            using (var stream = new MemoryStream(resourceNameData))
+            using (var buffer = new PEBufferedReader(stream))
+            {
+                IMAGE_RESOURCE_DIRECTORY_ENTRY entry = default;
+                int* rawEntry = (int*)&entry;
+                rawEntry[0] = unchecked((int)0x80000000);
+
+                Assert.Equal(string.Empty, entry.GetName(buffer, resourceStartFileOffset: 0, resourceDirectorySize: 0));
+                Assert.Equal(string.Empty, entry.GetName(buffer, resourceStartFileOffset: 0, resourceDirectorySize: -1));
+                Assert.Equal(string.Empty, entry.GetName(buffer, resourceStartFileOffset: 0, resourceDirectorySize: int.MinValue));
+            }
+        }
+
+        [Fact]
+        public unsafe void PEFile_ResourceStringNameReturnsEmptyOnOverflow()
+        {
+            // A crafted PE can place NameOffset and resourceStartFileOffset such
+            // that their sum overflows Int32.  GetName must degrade gracefully
+            // (return string.Empty) rather than propagate an OverflowException out
+            // of the resource enumeration loop.
+            byte[] resourceNameData = new byte[16];
+
+            using (var stream = new MemoryStream(resourceNameData))
+            using (var buffer = new PEBufferedReader(stream))
+            {
+                IMAGE_RESOURCE_DIRECTORY_ENTRY entry = default;
+                int* rawEntry = (int*)&entry;
+                // String-name flag with the largest legal NameOffset (0x7FFFFFFE).
+                rawEntry[0] = unchecked((int)0xFFFFFFFE);
+
+                string resourceName = entry.GetName(buffer, resourceStartFileOffset: 1024, resourceDirectorySize: int.MaxValue);
+
+                Assert.Equal(string.Empty, resourceName);
+            }
+        }
+
+        [Fact]
+        public unsafe void PEFile_ResourceStringNameReturnsEmptyOnFetchOffsetOverflow()
+        {
+            // Pick values that pass the earlier bounds and base-offset overflow
+            // guards but make nameOffset == int.MaxValue, so that the absolute
+            // file offset plus the length-prefix size would overflow inside
+            // PEBufferedReader.Fetch.  Without an explicit guard placed before
+            // the first Fetch, the overflow happens inside Fetch's own filePos
+            // + size arithmetic and yields an out-of-bounds pointer.
+            byte[] resourceNameData = new byte[16];
+
+            using (var stream = new MemoryStream(resourceNameData))
+            using (var buffer = new PEBufferedReader(stream))
+            {
+                IMAGE_RESOURCE_DIRECTORY_ENTRY entry = default;
+                int* rawEntry = (int*)&entry;
+                // String-name flag with NameOffset == int.MaxValue - 2.
+                rawEntry[0] = unchecked((int)0xFFFFFFFD);
+
+                // resourceDirectorySize = int.MaxValue and resourceStartFileOffset = 2
+                // mean nameOffsetInResources passes the directory-size guard and the
+                // base+offset overflow guard, producing nameOffset == int.MaxValue.
+                string resourceName = entry.GetName(buffer, resourceStartFileOffset: 2, resourceDirectorySize: int.MaxValue);
+
+                Assert.Equal(string.Empty, resourceName);
+            }
+        }
+
+        [Fact]
+        public unsafe void PEFile_ResourceStringNameReturnsEmptyOnSecondFetchOverflow()
+        {
+            // The first Fetch overflow guard proves nameOffset + sizeof(ushort)
+            // fits in Int32, but the second Fetch passes nameOffset +
+            // sizeof(ushort) + nameByteLen.  A high-offset resource directory
+            // combined with a small declared nameLen still drives the second
+            // Fetch's internal filePos + size arithmetic past Int32, so a
+            // second guard is required and must fire here.
+            //
+            // The crafted resource layout reads a length-prefix of 1 (one wide
+            // character) at the start of the (sparse) "file"; with
+            // resourceStartFileOffset == int.MaxValue - 3 the first Fetch sits
+            // at offset int.MaxValue - 3 and the second Fetch would land at
+            // int.MaxValue - 1 + 2 == int.MaxValue + 1 (overflow).
+            var stream = new SparseLengthPrefixStream(declaredLength: int.MaxValue);
+            using (var buffer = new PEBufferedReader(stream))
+            {
+                IMAGE_RESOURCE_DIRECTORY_ENTRY entry = default;
+                int* rawEntry = (int*)&entry;
+                rawEntry[0] = unchecked((int)0x80000000); // String-name flag, NameOffset = 0.
+
+                string resourceName = entry.GetName(
+                    buffer,
+                    resourceStartFileOffset: int.MaxValue - 3,
+                    resourceDirectorySize: 4);
+
+                Assert.Equal(string.Empty, resourceName);
+            }
+        }
+
+        /// <summary>
+        /// Minimal read-only stream that exposes an arbitrarily large Length and,
+        /// for the first byte returned by every Read call, yields 0x01 (with all
+        /// subsequent bytes 0x00).  The first Fetch after a Seek therefore reads
+        /// a UInt16 value of 1 (little-endian) regardless of where it landed.
+        /// This lets the resource-name overflow regression test exercise file
+        /// offsets near Int32.MaxValue without allocating a 2 GB buffer.
+        /// </summary>
+        private sealed class SparseLengthPrefixStream : Stream
+        {
+            private readonly long _length;
+            private long _position;
+
+            public SparseLengthPrefixStream(long declaredLength)
+            {
+                _length = declaredLength;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => true;
+            public override bool CanWrite => false;
+            public override long Length => _length;
+
+            public override long Position
+            {
+                get => _position;
+                set => _position = value;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int produced = 0;
+                while (produced < count && _position < _length)
+                {
+                    // 0x01 as the first byte of every Read => the UInt16 length
+                    // prefix is 1 regardless of seek position.
+                    byte b = produced == 0 ? (byte)1 : (byte)0;
+                    buffer[offset + produced] = b;
+                    _position++;
+                    produced++;
+                }
+                return produced;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                switch (origin)
+                {
+                    case SeekOrigin.Begin: _position = offset; break;
+                    case SeekOrigin.Current: _position += offset; break;
+                    case SeekOrigin.End: _position = _length + offset; break;
+                }
+                return _position;
+            }
+
+            public override void Flush() { }
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
         /// <summary>
         /// Test multiple sequential reads from the same file
         /// </summary>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -103,6 +103,9 @@
     <Compile Include="..\Utilities\StreamUtilities.cs">
       <Link>Utilities\StreamUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\Utilities\PathUtilities.cs">
+      <Link>Utilities\PathUtilities.cs</Link>
+    </Compile>
     <Compile Include="..\Utilities\SymbolCachePathUtilities.cs">
       <Link>Utilities\SymbolCachePathUtilities.cs</Link>
     </Compile>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -103,6 +103,9 @@
     <Compile Include="..\Utilities\StreamUtilities.cs">
       <Link>Utilities\StreamUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\Utilities\SymbolCachePathUtilities.cs">
+      <Link>Utilities\SymbolCachePathUtilities.cs</Link>
+    </Compile>
     <Compile Include="..\Utilities\XmlUtilities.cs">
       <Link>Utilities\XmlUtilities.cs</Link>
     </Compile>

--- a/src/TraceEvent/TraceEvent.csproj
+++ b/src/TraceEvent/TraceEvent.csproj
@@ -72,6 +72,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" />
     <PackageReference Include="Microsoft.Win32.Registry" />
     <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />

--- a/src/TraceEvent/TraceUtilities/PEFile.cs
+++ b/src/TraceEvent/TraceUtilities/PEFile.cs
@@ -87,14 +87,20 @@ namespace PEFile
                 {
                     if (debugEntries[i].Type == IMAGE_DEBUG_TYPE.CODEVIEW)
                     {
+                        int sizeOfData = debugEntries[i].SizeOfData;
+                        if (sizeOfData < CV_INFO_PDB70.FixedSize)
+                        {
+                            continue;
+                        }
+
                         var stringBuff = AllocBuff();
-                        var info = (CV_INFO_PDB70*)stringBuff.Fetch((int)debugEntries[i].PointerToRawData, debugEntries[i].SizeOfData);
+                        var info = (CV_INFO_PDB70*)stringBuff.Fetch((int)debugEntries[i].PointerToRawData, sizeOfData);
                         if (info->CvSignature == CV_INFO_PDB70.PDB70CvSignature)
                         {
                             // If there are several this picks the last one.  
                             pdbGuid = info->Signature;
                             pdbAge = info->Age;
-                            pdbName = info->PdbFileName;
+                            pdbName = info->GetPdbFileName(sizeOfData);
                             ret = true;
                             if (first)
                             {
@@ -1619,19 +1625,30 @@ namespace PEFile
     internal unsafe struct CV_INFO_PDB70
     {
         public const int PDB70CvSignature = 0x53445352; // RSDS in ascii
+        public const int FixedSize = 24;
 
         public int CvSignature;
         public Guid Signature;
         public int Age;
         public fixed byte bytePdbFileName[1];   // Actually variable sized. 
-        public string PdbFileName
+
+        public string GetPdbFileName(int sizeOfData)
         {
-            get
+            int pdbFileNameBytes = sizeOfData - FixedSize;
+            if (pdbFileNameBytes <= 0)
             {
-                fixed (byte* ptr = bytePdbFileName)
+                return string.Empty;
+            }
+
+            fixed (byte* ptr = bytePdbFileName)
+            {
+                int pdbFileNameLength = 0;
+                while (pdbFileNameLength < pdbFileNameBytes && ptr[pdbFileNameLength] != 0)
                 {
-                    return System.Runtime.InteropServices.Marshal.PtrToStringAnsi((IntPtr)ptr);
+                    pdbFileNameLength++;
                 }
+
+                return System.Runtime.InteropServices.Marshal.PtrToStringAnsi((IntPtr)ptr, pdbFileNameLength) ?? string.Empty;
             }
         }
     };

--- a/src/TraceEvent/TraceUtilities/PEFile.cs
+++ b/src/TraceEvent/TraceUtilities/PEFile.cs
@@ -1402,7 +1402,7 @@ namespace PEFile
                         }
                         else
                         {
-                            entryName = entry->GetName(nameBuff, resourceStartFileOffset);
+                            entryName = entry->GetName(nameBuff, resourceStartFileOffset, m_file.Header.ResourceDirectory.Size);
                         }
 
                         Children.Add(new ResourceNode(entryName, resourceStartFileOffset + entry->DataOffset, m_file, entry->IsLeaf));
@@ -1701,13 +1701,91 @@ namespace PEFile
         private int NameOffsetAndFlag;
         private int DataOffsetAndFlag;
 
-        internal unsafe string GetName(PEBufferedReader buff, int resourceStartFileOffset)
+        internal unsafe string GetName(PEBufferedReader buff, int resourceStartFileOffset, int resourceDirectorySize)
         {
             if (IsStringName)
             {
-                int nameLen = *((ushort*)buff.Fetch(NameOffset + resourceStartFileOffset, 2));
-                char* namePtr = (char*)buff.Fetch(NameOffset + resourceStartFileOffset + 2, nameLen);
-                return new string(namePtr);
+                // IMAGE_RESOURCE_DIRECTORY_STRING is laid out as a UInt16 length (in
+                // UTF-16 characters, not bytes) immediately followed by Length wide
+                // characters.  Several historical bugs in this routine come from
+                // confusing the units (bytes vs. chars) or from trusting the
+                // attacker-controlled length without bounding it against the resource
+                // section.  Validate every step against the resource data directory
+                // size so a malformed PE cannot induce an out-of-bounds read.
+                //
+                // resourceDirectorySize originates from IMAGE_DATA_DIRECTORY.Size,
+                // which is declared as signed Int32 even though the on-disk field is
+                // unsigned.  A crafted PE that writes a value with the high bit set
+                // would deliver a negative size here; reject it up front so the
+                // subsequent subtractions cannot wrap and silently disable the
+                // bounds checks below.
+                if (resourceDirectorySize <= 0)
+                {
+                    return string.Empty;
+                }
+
+                int nameOffsetInResources = NameOffset;
+                if (nameOffsetInResources < 0 || nameOffsetInResources > resourceDirectorySize - sizeof(ushort))
+                {
+                    return string.Empty;
+                }
+
+                // Manual overflow guards in place of checked() so a crafted PE causes
+                // GetName to return string.Empty (consistent with the rest of this
+                // function) rather than throwing an OverflowException that would
+                // escape ResourceNode.Children and abort resource enumeration.
+                if (resourceStartFileOffset < 0 || resourceStartFileOffset > int.MaxValue - nameOffsetInResources)
+                {
+                    return string.Empty;
+                }
+
+                int nameOffset = nameOffsetInResources + resourceStartFileOffset;
+
+                // PEBufferedReader.Fetch internally evaluates filePos + size to
+                // check its cache, so guard against that addition overflowing
+                // BEFORE the first fetch.  Without this, an attacker who lined up
+                // nameOffsetInResources + resourceStartFileOffset to equal
+                // int.MaxValue could induce a 2GB out-of-bounds read inside the
+                // very call this guard was meant to protect.
+                if (nameOffset > int.MaxValue - sizeof(ushort))
+                {
+                    return string.Empty;
+                }
+
+                int nameLen = *((ushort*)buff.Fetch(nameOffset, sizeof(ushort)));
+
+                // nameLen is a UInt16 character count, so multiplying by sizeof(char)
+                // cannot overflow Int32, but write the bound explicitly to make the
+                // invariant obvious to readers.
+                int nameByteLen = nameLen * sizeof(char);
+
+                // Ensure the entire length-prefixed string lies inside the resource
+                // data directory.  Without this bound a crafted PE could declare a
+                // name length that walks past the resource section (and potentially
+                // past end-of-file), causing PEBufferedReader.Fetch to return zeroed
+                // padding that gets surfaced as the resource name.
+                if (nameByteLen > resourceDirectorySize - nameOffsetInResources - sizeof(ushort))
+                {
+                    return string.Empty;
+                }
+
+                // Apply the same Fetch-overflow guard to the second Fetch.  The
+                // earlier guard only proved that nameOffset + sizeof(ushort) does
+                // not overflow; adding nameByteLen on top can still wrap inside
+                // PEBufferedReader.Fetch's filePos + size cache check (e.g. a
+                // resource directory at very high file offsets with a non-trivial
+                // name length), so check the full extent here.
+                if (nameByteLen > int.MaxValue - nameOffset - sizeof(ushort))
+                {
+                    return string.Empty;
+                }
+
+                char* namePtr = (char*)buff.Fetch(nameOffset + sizeof(ushort), nameByteLen);
+
+                // Always pass the explicit length: new string(char*) is NUL-terminated
+                // and would walk past the fetched window if the name lacked a trailing
+                // double-NUL.
+                return new string(namePtr, 0, nameLen);
             }
             else
             {

--- a/src/TraceEvent/ZippedETL.cs
+++ b/src/TraceEvent/ZippedETL.cs
@@ -510,7 +510,7 @@ namespace Microsoft.Diagnostics.Tracing
                             {
                                 // .diagsession files (created by the Visual Studio Diagnostic Hub) put PDBs in a path like
                                 // 194BAE98-C4ED-470E-9204-1F9389FC9DC1\symcache\xyz.pdb
-                                m = Regex.Match(archivePath, @"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\(?:sym|pdb)cache\\(.*)", RegexOptions.IgnoreCase);
+                                m = Regex.Match(archivePath, @"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\(?:sym|pdb)cache\\(.*)", RegexOptions.IgnoreCase);
                                 if (m.Success)
                                 {
                                     pdbRelativePath = m.Groups[1].Value;
@@ -524,7 +524,11 @@ namespace Microsoft.Diagnostics.Tracing
                             }
                         }
 
-                        var pdbTargetPath = Path.Combine(SymbolDirectory, pdbRelativePath);
+                        if (!SymbolCachePathUtilities.TryGetPdbTargetPath(SymbolDirectory, pdbRelativePath, out var pdbTargetPath))
+                        {
+                            Log.WriteLine("WARNING: found PDB file with invalid path {0}, skipping extraction", pdbRelativePath);
+                            continue;
+                        }
                         var pdbTargetName = Path.GetFileName(pdbTargetPath);
                         if (File.Exists(pdbTargetPath) && (new System.IO.FileInfo(pdbTargetPath).Length == entry.Length))
                         {

--- a/src/Utilities/PathUtilities.cs
+++ b/src/Utilities/PathUtilities.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Utilities
+{
+    /// <summary>
+    /// Path-related helper methods for working with file paths.
+    /// </summary>
+#if UTILITIES_PUBLIC
+    public
+#endif
+    static class PathUtilities
+    {
+        /// <summary>
+        /// Returns true if <paramref name="filePath"/> is an obviously remote path
+        /// (UNC or absolute URI such as http/https/ftp/file).  This is intended as a
+        /// cheap, side-effect-free pre-filter so untrusted candidate paths never
+        /// reach <see cref="File.Exists(string)"/>, which on Windows triggers an SMB
+        /// authentication probe for UNC paths and can leak NTLM credentials even
+        /// when the target does not exist.  Returns false for null/empty input.
+        /// </summary>
+        public static bool IsRemotePath(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            if (Uri.TryCreate(filePath, UriKind.Absolute, out Uri uri) && (!uri.IsFile || uri.IsUnc))
+            {
+                return true;
+            }
+
+            // Win32 extended-length / device path prefixes (\\?\ and \\.\).  These map
+            // straight into the object manager and bypass normal path normalization, so
+            // we have to inspect what follows the prefix:
+            //   \\?\C:\foo,   \\?\Volume{...}\foo            -> local
+            //   \\.\C:\foo,   \\.\PhysicalDrive0             -> local
+            //   \\?\UNC\server\share, \\.\UNC\server\share   -> remote SMB
+            //   \\?\GLOBALROOT\Device\Mup\...                -> remote via SMB redirector
+            //   \\?\GLOBALROOT\Device\LanmanRedirector\...   -> remote via SMB redirector
+            if (filePath.StartsWith(@"\\?\", StringComparison.Ordinal) ||
+                filePath.StartsWith(@"\\.\", StringComparison.Ordinal))
+            {
+                if (filePath.StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase) ||
+                    filePath.StartsWith(@"\\.\UNC\", StringComparison.OrdinalIgnoreCase) ||
+                    filePath.StartsWith(@"\\?\GLOBALROOT\", StringComparison.OrdinalIgnoreCase) ||
+                    filePath.StartsWith(@"\\.\GLOBALROOT\", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (filePath.StartsWith(@"\\", StringComparison.Ordinal) ||
+                filePath.StartsWith("//", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // The NT object namespace prefix (\??\) bypasses Win32 path parsing and is
+            // accepted by File.Exists; \??\UNC\server\share\... and
+            // \??\GLOBALROOT\Device\Mup\... both reach the SMB redirector and would
+            // leak credentials.  Reject all NT-namespace paths -- legitimate symbol
+            // probing never uses them.
+            if (filePath.StartsWith(@"\??\", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            try
+            {
+                string root = Path.GetPathRoot(filePath);
+                return root != null &&
+                    (root.StartsWith(@"\\", StringComparison.Ordinal) ||
+                     root.StartsWith("//", StringComparison.Ordinal));
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="filePath"/> normalizes to a location inside
+        /// <paramref name="directoryPath"/> (or one of its subdirectories).  Used to
+        /// enforce containment when a caller resolves an untrusted relative or
+        /// absolute path against a trusted base directory.
+        /// </summary>
+        public static bool IsPathWithinDirectory(string filePath, string directoryPath)
+        {
+            string normalizedDirectory = Path.GetFullPath(directoryPath);
+            if (!normalizedDirectory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) &&
+                !normalizedDirectory.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+            {
+                normalizedDirectory += Path.DirectorySeparatorChar;
+            }
+
+            string normalizedFilePath = Path.GetFullPath(filePath);
+
+            // Windows path comparisons are case-insensitive; POSIX file systems are not.
+            // Using OrdinalIgnoreCase on a case-sensitive file system would let
+            // "/trusted/Foo/bar" be treated as contained in "/trusted/foo/", silently
+            // breaking the containment guarantee callers rely on.
+            StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            return normalizedFilePath.StartsWith(normalizedDirectory, comparison);
+        }
+    }
+}

--- a/src/Utilities/PathUtilities.cs
+++ b/src/Utilities/PathUtilities.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Microsoft.Diagnostics.Utilities
 {
@@ -108,6 +110,92 @@ namespace Microsoft.Diagnostics.Utilities
                 ? StringComparison.OrdinalIgnoreCase
                 : StringComparison.Ordinal;
             return normalizedFilePath.StartsWith(normalizedDirectory, comparison);
+        }
+
+        /// <summary>
+        /// Reduces <paramref name="name"/> to a value safe to embed in a single file-name
+        /// component on disk.  Every character reported by
+        /// <see cref="Path.GetInvalidFileNameChars"/>, every path / volume separator,
+        /// and every control character is replaced with '_'.  Trailing '.' and ' '
+        /// characters are removed because Windows silently trims them, which would
+        /// otherwise let two distinct names collide on disk and let inputs like "NUL."
+        /// slip past the reserved-name guard.  Reserved DOS device names (CON, PRN,
+        /// AUX, NUL, CLOCK$, CONIN$, CONOUT$, COM0-9, LPT0-9) are detected on the
+        /// stem before the first '.' (Win32 opens the device for paths like
+        /// "NUL.txt") and prefixed with '_' on match.
+        ///
+        /// Returns <c>null</c> if the input is null, empty, '.', '..', or sanitizes
+        /// to an empty string so callers can choose to skip the resource rather than
+        /// substitute an arbitrary placeholder.
+        /// </summary>
+        public static string SanitizeFileName(string name)
+        {
+            if (string.IsNullOrEmpty(name) || name == "." || name == "..")
+            {
+                return null;
+            }
+
+            HashSet<char> invalid = s_invalidFileNameChars;
+            StringBuilder sanitized = new StringBuilder(name.Length);
+            foreach (char c in name)
+            {
+                sanitized.Append(invalid.Contains(c) || char.IsControl(c) ? '_' : c);
+            }
+
+            while (sanitized.Length > 0)
+            {
+                char last = sanitized[sanitized.Length - 1];
+                if (last != '.' && last != ' ')
+                {
+                    break;
+                }
+                sanitized.Length--;
+            }
+
+            if (sanitized.Length == 0)
+            {
+                return null;
+            }
+
+            string candidate = sanitized.ToString();
+            int firstDot = candidate.IndexOf('.');
+            string stem = firstDot < 0 ? candidate : candidate.Substring(0, firstDot);
+            if (s_reservedDosDeviceNames.Contains(stem))
+            {
+                return "_" + candidate;
+            }
+
+            return candidate;
+        }
+
+        private static readonly HashSet<char> s_invalidFileNameChars = BuildInvalidFileNameChars();
+        private static readonly HashSet<string> s_reservedDosDeviceNames = BuildReservedDosDeviceNames();
+
+        private static HashSet<char> BuildInvalidFileNameChars()
+        {
+            HashSet<char> chars = new HashSet<char>(Path.GetInvalidFileNameChars());
+            chars.Add('\0');
+            chars.Add(Path.DirectorySeparatorChar);
+            chars.Add(Path.AltDirectorySeparatorChar);
+            chars.Add(Path.VolumeSeparatorChar);
+            chars.Add('\\');
+            chars.Add('/');
+            chars.Add(':');
+            return chars;
+        }
+
+        private static HashSet<string> BuildReservedDosDeviceNames()
+        {
+            HashSet<string> names = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$",
+            };
+            for (int i = 0; i <= 9; i++)
+            {
+                names.Add("COM" + i);
+                names.Add("LPT" + i);
+            }
+            return names;
         }
     }
 }

--- a/src/Utilities/SymbolCachePathUtilities.cs
+++ b/src/Utilities/SymbolCachePathUtilities.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Utilities
+{
+    /// <summary>
+    /// Utilities for validating paths that will be combined with a symbol cache
+    /// directory before a file is extracted into it.  Designed to prevent
+    /// path-traversal and prefix-collision attacks where a malicious archive
+    /// entry name could cause a file to be written outside the symbol cache or
+    /// could overwrite an unrelated cache entry.
+    /// </summary>
+#if UTILITIES_PUBLIC
+    public
+#endif
+    static class SymbolCachePathUtilities
+    {
+        /// <summary>
+        /// Validates that <paramref name="pdbRelativePath"/> can be safely combined with
+        /// <paramref name="symbolDirectory"/> to form a PDB extraction target that lives
+        /// inside <paramref name="symbolDirectory"/>.  Rejects null/empty inputs, any path
+        /// containing a <c>..</c> segment (including whitespace-padded variants), any
+        /// <c>:</c> character, and any
+        /// combined path that would land outside <paramref name="symbolDirectory"/> after
+        /// canonicalization.
+        /// </summary>
+        /// <param name="symbolDirectory">The directory under which the file must be written.</param>
+        /// <param name="pdbRelativePath">The relative path of the file (e.g. as it appeared in an
+        /// archive entry name).</param>
+        /// <param name="pdbTargetPath">On success, the canonicalized absolute path where the file
+        /// should be written; otherwise <c>null</c>.</param>
+        /// <returns><c>true</c> if the combined path is safe to use; otherwise <c>false</c>.</returns>
+        public static bool TryGetPdbTargetPath(string symbolDirectory, string pdbRelativePath, out string pdbTargetPath)
+        {
+            pdbTargetPath = null;
+
+            if (string.IsNullOrEmpty(symbolDirectory) || string.IsNullOrEmpty(pdbRelativePath))
+            {
+                return false;
+            }
+
+            // Reject any traversal segment.  Even when '..' cancels out inside the symbol directory,
+            // it can be used to overwrite an unrelated cache entry (e.g. evil.pdb\HASH\..\..\real.pdb).
+            // Trim handles whitespace-padded variants like ".. " that some filesystems may otherwise
+            // accept or that downstream code might collapse.  Also reject ':' to prevent NTFS alternate
+            // data stream names and Windows drive-qualified paths from reaching extraction.
+            foreach (string segment in pdbRelativePath.Split('\\', '/'))
+            {
+                if (segment.Trim() == ".." || segment.Contains(":"))
+                {
+                    return false;
+                }
+            }
+
+            try
+            {
+                string fullSymbolDirectory = Path.GetFullPath(symbolDirectory);
+                string fullPdbTargetPath = Path.GetFullPath(Path.Combine(fullSymbolDirectory, pdbRelativePath));
+
+                string symbolDirectoryPrefix = fullSymbolDirectory[fullSymbolDirectory.Length - 1] == Path.DirectorySeparatorChar
+                    ? fullSymbolDirectory
+                    : fullSymbolDirectory + Path.DirectorySeparatorChar;
+
+                StringComparison directoryComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+
+                if (!fullPdbTargetPath.StartsWith(symbolDirectoryPrefix, directoryComparison))
+                {
+                    return false;
+                }
+
+                pdbTargetPath = fullPdbTargetPath;
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+            catch (PathTooLongException)
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

These changes shipped in the **PerfView and TraceEvent 3.2.4** release. This PR brings them into `main` so that all future releases also contain them.

## Hardening fixes

**Malformed-input bounds checking**
- Fix BPerf WildCopy so short copies do not write past the requested output range
- Validate BPerf event record bounds
- Validate dynamic event array bounds
- Bounds-check StackBytesSize in EventPipe V3 event headers
- Bounds-check GCDynamic event payloads
- Bounds-check TDH metadata offsets in RegisteredTraceEventParser
- Bound CodeView PDB filename read by IMAGE_DEBUG_DIRECTORY SizeOfData
- Bound PE resource name reads by the resource data directory size

**Path-containment hardening**
- Fix source-server path traversal and command injection
- Validate PDB extraction target paths against the symbol directory
- Sanitize R2R perf map symbol paths
- Constrain DiagSession resource extraction paths
- Validate PdbScope XML module paths
- Sanitize provider names when writing dynamic manifests

## Release mechanics
- Bump ReleaseVersion to 3.2.4
