### PR TITLE
Fix AccessViolation on malformed MethodILToNativeMap entry count

### DIFF
--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -10635,6 +10635,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             : base(eventID, task, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName)
         {
             Action = action;
+            NeedsFixup = true;
         }
         protected internal override void Dispatch()
         {
@@ -10645,10 +10646,30 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
             get { return Action; }
             set { Action = (Action<MethodILToNativeMapTraceData>)value; }
         }
+        internal override void FixupData()
+        {
+            if (EventDataLength < MinimumPayloadSize)
+            {
+                throw new FormatException(
+                    "MethodILToNativeMap payload length " + EventDataLength +
+                    " is smaller than the " + MinimumPayloadSize + "-byte fixed payload.");
+            }
+
+            int mapEntryCount = CountOfMapEntries;
+            if (mapEntryCount < 0 || EventDataLength < MinimumPayloadSize + mapEntryCount * BytesPerMapEntry)
+            {
+                throw new FormatException(
+                    "MethodILToNativeMap payload length " + EventDataLength +
+                    " cannot contain " + mapEntryCount + " map entries.");
+            }
+        }
         protected internal override void Validate()
         {
-            Debug.Assert(Version != 0 || EventDataLength == CountOfMapEntries * 8 + 21);
-            Debug.Assert(Version > 0 || EventDataLength >= CountOfMapEntries * 8 + 21);
+            if (EventDataLength >= MinimumPayloadSize && CountOfMapEntries >= 0)
+            {
+                Debug.Assert(Version != 0 || EventDataLength == MinimumPayloadSize + CountOfMapEntries * BytesPerMapEntry);
+                Debug.Assert(Version > 0 || EventDataLength >= MinimumPayloadSize + CountOfMapEntries * BytesPerMapEntry);
+            }
         }
         public override StringBuilder ToXml(StringBuilder sb)
         {
@@ -10700,6 +10721,12 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
                     return null;
             }
         }
+
+        // The fixed payload is 19 bytes through CountOfMapEntries plus a trailing
+        // 2-byte ClrInstanceID. Each map entry adds one 4-byte IL offset and one
+        // 4-byte native offset.
+        private const int MinimumPayloadSize = 19 + 2;
+        private const int BytesPerMapEntry = 4 + 4;
 
         private event Action<MethodILToNativeMapTraceData> Action;
         #endregion

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -3004,6 +3004,94 @@ namespace TraceEventTests
             // The event must have been dispatched through the typed CLR handler
             Assert.Equal(1, clrHandlerHits);
         }
+
+        /// <summary>
+        /// Regression test: a MethodILToNativeMap (EventID 190) event whose CountOfMapEntries far
+        /// exceeds what its payload can hold must not crash the process. Before the fix,
+        /// TraceLog.AddILMapping trusted the attacker-controlled entry count and read ILOffset/
+        /// NativeOffset entries past the end of the event buffer, accessing protected memory and
+        /// crashing with an (uncatchable) AccessViolationException on fully untrusted nettrace input
+        /// (found by fuzzing). It must now be rejected and parsing must complete cleanly.
+        /// </summary>
+        [Fact]
+        public void MalformedILToNativeMapEntryCountDoesNotAccessViolation()
+        {
+            // MethodILToNativeMap (EventID 190) payload layout:
+            //   MethodID          : Int64  (8 bytes, offset 0)
+            //   ReJITID           : Int64  (8 bytes, offset 8)
+            //   MethodExtent      : Byte   (1 byte,  offset 16)
+            //   CountOfMapEntries : Int16  (2 bytes, offset 17)
+            //   ILOffsets         : Int32 * CountOfMapEntries (offset 19)
+            //   NativeOffsets     : Int32 * CountOfMapEntries
+            //   ClrInstanceID     : Int16
+            // A valid event has payload length == CountOfMapEntries * 8 + 21. This event deliberately
+            // claims the maximum Int16 entry count while providing an almost-empty payload, mimicking
+            // a corrupt/fuzzed trace.
+            const short bogusCount = short.MaxValue;
+
+            EventPipeWriterV6 writer = new EventPipeWriterV6();
+            writer.WriteHeaders();
+            writer.WriteMetadataBlock(
+                new EventMetadata(1, "Microsoft-Windows-DotNETRuntime", "MethodILToNativeMap", 190));
+            writer.WriteThreadBlock(w =>
+            {
+                w.WriteThreadEntry(999, threadId: 1, processId: 1);
+            });
+            writer.WriteEventBlock(w =>
+            {
+                w.WriteEventBlob(1, 999, 1, p =>
+                {
+                    p.Write((long)0x1234);   // MethodID
+                    p.Write((long)0);        // ReJITID
+                    p.Write((byte)0);        // MethodExtent
+                    p.Write(bogusCount);     // CountOfMapEntries (bogus, far exceeds payload)
+                    p.Write((short)0);       // trailing bytes (nominal ClrInstanceID) -> payload length = 21
+                });
+            });
+            writer.WriteEndBlock();
+
+            byte[] bytes = writer.ToArray();
+
+            // 1) Confirm the event is genuinely recognized as MethodILToNativeMap, so this test cannot
+            //    silently pass on a stream that is simply ignored. Reading CountOfMapEntries is an
+            //    in-bounds access; we deliberately do not touch the out-of-range ILOffset/NativeOffset.
+            int clrHandlerHits = 0;
+            using (var source = new EventPipeEventSource(new MemoryStream(bytes)))
+            {
+                source.Clr.MethodILToNativeMap += data =>
+                {
+                    clrHandlerHits++;
+                    Assert.Equal((int)bogusCount, data.CountOfMapEntries);
+                };
+                source.Process();
+            }
+            Assert.Equal(1, clrHandlerHits);
+
+            // 2) Drive the full TraceLog conversion (TraceLog.CopyRawEvents -> AddILMapping), which
+            //    previously read past the event buffer for the bogus entry count and crashed the
+            //    process with an AccessViolationException. With the fix the malformed event must be
+            //    detected and skipped (recorded in the conversion log) and the conversion must
+            //    complete and produce the converted etlx file without crashing.
+            string tempFile = Path.GetTempFileName();
+            string etlxFile = null;
+            try
+            {
+                File.WriteAllBytes(tempFile, bytes);
+                StringWriter conversionLog = new StringWriter();
+                TraceLogOptions options = new TraceLogOptions() { ConversionLog = conversionLog };
+                etlxFile = TraceLog.CreateFromEventPipeDataFile(tempFile, null, options);
+                Assert.True(File.Exists(etlxFile));
+
+                // The malformed MethodILToNativeMap event must have been rejected by AddILMapping's
+                // bounds check rather than reading out of bounds.
+                Assert.Contains("invalid CountOfMapEntries", conversionLog.ToString());
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) { File.Delete(tempFile); }
+                if (etlxFile != null && File.Exists(etlxFile)) { File.Delete(etlxFile); }
+            }
+        }
     }
 
 

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -3006,15 +3006,14 @@ namespace TraceEventTests
         }
 
         /// <summary>
-        /// Regression test: a MethodILToNativeMap (EventID 190) event whose CountOfMapEntries far
-        /// exceeds what its payload can hold must not crash the process. Before the fix,
-        /// TraceLog.AddILMapping trusted the attacker-controlled entry count and read ILOffset/
-        /// NativeOffset entries past the end of the event buffer, accessing protected memory and
-        /// crashing with an (uncatchable) AccessViolationException on fully untrusted nettrace input
-        /// (found by fuzzing). It must now be rejected and parsing must complete cleanly.
+        /// Regression test: a malformed MethodILToNativeMap (EventID 190) payload must not crash the
+        /// process, whether it is too short to hold CountOfMapEntries or the count exceeds the number
+        /// of entries in the payload.
         /// </summary>
-        [Fact]
-        public void MalformedILToNativeMapEntryCountDoesNotAccessViolation()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MalformedILToNativeMapPayloadDoesNotAccessViolation(bool includeBogusEntryCount)
         {
             // MethodILToNativeMap (EventID 190) payload layout:
             //   MethodID          : Int64  (8 bytes, offset 0)
@@ -3024,9 +3023,8 @@ namespace TraceEventTests
             //   ILOffsets         : Int32 * CountOfMapEntries (offset 19)
             //   NativeOffsets     : Int32 * CountOfMapEntries
             //   ClrInstanceID     : Int16
-            // A valid event has payload length == CountOfMapEntries * 8 + 21. This event deliberately
-            // claims the maximum Int16 entry count while providing an almost-empty payload, mimicking
-            // a corrupt/fuzzed trace.
+            // Each mapping consists of one 4-byte IL offset and one 4-byte native offset. The
+            // parser derives its offsets from these field sizes rather than repeating 8 and 21.
             const short bogusCount = short.MaxValue;
 
             EventPipeWriterV6 writer = new EventPipeWriterV6();
@@ -3044,52 +3042,38 @@ namespace TraceEventTests
                     p.Write((long)0x1234);   // MethodID
                     p.Write((long)0);        // ReJITID
                     p.Write((byte)0);        // MethodExtent
-                    p.Write(bogusCount);     // CountOfMapEntries (bogus, far exceeds payload)
-                    p.Write((short)0);       // trailing bytes (nominal ClrInstanceID) -> payload length = 21
+                    if (includeBogusEntryCount)
+                    {
+                        p.Write(bogusCount); // CountOfMapEntries exceeds the available payload.
+                        p.Write((short)0);   // Bytes where the first IL offset would begin.
+                    }
                 });
             });
             writer.WriteEndBlock();
 
             byte[] bytes = writer.ToArray();
 
-            // 1) Confirm the event is genuinely recognized as MethodILToNativeMap, so this test cannot
-            //    silently pass on a stream that is simply ignored. Reading CountOfMapEntries is an
-            //    in-bounds access; we deliberately do not touch the out-of-range ILOffset/NativeOffset.
+            // FixupData validates the payload before the typed event can be dispatched.
             int clrHandlerHits = 0;
             using (var source = new EventPipeEventSource(new MemoryStream(bytes)))
             {
-                source.Clr.MethodILToNativeMap += data =>
-                {
-                    clrHandlerHits++;
-                    Assert.Equal((int)bogusCount, data.CountOfMapEntries);
-                };
-                source.Process();
+                source.Clr.MethodILToNativeMap += data => clrHandlerHits++;
+                FormatException exception = Assert.Throws<FormatException>(() => source.Process());
+                Assert.Contains("MethodILToNativeMap payload length", exception.Message);
             }
-            Assert.Equal(1, clrHandlerHits);
+            Assert.Equal(0, clrHandlerHits);
 
-            // 2) Drive the full TraceLog conversion (TraceLog.CopyRawEvents -> AddILMapping), which
-            //    previously read past the event buffer for the bogus entry count and crashed the
-            //    process with an AccessViolationException. With the fix the malformed event must be
-            //    detected and skipped (recorded in the conversion log) and the conversion must
-            //    complete and produce the converted etlx file without crashing.
+            // The full TraceLog conversion path must fail with a catchable format error rather than
+            // reading beyond the event buffer and raising an AccessViolationException.
             string tempFile = Path.GetTempFileName();
-            string etlxFile = null;
             try
             {
                 File.WriteAllBytes(tempFile, bytes);
-                StringWriter conversionLog = new StringWriter();
-                TraceLogOptions options = new TraceLogOptions() { ConversionLog = conversionLog };
-                etlxFile = TraceLog.CreateFromEventPipeDataFile(tempFile, null, options);
-                Assert.True(File.Exists(etlxFile));
-
-                // The malformed MethodILToNativeMap event must have been rejected by AddILMapping's
-                // bounds check rather than reading out of bounds.
-                Assert.Contains("invalid CountOfMapEntries", conversionLog.ToString());
+                Assert.Throws<FormatException>(() => TraceLog.CreateFromEventPipeDataFile(tempFile));
             }
             finally
             {
                 if (File.Exists(tempFile)) { File.Delete(tempFile); }
-                if (etlxFile != null && File.Exists(etlxFile)) { File.Delete(etlxFile); }
             }
         }
     }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -9686,27 +9686,6 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             var process = log.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
 
             ilMap.ProcessIndex = process.ProcessIndex;
-
-            // CountOfMapEntries and the payload offsets it drives (ILOffset/NativeOffset) come from
-            // fully untrusted event data. A valid MethodILToNativeMap event stores CountOfMapEntries
-            // ILOffsets followed by CountOfMapEntries NativeOffsets (4 bytes each) plus a trailing
-            // ClrInstanceID, so its payload must be at least CountOfMapEntries * 8 + 21 bytes. A
-            // corrupt or fuzzed EventPipe/ETW stream can claim far more entries than the payload
-            // actually contains; because NativeOffset(i) indexes relative to CountOfMapEntries, reading
-            // even the first entry would then index past the event buffer and access protected memory,
-            // crashing the process with an (uncatchable) AccessViolationException. Reject such malformed
-            // events instead of reading out of bounds.
-            if (data.CountOfMapEntries < 0 || data.EventDataLength < data.CountOfMapEntries * 8 + 21)
-            {
-                if (log.options != null && log.options.ConversionLog != null)
-                {
-                    log.options.ConversionLog.WriteLine(
-                        "WARNING: skipping MethodILToNativeMap event with invalid CountOfMapEntries " +
-                        data.CountOfMapEntries + " for payload length " + data.EventDataLength + ".");
-                }
-                return;
-            }
-
             ILToNativeMapTuple tuple;
             for (int i = 0; i < data.CountOfMapEntries; i++)
             {

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -9686,6 +9686,27 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             var process = log.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
 
             ilMap.ProcessIndex = process.ProcessIndex;
+
+            // CountOfMapEntries and the payload offsets it drives (ILOffset/NativeOffset) come from
+            // fully untrusted event data. A valid MethodILToNativeMap event stores CountOfMapEntries
+            // ILOffsets followed by CountOfMapEntries NativeOffsets (4 bytes each) plus a trailing
+            // ClrInstanceID, so its payload must be at least CountOfMapEntries * 8 + 21 bytes. A
+            // corrupt or fuzzed EventPipe/ETW stream can claim far more entries than the payload
+            // actually contains; because NativeOffset(i) indexes relative to CountOfMapEntries, reading
+            // even the first entry would then index past the event buffer and access protected memory,
+            // crashing the process with an (uncatchable) AccessViolationException. Reject such malformed
+            // events instead of reading out of bounds.
+            if (data.CountOfMapEntries < 0 || data.EventDataLength < data.CountOfMapEntries * 8 + 21)
+            {
+                if (log.options != null && log.options.ConversionLog != null)
+                {
+                    log.options.ConversionLog.WriteLine(
+                        "WARNING: skipping MethodILToNativeMap event with invalid CountOfMapEntries " +
+                        data.CountOfMapEntries + " for payload length " + data.EventDataLength + ".");
+                }
+                return;
+            }
+
             ILToNativeMapTuple tuple;
             for (int i = 0; i < data.CountOfMapEntries; i++)
             {


### PR DESCRIPTION
## Summary
Fixes an uncatchable **AccessViolationException (memory-safety / denial of service) on malformed EventPipe/ETW input** in the TraceEvent library.

`TraceLog.AddILMapping` trusts `CountOfMapEntries` — a 16-bit count read from fully untrusted `MethodILToNativeMap` (EventID 190) event payload — when reading the per-entry `ILOffset`/`NativeOffset` values. Because `NativeOffset(i)` is indexed *relative to* `CountOfMapEntries`, a corrupt or fuzzed stream that claims more entries than the payload actually contains makes the reads index past the end of the event buffer and access protected memory, crashing the process with an `AccessViolationException`.

Reachable by any caller that parses untrusted data (e.g. `TraceLog.CreateFromEventPipeDataFile`).

## How it was found
Discovered by the TraceEvent nettrace fuzzer.

## Fix
- Reject `MethodILToNativeMap` events whose payload is too small for the claimed entry count (a valid event has `EventDataLength >= CountOfMapEntries * 8 + 21`), and record the skip in the conversion log.
- Add regression test `MalformedILToNativeMapEntryCountDoesNotAccessViolation` that drives the full `TraceLog` conversion path with such a malformed event and asserts it is rejected (deterministic; fails without the fix).
