### PR TITLE
Consolidate NuGet Sources To The PerfView-Build Feed

### DIFF
--- a/Nuget.config
+++ b/Nuget.config
@@ -5,18 +5,8 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear/>
-    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="perfview-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/perfview-build/nuget/v3/index.json" />
   </packageSources>
-  <packageSourceMapping>
-    <packageSource key="dotnet-public">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="perfview-build">
-      <package pattern="Microsoft.Diagnostics.Tracing*" />
-      <package pattern="PerfView.*" />
-    </packageSource>
-  </packageSourceMapping>
   <disabledPackageSources>
       <clear />
   </disabledPackageSources>


### PR DESCRIPTION
The `dotnet-public` feed is now configured as an upstream source of `perfview-build`.

This change:
- Removes the direct `dotnet-public` package source.
- Removes package source mappings, which are unnecessary with a single configured feed.
- Routes all NuGet package restoration through `perfview-build`.