### PR TITLE
Fix infinite loop in LinuxPerfScriptEventParser on truncated sched_switch lines

### DIFF
--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
@@ -1192,6 +1192,12 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                 {
                     break;
                 }
+                else if (source.EndOfStream)
+                {
+                    // The input is malformed or truncated: the expected next field name was
+                    // never found before the end of the stream. Break to avoid an infinite loop.
+                    break;
+                }
                 else
                 {
                     source.RestoreToMark(pos);

--- a/src/TraceEvent/TraceEvent.Tests/LinuxStackSource/LinuxPerfScriptEventParserTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/LinuxStackSource/LinuxPerfScriptEventParserTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing.StackSources;
+using Xunit;
+
+namespace TraceEventTests
+{
+    public class LinuxPerfScriptEventParserTests
+    {
+        /// <summary>
+        /// A truncated sched_switch line whose expected next field name (e.g. "prev_pid") never
+        /// appears used to send ReadProcessNameUntilNextField into an infinite loop, hanging the
+        /// parser. This test ensures parsing such malformed input terminates instead of hanging.
+        /// </summary>
+        [Fact]
+        public async Task TruncatedSchedSwitchDoesNotHang()
+        {
+            // Header parses far enough to reach ReadScheduleSwitch, then the input ends right after
+            // "prev_comm=swapper" so the "prev_pid" field is never found.
+            const string input = "myproc 100/100 [000] 1234.500000: sched:sched_switch: prev_comm=swapper";
+
+            byte[] bytes = Encoding.ASCII.GetBytes(input);
+
+            Task parseTask = Task.Run(() =>
+            {
+                LinuxPerfScriptEventParser parser = new LinuxPerfScriptEventParser();
+                using (MemoryStream stream = new MemoryStream(bytes))
+                {
+                    foreach (var _ in parser.ParseSkippingPreamble(stream))
+                    {
+                    }
+                }
+            });
+
+            // Before the fix this loops forever; allow generous headroom for slow CI machines.
+            Task completedTask = await Task.WhenAny(parseTask, Task.Delay(30000));
+            Assert.True(completedTask == parseTask, "Parsing a truncated sched_switch line did not terminate (infinite loop).");
+
+            // Surface any exception thrown by the parse task.
+            await parseTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes an infinite loop (parser hang) in `LinuxPerfScriptEventParser` when parsing malformed or truncated `sched_switch` lines.

`ReadProcessNameUntilNextField` loops until it finds the expected next field name (e.g. `prev_pid`, `next_pid`, `pid`). If that field name never appears before the end of the stream — as happens with truncated/malformed perf script input — the loop never terminated and the parser hung indefinitely.

## Root cause
The `while (true)` loop in `ReadProcessNameUntilNextField` had no end-of-stream termination condition. At EOF, `FastStream` returns a sentinel and `ReadFixedString` never matches the target field name, so the loop spins forever appending spaces.

## Fix
Break out of the loop when `source.EndOfStream` is reached.

## How it was found
OneFuzz fuzzing of the Linux perf script parser produced 146 hang inputs (out of 155 recorded crashes). All 146 replayed as 30s timeouts before this change; with the fix all inputs terminate cleanly.

## Test
Adds `LinuxPerfScriptEventParserTests.TruncatedSchedSwitchDoesNotHang`, which parses a truncated `sched_switch` line and asserts parsing terminates (fails via timeout if the infinite loop regresses). Passes on net462 and net8.0.