### PR TITLE
Fix Main Window Keyboard Focus Order

### DIFF
--- a/src/PerfView.Tests/MainWindowTests.cs
+++ b/src/PerfView.Tests/MainWindowTests.cs
@@ -1,0 +1,81 @@
+using PerfView;
+using PerfViewTests.Utilities;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PerfViewTests
+{
+    public class MainWindowTests : PerfViewTestBase
+    {
+        public MainWindowTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [WpfFact]
+        public Task TabNavigationReachesMainContentBeforeStatusBarAsync()
+        {
+            return RunUITestAsync(
+                () => Task.FromResult(GuiApp.MainWindow),
+                async window =>
+                {
+                    await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    Grid root = Assert.IsType<Grid>(window.Content);
+                    Grid mainContent = root.Children
+                        .OfType<Grid>()
+                        .Single(child => Grid.GetRow(child) == 1);
+                    Hyperlink videosLink = window.VideoLink.Inlines
+                        .OfType<Hyperlink>()
+                        .Single();
+
+                    Assert.Same(videosLink, Keyboard.Focus(videosLink));
+
+                    var visitedElements = new HashSet<IInputElement> { videosLink };
+                    while (!mainContent.IsKeyboardFocusWithin)
+                    {
+                        Assert.True(MoveFocusToNextElement());
+                        Assert.False(window.StatusBar.IsKeyboardFocusWithin);
+
+                        IInputElement focusedElement = Keyboard.FocusedElement;
+                        Assert.NotNull(focusedElement);
+                        Assert.True(
+                            visitedElements.Add(focusedElement),
+                            "Focus cycled without reaching the main content.");
+                    }
+
+                    Assert.True(mainContent.IsKeyboardFocusWithin);
+                },
+                window => Task.CompletedTask);
+        }
+
+        #region private
+
+        private static bool MoveFocusToNextElement()
+        {
+            var request = new TraversalRequest(FocusNavigationDirection.Next);
+            IInputElement focusedElement = Keyboard.FocusedElement;
+
+            if (focusedElement is UIElement uiElement)
+            {
+                return uiElement.MoveFocus(request);
+            }
+
+            if (focusedElement is ContentElement contentElement)
+            {
+                return contentElement.MoveFocus(request);
+            }
+
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/src/PerfView/MainWindow.xaml
+++ b/src/PerfView/MainWindow.xaml
@@ -58,8 +58,13 @@
     <Window.InputBindings>
         <KeyBinding Gesture="CTRL+L" Command="{x:Static src:MainWindow.FocusDirectoryCommand}" />
     </Window.InputBindings>
-    <DockPanel>
-        <Grid DockPanel.Dock="Top">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition/>
@@ -167,8 +172,7 @@
             <Button Name="WikiButton" Grid.Column="7" Margin="5,1,10,1" Content="Wiki" FontSize="9"
                     ToolTip="Goto the PerfView Wiki." Click="DoWikiClick"/>
         </Grid>
-        <src:StatusBar x:Name="StatusBar" DockPanel.Dock="Bottom"/>
-        <Grid>
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="220*"/>
                 <ColumnDefinition Width="auto"/>
@@ -345,5 +349,6 @@
                 </RichTextBox.Document>
             </RichTextBox>
         </Grid>
-    </DockPanel>
+        <src:StatusBar x:Name="StatusBar" Grid.Row="2"/>
+    </Grid>
 </Window>


### PR DESCRIPTION
Keyboard users could move from the top Videos link directly to bottom status-bar controls because the main window's WPF logical order did not match its visual layout.

## Summary

- Align the main window's logical and visual layout order.
- Keep status-bar controls keyboard accessible after the main content.
- Add regression coverage that detects premature status-bar focus or a focus cycle.