### PR TITLE
Fix Crash Opening OS Heap Allocation Stacks

### DIFF
--- a/src/PerfView.Tests/Dialogs/XamlMessageBoxTests.cs
+++ b/src/PerfView.Tests/Dialogs/XamlMessageBoxTests.cs
@@ -18,6 +18,7 @@ namespace PerfViewTests.Dialogs
         /// to the UI thread when called from a background thread, rather than throwing
         /// "The calling thread must be STA, because many UI components require this."
         /// Also verifies that calling from the UI thread directly still works (no-op dispatch).
+        /// An owner which has never been shown must also be ignored rather than assigned.
         /// This is the core regression test for issue #2300.
         /// </summary>
 #pragma warning disable VSTHRD200 // Keep the original regression test name stable.
@@ -35,7 +36,15 @@ namespace PerfViewTests.Dialogs
             // Part 1: Call directly from the UI thread (dispatch is a no-op).
             MessageBoxResult uiResult = XamlMessageBox.Show("Test message", "XamlMBTest_UI", MessageBoxButton.OK);
 
-            // Part 2: Call from a background thread — before the fix for issue #2300,
+            // Part 2: Use an owner that has not been shown.
+            Window unshownOwner = new Window();
+            MessageBoxResult unshownOwnerResult = XamlMessageBox.Show(
+                unshownOwner,
+                "Test message",
+                "XamlMBTest_UnshownOwner",
+                MessageBoxButton.OK);
+
+            // Part 3: Call from a background thread — before the fix for issue #2300,
             // this would throw InvalidOperationException ("The calling thread must be STA")
             // because XamlMessageBox creates a WPF Window requiring the UI thread.
             Task<MessageBoxResult> backgroundShowTask = Task.Run(() =>
@@ -48,9 +57,11 @@ namespace PerfViewTests.Dialogs
 
             MessageBoxResult bgResult = await backgroundShowTask;
 
-            // Both dialogs were auto-closed without clicking a button, so Result is None.
+            // All dialogs were auto-closed without clicking a button, so Result is None.
             Assert.Equal(MessageBoxResult.None, uiResult);
+            Assert.Equal(MessageBoxResult.None, unshownOwnerResult);
             Assert.Equal(MessageBoxResult.None, bgResult);
+            Assert.False(unshownOwner.IsLoaded);
         }
 
         private static bool s_autoCloseHandlerRegistered;

--- a/src/PerfView/Dialogs/XamlMessageBox.cs
+++ b/src/PerfView/Dialogs/XamlMessageBox.cs
@@ -57,7 +57,7 @@ public static class XamlMessageBox
         }
 
         MessageBoxWindow window = new(message, caption, buttons, icon, defaultResult);
-        if (owner is not null)
+        if (owner?.IsLoaded == true)
         {
             window.Owner = owner;
         }

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -7685,7 +7685,7 @@ namespace PerfView
                 if (App.UserConfigData["WarnedAboutOsHeapAllocTypes"] == null)
                 {
                     XamlMessageBox.Show(
-                        stackWindow,
+                        stackWindow.ParentWindow,
                         """
                         Warning: Allocation type resolution only happens on window launch.
                         Thus if you manually lookup symbols in this view you will get method


### PR DESCRIPTION
## Summary

PerfView can crash the first time **Net OS Heap Alloc Stacks** is opened because its warning dialog assigns a stack window that has not yet been shown as the WPF owner.

- Prevent `XamlMessageBox` from assigning an owner that has not been shown.
- Use the visible parent window for the OS heap allocation warning.
- Add regression coverage for unshown dialog owners.