### PR TITLE
Update Azure Pipelines VSTest task to v3

### DIFF
--- a/.pipelines/perfview-job.yml
+++ b/.pipelines/perfview-job.yml
@@ -23,7 +23,7 @@ steps:
     packageFeedSelector: 'customFeed'
     customFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json'
 
-- task: VSTest@2
+- task: VSTest@3
   displayName: 'Run Tests'
   inputs:
     testAssemblyVer2: |

--- a/.pipelines/perfview-job.yml
+++ b/.pipelines/perfview-job.yml
@@ -36,6 +36,7 @@ steps:
     testRunTitle: 'PerfView - ${{ parameters.flavor }}'
     vsTestVersion: 'toolsInstaller'
     runTestsInIsolation: true
+    donotPublishTestResults: true
     otherConsoleOptions: '--blame'
 
 - task: CopyFiles@2


### PR DESCRIPTION
Updates the shared PerfView build job from `VSTest@2` to the current `VSTest@3` task and disables uploading of data to Azure DevOps, which is currently failing.

CI status is still correct - we just won't get AzDO test execution analysis.