### PR TITLE
Fix StackOverflow on malformed EventPipe object type length

### DIFF
--- a/src/TraceEvent/EventPipe/EventPipeEventSource.cs
+++ b/src/TraceEvent/EventPipe/EventPipeEventSource.cs
@@ -876,7 +876,12 @@ namespace Microsoft.Diagnostics.Tracing
             int minVersion = _stream.Read<int>();
             int typeLen = _stream.Read<int>();
             int maxLen = BlockName.EventPipeFile.Length;
-            if (typeLen > maxLen)
+            // typeLen comes from fully untrusted input. It must be validated against BOTH bounds before it is
+            // used as a stackalloc size: a negative value is not caught by the upper-bound check and, once
+            // converted to the unsigned size the runtime uses for the stack allocation, requests an enormous
+            // amount of stack and reliably crashes the process with a StackOverflowException (an uncatchable,
+            // fuzzer-discoverable denial of service on a malformed nettrace/EventPipe stream).
+            if (typeLen < 0 || typeLen > maxLen)
             {
                 throw new FormatException($"Invalid FastSerialization object type length {typeLen}");
             }

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -263,6 +263,39 @@ namespace TraceEventTests
             });
         }
 
+        // Regression test: a malformed FastSerialization object header with a negative type-name length must be
+        // rejected with a FormatException. Before validation was added the negative length flowed into a
+        // stackalloc whose size was interpreted as an enormous unsigned value, crashing the process with an
+        // uncatchable StackOverflowException on fully untrusted nettrace input (found by fuzzing).
+        [Fact]
+        public void NegativeObjectTypeLengthThrowsInsteadOfStackOverflow()
+        {
+            MemoryStream stream = new MemoryStream();
+            using (BinaryWriter writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+            {
+                writer.WriteNetTraceHeaderV5();
+                writer.WriteFastSerializationHeader();
+
+                // Begin a FastSerialization object exactly as the reader expects, but write a negative
+                // type-name length where a valid (small, non-negative) length is required.
+                writer.Write((byte)5); // BeginPrivateObject
+                writer.Write((byte)5); // BeginPrivateObject (type)
+                writer.Write((byte)1); // NullReference (type of type)
+                writer.Write((int)4);  // version
+                writer.Write((int)4);  // minVersion
+                writer.Write((int)(-1)); // malformed: negative type-name length
+            }
+
+            stream.Position = 0;
+            Assert.Throws<FormatException>(() =>
+            {
+                using (var source = new EventPipeEventSource(stream))
+                {
+                    source.Process();
+                }
+            });
+        }
+
         [Fact]
         public void CanParseHeaderOfV3EventPipeFile()
         {


### PR DESCRIPTION
## Summary
Fixes an uncatchable **StackOverflow (denial of service) on malformed EventPipe/nettrace input** in the TraceEvent library.

`FastSerializationObjectParser.ReadBlockHeader` reads an attacker-controlled 32-bit object type-name length from fully untrusted input and only validated the **upper** bound (`typeLen > maxLen`). A **negative** length passed that check and flowed into `stackalloc byte[typeLen]`, where the count is converted to an enormous unsigned size, reliably crashing the process with a `StackOverflowException`.

This is reachable by any caller that parses untrusted data (e.g. `TraceLog.CreateFromEventPipeDataFile`, `new EventPipeEventSource(...)`).

## How it was found
Discovered by the TraceEvent nettrace fuzzer. Reproduces deterministically with a **693-byte** input on both .NET 9 and .NET 10.

## Fix
- Reject `typeLen < 0` alongside oversized lengths in `EventPipeEventSource.cs`.
- Add regression test `NegativeObjectTypeLengthThrowsInsteadOfStackOverflow` asserting a `FormatException` (graceful rejection) instead of a crash.

## Validation
Regression test passes on net8.0 and net462; the fuzzer crash inputs now return cleanly.
