### PR TITLE
Add TraceLog.TrimLiveSessionState to bound real time call stack growth

### DIFF
--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -354,6 +354,41 @@ namespace TraceEventTests
             return RecursiveWork(depth - 1) + depth;
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+#else
+        [Fact(Skip = "EventPipeSession connection is only available to target apps on .NET Core 3.0 or later")]
+#endif
+        public async Task TrimLiveSessionStateThrowsWhenCalledOffTheDispatchThread()
+        {
+            var client = new DiagnosticsClient(Process.GetCurrentProcess().Id);
+            var providers = new[]
+            {
+                new EventPipeProvider(SampleProfilerTraceEventParser.ProviderName, EventLevel.Informational),
+            };
+
+            using (var session = client.StartEventPipeSession(providers, requestRundown: false))
+            {
+                using (var traceSource = CreateFromEventPipeSession(session, EventPipeRundownConfiguration.None()))
+                {
+                    var traceLog = traceSource.TraceLog;
+
+                    // Wait until dispatching is under way, so we are asserting against a live dispatcher
+                    // rather than a session that has not started. The assertion below holds either way -
+                    // this thread is never the dispatch thread - so a timeout here is not a failure.
+                    var dispatching = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    traceSource.AllEvents += delegate (TraceEvent _) { dispatching.TrySetResult(true); };
+                    var processingTask = Task.Run(traceSource.Process);
+                    await Task.WhenAny(dispatching.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+
+                    Assert.Throws<InvalidOperationException>(() => traceLog.TrimLiveSessionState());
+
+                    session.Stop();
+                    await processingTask;
+                }
+            }
+        }
+
         [Fact]
         public void V1IsUnsupported()
         {

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -215,6 +216,139 @@ namespace TraceEventTests
                     await processingTask;
                 }
             }
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+#else
+        [Fact(Skip = "EventPipeSession connection is only available to target apps on .NET Core 3.0 or later")]
+#endif
+        public async Task ResetCallStacksDiscardsInternedStacksAndKeepsInterning()
+        {
+            // In a real time session the call stack interning tables grow for the lifetime of the
+            // session: every distinct stack observed is interned and nothing is released, so a long
+            // running session grows without bound.  ResetCallStacks discards them.
+            //
+            // This verifies both halves of the contract: the tables are actually emptied, and stacks
+            // observed afterwards are still interned and still resolve to methods.
+            const int MinimumInternedStacks = 8;
+
+            var client = new DiagnosticsClient(Process.GetCurrentProcess().Id);
+            var providers = new[]
+            {
+                new EventPipeProvider(SampleProfilerTraceEventParser.ProviderName, EventLevel.Informational),
+            };
+
+            using (var session = client.StartEventPipeSession(providers, requestRundown: false))
+            {
+                using (var traceSource = CreateFromEventPipeSession(session, EventPipeRundownConfiguration.Enable(client)))
+                {
+                    var traceLog = traceSource.TraceLog;
+                    var sampleEventParser = new SampleProfilerTraceEventParser(traceSource);
+
+                    int stacksBeforeReset = 0;
+                    int stacksAfterReset = -1;
+                    var stackAfterReset = new TaskCompletionSource<CallStackIndex>();
+
+                    sampleEventParser.ThreadSample += delegate (ClrThreadSampleTraceData e)
+                    {
+                        // ResetCallStacks has to run on the thread that processes events, which is the
+                        // thread this callback runs on.
+                        if (stacksAfterReset < 0)
+                        {
+                            // Let enough distinct stacks accumulate for the 'before' value to be meaningful.
+                            if (traceLog.CallStacks.Count < MinimumInternedStacks)
+                            {
+                                return;
+                            }
+
+                            stacksBeforeReset = traceLog.CallStacks.Count;
+                            traceLog.ResetCallStacks();
+                            stacksAfterReset = traceLog.CallStacks.Count;
+                            return;
+                        }
+
+                        // Anything interned after the reset must still be usable.
+                        CallStackIndex callStackIndex = e.CallStackIndex();
+                        if (callStackIndex != CallStackIndex.Invalid)
+                        {
+                            stackAfterReset.TrySetResult(callStackIndex);
+                        }
+                    };
+
+                    var processingTask = Task.Run(traceSource.Process);
+
+                    // Keep a little work running so the sampler sees a variety of stacks.
+                    var workDone = new CancellationTokenSource();
+                    var workTask = Task.Run(() =>
+                    {
+                        while (!workDone.IsCancellationRequested)
+                        {
+                            RecursiveWork(12);
+                        }
+                    });
+
+                    try
+                    {
+                        Task completed = await Task.WhenAny(stackAfterReset.Task, Task.Delay(TimeSpan.FromSeconds(60)));
+                        Assert.True(completed == stackAfterReset.Task,
+                            $"Timed out waiting for a call stack after the reset (interned before reset: {stacksBeforeReset}).");
+                    }
+                    finally
+                    {
+                        workDone.Cancel();
+                        await workTask;
+                    }
+
+                    Assert.True(stacksBeforeReset >= MinimumInternedStacks,
+                        $"Expected at least {MinimumInternedStacks} interned call stacks before the reset, saw {stacksBeforeReset}.");
+
+                    // The interning tables were emptied.
+                    Assert.Equal(0, stacksAfterReset);
+
+                    // ...and interning continued to work afterwards, all the way through to a method name.
+                    CallStackIndex postResetStack = await stackAfterReset.Task;
+                    CodeAddressIndex codeAddressIndex = traceLog.CallStacks.CodeAddressIndex(postResetStack);
+                    Assert.NotEqual(CodeAddressIndex.Invalid, codeAddressIndex);
+                    MethodIndex methodIndex = traceLog.CodeAddresses.MethodIndex(codeAddressIndex);
+                    Assert.NotEqual(MethodIndex.Invalid, methodIndex);
+                    Assert.NotEmpty(traceLog.CodeAddresses.Methods[methodIndex].FullMethodName);
+                    Assert.True(traceLog.CallStacks.Count > 0, "Expected the interning tables to refill after the reset.");
+
+                    // Every index in a post-reset stack must refer to the *new* table.  If any part of
+                    // the interning state survived the reset (for example the per-thread roots), stale
+                    // indexes from the old table leak back in here.  Those do not throw - GrowableArray
+                    // indexes its backing store without bounds checking against Count - so the stack
+                    // would silently resolve to the wrong frames.  Walking the whole chain and range
+                    // checking each link is what actually catches that.
+                    int stackCount = traceLog.CallStacks.Count;
+                    int depth = 0;
+                    for (CallStackIndex frame = postResetStack; frame != CallStackIndex.Invalid; frame = traceLog.CallStacks.Caller(frame))
+                    {
+                        Assert.InRange((int)frame, 0, stackCount - 1);
+                        Assert.True(++depth <= stackCount,
+                            "Walking the post-reset call stack did not terminate; the interning tables are inconsistent.");
+                    }
+
+                    session.Stop();
+                    await processingTask;
+                }
+            }
+        }
+
+        private static long RecursiveWork(int depth)
+        {
+            if (depth <= 0)
+            {
+                double sink = 0;
+                for (int i = 1; i < 10000; i++)
+                {
+                    sink += Math.Sqrt(i);
+                }
+                return (long)sink;
+            }
+
+            return RecursiveWork(depth - 1) + depth;
         }
 
         [Fact]

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -248,7 +248,10 @@ namespace TraceEventTests
 
                     int stacksBeforeReset = 0;
                     int stacksAfterReset = -1;
-                    var stackAfterReset = new TaskCompletionSource<CallStackIndex>();
+                    // RunContinuationsAsynchronously so awaiting this cannot resume inline on the
+                    // event processing thread - the continuation below stops the session and waits
+                    // on the processing task, which would deadlock if it ran on that thread.
+                    var stackAfterReset = new TaskCompletionSource<CallStackIndex>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     sampleEventParser.ThreadSample += delegate (ClrThreadSampleTraceData e)
                     {

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -223,11 +223,11 @@ namespace TraceEventTests
 #else
         [Fact(Skip = "EventPipeSession connection is only available to target apps on .NET Core 3.0 or later")]
 #endif
-        public async Task ResetCallStacksDiscardsInternedStacksAndKeepsInterning()
+        public async Task TrimLiveSessionStateDiscardsInternedStacksAndKeepsInterning()
         {
             // In a real time session the call stack interning tables grow for the lifetime of the
             // session: every distinct stack observed is interned and nothing is released, so a long
-            // running session grows without bound.  ResetCallStacks discards them.
+            // running session grows without bound.  TrimLiveSessionState discards them.
             //
             // This verifies both halves of the contract: the tables are actually emptied, and stacks
             // observed afterwards are still interned and still resolve to methods.
@@ -255,7 +255,7 @@ namespace TraceEventTests
 
                     sampleEventParser.ThreadSample += delegate (ClrThreadSampleTraceData e)
                     {
-                        // ResetCallStacks has to run on the thread that processes events, which is the
+                        // TrimLiveSessionState has to run on the thread that processes events, which is the
                         // thread this callback runs on.
                         if (stacksAfterReset < 0)
                         {
@@ -266,7 +266,7 @@ namespace TraceEventTests
                             }
 
                             stacksBeforeReset = traceLog.CallStacks.Count;
-                            traceLog.ResetCallStacks();
+                            traceLog.TrimLiveSessionState();
                             stacksAfterReset = traceLog.CallStacks.Count;
                             return;
                         }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -7864,12 +7864,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </summary>
         internal void Clear()
         {
-            // Deliberately assign fresh arrays rather than calling GrowableArray.Clear().  Clear()
-            // only resets the length, so the backing arrays would survive - and for 'callees' and
-            // 'threads' those arrays hold references to every List<CallStackIndex> ever created,
-            // which is the bulk of the memory we are trying to release.
-            // InternCallStackIndex reallocates callStacks/callees on its next call, and 'threads'
-            // grows on demand, so no explicit re-initialization is needed here.
+            // GrowableArray.Clear() only resets the length, so assign fresh arrays to actually
+            // release the memory - callees and threads reference every List ever created.
             callStacks = new GrowableArray<CallStackInfo>();
             callees = new GrowableArray<List<CallStackIndex>>();
             threads = new GrowableArray<List<CallStackIndex>>();

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -976,6 +976,43 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
 
         /// <summary>
+        /// Discards every call stack interned so far, releasing the memory held by the call stack
+        /// interning tables (see <see cref="CallStacks"/>).
+        /// <para>
+        /// In a real time session those tables grow for the lifetime of the session: every distinct
+        /// call stack that is observed is interned and nothing is ever released.  For a long running
+        /// process with diverse stacks that growth is unbounded.  Trace files do not have this problem
+        /// because the session is finite, which is why this is restricted to real time sessions.
+        /// </para>
+        /// <para>
+        /// Every <see cref="CallStackIndex"/> obtained before this call is invalidated and must not be
+        /// used afterwards, so only call this when no such index is still live.  Call stacks observed
+        /// after the call are interned from scratch, so no information is lost going forward - only
+        /// the ability to resolve indexes handed out earlier.
+        /// </para>
+        /// <para>
+        /// Must be called from the thread that processes events (for example from within an event
+        /// callback).  Calling it concurrently with event processing races with call stack interning.
+        /// </para>
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The TraceLog is not a real time session.</exception>
+        public void ResetCallStacks()
+        {
+            if (!IsRealTime)
+            {
+                throw new InvalidOperationException("ResetCallStacks is only supported for real time sessions.");
+            }
+
+            callStacks.Clear();
+
+            // These map events to the call stack indexes we have just invalidated, so they cannot be
+            // allowed to survive.  On the EventPipe real time path they are already cleared after every
+            // event; on the ETW path FlushRealTimeEvents only trims them, so clear them explicitly.
+            eventsToStacks.Clear();
+            cswitchBlockingEventsToStacks.Clear();
+        }
+
+        /// <summary>
         /// Given a process's virtual address 'address' and an event which acts as a
         /// context (determines which process and what time in that process), return
         /// a CodeAddressIndex (which represents a particular location in a particular
@@ -7819,6 +7856,24 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         internal void SetSize(int origSize)
         {
             callStacks.RemoveRange(origSize, callStacks.Count - origSize);
+        }
+
+        /// <summary>
+        /// Discards every interned call stack, returning the interning tables to their initial state.
+        /// Only meaningful for a real time session, where these tables would otherwise grow for the
+        /// lifetime of the session.  See <see cref="TraceLog.ResetCallStacks"/>.
+        /// </summary>
+        internal void Clear()
+        {
+            // Deliberately assign fresh arrays rather than calling GrowableArray.Clear().  Clear()
+            // only resets the length, so the backing arrays would survive - and for 'callees' and
+            // 'threads' those arrays hold references to every List<CallStackIndex> ever created,
+            // which is the bulk of the memory we are trying to release.
+            // InternCallStackIndex reallocates callStacks/callees on its next call, and 'threads'
+            // grows on demand, so no explicit re-initialization is needed here.
+            callStacks = new GrowableArray<CallStackInfo>();
+            callees = new GrowableArray<List<CallStackIndex>>();
+            threads = new GrowableArray<List<CallStackIndex>>();
         }
 
         /// <summary>

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -7864,8 +7864,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </summary>
         internal void Clear()
         {
-            // GrowableArray.Clear() only resets the length, so assign fresh arrays to actually
-            // release the memory - callees and threads reference every List ever created.
+            // GrowableArray.Clear() only resets the length so we have to assign fresh arrays
             callStacks = new GrowableArray<CallStackInfo>();
             callees = new GrowableArray<List<CallStackIndex>>();
             threads = new GrowableArray<List<CallStackIndex>>();

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -976,8 +976,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
 
         /// <summary>
-        /// Discards every call stack interned so far, releasing the memory held by the call stack
-        /// interning tables (see <see cref="CallStacks"/>).
+        /// Releases the state a live session can afford to discard.  Today that is the call stack
+        /// interning tables (see <see cref="CallStacks"/>); more may be trimmed here in future.
         /// <para>
         /// In a real time session those tables grow for the lifetime of the session: every distinct
         /// call stack that is observed is interned and nothing is ever released.  For a long running
@@ -996,11 +996,11 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </para>
         /// </summary>
         /// <exception cref="InvalidOperationException">The TraceLog is not a real time session.</exception>
-        public void ResetCallStacks()
+        public void TrimLiveSessionState()
         {
             if (!IsRealTime)
             {
-                throw new InvalidOperationException("ResetCallStacks is only supported for real time sessions.");
+                throw new InvalidOperationException("TrimLiveSessionState is only supported for real time sessions.");
             }
 
             callStacks.Clear();
@@ -7860,7 +7860,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// <summary>
         /// Discards every interned call stack, returning the interning tables to their initial state.
         /// Only meaningful for a real time session, where these tables would otherwise grow for the
-        /// lifetime of the session.  See <see cref="TraceLog.ResetCallStacks"/>.
+        /// lifetime of the session.  See <see cref="TraceLog.TrimLiveSessionState"/>.
         /// </summary>
         internal void Clear()
         {

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1008,6 +1008,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             // These map events to the call stack indexes we have just invalidated, so they cannot be
             // allowed to survive.  On the EventPipe real time path they are already cleared after every
             // event; on the ETW path FlushRealTimeEvents only trims them, so clear them explicitly.
+            // Clearing the length is enough here - these hold structs, so nothing is retained.
             eventsToStacks.Clear();
             cswitchBlockingEventsToStacks.Clear();
         }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1023,8 +1023,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// </para>
         /// <para>
         /// Must be called from within an event callback, on the thread dispatching that event.  Calling
-        /// it concurrently with event processing would race with call stack interning, so this is
-        /// enforced rather than merely documented.
+        /// it concurrently with event processing would race with call stack interning
         /// </para>
         /// </summary>
         /// <exception cref="InvalidOperationException">

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -1005,10 +1005,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             callStacks.Clear();
 
-            // These map events to the call stack indexes we have just invalidated, so they cannot be
-            // allowed to survive.  On the EventPipe real time path they are already cleared after every
-            // event; on the ETW path FlushRealTimeEvents only trims them, so clear them explicitly.
-            // Clearing the length is enough here - these hold structs, so nothing is retained.
+            // These map events to the indexes we just invalidated, so also need clearing.
+            // A length reset is enough here - they hold structs, so nothing is retained.
             eventsToStacks.Clear();
             cswitchBlockingEventsToStacks.Clear();
         }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -384,7 +384,15 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             // We need to look up the event to get the dispatch Target assigned.
             TraceEvent rtEvent = realTimeSource.Lookup(data.eventRecord);
-            realTimeSource.Dispatch(rtEvent);
+            m_DispatchThreadID = Thread.CurrentThread.ManagedThreadId;
+            try
+            {
+                realTimeSource.Dispatch(rtEvent);
+            }
+            finally
+            {
+                m_DispatchThreadID = -1;
+            }
 
             // Clean up interim data structures - they're not necessary after the event has been processed (Dispatched).
             eventsToStacks.Clear();
@@ -871,6 +879,27 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
 
         /// <summary>
+        /// The managed thread ID of the thread currently dispatching an event to the real time source,
+        /// or -1 when no dispatch is in progress.
+        /// </summary>
+        private int m_DispatchThreadID = -1;
+
+        /// <summary>
+        /// Throws unless the caller is running on the thread that is currently dispatching an event.
+        /// Operations that mutate state the dispatcher is actively using can only run from within an
+        /// event callback, and this is how they enforce it.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The caller is not on the dispatch thread.</exception>
+        internal void ThrowIfNotRunningOnDispatchThread()
+        {
+            if (m_DispatchThreadID != Thread.CurrentThread.ManagedThreadId)
+            {
+                throw new InvalidOperationException(
+                    "This operation must be called from within an event callback, on the thread dispatching the event.");
+            }
+        }
+
+        /// <summary>
         /// Removes all but the last 'keepCount' entries in 'growableArray' by sliding them down.
         /// </summary>
         private static void RemoveAllButLastEntries<T>(ref GrowableArray<T> growableArray, int keepCount)
@@ -886,6 +915,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             realTimeEvent = toSend;
             TraceEvent eventInRealTimeSource = null;
+            m_DispatchThreadID = Thread.CurrentThread.ManagedThreadId;
             try
             {
                 eventInRealTimeSource = realTimeSource.Lookup(toSend.eventRecord);
@@ -897,6 +927,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             finally
             {
                 realTimeEvent = null;
+                m_DispatchThreadID = -1;
             }
 
             // Optimization, remove 'toSend' from the finalization queue.
@@ -991,17 +1022,22 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         /// the ability to resolve indexes handed out earlier.
         /// </para>
         /// <para>
-        /// Must be called from the thread that processes events (for example from within an event
-        /// callback).  Calling it concurrently with event processing races with call stack interning.
+        /// Must be called from within an event callback, on the thread dispatching that event.  Calling
+        /// it concurrently with event processing would race with call stack interning, so this is
+        /// enforced rather than merely documented.
         /// </para>
         /// </summary>
-        /// <exception cref="InvalidOperationException">The TraceLog is not a real time session.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The TraceLog is not a real time session, or the caller is not on the dispatch thread.
+        /// </exception>
         public void TrimLiveSessionState()
         {
             if (!IsRealTime)
             {
                 throw new InvalidOperationException("TrimLiveSessionState is only supported for real time sessions.");
             }
+
+            ThrowIfNotRunningOnDispatchThread();
 
             callStacks.Clear();
 


### PR DESCRIPTION
## Background

The .NET runtime includes [EventPipe](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/eventpipe) which creates a *nettrace* stream for runtime events that are used for profiling. `TraceLog`, from the TraceEvent library in PerfView, turns those raw events into something symbolic — it tracks processes, threads, modules, methods and code addresses so that `TraceEvent.CallStack()` returns frames rather than hex addresses.

Call stacks are the bulk of that data and the most redundant: consecutive samples usually share almost every frame. So `TraceCallStacks` does not store stacks, it interns them into a prefix tree. Each node is `CallStackInfo { codeAddressIndex, callerIndex }`, a whole stack is identified by a single `CallStackIndex`. This structure is maintained in three arrays: `callStacks` (nodes), `callees` (each node's children, searched when interning) and `threads` (per-thread roots).

For a trace **file** this works really well. The input is finite, and while you are analysing it you want every stack it contains to stay resolvable, so the tree is deliberately a cache with no eviction.

## Real time use case

microsoft/perfview#1867 added streaming / in-memory EventPipe support, and microsoft/perfview#2169 added the rundown-provider API that lets frames resolve mid-session. Those made `TraceLog` usable against a live session rather than a file — which is what continuous profilers need, and what the Sentry .NET SDK is built on.

The data model came along unchanged. `InternCallStackIndex` still appends, and nothing is ever released. If you point that at a server process that runs for weeks then the tree grows for the life of the session (i.e. indefinitely).

Additionally:

- **It grows with stack *diversity*, not sample volume.** Repeated stacks are free — they resolve to   an existing node. Every new stack *shape* appends nodes. A fresh async state machine, a new code path, a JIT'd generic each add more, so a busy service keeps minting them indefinitely.
- **It grows whether or not anyone is consuming stacks.** The session interns everything it sees, so   a profiler that samples 10% of transactions pays the same growth as one that samples all of them.

## This is already known

- microsoft/perfview#1199 reported the same `CallStackInfo[]` growth in 2022. It was closed as not  planned because the original reporter stopped seeing it, not because it was resolved or ruled out. 
- microsoft/perfview#2451 was opened recently by a Sentry customer running into this issue. 
- `FlushRealTimeEvents` already carries deliberate memory management for real time sessions ([TraceLog.cs#L952-L955](https://github.com/microsoft/perfview/blob/af227405c475b7d8a04f2a4353bc28fccc379b3a/src/TraceEvent/TraceLog.cs#L952-L955)):

  > Try to keep our memory under control by removing old data.
  > Lots of data structures in TraceLog can grow over time.
  > However currently we only trim three, all CAN grow on every event (so they grow most quickly of
  > all data structures) and we know they are not needed after dispatched the events they are for.

The three it trims are the small event-to-stack maps. **This PR adds a fourth — the largest one**, roughly fourteen times the size of the next biggest structure in the dump above.

## The change

The addition of a new `TraceLog.TrimLiveSessionState()` method that discards the interned call stacks and returns the tree to its initial state.

**It is inert for every existing consumer.** It is opt in, nothing calls it, no existing behaviour changes, and it throws outside a real time session.

Two implementation details worth review attention:

1. It assigns **fresh** `GrowableArray`s rather than calling `GrowableArray.Clear()`. `Clear()` only resets the length and keeps the backing store — and for `callees` and `threads` that store holds a reference to every child `List<CallStackIndex>` ever created, which is the bulk of the memory being released.
2. It also clears `eventsToStacks` and `cswitchBlockingEventsToStacks`, which map events to the indexes just invalidated. Those hold plain structs, so a length reset genuinely is enough there — they are cleared for correctness, not for memory.

## Measured

Synthetic workload, 600 s, real time EventPipe session, .NET 9, Linux container:

| | without reset | with reset |
|---|--:|--:|
| interned call stacks at 600 s | 1,231,862, still climbing | bounded, cycling 919 – 7,121 |
| managed heap | 3.4 → 119.2 MiB | 3.5 → ~7 MiB, flat |
| RSS | 65.2 → 200.7 MiB | 65.6 → 81.4 MiB |
| samples processed | 307,418 | 340,987 |

After warm up the reset run moved **+2.1 MiB over 9 minutes and 174 resets** — about 0.012 MiB per reset. Sample throughput went *up*, because the baseline spends real time growing and collecting those tables. The workload is deliberately far more stack-diverse than a real service, to make the effect measurable in minutes; the shape matches the field report below, the rate is exaggerated.

From the field — getsentry/sentry-dotnet#5469, an ASP.NET Core service on Linux growing ~0.6 GB/day until the kernel OOM-killed it at ~8 days of uptime. `dotnet-gcdump` showed the two halves of this tree at **exactly** the same size:

```
35,087,256   CallStackInfo[]
35,087,256   List<CallStackIndex>[]
 2,548,664   MethodInfo[]
 2,548,536   CodeAddressInfo[]
```

Setting the profile sample rate to 0 — the only thing that stops a session being created at all — cured it completely, with every TraceEvent type disappearing from the heap.

## Why the other tables are left alone

`codeAddresses`, `methods` and `ILToNativeMap` also grow, and are deliberately untouched.

Clearing them would be **irreversible**. The rundown that populates method names for code JIT'd *before* the session started runs once, as a separate short-lived session at `TraceLog` creation, and cannot be re-run against a live session.

They are not *strictly* bounded — tiered compilation, expression trees, `RegexOptions.Compiled` and reflection emit all mint new methods over time — so a residual, much smaller growth remains for apps doing continuous runtime codegen.

Addressing this needs a different mechanism, and is left as separate work.

## The contract `TrimLiveSessionState` asks of callers

Universal preconditions:
1. No `CallStackIndex` obtained earlier may still be in use
2. It must be called from within an event callback, on the thread dispatching that event.
   This is now enforced rather than merely documented — `TrimLiveSessionState` calls
   `ThrowIfNotRunningOnDispatchThread()`, which validates against the dispatcher's thread ID.

What is *not* universal is when a given consumer can know its indexes are dead — a consumer that resolves synchronously in the callback can reset between any two events, while one that caches by index can only do so between cache lifetimes. That depends entirely on its own retention pattern, so the API states the invariant and leaves the timing to the caller.

This is also why we've added an explicit method rather than, say, a `MaxCallStackCount` property that resets itself inside the event pump. 

The dispatch-thread check is deliberately generic rather than named for this feature: `TraceLog` now tracks the thread ID of the in-progress dispatch on both real time paths (EventPipe, and the cloned-event ETW path), so other operations that mutate state the dispatcher is actively using can reuse the same guard.

## Test

`EventPipeParsing.TrimLiveSessionStateDiscardsInternedStacksAndKeepsInterning`, modelled on the existing
`SessionStreaming` test. It starts a real time session, lets stacks accumulate, resets from inside the sample callback, then asserts both halves of the contract: the tables are emptied, *and* stacks interned afterwards still resolve through to a method name.

It also walks the entire post-reset caller chain, range checking every link. That is deliberate — `GrowableArray`'s indexer only guards with `Debug.Assert`, so in Release a stale index reads the backing store and silently resolves to the wrong frame instead of throwing. Asserting one frame resolves is not enough to catch that; walking the chain is.

Runs in ~350 ms, and is skipped below .NET Core 3.0 like its neighbour.

`TrimLiveSessionStateThrowsWhenCalledOffTheDispatchThread` covers the enforcement from the other side: calling from the test thread while a dispatch is live throws. Together the two pin both halves — the guard admits the legitimate in-callback call and rejects the off-thread one.

**A known gap, flagged deliberately.** The test does not fail if `threads` is left uncleared — verified this by mutation. Stale per-thread roots resolve to `default(CallStackInfo)`, whose code address index is 0, which is almost never a valid/real address, so they sit inert and get appended to. The consequence is retained memory plus a rare correctness risk (a code-address-0 collision, or `IndexOutOfRangeException` once a stale index exceeds the new capacity) rather than deterministic corruption. A memory-based test would cover it but seems a poor trade for CI time. Suggestions welcome.

