### PR TITLE
Enable W4 and warnings as errors for C++ projects

### DIFF
--- a/src/EtwClrProfiler/COMInfrastructure.cpp
+++ b/src/EtwClrProfiler/COMInfrastructure.cpp
@@ -12,7 +12,7 @@ public:
     ULONG __stdcall  AddRef( ) { return InterlockedIncrement(&m_refCount);  } 
     ULONG __stdcall Release( ) { auto ret = InterlockedDecrement (&m_refCount); if (ret <= 0) delete(this); return ret; } 
     HRESULT __stdcall QueryInterface (REFIID  riid,void ** ppInterface );
-    HRESULT __stdcall  LockServer(BOOL bLock) { return S_OK; } 
+    HRESULT __stdcall  LockServer(BOOL) { return S_OK; }
     HRESULT __stdcall  CreateInstance(IUnknown * pUnkOuter, REFIID riid, void** ppInterface);
 private:
     long m_refCount ;
@@ -31,7 +31,7 @@ int main()
 BOOL WINAPI DllMain( 
     HINSTANCE   hInstance   , 
     DWORD       dwReason    , 
-    LPVOID      lpReserved  )
+    LPVOID      )
 {    
     switch ( dwReason )
     {

--- a/src/EtwClrProfiler/CorProfilerTracer.cpp
+++ b/src/EtwClrProfiler/CorProfilerTracer.cpp
@@ -573,10 +573,6 @@ STDMETHODIMP CorProfilerTracer::ObjectAllocated(ObjectID objectId, ClassID class
 			classInfo->SamplingRate = min((int)(classInfo->AllocPerMSec * 10), 1000);
 			if (classInfo->SamplingRate == 1)
 				classInfo->SamplingRate = 0;
-
-			// TODO This is for debugging.  Can remove after we are happy with the algorithm.   
-			// if (classInfo->SamplingRate != oldSamplingRate)
-			// 	   EventWriteSamplingRateChangeEvent(classId, classInfo->Name, delta, minAllocPerMSec, newAllocPerMSec, classInfo->AllocPerMSec, classInfo->SamplingRate);
 		}
 
 		// We are done calculating the sampling rate since we are logging an event we can reset the 'Ignored' stats and log the event.  

--- a/src/EtwClrProfiler/CorProfilerTracer.cpp
+++ b/src/EtwClrProfiler/CorProfilerTracer.cpp
@@ -97,6 +97,9 @@ void WINAPI ProfilerControlCallback(
 	PEVENT_FILTER_DESCRIPTOR FilterData,
 	PVOID CallbackContext)
 {
+	UNREFERENCED_PARAMETER(SourceId);
+	UNREFERENCED_PARAMETER(MatchAllKeywords);
+
 	CorProfilerTracer* profiler = (CorProfilerTracer*)CallbackContext;
 	LOG_TRACE(L"ProfilerControlCallback DoETWCommand IsEnabled 0x%x Level 0x%xI64 MatchAny 0x%x\n", IsEnabled, Level, MatchAnyKeywords);
 	profiler->DoETWCommand(IsEnabled, Level, MatchAnyKeywords, FilterData);
@@ -121,7 +124,7 @@ EXTERN_C void __stdcall EnterMethod(FunctionID functionID)
 #if defined(_M_IX86)
 // see http://msdn.microsoft.com/en-us/library/4ks26t93.aspx  for inline assembly.   Not supported on X64.   
 
-void __declspec(naked) __stdcall EnterMethodNaked(FunctionIDOrClientID funcID)
+void __declspec(naked) __stdcall EnterMethodNaked(FunctionIDOrClientID)
 {
 	__asm
 	{
@@ -142,7 +145,7 @@ void __declspec(naked) __stdcall EnterMethodNaked(FunctionIDOrClientID funcID)
 	}
 } // EnterNaked
 
-void __declspec(naked) __stdcall TailcallMethodNaked(FunctionIDOrClientID funcID)
+void __declspec(naked) __stdcall TailcallMethodNaked(FunctionIDOrClientID)
 {
 	__asm
 	{
@@ -166,6 +169,8 @@ HRESULT STDMETHODCALLTYPE CorProfilerTracer::InitializeForAttach(
 	/* [in] */ void *pvClientData,
 	/* [in] */ UINT cbClientData)
 {
+	UNREFERENCED_PARAMETER(pvClientData);
+
 	HRESULT             hr = S_OK;
 	LOG_TRACE(L"ClrProfiler Initializing\n");
 	CALL_N_LOGONBADHR(pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo3), (void **)&m_info));
@@ -223,6 +228,9 @@ exit:
 // This routine does the work of responding to a ETW request from the controller 
 void CorProfilerTracer::DoETWCommand(ULONG IsEnabled, UCHAR Level, ULONGLONG MatchAnyKeywords, struct _EVENT_FILTER_DESCRIPTOR* filterData)
 {
+	UNREFERENCED_PARAMETER(Level);
+	UNREFERENCED_PARAMETER(filterData);
+
 	LOG_TRACE(L"DoETWCommand(IsEnabled=%d, Level=%d Keywords=0x%x,%x)\n", IsEnabled, Level, (int)(MatchAnyKeywords >> 32), (int)MatchAnyKeywords);
 
 	const DWORD FLAGS_CAN_SET = (COR_PRF_MONITOR_OBJECT_ALLOCATED | COR_PRF_MONITOR_MODULE_LOADS | COR_PRF_MONITOR_GC);
@@ -460,6 +468,7 @@ void CorProfilerTracer::ForceGC()
 	m_forcingGC = true;
 	HANDLE thread = CreateThread(0, 0, ForceGCBody, this, 0, NULL);
 	LOG_TRACE(L"ForceGC: thread 0x%x\n", thread);
+	UNREFERENCED_PARAMETER(thread);
 	for (int i = 0; i < 2000; i++)
 	{
 		if (!m_forcingGC)
@@ -561,7 +570,6 @@ STDMETHODIMP CorProfilerTracer::ObjectAllocated(ObjectID objectId, ClassID class
 
 			// We want to sample at a rate that ensures less 100 allocations per second per type.  
 			// However don't sample less than 1/1000, 
-			int oldSamplingRate = classInfo->SamplingRate;
 			classInfo->SamplingRate = min((int)(classInfo->AllocPerMSec * 10), 1000);
 			if (classInfo->SamplingRate == 1)
 				classInfo->SamplingRate = 0;
@@ -617,6 +625,8 @@ STDMETHODIMP CorProfilerTracer::GarbageCollectionFinished(void)
 //==============================================================================
 STDMETHODIMP CorProfilerTracer::FinalizeableObjectQueued(DWORD finalizerFlags, ObjectID objectID)
 {
+	UNREFERENCED_PARAMETER(finalizerFlags);
+
 	LOG_TRACE(L"FinalizeableObjectQueued\n");
 #ifndef PIN_INVESTIGATION
 	// TODO FIX NOW HACK for exchange data collection 
@@ -678,7 +688,7 @@ STDMETHODIMP CorProfilerTracer::ObjectReferences(ObjectID objectId, ClassID clas
 	// LOG_TRACE(L"ObjectReferences\n");
 
 	// We do this for the side effect of logging the class  
-	ClassInfo* classInfo = GetClassInfo(classId);
+	(void)GetClassInfo(classId);
 	/** TODO FIX NOW
 	if (classInfo == NULL)
 	return E_FAIL;
@@ -725,11 +735,11 @@ ClassInfo* CorProfilerTracer::GetClassInfo(ClassID classId)
 	ClassInfo*& classInfo = m_classInfo[classId];
 	if (classInfo == NULL)
 		classInfo = new ClassInfo();
-	if (classInfo->ID == -1)     // We failed to get info on the class. 
+	if (classInfo->ID == static_cast<ClassID>(-1))     // We failed to get info on the class.
 		return NULL;
 	if (classInfo->ID == 0)
 	{
-		classInfo->ID = -1;
+		classInfo->ID = static_cast<ClassID>(-1);
 		DWORD classFlags = 0;           // TODO FIX NOW, set class flags properly.  
 		ModuleID moduleId = 0;
 
@@ -803,7 +813,7 @@ ClassInfo* CorProfilerTracer::GetClassInfo(ClassID classId)
 			classInfo->ForceKeepSize = 0x0;
 #endif 
 
-		if (classInfo->ID != -1)
+		if (classInfo->ID != static_cast<ClassID>(-1))
 		{
 			EventWriteClassIDDefintionEvent(classInfo->ID, classInfo->Token, classFlags, moduleId, classInfo->Name);
 		}
@@ -830,7 +840,7 @@ ModuleInfo* CorProfilerTracer::GetModuleInfo(ModuleID moduleId)
 	if (!moduleInfo->MetaDataImport)
 	{
 		HRESULT hr = m_info->GetModuleMetaData(moduleId, ofRead, IID_IMetaDataImport, (IUnknown**)&moduleInfo->MetaDataImport);
-		if (!moduleInfo->MetaDataImport)
+		if (FAILED(hr) || !moduleInfo->MetaDataImport)
 		{
 			moduleInfo->MetaDataFailed = true;
 			return nullptr;
@@ -855,4 +865,3 @@ ModuleInfo* CorProfilerTracer::GetModuleInfo(ModuleID moduleId)
 
 	return moduleInfo;
 }
-

--- a/src/EtwClrProfiler/CorProfilerTracer.h
+++ b/src/EtwClrProfiler/CorProfilerTracer.h
@@ -3,7 +3,10 @@
 // Headers needed for CLR Profiling
 #include <cor.h>
 #include <corprof.h>
+#pragma warning(push)
+#pragma warning(disable: 4458) // The .NET Framework SDK header shadows a member named Size.
 #include <corhlpr.h>
+#pragma warning(pop)
 
 #include <unordered_map> 
 
@@ -34,7 +37,7 @@ public:
 	STDMETHODIMP QueryInterface(REFIID riid, void **ppInterface);
 
 	// ICorProfilerCallback interface implementation
-	STDMETHODIMP Initialize(IUnknown * pICorProfilerInfoUnk) { return InitializeForAttach(pICorProfilerInfoUnk, NULL, -1); }
+	STDMETHODIMP Initialize(IUnknown * pICorProfilerInfoUnk) { return InitializeForAttach(pICorProfilerInfoUnk, NULL, static_cast<UINT>(-1)); }
 	STDMETHODIMP Shutdown();
 
 	// ICorProfilerCallback3
@@ -49,71 +52,71 @@ public:
 		return Shutdown();
 	}
 
-	STDMETHODIMP AppDomainCreationStarted(AppDomainID appDomainId) { return S_OK; };
-	STDMETHODIMP AppDomainCreationFinished(AppDomainID appDomainId, HRESULT hrStatus) { return S_OK; };
-	STDMETHODIMP AppDomainShutdownStarted(AppDomainID appDomainId) { return S_OK; };
-	STDMETHODIMP AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus) { return S_OK; };
-	STDMETHODIMP AssemblyLoadStarted(AssemblyID assemblyId) { return S_OK; };
-	STDMETHODIMP AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus) { return S_OK; };
-	STDMETHODIMP AssemblyUnloadStarted(AssemblyID assemblyId) { return S_OK; };
-	STDMETHODIMP AssemblyUnloadFinished(AssemblyID assemblyId, HRESULT hrStatus) { return S_OK; };
-	STDMETHODIMP ModuleLoadStarted(ModuleID moduleId) { return S_OK; };
-	STDMETHODIMP ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus) { return S_OK; };
-	STDMETHODIMP ModuleUnloadStarted(ModuleID moduleId) { return S_OK; };
-	STDMETHODIMP ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus) { return S_OK; };
+	STDMETHODIMP AppDomainCreationStarted(AppDomainID) { return S_OK; };
+	STDMETHODIMP AppDomainCreationFinished(AppDomainID, HRESULT) { return S_OK; };
+	STDMETHODIMP AppDomainShutdownStarted(AppDomainID) { return S_OK; };
+	STDMETHODIMP AppDomainShutdownFinished(AppDomainID, HRESULT) { return S_OK; };
+	STDMETHODIMP AssemblyLoadStarted(AssemblyID) { return S_OK; };
+	STDMETHODIMP AssemblyLoadFinished(AssemblyID, HRESULT) { return S_OK; };
+	STDMETHODIMP AssemblyUnloadStarted(AssemblyID) { return S_OK; };
+	STDMETHODIMP AssemblyUnloadFinished(AssemblyID, HRESULT) { return S_OK; };
+	STDMETHODIMP ModuleLoadStarted(ModuleID) { return S_OK; };
+	STDMETHODIMP ModuleLoadFinished(ModuleID, HRESULT) { return S_OK; };
+	STDMETHODIMP ModuleUnloadStarted(ModuleID) { return S_OK; };
+	STDMETHODIMP ModuleUnloadFinished(ModuleID, HRESULT) { return S_OK; };
 	STDMETHODIMP ModuleAttachedToAssembly(ModuleID moduleId, AssemblyID assemblyId);
-	STDMETHODIMP ClassLoadStarted(ClassID classId) { return S_OK; };
-	STDMETHODIMP ClassLoadFinished(ClassID classId, HRESULT hrStatus) { return S_OK; };
-	STDMETHODIMP ClassUnloadStarted(ClassID classId) { return S_OK; };
-	STDMETHODIMP ClassUnloadFinished(ClassID classId, HRESULT hrStatus) { return S_OK; };
-	STDMETHODIMP FunctionUnloadStarted(FunctionID functionId) { return S_OK; };
-	STDMETHODIMP JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock) { return S_OK; };
-	STDMETHODIMP JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) { return S_OK; };
-	STDMETHODIMP JITCachedFunctionSearchStarted(FunctionID functionId, BOOL * pbUseCachedFunction) { return S_OK; };
-	STDMETHODIMP JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result) { return S_OK; };
-	STDMETHODIMP JITFunctionPitched(FunctionID functionId) { return S_OK; };
-	STDMETHODIMP JITInlining(FunctionID callerId, FunctionID calleeId, BOOL * pfShouldInline) { return S_OK; };
-	STDMETHODIMP ThreadCreated(ThreadID threadId) { return S_OK; };
-	STDMETHODIMP ThreadDestroyed(ThreadID threadId) { return S_OK; };
-	STDMETHODIMP ThreadAssignedToOSThread(ThreadID managedThreadId, ULONG osThreadId) { return S_OK; };
+	STDMETHODIMP ClassLoadStarted(ClassID) { return S_OK; };
+	STDMETHODIMP ClassLoadFinished(ClassID, HRESULT) { return S_OK; };
+	STDMETHODIMP ClassUnloadStarted(ClassID) { return S_OK; };
+	STDMETHODIMP ClassUnloadFinished(ClassID, HRESULT) { return S_OK; };
+	STDMETHODIMP FunctionUnloadStarted(FunctionID) { return S_OK; };
+	STDMETHODIMP JITCompilationStarted(FunctionID, BOOL) { return S_OK; };
+	STDMETHODIMP JITCompilationFinished(FunctionID, HRESULT, BOOL) { return S_OK; };
+	STDMETHODIMP JITCachedFunctionSearchStarted(FunctionID, BOOL *) { return S_OK; };
+	STDMETHODIMP JITCachedFunctionSearchFinished(FunctionID, COR_PRF_JIT_CACHE) { return S_OK; };
+	STDMETHODIMP JITFunctionPitched(FunctionID) { return S_OK; };
+	STDMETHODIMP JITInlining(FunctionID, FunctionID, BOOL *) { return S_OK; };
+	STDMETHODIMP ThreadCreated(ThreadID) { return S_OK; };
+	STDMETHODIMP ThreadDestroyed(ThreadID) { return S_OK; };
+	STDMETHODIMP ThreadAssignedToOSThread(ThreadID, ULONG) { return S_OK; };
 	STDMETHODIMP RemotingClientInvocationStarted() { return S_OK; };
-	STDMETHODIMP RemotingClientSendingMessage(GUID * pCookie, BOOL fIsAsync) { return S_OK; };
-	STDMETHODIMP RemotingClientReceivingReply(GUID * pCookie, BOOL fIsAsync) { return S_OK; };
+	STDMETHODIMP RemotingClientSendingMessage(GUID *, BOOL) { return S_OK; };
+	STDMETHODIMP RemotingClientReceivingReply(GUID *, BOOL) { return S_OK; };
 	STDMETHODIMP RemotingClientInvocationFinished() { return S_OK; };
-	STDMETHODIMP RemotingServerReceivingMessage(GUID * pCookie, BOOL fIsAsync) { return S_OK; };
+	STDMETHODIMP RemotingServerReceivingMessage(GUID *, BOOL) { return S_OK; };
 	STDMETHODIMP RemotingServerInvocationStarted() { return S_OK; };
 	STDMETHODIMP RemotingServerInvocationReturned() { return S_OK; };
-	STDMETHODIMP RemotingServerSendingReply(GUID * pCookie, BOOL fIsAsync) { return S_OK; };
-	STDMETHODIMP UnmanagedToManagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason) { return S_OK; };
-	STDMETHODIMP ManagedToUnmanagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason) { return S_OK; };
-	STDMETHODIMP RuntimeSuspendStarted(COR_PRF_SUSPEND_REASON suspendReason) { return S_OK; };
+	STDMETHODIMP RemotingServerSendingReply(GUID *, BOOL) { return S_OK; };
+	STDMETHODIMP UnmanagedToManagedTransition(FunctionID, COR_PRF_TRANSITION_REASON) { return S_OK; };
+	STDMETHODIMP ManagedToUnmanagedTransition(FunctionID, COR_PRF_TRANSITION_REASON) { return S_OK; };
+	STDMETHODIMP RuntimeSuspendStarted(COR_PRF_SUSPEND_REASON) { return S_OK; };
 	STDMETHODIMP RuntimeSuspendFinished() { return S_OK; };
 	STDMETHODIMP RuntimeSuspendAborted() { return S_OK; };
 	STDMETHODIMP RuntimeResumeStarted() { return S_OK; };
 	STDMETHODIMP RuntimeResumeFinished() { return S_OK; };
-	STDMETHODIMP RuntimeThreadSuspended(ThreadID threadId) { return S_OK; };
-	STDMETHODIMP RuntimeThreadResumed(ThreadID threadId) { return S_OK; };
+	STDMETHODIMP RuntimeThreadSuspended(ThreadID) { return S_OK; };
+	STDMETHODIMP RuntimeThreadResumed(ThreadID) { return S_OK; };
 	STDMETHODIMP MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], ULONG cObjectIDRangeLength[]);
 	STDMETHODIMP ObjectAllocated(ObjectID objectId, ClassID classId);
-	STDMETHODIMP ObjectsAllocatedByClass(ULONG cClassCount, ClassID classIds[], ULONG cObjects[]) { return S_OK; };
+	STDMETHODIMP ObjectsAllocatedByClass(ULONG, ClassID[], ULONG[]) { return S_OK; };
 	STDMETHODIMP ObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[]);
-	STDMETHODIMP RootReferences(ULONG cRootRefs, ObjectID rootRefIds[]) { return S_OK; }
-	STDMETHODIMP ExceptionThrown(ObjectID thrownObjectId) { return S_OK; };
-	STDMETHODIMP ExceptionSearchFunctionEnter(FunctionID functionId) { return S_OK; };
+	STDMETHODIMP RootReferences(ULONG, ObjectID[]) { return S_OK; }
+	STDMETHODIMP ExceptionThrown(ObjectID) { return S_OK; };
+	STDMETHODIMP ExceptionSearchFunctionEnter(FunctionID) { return S_OK; };
 	STDMETHODIMP ExceptionSearchFunctionLeave() { return S_OK; };
-	STDMETHODIMP ExceptionSearchFilterEnter(FunctionID functionId) { return S_OK; };
+	STDMETHODIMP ExceptionSearchFilterEnter(FunctionID) { return S_OK; };
 	STDMETHODIMP ExceptionSearchFilterLeave() { return S_OK; };
-	STDMETHODIMP ExceptionSearchCatcherFound(FunctionID functionId) { return S_OK; };
-	STDMETHODIMP ExceptionOSHandlerEnter(FunctionID functionId) { return S_OK; };
-	STDMETHODIMP ExceptionOSHandlerLeave(FunctionID functionId) { return S_OK; };
-	STDMETHODIMP ExceptionUnwindFunctionEnter(FunctionID functionId) { return S_OK; };
+	STDMETHODIMP ExceptionSearchCatcherFound(FunctionID) { return S_OK; };
+	STDMETHODIMP ExceptionOSHandlerEnter(FunctionID) { return S_OK; };
+	STDMETHODIMP ExceptionOSHandlerLeave(FunctionID) { return S_OK; };
+	STDMETHODIMP ExceptionUnwindFunctionEnter(FunctionID) { return S_OK; };
 	STDMETHODIMP ExceptionUnwindFunctionLeave() { return S_OK; };
-	STDMETHODIMP ExceptionUnwindFinallyEnter(FunctionID functionId) { return S_OK; };
+	STDMETHODIMP ExceptionUnwindFinallyEnter(FunctionID) { return S_OK; };
 	STDMETHODIMP ExceptionUnwindFinallyLeave() { return S_OK; };
-	STDMETHODIMP ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId) { return S_OK; };
+	STDMETHODIMP ExceptionCatcherEnter(FunctionID, ObjectID) { return S_OK; };
 	STDMETHODIMP ExceptionCatcherLeave() { return S_OK; };
-	STDMETHODIMP COMClassicVTableCreated(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable, ULONG cSlots) { return S_OK; };
-	STDMETHODIMP COMClassicVTableDestroyed(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable) { return S_OK; };
+	STDMETHODIMP COMClassicVTableCreated(ClassID, REFGUID, void *, ULONG) { return S_OK; };
+	STDMETHODIMP COMClassicVTableDestroyed(ClassID, REFGUID, void *) { return S_OK; };
 	STDMETHODIMP ExceptionCLRCatcherFound(void) { return S_OK; };
 	STDMETHODIMP ExceptionCLRCatcherExecute(void) { return S_OK; };
 
@@ -121,7 +124,7 @@ public:
 
 	// ICorProfilerCallback2 interface implementation
 
-	STDMETHODIMP ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR* name) { return S_OK; };
+	STDMETHODIMP ThreadNameChanged(ThreadID, ULONG, WCHAR*) { return S_OK; };
 	STDMETHODIMP GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason);
 	STDMETHODIMP SurvivingReferences(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], ULONG cObjectIDRangeLength[]);
 

--- a/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX64.vcxproj
@@ -57,7 +57,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;NDEBUG;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -83,7 +84,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>WIN32;NDEBUG;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
+++ b/src/EtwClrProfiler/ETWClrProfilerX86.vcxproj
@@ -56,7 +56,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;NDEBUG;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -82,7 +83,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>WIN32;NDEBUG;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>


### PR DESCRIPTION
Enables /W4 and /WX for both ETW CLR profiler projects and fixes the resulting warnings.