### PR TITLE
Add Accessible Label To Directory Search Field

### DIFF
--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -178,7 +178,7 @@
                 <DockPanel DockPanel.Dock="Top">
                     <Label x:Name="DirectoryLabel" Content="Path:" Target="{Binding ElementName=Directory}"
                            VerticalAlignment="Center" Padding="5,0" />
-                    <controls:HistoryComboBox x:Name="Directory" AutomationProperties.Name="Path"
+                    <controls:HistoryComboBox x:Name="Directory" AutomationProperties.Name="Directory Search Bar"
                              AutomationProperties.LabeledBy="{Binding ElementName=DirectoryLabel}"
                              ToolTip="This is the directory to search for performance data files." TextEntered="DoTextEnteredInDirectoryTextBox" />
                 </DockPanel>

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -175,8 +175,13 @@
                 <ColumnDefinition Width="619*"/>
             </Grid.ColumnDefinitions>
             <DockPanel Background="{DynamicResource ContainerBackground}" Grid.Column="0">
-                <controls:HistoryComboBox x:Name="Directory" DockPanel.Dock="Top" AutomationProperties.Name="Directory Search Bar"
-                         ToolTip="This is the directory to search for performance data files." TextEntered="DoTextEnteredInDirectoryTextBox" />
+                <DockPanel DockPanel.Dock="Top">
+                    <Label x:Name="DirectoryLabel" Content="Path:" Target="{Binding ElementName=Directory}"
+                           VerticalAlignment="Center" Padding="5,0" />
+                    <controls:HistoryComboBox x:Name="Directory" AutomationProperties.Name="Directory Search Bar"
+                             AutomationProperties.LabeledBy="{Binding ElementName=DirectoryLabel}"
+                             ToolTip="This is the directory to search for performance data files." TextEntered="DoTextEnteredInDirectoryTextBox" />
+                </DockPanel>
                 <Grid DockPanel.Dock="Top" >
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -178,7 +178,7 @@
                 <DockPanel DockPanel.Dock="Top">
                     <Label x:Name="DirectoryLabel" Content="Path:" Target="{Binding ElementName=Directory}"
                            VerticalAlignment="Center" Padding="5,0" />
-                    <controls:HistoryComboBox x:Name="Directory" AutomationProperties.Name="Directory Search Bar"
+                    <controls:HistoryComboBox x:Name="Directory" AutomationProperties.Name="Path"
                              AutomationProperties.LabeledBy="{Binding ElementName=DirectoryLabel}"
                              ToolTip="This is the directory to search for performance data files." TextEntered="DoTextEnteredInDirectoryTextBox" />
                 </DockPanel>


### PR DESCRIPTION
The main view's directory search field lacks a persistent visible label, making its purpose harder to identify.

Add a visible **Path:** label beside the field and associate it through WPF's `Label.Target` and `AutomationProperties.LabeledBy`. Existing directory history, tooltip, and keyboard navigation behavior remain unchanged.