### PR TITLE
Harden GNU Debuglink Parsing And Path Handling

### DIFF
--- a/src/PerfView.Tests/Memory/PathUtilitiesTests.cs
+++ b/src/PerfView.Tests/Memory/PathUtilitiesTests.cs
@@ -130,6 +130,30 @@ namespace PerfViewTests.Memory
         {
             Assert.Equal(expected, PathUtilities.SanitizeFileName(input));
         }
+
+        [Theory]
+        [InlineData("foo.debug")]
+        [InlineData("My Provider")]
+        [InlineData("provider.with.dots")]
+        public void IsSafeFileName_AcceptsNamesThatNeedNoSanitization(string input)
+        {
+            Assert.True(PathUtilities.IsSafeFileName(input));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(".")]
+        [InlineData("..")]
+        [InlineData("../outside")]
+        [InlineData(@"..\outside")]
+        [InlineData("with:stream")]
+        [InlineData("with?wildcard")]
+        [InlineData("Trailing.")]
+        [InlineData("NUL.debug")]
+        public void IsSafeFileName_RejectsNamesThatWouldBeSanitized(string input)
+        {
+            Assert.False(PathUtilities.IsSafeFileName(input));
+        }
     }
 }
-

--- a/src/TraceEvent/Symbols/ElfSymbolModule.cs
+++ b/src/TraceEvent/Symbols/ElfSymbolModule.cs
@@ -251,6 +251,12 @@ namespace Microsoft.Diagnostics.Symbols
 
                     // Read all section headers in one bulk read.
                     int shTableSize = hdr.ShCount * hdr.ShEntrySize;
+                    if (!IsValidFileRange(stream, hdr.ShOffset, (ulong)shTableSize))
+                    {
+                        Debug.WriteLine("ReadDebugLink: Section headers are outside the file.");
+                        return null;
+                    }
+
                     byte[] shTable = new byte[shTableSize];
                     stream.Seek((long)hdr.ShOffset, SeekOrigin.Begin);
                     if (ReadFully(stream, shTable, 0, shTableSize) < shTableSize)
@@ -266,6 +272,12 @@ namespace Microsoft.Diagnostics.Symbols
                     if (shstrSize == 0 || shstrSize > MaxShstrtabSize)
                     {
                         Debug.WriteLine("ReadDebugLink: Invalid shstrtab size.");
+                        return null;
+                    }
+
+                    if (!IsValidFileRange(stream, shstrOffset, shstrSize))
+                    {
+                        Debug.WriteLine("ReadDebugLink: shstrtab is outside the file.");
                         return null;
                     }
 
@@ -303,6 +315,12 @@ namespace Microsoft.Diagnostics.Symbols
                             return null;
                         }
 
+                        if (!IsValidFileRange(stream, secOffset, secSize))
+                        {
+                            Debug.WriteLine("ReadDebugLink: .gnu_debuglink section is outside the file.");
+                            return null;
+                        }
+
                         byte[] sectionData = new byte[(int)secSize];
                         stream.Seek((long)secOffset, SeekOrigin.Begin);
                         if (ReadFully(stream, sectionData, 0, sectionData.Length) < sectionData.Length)
@@ -311,15 +329,13 @@ namespace Microsoft.Diagnostics.Symbols
                             return null;
                         }
 
-                        // Extract the null-terminated filename.
-                        int nullPos = Array.IndexOf(sectionData, (byte)0);
-                        if (nullPos <= 0)
+                        if (!TryParseDebugLinkSection(sectionData, out string debugLink))
                         {
-                            Debug.WriteLine("ReadDebugLink: Empty or missing filename in .gnu_debuglink.");
+                            Debug.WriteLine("ReadDebugLink: Invalid .gnu_debuglink section data.");
                             return null;
                         }
 
-                        return Encoding.UTF8.GetString(sectionData, 0, nullPos);
+                        return debugLink;
                     }
 
                     Debug.WriteLine("ReadDebugLink: No .gnu_debuglink section found.");
@@ -337,6 +353,104 @@ namespace Microsoft.Diagnostics.Symbols
 
         // Name of the .gnu_debuglink section (UTF-8 bytes for fast comparison).
         private static readonly byte[] GnuDebugLinkName = Encoding.UTF8.GetBytes(".gnu_debuglink");
+        private static readonly UTF8Encoding StrictUtf8 = new UTF8Encoding(false, true);
+
+        /// <summary>
+        /// Returns whether <paramref name="fileName"/> is a platform-independent single file name.
+        /// </summary>
+        internal static bool IsValidDebugLinkFileName(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName) ||
+                fileName == "." ||
+                fileName == ".." ||
+                fileName[fileName.Length - 1] == ' ' ||
+                fileName[fileName.Length - 1] == '.')
+            {
+                return false;
+            }
+
+            for (int i = 0; i < fileName.Length; i++)
+            {
+                char c = fileName[i];
+                if (c < 0x20 || c == '<' || c == '>' || c == ':' || c == '"' ||
+                    c == '/' || c == '\\' || c == '|' || c == '?' || c == '*')
+                {
+                    return false;
+                }
+            }
+
+            // Windows treats these names as devices even when an extension is present.
+            int extensionPos = fileName.IndexOf('.');
+            string baseName = extensionPos >= 0 ? fileName.Substring(0, extensionPos) : fileName;
+            if (baseName.Equals("CON", StringComparison.OrdinalIgnoreCase) ||
+                baseName.Equals("PRN", StringComparison.OrdinalIgnoreCase) ||
+                baseName.Equals("AUX", StringComparison.OrdinalIgnoreCase) ||
+                baseName.Equals("NUL", StringComparison.OrdinalIgnoreCase) ||
+                IsNumberedDeviceName(baseName, "COM") ||
+                IsNumberedDeviceName(baseName, "LPT"))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool IsNumberedDeviceName(string fileName, string prefix)
+        {
+            return fileName.Length == prefix.Length + 1 &&
+                   fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+                   fileName[prefix.Length] >= '1' &&
+                   fileName[prefix.Length] <= '9';
+        }
+
+        private static bool IsValidFileRange(Stream stream, ulong offset, ulong size)
+        {
+            ulong streamLength = (ulong)stream.Length;
+            return offset <= streamLength && size <= streamLength - offset;
+        }
+
+        private static bool TryParseDebugLinkSection(byte[] sectionData, out string debugLink)
+        {
+            debugLink = null;
+
+            int crcOffset = sectionData.Length - DebugLinkCrcSize;
+            int nullPos = Array.IndexOf(sectionData, (byte)0, 0, crcOffset);
+            if (nullPos <= 0)
+            {
+                return false;
+            }
+
+            int alignedCrcOffset = (nullPos + 1 + 3) & ~3;
+            if (alignedCrcOffset != crcOffset)
+            {
+                return false;
+            }
+
+            for (int i = nullPos + 1; i < crcOffset; i++)
+            {
+                if (sectionData[i] != 0)
+                {
+                    return false;
+                }
+            }
+
+            try
+            {
+                debugLink = StrictUtf8.GetString(sectionData, 0, nullPos);
+            }
+            catch (DecoderFallbackException)
+            {
+                return false;
+            }
+
+            if (!IsValidDebugLinkFileName(debugLink))
+            {
+                debugLink = null;
+                return false;
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// Common fields extracted from an ELF header (Ehdr) after validation.
@@ -566,6 +680,7 @@ namespace Microsoft.Diagnostics.Symbols
         private const int MaxShstrtabSize = 1024 * 1024;    // 1 MB
         private const int MinDebugLinkSectionSize = 6;       // 1-char filename + null + 4-byte CRC
         private const int MaxDebugLinkSectionSize = 4096;
+        private const int DebugLinkCrcSize = sizeof(uint);
 
         // Symbol table constants.
         private const byte STT_FUNC = 2;        // Symbol type: function.

--- a/src/TraceEvent/Symbols/ElfSymbolModule.cs
+++ b/src/TraceEvent/Symbols/ElfSymbolModule.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using Microsoft.Diagnostics.Utilities;
 
 namespace Microsoft.Diagnostics.Symbols
 {
@@ -355,54 +356,6 @@ namespace Microsoft.Diagnostics.Symbols
         private static readonly byte[] GnuDebugLinkName = Encoding.UTF8.GetBytes(".gnu_debuglink");
         private static readonly UTF8Encoding StrictUtf8 = new UTF8Encoding(false, true);
 
-        /// <summary>
-        /// Returns whether <paramref name="fileName"/> is a platform-independent single file name.
-        /// </summary>
-        internal static bool IsValidDebugLinkFileName(string fileName)
-        {
-            if (string.IsNullOrEmpty(fileName) ||
-                fileName == "." ||
-                fileName == ".." ||
-                fileName[fileName.Length - 1] == ' ' ||
-                fileName[fileName.Length - 1] == '.')
-            {
-                return false;
-            }
-
-            for (int i = 0; i < fileName.Length; i++)
-            {
-                char c = fileName[i];
-                if (c < 0x20 || c == '<' || c == '>' || c == ':' || c == '"' ||
-                    c == '/' || c == '\\' || c == '|' || c == '?' || c == '*')
-                {
-                    return false;
-                }
-            }
-
-            // Windows treats these names as devices even when an extension is present.
-            int extensionPos = fileName.IndexOf('.');
-            string baseName = extensionPos >= 0 ? fileName.Substring(0, extensionPos) : fileName;
-            if (baseName.Equals("CON", StringComparison.OrdinalIgnoreCase) ||
-                baseName.Equals("PRN", StringComparison.OrdinalIgnoreCase) ||
-                baseName.Equals("AUX", StringComparison.OrdinalIgnoreCase) ||
-                baseName.Equals("NUL", StringComparison.OrdinalIgnoreCase) ||
-                IsNumberedDeviceName(baseName, "COM") ||
-                IsNumberedDeviceName(baseName, "LPT"))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private static bool IsNumberedDeviceName(string fileName, string prefix)
-        {
-            return fileName.Length == prefix.Length + 1 &&
-                   fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-                   fileName[prefix.Length] >= '1' &&
-                   fileName[prefix.Length] <= '9';
-        }
-
         private static bool IsValidFileRange(Stream stream, ulong offset, ulong size)
         {
             ulong streamLength = (ulong)stream.Length;
@@ -413,6 +366,8 @@ namespace Microsoft.Diagnostics.Symbols
         {
             debugLink = null;
 
+            // Reserve the final four bytes for the CRC so zero bytes in the CRC cannot be
+            // mistaken for the filename's required null terminator.
             int crcOffset = sectionData.Length - DebugLinkCrcSize;
             int nullPos = Array.IndexOf(sectionData, (byte)0, 0, crcOffset);
             if (nullPos <= 0)
@@ -420,12 +375,14 @@ namespace Microsoft.Diagnostics.Symbols
                 return false;
             }
 
+            // The CRC starts at the next 4-byte boundary after the null-terminated filename.
             int alignedCrcOffset = (nullPos + 1 + 3) & ~3;
             if (alignedCrcOffset != crcOffset)
             {
                 return false;
             }
 
+            // GNU requires any bytes between the filename terminator and aligned CRC to be zero.
             for (int i = nullPos + 1; i < crcOffset; i++)
             {
                 if (sectionData[i] != 0)
@@ -434,6 +391,7 @@ namespace Microsoft.Diagnostics.Symbols
                 }
             }
 
+            // Decode without replacement characters so malformed section bytes fail explicitly.
             try
             {
                 debugLink = StrictUtf8.GetString(sectionData, 0, nullPos);
@@ -443,7 +401,8 @@ namespace Microsoft.Diagnostics.Symbols
                 return false;
             }
 
-            if (!IsValidDebugLinkFileName(debugLink))
+            // The section value is a filename, not a path. Reject it before any path construction.
+            if (!PathUtilities.IsSafeFileName(debugLink))
             {
                 debugLink = null;
                 return false;

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -452,20 +452,32 @@ namespace Microsoft.Diagnostics.Symbols
             string binaryIndexPath = $"{simpleFileName}/elf-buildid-{normalizedBuildId}/{simpleFileName}";
 
             string resultPath = null;
+            string localElfFilePath = null;
+            if (elfFilePath != null)
+            {
+                if (!PathUtilities.TryGetSafeLocalFilePath(elfFilePath, out localElfFilePath))
+                {
+                    m_log.WriteLine(
+                        "FindElfSymbolFilePath: Ignoring unsafe ELF file path {0}.",
+                        elfFilePath);
+                }
+            }
 
             // Phase 1: Check for debug symbol files adjacent to the binary (mirrors PDB local search).
             // Only look for dedicated debug files here — the binary itself is deferred to Phase 3.
-            if (elfFilePath != null)
+            if (localElfFilePath != null)
             {
-                string elfDir = Path.GetDirectoryName(elfFilePath);
+                string elfDir = Path.GetDirectoryName(localElfFilePath);
                 if (!string.IsNullOrEmpty(elfDir))
                 {
-                    m_log.WriteLine("FindElfSymbolFilePath: Checking relative to ELF binary path {0}", elfFilePath);
-                    string basePath = elfFilePath;
+                    m_log.WriteLine("FindElfSymbolFilePath: Checking relative to ELF binary path {0}", localElfFilePath);
+                    string basePath = localElfFilePath;
+                    string executableFileName = Path.GetFileName(basePath);
 
                     // Try {path}.debug
-                    string candidate = basePath + ".debug";
-                    if (ElfBuildIdMatches(candidate, normalizedBuildId))
+                    string candidate;
+                    if (TryGetDebugLinkCandidate(elfDir, executableFileName + ".debug", out candidate) &&
+                        ElfBuildIdMatches(candidate, normalizedBuildId))
                     {
                         resultPath = candidate;
                     }
@@ -473,8 +485,8 @@ namespace Microsoft.Diagnostics.Symbols
                     // Try {path}.dbg
                     if (resultPath == null)
                     {
-                        candidate = basePath + ".dbg";
-                        if (ElfBuildIdMatches(candidate, normalizedBuildId))
+                        if (TryGetDebugLinkCandidate(elfDir, executableFileName + ".dbg", out candidate) &&
+                            ElfBuildIdMatches(candidate, normalizedBuildId))
                         {
                             resultPath = candidate;
                         }
@@ -580,11 +592,11 @@ namespace Microsoft.Diagnostics.Symbols
             // Phase 3: Last resort — try the binary itself (has .dynsym at minimum).
             // This is deferred until after symbol servers so we prefer proper debug symbols
             // (.symtab) over the stripped binary whenever a symbol server can provide them.
-            if (resultPath == null && elfFilePath != null)
+            if (resultPath == null && localElfFilePath != null)
             {
-                if (ElfBuildIdMatches(elfFilePath, normalizedBuildId))
+                if (ElfBuildIdMatches(localElfFilePath, normalizedBuildId))
                 {
-                    resultPath = elfFilePath;
+                    resultPath = localElfFilePath;
                 }
             }
 
@@ -613,21 +625,17 @@ namespace Microsoft.Diagnostics.Symbols
         internal static bool TryGetDebugLinkCandidate(string searchDirectory, string debugLink, out string candidate)
         {
             candidate = null;
-            if (string.IsNullOrEmpty(searchDirectory) || !ElfSymbolModule.IsValidDebugLinkFileName(debugLink))
+            if (string.IsNullOrEmpty(searchDirectory) ||
+                !PathUtilities.IsSafeFileName(debugLink))
             {
                 return false;
             }
 
             try
             {
-                string canonicalSearchDirectory = NormalizeDirectoryPath(Path.GetFullPath(searchDirectory));
+                string canonicalSearchDirectory = Path.GetFullPath(searchDirectory);
                 string canonicalCandidate = Path.GetFullPath(Path.Combine(canonicalSearchDirectory, debugLink));
-                string candidateDirectory = NormalizeDirectoryPath(Path.GetDirectoryName(canonicalCandidate));
-                StringComparison comparison = Path.DirectorySeparatorChar == '\\'
-                    ? StringComparison.OrdinalIgnoreCase
-                    : StringComparison.Ordinal;
-
-                if (!string.Equals(canonicalSearchDirectory, candidateDirectory, comparison))
+                if (!PathUtilities.IsPathWithinDirectory(canonicalCandidate, canonicalSearchDirectory))
                 {
                     return false;
                 }
@@ -651,26 +659,6 @@ namespace Microsoft.Diagnostics.Symbols
             {
                 return false;
             }
-        }
-
-        private static string NormalizeDirectoryPath(string path)
-        {
-            if (string.IsNullOrEmpty(path))
-            {
-                return path;
-            }
-
-            string root = Path.GetPathRoot(path);
-            int minimumLength = root == null ? 0 : root.Length;
-            int length = path.Length;
-            while (length > minimumLength &&
-                   (path[length - 1] == Path.DirectorySeparatorChar ||
-                    path[length - 1] == Path.AltDirectorySeparatorChar))
-            {
-                length--;
-            }
-
-            return length == path.Length ? path : path.Substring(0, length);
         }
 
         // Find an executable file path (not a PDB) based on information about the file image.  

--- a/src/TraceEvent/Symbols/SymbolReader.cs
+++ b/src/TraceEvent/Symbols/SymbolReader.cs
@@ -497,8 +497,8 @@ namespace Microsoft.Diagnostics.Symbols
                         if (debugLink != null)
                         {
                             // Try {bindir}/{debuglink}
-                            candidate = Path.Combine(elfDir, debugLink);
-                            if (ElfBuildIdMatches(candidate, normalizedBuildId))
+                            if (TryGetDebugLinkCandidate(elfDir, debugLink, out candidate) &&
+                                ElfBuildIdMatches(candidate, normalizedBuildId))
                             {
                                 resultPath = candidate;
                             }
@@ -506,8 +506,9 @@ namespace Microsoft.Diagnostics.Symbols
                             // Try {bindir}/.debug/{debuglink}
                             if (resultPath == null)
                             {
-                                candidate = Path.Combine(elfDir, ".debug", debugLink);
-                                if (ElfBuildIdMatches(candidate, normalizedBuildId))
+                                string debugDirectory = Path.Combine(elfDir, ".debug");
+                                if (TryGetDebugLinkCandidate(debugDirectory, debugLink, out candidate) &&
+                                    ElfBuildIdMatches(candidate, normalizedBuildId))
                                 {
                                     resultPath = candidate;
                                 }
@@ -604,6 +605,72 @@ namespace Microsoft.Diagnostics.Symbols
 
             m_elfPathCache.Add(cacheKey, resultPath);
             return resultPath;
+        }
+
+        /// <summary>
+        /// Constructs a debug-link candidate that is a direct child of the intended search directory.
+        /// </summary>
+        internal static bool TryGetDebugLinkCandidate(string searchDirectory, string debugLink, out string candidate)
+        {
+            candidate = null;
+            if (string.IsNullOrEmpty(searchDirectory) || !ElfSymbolModule.IsValidDebugLinkFileName(debugLink))
+            {
+                return false;
+            }
+
+            try
+            {
+                string canonicalSearchDirectory = NormalizeDirectoryPath(Path.GetFullPath(searchDirectory));
+                string canonicalCandidate = Path.GetFullPath(Path.Combine(canonicalSearchDirectory, debugLink));
+                string candidateDirectory = NormalizeDirectoryPath(Path.GetDirectoryName(canonicalCandidate));
+                StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+
+                if (!string.Equals(canonicalSearchDirectory, candidateDirectory, comparison))
+                {
+                    return false;
+                }
+
+                candidate = canonicalCandidate;
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+            catch (PathTooLongException)
+            {
+                return false;
+            }
+            catch (System.Security.SecurityException)
+            {
+                return false;
+            }
+        }
+
+        private static string NormalizeDirectoryPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            string root = Path.GetPathRoot(path);
+            int minimumLength = root == null ? 0 : root.Length;
+            int length = path.Length;
+            while (length > minimumLength &&
+                   (path[length - 1] == Path.DirectorySeparatorChar ||
+                    path[length - 1] == Path.AltDirectorySeparatorChar))
+            {
+                length--;
+            }
+
+            return length == path.Length ? path : path.Substring(0, length);
         }
 
         // Find an executable file path (not a PDB) based on information about the file image.  
@@ -2850,4 +2917,3 @@ namespace Microsoft.Diagnostics.Symbols
         #endregion
     }
 }
-

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/ElfBuilder.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/ElfBuilder.cs
@@ -17,6 +17,9 @@ namespace TraceEventTests
         private ulong m_pOffset = 0;
         private byte[] m_buildId = null;
         private string m_debugLink = null;
+        private byte[] m_debugLinkSectionData = null;
+        private ulong? m_debugLinkSectionOffset = null;
+        private ulong? m_debugLinkSectionSize = null;
         private readonly List<SymbolDef> m_symtabSymbols = new List<SymbolDef>();
         private readonly List<SymbolDef> m_dynsymSymbols = new List<SymbolDef>();
 
@@ -83,6 +86,27 @@ namespace TraceEventTests
         public ElfBuilder SetDebugLink(string filename)
         {
             m_debugLink = filename;
+            m_debugLinkSectionData = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the raw .gnu_debuglink section data for malformed-section tests.
+        /// </summary>
+        public ElfBuilder SetDebugLinkSectionData(byte[] sectionData)
+        {
+            m_debugLink = null;
+            m_debugLinkSectionData = sectionData;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the .gnu_debuglink section header bounds for malformed-section tests.
+        /// </summary>
+        public ElfBuilder SetDebugLinkSectionBounds(ulong offset, ulong size)
+        {
+            m_debugLinkSectionOffset = offset;
+            m_debugLinkSectionSize = size;
             return this;
         }
 
@@ -150,7 +174,7 @@ namespace TraceEventTests
                 // [N+1] .shstrtab — only if debuglink is set (needed for section names)
                 bool hasDynsym = m_dynsymSymbols.Count > 0;
                 bool hasBuildId = m_buildId != null;
-                bool hasDebugLink = m_debugLink != null;
+                bool hasDebugLink = m_debugLink != null || m_debugLinkSectionData != null;
                 int sectionCount = hasDynsym ? 5 : 3;
                 if (hasDebugLink)
                 {
@@ -193,7 +217,7 @@ namespace TraceEventTests
                 int shstrtabSectionIndex = 0;
                 if (hasDebugLink)
                 {
-                    debugLinkData = BuildDebugLinkSection(m_debugLink);
+                    debugLinkData = m_debugLinkSectionData ?? BuildDebugLinkSection(m_debugLink);
                     debugLinkSectionIndex = hasDynsym ? 5 : 3;
                     shstrtabSectionIndex = debugLinkSectionIndex + 1;
 
@@ -310,7 +334,8 @@ namespace TraceEventTests
                 {
                     // .gnu_debuglink (SHT_PROGBITS)
                     WriteSectionHeader(writer, (uint)debugLinkShName, SHT_PROGBITS,
-                        (ulong)debugLinkOffset, (ulong)debugLinkData.Length, 0, 0);
+                        m_debugLinkSectionOffset ?? (ulong)debugLinkOffset,
+                        m_debugLinkSectionSize ?? (ulong)debugLinkData.Length, 0, 0);
 
                     // .shstrtab (SHT_STRTAB)
                     WriteSectionHeader(writer, (uint)shstrtabShName, SHT_STRTAB,

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
@@ -824,14 +824,128 @@ namespace TraceEventTests
             var builder = new ElfBuilder()
                 .Set64Bit(true)
                 .SetPTLoad(0x400000, 0)
-                .SetDebugLink("libcoreclr.so.dbg");
+                .SetDebugLink("foo.debug");
 
             byte[] data = builder.Build();
             RunWithTempFile(data, (path) =>
             {
                 string result = ElfSymbolModule.ReadDebugLink(path);
-                Assert.Equal("libcoreclr.so.dbg", result);
+                Assert.Equal("foo.debug", result);
             });
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(".")]
+        [InlineData("..")]
+        [InlineData("dir/foo.debug")]
+        [InlineData(@"dir\foo.debug")]
+        [InlineData("../foo.debug")]
+        [InlineData(@"..\foo.debug")]
+        [InlineData("/foo.debug")]
+        [InlineData(@"\foo.debug")]
+        [InlineData(@"C:\foo.debug")]
+        [InlineData("C:foo.debug")]
+        [InlineData(@"\\server\share\foo.debug")]
+        [InlineData(@"\\?\C:\foo.debug")]
+        [InlineData(@"\\.\C:\foo.debug")]
+        [InlineData("foo.debug:stream")]
+        [InlineData("foo?.debug")]
+        [InlineData("foo.debug.")]
+        [InlineData("foo.debug ")]
+        [InlineData("CON")]
+        [InlineData("NUL.debug")]
+        public void ReadDebugLink_InvalidFileName_ReturnsNull(string debugLink)
+        {
+            byte[] data = new ElfBuilder()
+                .Set64Bit(true)
+                .SetPTLoad(0x400000, 0)
+                .SetDebugLink(debugLink)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Null(ElfSymbolModule.ReadDebugLink(path)));
+        }
+
+        [Fact]
+        public void ReadDebugLink_MissingNullTerminator_ReturnsNull()
+        {
+            byte[] sectionData = new byte[]
+            {
+                (byte)'f', (byte)'o', (byte)'o', (byte)'.', (byte)'d',
+                (byte)'e', (byte)'b', (byte)'u', (byte)'g',
+                0, 0, 0, 0,
+            };
+            byte[] data = new ElfBuilder()
+                .SetDebugLinkSectionData(sectionData)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Null(ElfSymbolModule.ReadDebugLink(path)));
+        }
+
+        [Fact]
+        public void ReadDebugLink_TruncatedCrc_ReturnsNull()
+        {
+            byte[] sectionData = new byte[] { (byte)'a', 0, 0, 0, 1, 2, 3 };
+            byte[] data = new ElfBuilder()
+                .SetDebugLinkSectionData(sectionData)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Null(ElfSymbolModule.ReadDebugLink(path)));
+        }
+
+        [Fact]
+        public void ReadDebugLink_NonZeroPadding_ReturnsNull()
+        {
+            byte[] sectionData = new byte[] { (byte)'a', 0, 1, 0, 1, 2, 3, 4 };
+            byte[] data = new ElfBuilder()
+                .SetDebugLinkSectionData(sectionData)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Null(ElfSymbolModule.ReadDebugLink(path)));
+        }
+
+        [Fact]
+        public void ReadDebugLink_MalformedUtf8_ReturnsNull()
+        {
+            byte[] sectionData = new byte[] { 0xc3, 0x28, 0, 0, 1, 2, 3, 4 };
+            byte[] data = new ElfBuilder()
+                .SetDebugLinkSectionData(sectionData)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Null(ElfSymbolModule.ReadDebugLink(path)));
+        }
+
+        [Fact]
+        public void ReadDebugLink_NonZeroCrc_ReturnsFilename()
+        {
+            byte[] sectionData = new byte[] { (byte)'a', 0, 0, 0, 1, 2, 3, 4 };
+            byte[] data = new ElfBuilder()
+                .SetDebugLinkSectionData(sectionData)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Equal("a", ElfSymbolModule.ReadDebugLink(path)));
+        }
+
+        [Fact]
+        public void ReadDebugLink_SectionOutsideFile_ReturnsNull()
+        {
+            byte[] data = new ElfBuilder()
+                .SetDebugLink("foo.debug")
+                .SetDebugLinkSectionBounds(ulong.MaxValue, 16)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Null(ElfSymbolModule.ReadDebugLink(path)));
+        }
+
+        [Fact]
+        public void ReadDebugLink_SectionExtendsPastFile_ReturnsNull()
+        {
+            byte[] data = new ElfBuilder()
+                .SetDebugLink("foo.debug")
+                .SetDebugLinkSectionBounds(64, 4096)
+                .Build();
+
+            RunWithTempFile(data, path => Assert.Null(ElfSymbolModule.ReadDebugLink(path)));
         }
 
         [Fact]

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
@@ -855,6 +855,9 @@ namespace TraceEventTests
         [InlineData("foo.debug ")]
         [InlineData("CON")]
         [InlineData("NUL.debug")]
+        [InlineData("COM0")]
+        [InlineData("CLOCK$.debug")]
+        [InlineData("foo\u007f.debug")]
         public void ReadDebugLink_InvalidFileName_ReturnsNull(string debugLink)
         {
             byte[] data = new ElfBuilder()

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
@@ -1054,6 +1054,86 @@ namespace TraceEventTests
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TryGetDebugLinkCandidate_ValidSearchLocation_ReturnsContainedPath(bool useDebugSubdirectory)
+        {
+            string executableDirectory = Path.GetFullPath(Path.Combine(OutputDir, "elf-debuglink-candidate"));
+            string searchDirectory = useDebugSubdirectory
+                ? Path.Combine(executableDirectory, ".debug")
+                : executableDirectory;
+
+            Assert.True(SymbolReader.TryGetDebugLinkCandidate(searchDirectory, "foo.debug", out string candidate));
+            Assert.Equal("foo.debug", Path.GetFileName(candidate));
+
+            StringComparer comparer = Path.DirectorySeparatorChar == '\\'
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+            Assert.Equal(Path.GetFullPath(searchDirectory), Path.GetDirectoryName(candidate), comparer);
+        }
+
+        [Theory]
+        [InlineData("../foo.debug")]
+        [InlineData(@"..\foo.debug")]
+        [InlineData("/foo.debug")]
+        [InlineData(@"C:\foo.debug")]
+        [InlineData(@"\\server\share\foo.debug")]
+        [InlineData(@"\\?\C:\foo.debug")]
+        [InlineData("foo.debug:stream")]
+        public void TryGetDebugLinkCandidate_InvalidFileName_ReturnsFalse(string debugLink)
+        {
+            Assert.False(SymbolReader.TryGetDebugLinkCandidate(OutputDir, debugLink, out string candidate));
+            Assert.Null(candidate);
+        }
+
+        [Fact]
+        public void FindElfSymbolFilePath_RejectedDebugLinkDoesNotProbeOutsideDirectory()
+        {
+            string tempDir = Path.Combine(OutputDir, "elf-debuglink-rejected");
+            try
+            {
+                const string buildId = "1122aabb";
+                string binaryDirectory = Path.Combine(tempDir, "bin");
+                string emptySymbolDirectory = Path.Combine(tempDir, "empty");
+                Directory.CreateDirectory(binaryDirectory);
+                Directory.CreateDirectory(emptySymbolDirectory);
+
+                string binaryPath = Path.Combine(binaryDirectory, "libunsafe.so");
+                byte[] binaryData = new ElfBuilder()
+                    .Set64Bit(true)
+                    .SetPTLoad(0x400000, 0)
+                    .SetDebugLink("../outside.debug")
+                    .Build();
+                File.WriteAllBytes(binaryPath, binaryData);
+
+                string outsidePath = Path.Combine(tempDir, "outside.debug");
+                File.WriteAllBytes(outsidePath, CreateMinimalElfWithBuildId(buildId));
+
+                var securityChecks = new List<string>();
+                _symbolReader.SymbolPath = emptySymbolDirectory;
+                _symbolReader.SecurityCheck = path =>
+                {
+                    securityChecks.Add(Path.GetFullPath(path));
+                    return true;
+                };
+
+                string result = _symbolReader.FindElfSymbolFilePath(
+                    "libunsafe.so",
+                    buildId,
+                    elfFilePath: binaryPath);
+
+                Assert.Null(result);
+                Assert.DoesNotContain(Path.GetFullPath(outsidePath), securityChecks);
+                Assert.Empty(_handler.Requests);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
         #endregion
 
         #region FindR2RPerfMapSymbolFilePath Tests

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/SymbolReaderTests.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1067,7 +1068,7 @@ namespace TraceEventTests
             Assert.True(SymbolReader.TryGetDebugLinkCandidate(searchDirectory, "foo.debug", out string candidate));
             Assert.Equal("foo.debug", Path.GetFileName(candidate));
 
-            StringComparer comparer = Path.DirectorySeparatorChar == '\\'
+            StringComparer comparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
             Assert.Equal(Path.GetFullPath(searchDirectory), Path.GetDirectoryName(candidate), comparer);
@@ -1085,6 +1086,72 @@ namespace TraceEventTests
         {
             Assert.False(SymbolReader.TryGetDebugLinkCandidate(OutputDir, debugLink, out string candidate));
             Assert.Null(candidate);
+        }
+
+        [Theory]
+        [InlineData(".debug")]
+        [InlineData(".dbg")]
+        public void FindElfSymbolFilePath_ExecutableSuffixCandidateRemainsAdjacent(string suffix)
+        {
+            string tempDir = Path.Combine(OutputDir, "elf-adjacent-suffix-" + suffix.Substring(1));
+            try
+            {
+                const string buildId = "66778899";
+                Directory.CreateDirectory(tempDir);
+                string binaryPath = Path.Combine(tempDir, "libsuffix.so");
+                File.WriteAllBytes(binaryPath, new ElfBuilder().Build());
+
+                string debugPath = binaryPath + suffix;
+                File.WriteAllBytes(debugPath, CreateMinimalElfWithBuildId(buildId));
+
+                string emptySymbolDirectory = Path.Combine(tempDir, "empty");
+                Directory.CreateDirectory(emptySymbolDirectory);
+                _symbolReader.SymbolPath = emptySymbolDirectory;
+                _symbolReader.SecurityCheck = _ => true;
+
+                string result = _symbolReader.FindElfSymbolFilePath(
+                    "libsuffix.so",
+                    buildId,
+                    elfFilePath: binaryPath);
+
+                Assert.Equal(debugPath, result);
+                Assert.Equal(
+                    Path.GetFullPath(tempDir),
+                    Path.GetDirectoryName(Path.GetFullPath(result)));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData("../relative/libunsafe.so")]
+        [InlineData(@"C:relative\libunsafe.so")]
+        [InlineData(@"\\server\share\libunsafe.so")]
+        [InlineData(@"\\?\C:\libunsafe.so")]
+        [InlineData(@"\\.\C:\libunsafe.so")]
+        public void FindElfSymbolFilePath_UnsafeExecutablePathCausesNoAccess(string executablePath)
+        {
+            string emptySymbolDirectory = Path.Combine(OutputDir, "elf-unsafe-path-empty");
+            Directory.CreateDirectory(emptySymbolDirectory);
+            var securityChecks = new List<string>();
+            _symbolReader.SymbolPath = emptySymbolDirectory;
+            _symbolReader.SecurityCheck = path =>
+            {
+                securityChecks.Add(path);
+                return true;
+            };
+
+            string result = _symbolReader.FindElfSymbolFilePath(
+                "libunsafe.so",
+                "1234abcd",
+                elfFilePath: executablePath);
+
+            Assert.Null(result);
+            Assert.Empty(securityChecks);
+            Assert.Empty(_handler.Requests);
         }
 
         [Fact]

--- a/src/Utilities/PathUtilities.cs
+++ b/src/Utilities/PathUtilities.cs
@@ -113,16 +113,136 @@ namespace Microsoft.Diagnostics.Utilities
         }
 
         /// <summary>
+        /// Returns true if <paramref name="name"/> can be used unchanged as one file-name
+        /// component on Windows and POSIX systems.
+        /// </summary>
+        public static bool IsSafeFileName(string name)
+        {
+            return string.Equals(name, SanitizeFileName(name), StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Converts an absolute Windows drive path or POSIX path into safe directory
+        /// components, excluding the final file name. UNC, device, relative, traversal,
+        /// and otherwise unsafe paths are rejected.
+        /// </summary>
+        private static bool TryGetAbsoluteFileDirectorySegments(string filePath, out string[] directorySegments)
+        {
+            directorySegments = null;
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            var segments = new List<string>();
+            int segmentStart;
+            bool isWindowsPath = IsWindowsDriveAbsolutePath(filePath);
+            if (isWindowsPath)
+            {
+                segments.Add(char.ToUpperInvariant(filePath[0]).ToString());
+                segmentStart = 3;
+            }
+            else if (filePath[0] == '/' &&
+                     (filePath.Length == 1 || filePath[1] != '/') &&
+                     filePath.IndexOf('\\') < 0)
+            {
+                segmentStart = 1;
+            }
+            else
+            {
+                return false;
+            }
+
+            int currentStart = segmentStart;
+            for (int i = segmentStart; i <= filePath.Length; i++)
+            {
+                bool atEnd = i == filePath.Length;
+                bool atSeparator = !atEnd &&
+                    (filePath[i] == '/' || (isWindowsPath && filePath[i] == '\\'));
+                if (!atEnd && !atSeparator)
+                {
+                    continue;
+                }
+
+                if (i == currentStart)
+                {
+                    return false;
+                }
+
+                string segment = filePath.Substring(currentStart, i - currentStart);
+                if (!IsSafeFileName(segment))
+                {
+                    return false;
+                }
+
+                segments.Add(segment);
+                currentStart = i + 1;
+            }
+
+            if (segments.Count == 0)
+            {
+                return false;
+            }
+
+            segments.RemoveAt(segments.Count - 1);
+            directorySegments = segments.ToArray();
+            return true;
+        }
+
+        /// <summary>
+        /// Canonicalizes an absolute file path that uses the current platform's path
+        /// syntax and is safe for local filesystem access.
+        /// </summary>
+        public static bool TryGetSafeLocalFilePath(string filePath, out string safeFilePath)
+        {
+            safeFilePath = null;
+            if (!TryGetAbsoluteFileDirectorySegments(filePath, out _))
+            {
+                return false;
+            }
+
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            bool isWindowsDrivePath = IsWindowsDriveAbsolutePath(filePath);
+            if ((isWindows && !isWindowsDrivePath) ||
+                (!isWindows && isWindowsDrivePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                safeFilePath = Path.GetFullPath(filePath);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+            catch (PathTooLongException)
+            {
+                return false;
+            }
+            catch (System.Security.SecurityException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Reduces <paramref name="name"/> to a value safe to embed in a single file-name
         /// component on disk.  Every character reported by
-        /// <see cref="Path.GetInvalidFileNameChars"/>, every path / volume separator,
-        /// and every control character is replaced with '_'.  Trailing '.' and ' '
-        /// characters are removed because Windows silently trims them, which would
-        /// otherwise let two distinct names collide on disk and let inputs like "NUL."
-        /// slip past the reserved-name guard.  Reserved DOS device names (CON, PRN,
-        /// AUX, NUL, CLOCK$, CONIN$, CONOUT$, COM0-9, LPT0-9) are detected on the
-        /// stem before the first '.' (Win32 opens the device for paths like
-        /// "NUL.txt") and prefixed with '_' on match.
+        /// <see cref="Path.GetInvalidFileNameChars"/>, every Windows file-name
+        /// metacharacter, every path / volume separator, and every control character is
+        /// replaced with '_'.  Trailing '.' and ' ' characters are removed because
+        /// Windows silently trims them, which would otherwise let two distinct names
+        /// collide on disk and let inputs like "NUL." slip past the reserved-name guard.
+        /// Reserved DOS device names (CON, PRN, AUX, NUL, CLOCK$, CONIN$, CONOUT$,
+        /// COM0-9, LPT0-9) are detected on the stem before the first '.' (Win32 opens
+        /// the device for paths like "NUL.txt") and prefixed with '_' on match.
         ///
         /// Returns <c>null</c> if the input is null, empty, '.', '..', or sanitizes
         /// to an empty string so callers can choose to skip the resource rather than
@@ -181,6 +301,12 @@ namespace Microsoft.Diagnostics.Utilities
             chars.Add('\\');
             chars.Add('/');
             chars.Add(':');
+            chars.Add('<');
+            chars.Add('>');
+            chars.Add('"');
+            chars.Add('|');
+            chars.Add('?');
+            chars.Add('*');
             return chars;
         }
 
@@ -196,6 +322,14 @@ namespace Microsoft.Diagnostics.Utilities
                 names.Add("LPT" + i);
             }
             return names;
+        }
+
+        private static bool IsWindowsDriveAbsolutePath(string path)
+        {
+            return path.Length >= 3 &&
+                   ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) &&
+                   path[1] == ':' &&
+                   (path[2] == '\\' || path[2] == '/');
         }
     }
 }

--- a/src/Utilities/PathUtilities.cs
+++ b/src/Utilities/PathUtilities.cs
@@ -118,7 +118,8 @@ namespace Microsoft.Diagnostics.Utilities
         /// </summary>
         public static bool IsSafeFileName(string name)
         {
-            return string.Equals(name, SanitizeFileName(name), StringComparison.Ordinal);
+            return name != null &&
+                string.Equals(name, SanitizeFileName(name), StringComparison.Ordinal);
         }
 
         /// <summary>


### PR DESCRIPTION
GNU `.gnu_debuglink` values are filenames, but malformed section data could previously influence path construction and filesystem access. This change enforces the GNU contract at parse time and keeps candidate construction within trusted search directories.

- Strictly validate section bounds, null termination, UTF-8, and filename syntax.
- Reject paths, traversal, device names, alternate streams, and malformed values before filesystem access.
- Canonicalize and containment-check executable-adjacent symbol candidates.
- Treat invalid debug links as not found while preserving existing CRC and build-ID behavior.
- Consolidate reusable validation in `PathUtilities`.