### PR TITLE
Bump ReleaseVersion to 3.2.5

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <ReleaseVersion>3.2.4</ReleaseVersion>
+    <ReleaseVersion>3.2.5</ReleaseVersion>
     <FastSerializationVersion>$(ReleaseVersion)</FastSerializationVersion>
     <HeapDumpDllVersion>$(ReleaseVersion)</HeapDumpDllVersion>
     <MemoryGraphVersion>$(ReleaseVersion)</MemoryGraphVersion>


### PR DESCRIPTION
Prepares the repository for the next patch release by updating the shared release version from 3.2.4 to 3.2.5. All projects that consume \ReleaseVersion\ will inherit the new package and assembly version.