### PR TITLE
Improve Keyboard Focus Indicator Contrast

### DIFF
--- a/src/PerfView.Tests/Accessibility/FocusVisualTests.cs
+++ b/src/PerfView.Tests/Accessibility/FocusVisualTests.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Shapes;
+using REghZyFramework.Themes;
 using Xunit;
 
 namespace PerfViewTests.Accessibility
@@ -32,9 +33,7 @@ namespace PerfViewTests.Accessibility
         [WpfFact]
         public void ReportedControlsUseAccessibleFocusVisual()
         {
-            Application application = Application.Current ?? new Application();
             ResourceDictionary theme = LoadTheme("LightTheme.xaml");
-            application.Resources.MergedDictionaries.Add(theme);
 
             MainWindow mainWindow = null;
             try
@@ -42,6 +41,7 @@ namespace PerfViewTests.Accessibility
                 App.CommandLineArgs = new CommandLineArgs();
                 App.CommandProcessor = new CommandProcessor();
                 mainWindow = new MainWindow(true);
+                mainWindow.Resources.MergedDictionaries.Add(theme);
 
                 Style expectedStyle = (Style)theme["AccessibleFocusVisual"];
                 Assert.Same(expectedStyle, mainWindow.Body.FocusVisualStyle);
@@ -61,7 +61,6 @@ namespace PerfViewTests.Accessibility
             finally
             {
                 mainWindow?.Close();
-                application.Resources.MergedDictionaries.Remove(theme);
             }
         }
 
@@ -96,17 +95,21 @@ namespace PerfViewTests.Accessibility
 
         private static ResourceDictionary LoadTheme(string themeName)
         {
-            if (Application.Current == null)
+            if (themeName == "LightTheme.xaml")
             {
-                new Application();
+                var theme = new LightTheme();
+                theme.InitializeComponent();
+                return theme;
             }
 
-            return new ResourceDictionary
+            if (themeName == "DarkTheme.xaml")
             {
-                Source = new Uri(
-                    $"/PerfView;component/Themes/{themeName}",
-                    UriKind.Relative)
-            };
+                var theme = new DarkTheme();
+                theme.InitializeComponent();
+                return theme;
+            }
+
+            throw new ArgumentException($"Unknown theme '{themeName}'.", nameof(themeName));
         }
 
         private static double GetContrastRatio(Color first, Color second)

--- a/src/PerfView.Tests/Accessibility/FocusVisualTests.cs
+++ b/src/PerfView.Tests/Accessibility/FocusVisualTests.cs
@@ -1,0 +1,137 @@
+using PerfView;
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using Xunit;
+
+namespace PerfViewTests.Accessibility
+{
+    public class FocusVisualTests
+    {
+        private const double MinimumContrastRatio = 3.0;
+
+        [WpfFact]
+        public void AccessibleFocusVisualMeetsContrastRequirements()
+        {
+            AssertThemeFocusVisual(
+                "LightTheme.xaml",
+                Colors.White,
+                GetThemeColor("LightTheme.xaml", "ContainerBackground"),
+                GetThemeColor("LightTheme.xaml", "ControlDefaultBackground"));
+
+            AssertThemeFocusVisual(
+                "DarkTheme.xaml",
+                GetThemeColor("DarkTheme.xaml", "ContainerBackground"),
+                GetThemeColor("DarkTheme.xaml", "ControlDefaultBackground"));
+        }
+
+        [WpfFact]
+        public void ReportedControlsUseAccessibleFocusVisual()
+        {
+            Application application = Application.Current ?? new Application();
+            ResourceDictionary theme = LoadTheme("LightTheme.xaml");
+            application.Resources.MergedDictionaries.Add(theme);
+
+            MainWindow mainWindow = null;
+            try
+            {
+                App.CommandLineArgs = new CommandLineArgs();
+                App.CommandProcessor = new CommandProcessor();
+                mainWindow = new MainWindow(true);
+
+                Style expectedStyle = (Style)theme["AccessibleFocusVisual"];
+                Assert.Same(expectedStyle, mainWindow.Body.FocusVisualStyle);
+
+                StatusBar statusBar = mainWindow.StatusBar;
+                Assert.Same(expectedStyle, ((TextBox)statusBar.FindName("m_StatusMessage")).FocusVisualStyle);
+                Assert.Same(expectedStyle, ((Button)statusBar.FindName("m_LogButton")).FocusVisualStyle);
+                Assert.Same(expectedStyle, ((Button)statusBar.FindName("m_CancelButton")).FocusVisualStyle);
+
+                Hyperlink welcomeLink = mainWindow.Body.Document.Blocks
+                    .OfType<Paragraph>()
+                    .SelectMany(paragraph => paragraph.Inlines)
+                    .OfType<Hyperlink>()
+                    .First();
+                Assert.Same(expectedStyle, welcomeLink.FocusVisualStyle);
+            }
+            finally
+            {
+                mainWindow?.Close();
+                application.Resources.MergedDictionaries.Remove(theme);
+            }
+        }
+
+        #region private
+
+        private static void AssertThemeFocusVisual(string themeName, params Color[] adjacentColors)
+        {
+            ResourceDictionary theme = LoadTheme(themeName);
+            SolidColorBrush focusBrush = (SolidColorBrush)theme["AccessibleFocusVisualBrush"];
+            Style focusStyle = (Style)theme["AccessibleFocusVisual"];
+            Setter templateSetter = focusStyle.Setters
+                .OfType<Setter>()
+                .Single(setter => setter.Property == Control.TemplateProperty);
+            Rectangle focusRectangle = (Rectangle)((ControlTemplate)templateSetter.Value).LoadContent();
+
+            Assert.True(focusRectangle.StrokeThickness >= 2);
+            Assert.Equal(focusBrush.Color, ((SolidColorBrush)focusRectangle.Stroke).Color);
+
+            foreach (Color adjacentColor in adjacentColors)
+            {
+                double contrastRatio = GetContrastRatio(focusBrush.Color, adjacentColor);
+                Assert.True(
+                    contrastRatio >= MinimumContrastRatio,
+                    $"{themeName} focus color {focusBrush.Color} has a contrast ratio of only {contrastRatio:F3}:1 against {adjacentColor}.");
+            }
+        }
+
+        private static Color GetThemeColor(string themeName, string resourceKey)
+        {
+            return ((SolidColorBrush)LoadTheme(themeName)[resourceKey]).Color;
+        }
+
+        private static ResourceDictionary LoadTheme(string themeName)
+        {
+            if (Application.Current == null)
+            {
+                new Application();
+            }
+
+            return new ResourceDictionary
+            {
+                Source = new Uri(
+                    $"/PerfView;component/Themes/{themeName}",
+                    UriKind.Relative)
+            };
+        }
+
+        private static double GetContrastRatio(Color first, Color second)
+        {
+            double firstLuminance = GetRelativeLuminance(first);
+            double secondLuminance = GetRelativeLuminance(second);
+            return (Math.Max(firstLuminance, secondLuminance) + 0.05) /
+                (Math.Min(firstLuminance, secondLuminance) + 0.05);
+        }
+
+        private static double GetRelativeLuminance(Color color)
+        {
+            return (0.2126 * GetLinearChannel(color.R)) +
+                (0.7152 * GetLinearChannel(color.G)) +
+                (0.0722 * GetLinearChannel(color.B));
+        }
+
+        private static double GetLinearChannel(byte channel)
+        {
+            double value = channel / 255.0;
+            return value <= 0.04045
+                ? value / 12.92
+                : Math.Pow((value + 0.055) / 1.055, 2.4);
+        }
+
+        #endregion
+    }
+}

--- a/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
+++ b/src/PerfView/GuiUtilities/StatusBar/StatusBar.xaml
@@ -13,7 +13,9 @@
             <ColumnDefinition Width="auto"/>
             <ColumnDefinition Width="auto"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" Name="m_StatusMessage" ContextMenu="{x:Null}" IsReadOnly="True" VerticalScrollBarVisibility="Auto" AutomationProperties.Name="Status Message">
+        <TextBox Grid.Column="0" Name="m_StatusMessage" ContextMenu="{x:Null}" IsReadOnly="True"
+                 FocusVisualStyle="{DynamicResource AccessibleFocusVisual}"
+                 VerticalScrollBarVisibility="Auto" AutomationProperties.Name="Status Message">
             <TextBox.Triggers>
                 <EventTrigger RoutedEvent="perfview:StatusBar.HighlightMessage">
                     <EventTrigger.Actions>
@@ -38,7 +40,11 @@
             </TextBox.Triggers>
         </TextBox>
         <TextBlock Grid.Column="1" Name ="m_ProgressText" Width="85" Text="Ready" Margin="5,0,0,0" TextAlignment="Left" VerticalAlignment="Center"></TextBlock>
-        <Button Grid.Column="2" Name ="m_LogButton" IsEnabled="true" Margin="5,2" ToolTip="Open the diagnostic log" Click="Log_Click">Log</Button>
-        <Button Grid.Column="3" Name ="m_CancelButton" IsEnabled="false" Margin="5,2" ToolTip="Cancel the operation in flight (ESC)" Click="Cancel_Click">Cancel</Button>
+        <Button Grid.Column="2" Name ="m_LogButton" IsEnabled="true" Margin="5,2"
+                FocusVisualStyle="{DynamicResource AccessibleFocusVisual}"
+                ToolTip="Open the diagnostic log" Click="Log_Click">Log</Button>
+        <Button Grid.Column="3" Name ="m_CancelButton" IsEnabled="false" Margin="5,2"
+                FocusVisualStyle="{DynamicResource AccessibleFocusVisual}"
+                ToolTip="Cancel the operation in flight (ESC)" Click="Cancel_Click">Cancel</Button>
     </Grid>
 </UserControl>

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -227,12 +227,15 @@
             <GridSplitter Grid.Column="1" Width="3"  HorizontalAlignment="Center" VerticalAlignment="Stretch"/>
             <RichTextBox Name="Body" Grid.Column="2" IsReadOnly="True" IsDocumentEnabled="True"
                          IsEnabled="{Binding ElementName=StatusBar, Path=IsNotWorking}"
+                         FocusVisualStyle="{DynamicResource AccessibleFocusVisual}"
                          VerticalScrollBarVisibility="auto" AutomationProperties.Name="Usage Information">
                 <RichTextBox.Resources>
                     <Style TargetType="{x:Type Paragraph}">
                         <Setter Property="Margin" Value="0"/>
                     </Style>
-
+                    <Style TargetType="{x:Type Hyperlink}" BasedOn="{StaticResource {x:Type Hyperlink}}">
+                        <Setter Property="FocusVisualStyle" Value="{DynamicResource AccessibleFocusVisual}"/>
+                    </Style>
                 </RichTextBox.Resources>
                 <RichTextBox.Document>
                     <FlowDocument>

--- a/src/PerfView/Themes/DarkTheme.xaml
+++ b/src/PerfView/Themes/DarkTheme.xaml
@@ -62,6 +62,7 @@ SOFTWARE.
 
     <SolidColorBrush x:Key="AlternateRowBackground" Color="#FF424124" />
     <SolidColorBrush x:Key="HelpRibbonBackground" Color="#FF323838" />
+    <SolidColorBrush x:Key="AccessibleFocusVisualBrush" Color="#FF60CDFF" />
 
     <SolidColorBrush x:Key="ScrollBarBackground" Color="#2e2e2e" />
     <SolidColorBrush x:Key="ScrollBarControlForground" Color="#4d4d4d" />
@@ -106,6 +107,20 @@ SOFTWARE.
                                Stroke="{StaticResource ControlBrightPrimaryColourBorderBrush}"
                                SnapsToDevicePixels="true"
                                Margin="2" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Two-pixel keyboard focus visual for surfaces that require enhanced visibility. -->
+    <Style x:Key="AccessibleFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="1"
+                               SnapsToDevicePixels="true"
+                               Stroke="{StaticResource AccessibleFocusVisualBrush}"
+                               StrokeThickness="2" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/PerfView/Themes/LightTheme.xaml
+++ b/src/PerfView/Themes/LightTheme.xaml
@@ -63,6 +63,7 @@ SOFTWARE.
 
     <SolidColorBrush x:Key="AlternateRowBackground" Color="#FFF2F1A4" />
     <SolidColorBrush x:Key="HelpRibbonBackground" Color="#FFE2E8F8" />
+    <SolidColorBrush x:Key="AccessibleFocusVisualBrush" Color="#FF005FB8" />
 
     <!-- Colourful theme  Colours -->
 
@@ -70,6 +71,20 @@ SOFTWARE.
     <SolidColorBrush x:Key="ControlPrimaryColourBorderBrush" Color="#FF3294E8" />
     <SolidColorBrush x:Key="ControlBrightPrimaryColourBackground" Color="#FF3296FA" />
     <SolidColorBrush x:Key="ControlBrightPrimaryColourBorderBrush" Color="#FF50A4FA" />
+
+    <!-- Two-pixel keyboard focus visual for surfaces that require enhanced visibility. -->
+    <Style x:Key="AccessibleFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="1"
+                               SnapsToDevicePixels="true"
+                               Stroke="{StaticResource AccessibleFocusVisualBrush}"
+                               StrokeThickness="2" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
     <!-- Custom Window style (unaffected by win32 style stuff) -->
     <Style x:Key="CustomWindowStyle" TargetType="{x:Type Window}">


### PR DESCRIPTION
The keyboard focus indicator on the status bar controls and Welcome to PerfView content did not consistently meet the WCAG 3:1 contrast requirement.

This adds a 2 px, theme-aware keyboard focus outline to those controls and links.

- Meets the WCAG 3:1 contrast requirement in light and dark themes
- Adds regression tests for contrast, thickness, and control wiring