### PR TITLE
Enable GitHub Source Link for mirrored official builds

### DIFF
--- a/.pipelines/mirror.yml
+++ b/.pipelines/mirror.yml
@@ -104,6 +104,20 @@ extends:
             inputs:
               script: 'git checkout $(SourceBranch)'
 
+          - task: PowerShell@1
+            displayName: 'Record GitHub Commit'
+            inputs:
+              scriptType: inlineScript
+              inlineScript: |
+                $githubCommit = (git rev-parse HEAD).Trim()
+                if ($LASTEXITCODE -ne 0 -or $githubCommit -notmatch '^[0-9a-f]{40}$')
+                {
+                  Write-Error "Failed to resolve the GitHub commit."
+                  exit 1
+                }
+
+                Write-Host "##vso[task.setvariable variable=GitHubCommit;]$githubCommit"
+
           - task: CmdLine@2
             displayName: 'Create Mirror Branch'
             inputs:
@@ -119,6 +133,51 @@ extends:
             displayName: 'Pull AzDO SourceBranch'
             inputs:
               script: 'git pull --strategy=recursive --strategy-option no-renames https://x-access-token:$(AzdoToken)@devdiv.visualstudio.com/DevDiv/_git/perfView $(SourceBranch)'
+
+          - task: PowerShell@1
+            displayName: 'Record GitHub Commit Metadata'
+            inputs:
+              scriptType: inlineScript
+              inlineScript: |
+                $ErrorActionPreference = 'Stop'
+                $existingCommit = @(
+                  Get-Content internal/.github-last-mirrored-commit -ErrorAction SilentlyContinue |
+                    Where-Object { $_ -and -not $_.TrimStart().StartsWith('#') }
+                )
+                if ($existingCommit.Count -eq 1)
+                {
+                  git merge-base --is-ancestor $existingCommit[0] $(GitHubCommit)
+                  if ($LASTEXITCODE -eq 1)
+                  {
+                    Write-Error "The previously mirrored GitHub commit is not an ancestor of the commit being mirrored. This may indicate that mirror runs completed out of order or that GitHub history was rewritten; refusing to replace the recorded commit."
+                    exit 1
+                  }
+                  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+                }
+                elseif ($existingCommit.Count -gt 1)
+                {
+                  Write-Error "The mirrored GitHub commit metadata contains multiple commit values."
+                  exit 1
+                }
+
+                $metadata = @(
+                  '# This file is updated by .pipelines/mirror.yml when GitHub main is mirrored to Azure DevOps.'
+                  '# Do not update this file manually.'
+                  '$(GitHubCommit)'
+                )
+                Set-Content -Path internal/.github-last-mirrored-commit -Value $metadata -Encoding Ascii
+                git add internal/.github-last-mirrored-commit
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+                git diff --cached --quiet
+                if ($LASTEXITCODE -eq 1)
+                {
+                  git commit -m "Update mirrored GitHub commit"
+                  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+                }
+                elseif ($LASTEXITCODE -ne 0)
+                {
+                  exit $LASTEXITCODE
+                }
 
           - task: CmdLine@2
             displayName: 'Run git push'

--- a/.pipelines/perfview-job.yml
+++ b/.pipelines/perfview-job.yml
@@ -1,5 +1,7 @@
 parameters:
   flavor: 'Debug'
+  sourceLinkRepositoryUrl: ''
+  sourceLinkRevisionId: ''
 
 steps:
 - task: UseDotNet@2
@@ -8,12 +10,21 @@ steps:
     version: 8.0.x
 
 - task: MSBuild@1
+  displayName: 'Restore PerfView.sln'
+  inputs:
+    solution: PerfView.sln
+    maximumCpuCount: true
+    msbuildArchitecture: 'x64'
+    msbuildArguments: '/t:restore'
+    configuration: ${{ parameters.flavor }}
+
+- task: MSBuild@1
   displayName: 'Build PerfView.sln'
   inputs:
     solution: PerfView.sln
     maximumCpuCount: true
     msbuildArchitecture: 'x64'
-    msbuildArguments: '/restore'
+    msbuildArguments: '/p:SourceLinkRepositoryUrl=${{ parameters.sourceLinkRepositoryUrl }} /p:SourceLinkRevisionId=${{ parameters.sourceLinkRevisionId }}'
     configuration: ${{ parameters.flavor }}
 
 - task: VisualStudioTestPlatformInstaller@1

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,4 +6,47 @@
     <None Include="$(AppDesignerFolder)\launchSettings.json" Condition="Exists('$(AppDesignerFolder)\launchSettings.json')" />
   </ItemGroup>
 
+  <!--
+    Official and internal CI builds resolve the equivalent GitHub commit before invoking
+    MSBuild. Set the standard repository properties early so assembly and package metadata
+    use the same GitHub identity as the PDB.
+  -->
+  <PropertyGroup Condition="'$(SourceLinkRevisionId)' != ''">
+    <RepositoryUrl>$(SourceLinkRepositoryUrl)</RepositoryUrl>
+    <SourceRevisionId>$(SourceLinkRevisionId)</SourceRevisionId>
+  </PropertyGroup>
+
+  <!-- Reject partial overrides instead of generating a PDB with mixed repository metadata. -->
+  <Target Name="ValidateGitHubSourceLinkOverride"
+          BeforeTargets="InitializeSourceControlInformation"
+          Condition="'$(SourceLinkRepositoryUrl)' != '' or '$(SourceLinkRevisionId)' != ''">
+    <Error Condition="'$(SourceLinkRepositoryUrl)' == ''"
+           Text="SourceLinkRepositoryUrl must be set when SourceLinkRevisionId is set." />
+    <Error Condition="'$(SourceLinkRevisionId)' == ''"
+           Text="SourceLinkRevisionId must be set when SourceLinkRepositoryUrl is set." />
+  </Target>
+
+  <!--
+    Git source discovery reads the Azure DevOps checkout. After source control information is
+    initialized, replace that discovered identity before Source Link generates its mapping.
+  -->
+  <Target Name="OverrideGitHubSourceLink"
+          AfterTargets="InitializeSourceControlInformation"
+          Condition="'$(SourceLinkRepositoryUrl)' != '' and '$(SourceLinkRevisionId)' != ''">
+    <PropertyGroup>
+      <PrivateRepositoryUrl>$(SourceLinkRepositoryUrl)</PrivateRepositoryUrl>
+      <ScmRepositoryUrl>$(SourceLinkRepositoryUrl)</ScmRepositoryUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Only rewrite this repository's root. Nested repositories retain their own identity. -->
+      <SourceRoot Update="@(SourceRoot)"
+                  Condition="'%(SourceRoot.SourceControl)' == 'git' and '%(SourceRoot.ContainingRoot)' == ''">
+        <RepositoryUrl>$(SourceLinkRepositoryUrl)</RepositoryUrl>
+        <ScmRepositoryUrl>$(SourceLinkRepositoryUrl)</ScmRepositoryUrl>
+        <RevisionId>$(SourceLinkRevisionId)</RevisionId>
+      </SourceRoot>
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
PerfView and TraceEvent official builds run from the internal Azure DevOps mirror. Source Link therefore discovers the internal repository and emits Azure DevOps source URLs, even though the projects are developed publicly on GitHub.

This change enables internal builds to supply the corresponding GitHub repository and revision while leaving normal GitHub and local builds unchanged.