### PR TITLE
Enable Escape key dismissal for PerfView help

### DIFF
--- a/src/PerfView.Tests/GuiUtilities/WebBrowserWindowAccessibilityTests.cs
+++ b/src/PerfView.Tests/GuiUtilities/WebBrowserWindowAccessibilityTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using PerfView.GuiUtilities;
+using Xunit;
+
+namespace PerfViewTests.GuiUtilities
+{
+    public class WebBrowserWindowAccessibilityTests
+    {
+        [WpfFact]
+        public void WpfEscapeRequestsClose()
+        {
+            AssertCloseRequested(window =>
+            {
+                var keyEvent = new KeyEventArgs(
+                    Keyboard.PrimaryDevice,
+                    PresentationSource.FromVisual(window),
+                    0,
+                    Key.Escape)
+                {
+                    RoutedEvent = Keyboard.PreviewKeyDownEvent
+                };
+
+                window.RaiseEvent(keyEvent);
+                Assert.True(keyEvent.Handled);
+            });
+        }
+
+        [WpfFact]
+        public void WebViewEscapeMessageRequestsClose()
+        {
+            AssertCloseRequested(window => window.ProcessWebMessage("\"PerfView.CloseWindow\""));
+        }
+
+        private static void AssertCloseRequested(Action<WebBrowserWindow> requestClose)
+        {
+            var window = new WebBrowserWindow(null)
+            {
+                Content = new Grid(),
+                Style = new Style(typeof(Window))
+            };
+            bool closeRequested = false;
+            CancelEventHandler cancelClose = (sender, e) =>
+            {
+                closeRequested = true;
+                e.Cancel = true;
+            };
+
+            window.Closing += cancelClose;
+            window.Show();
+            window.Activate();
+            DrainDispatcher(window);
+
+            try
+            {
+                requestClose(window);
+                DrainDispatcher(window);
+                Assert.True(closeRequested);
+            }
+            finally
+            {
+                window.Closing -= cancelClose;
+                window.Close();
+            }
+        }
+
+        private static void DrainDispatcher(DispatcherObject dispatcherObject)
+        {
+#pragma warning disable VSTHRD001 // WpfFact already runs this synchronous test on its dedicated UI thread.
+            dispatcherObject.Dispatcher.Invoke(
+                DispatcherPriority.ApplicationIdle,
+                new Action(() => { }));
+#pragma warning restore VSTHRD001
+        }
+    }
+}

--- a/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
+++ b/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml
@@ -5,6 +5,7 @@
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
         Style="{DynamicResource CustomWindowStyle}"
         Closing="Window_Closing"
+        PreviewKeyDown="Window_PreviewKeyDown"
         Title="Web Browser" Height="700" Width="1100">
     <DockPanel Background="{DynamicResource ControlDefaultBackground}">
         <Grid DockPanel.Dock="Top" Background="{DynamicResource ControlDefaultBackground}">

--- a/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml.cs
+++ b/src/PerfView/GuiUtilities/WebBrowser/WebBrowser.xaml.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
 using Utilities;
@@ -59,7 +60,6 @@ namespace PerfView.GuiUtilities
         }
 
         #region private
-        private bool _disposed = false;
         private void BackClick(object sender, RoutedEventArgs e)
         {
             if (CanGoBack)
@@ -73,6 +73,34 @@ namespace PerfView.GuiUtilities
             if (CanGoForward)
             {
                 Browser.GoForward();
+            }
+        }
+
+        private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && Keyboard.Modifiers == ModifierKeys.None)
+            {
+                e.Handled = true;
+                Close();
+            }
+        }
+
+        private void Browser_WebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            ProcessWebMessage(e.WebMessageAsJson);
+        }
+
+        internal void ProcessWebMessage(string messageJson)
+        {
+            if (messageJson == CloseWindowMessageJson)
+            {
+                Dispatcher.BeginInvoke((Action)(() =>
+                {
+                    if (IsLoaded)
+                    {
+                        Close();
+                    }
+                }));
             }
         }
 
@@ -91,6 +119,12 @@ namespace PerfView.GuiUtilities
                 // Dispose WebView2 to prevent finalizer crashes
                 if (!_disposed)
                 {
+                    if (_webMessageHandlerAttached)
+                    {
+                        Browser.CoreWebView2.WebMessageReceived -= Browser_WebMessageReceived;
+                        _webMessageHandlerAttached = false;
+                    }
+
                     Browser?.Dispose();
                     _disposed = true;
                 }
@@ -125,6 +159,13 @@ namespace PerfView.GuiUtilities
                 var environment = environmentAwaiter.GetResult();
                 await Browser.EnsureCoreWebView2Async(environment).ConfigureAwait(true);
 
+                if (!_webMessageHandlerAttached)
+                {
+                    Browser.CoreWebView2.WebMessageReceived += Browser_WebMessageReceived;
+                    await Browser.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(CloseWindowOnEscapeScript).ConfigureAwait(true);
+                    _webMessageHandlerAttached = true;
+                }
+
                 // Set the preferred color scheme directly on the profile
                 Browser.CoreWebView2.Profile.PreferredColorScheme = GuiApp.MainWindow.ThemeViewModel.IsLightTheme
                     ? CoreWebView2PreferredColorScheme.Light
@@ -134,6 +175,21 @@ namespace PerfView.GuiUtilities
                 Navigate();
             });
         }
+
+        private const string CloseWindowMessage = "PerfView.CloseWindow";
+        private const string CloseWindowMessageJson = "\"" + CloseWindowMessage + "\"";
+        private const string CloseWindowOnEscapeScript = @"
+            window.addEventListener('keydown', function (event) {
+                if (event.key === 'Escape' &&
+                    !event.altKey &&
+                    !event.ctrlKey &&
+                    !event.metaKey &&
+                    !event.shiftKey) {
+                    window.chrome.webview.postMessage('PerfView.CloseWindow');
+                }
+            }, true);";
+        private bool _disposed = false;
+        private bool _webMessageHandlerAttached;
 
         #endregion
     }


### PR DESCRIPTION
The PerfView Help window could not be dismissed with the keyboard when focus was inside its WebView2 content.

## Summary
- Close the Help window with unmodified `Esc`
- Handle focus in both WPF controls and WebView2 content
- Add regression coverage for both input paths