### PR TITLE
Prevent Test Hangs Caused By Concurrent Trace Listener Mutation

### DIFF
--- a/src/FastSerialization.Tests/app.config
+++ b/src/FastSerialization.Tests/app.config
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <system.diagnostics>
+    <assert assertuienabled="false" />
+    <trace>
+      <listeners>
+        <remove name="Default" />
+        <add name="ThrowingTraceListener" type="PerfView.TestUtilities.ThrowingTraceListener, PerfView.TestUtilities" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/src/LinuxTracing.Tests/App.config
+++ b/src/LinuxTracing.Tests/App.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
   </startup>
   <system.diagnostics>
+    <assert assertuienabled="false" />
     <trace>
       <listeners>
         <remove name="Default" />

--- a/src/PerfView.TestUtilities/DebugAssertionTests.cs
+++ b/src/PerfView.TestUtilities/DebugAssertionTests.cs
@@ -62,17 +62,26 @@
 
     internal static class DebugAssertionTestConfiguration
     {
+        /// <summary>
+        /// Verifies the runtime-specific configuration used to ensure assertion failures throw instead of
+        /// displaying interactive UI or being ignored.
+        /// </summary>
+        /// <remarks>
+        /// <para>On .NET Framework, each test assembly's app.config removes the DefaultTraceListener and
+        /// registers ThrowingTraceListener, which converts assertion failures into xUnit failures.</para>
+        /// <para>Modern .NET does not process the app.config diagnostics section, but its built-in assertion
+        /// behavior already throws. The assertion tests verify that behavior directly, so there is no listener
+        /// configuration to validate on that runtime.</para>
+        /// </remarks>
         internal static void AssertValid()
         {
-            // .NET Framework registers ThrowingTraceListener through app.config. Modern .NET does not
-            // process that configuration, but its assertion implementation already throws as the tests verify.
             if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
 
-            // Validate the existing process-wide configuration without repairing it so a misconfigured
-            // test assembly fails promptly instead of silently changing the behavior under test.
+            // Only inspect the existing process-wide configuration. Silently repairing Trace.Listeners here
+            // would change the behavior under test and could race with concurrent access from other tests.
             string configurationFile = AppDomain.CurrentDomain.GetData("APP_CONFIG_FILE") as string;
             bool foundThrowingTraceListener = false;
             foreach (TraceListener listener in Trace.Listeners)

--- a/src/PerfView.TestUtilities/DebugAssertionTests.cs
+++ b/src/PerfView.TestUtilities/DebugAssertionTests.cs
@@ -2,7 +2,16 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Runtime.InteropServices;
     using Xunit;
+
+    /// <summary>
+    /// Prevents tests that intentionally trigger process-wide assertions from running beside other tests.
+    /// </summary>
+    [CollectionDefinition("Debug assertion tests", DisableParallelization = true)]
+    public sealed class DebugAssertionTestCollection
+    {
+    }
 
     /// <summary>
     /// This class verifies the behavior of <see cref="Debug.Assert(bool)"/> and <see cref="Debug.Fail(string)"/> when
@@ -15,12 +24,14 @@
     /// app.config. On .NET 5+, the DefaultTraceListener already throws on assertion failures, so no
     /// additional listener configuration is needed.</para>
     /// </remarks>
+    [Collection("Debug assertion tests")]
     public class DebugAssertionTests
     {
 #if DEBUG
         [Fact]
         public void TestDebugAssertThrowsException()
         {
+            DebugAssertionTestConfiguration.AssertValid();
             Debug.Assert(true);
 
             Assert.ThrowsAny<Exception>(() => Debug.Assert(false));
@@ -29,6 +40,7 @@
         [Fact]
         public void TestDebugFailThrowsException()
         {
+            DebugAssertionTestConfiguration.AssertValid();
             Assert.ThrowsAny<Exception>(() => Debug.Fail("Bad things"));
         }
 #endif
@@ -36,13 +48,41 @@
         [Fact]
         public void TestTraceAssertThrowsException()
         {
+            DebugAssertionTestConfiguration.AssertValid();
             Assert.ThrowsAny<Exception>(() => Trace.Assert(false));
         }
 
         [Fact]
         public void TestTraceFailThrowsException()
         {
+            DebugAssertionTestConfiguration.AssertValid();
             Assert.ThrowsAny<Exception>(() => Trace.Fail("Bad things"));
         }
     }
+
+    internal static class DebugAssertionTestConfiguration
+    {
+        internal static void AssertValid()
+        {
+            if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            string configurationFile = AppDomain.CurrentDomain.GetData("APP_CONFIG_FILE") as string;
+            bool foundThrowingTraceListener = false;
+            foreach (TraceListener listener in Trace.Listeners)
+            {
+                Assert.False(
+                    listener is DefaultTraceListener,
+                    $"DefaultTraceListener can display an assertion dialog and hang the test run. Configuration file: {configurationFile}");
+                foundThrowingTraceListener |= listener is ThrowingTraceListener;
+            }
+
+            Assert.True(
+                foundThrowingTraceListener,
+                $"ThrowingTraceListener must be registered by the test assembly's app.config. Configuration file: {configurationFile}");
+        }
+    }
+
 }

--- a/src/PerfView.TestUtilities/DebugAssertionTests.cs
+++ b/src/PerfView.TestUtilities/DebugAssertionTests.cs
@@ -64,11 +64,15 @@
     {
         internal static void AssertValid()
         {
+            // .NET Framework registers ThrowingTraceListener through app.config. Modern .NET does not
+            // process that configuration, but its assertion implementation already throws as the tests verify.
             if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
 
+            // Validate the existing process-wide configuration without repairing it so a misconfigured
+            // test assembly fails promptly instead of silently changing the behavior under test.
             string configurationFile = AppDomain.CurrentDomain.GetData("APP_CONFIG_FILE") as string;
             bool foundThrowingTraceListener = false;
             foreach (TraceListener listener in Trace.Listeners)

--- a/src/PerfView.Tests/app.config
+++ b/src/PerfView.Tests/app.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.diagnostics>
+    <assert assertuienabled="false" />
     <trace>
       <listeners>
         <remove name="Default" />

--- a/src/SymbolsAuth.Tests/app.config
+++ b/src/SymbolsAuth.Tests/app.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.diagnostics>
+    <assert assertuienabled="false" />
     <trace>
       <listeners>
         <remove name="Default" />

--- a/src/TraceEvent/Ctf/CtfTracing.Tests/app.config
+++ b/src/TraceEvent/Ctf/CtfTracing.Tests/app.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.diagnostics>
+    <assert assertuienabled="false" />
     <trace>
       <listeners>
         <remove name="Default" />

--- a/src/TraceEvent/TraceEvent.Tests/Properties/AssemblyInfo.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Xunit;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -7,3 +8,4 @@
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("19281902-fbc4-48c0-962b-9fdadaf5c783")]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/TraceEvent/TraceEvent.Tests/Properties/AssemblyInfo.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
-﻿using System.Runtime.InteropServices;
-using Xunit;
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -8,4 +10,19 @@ using Xunit;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("19281902-fbc4-48c0-962b-9fdadaf5c783")]
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+internal static class TestAssemblyInitializer
+{
+    [ModuleInitializer]
+    internal static void InitializeTraceListeners()
+    {
+        if (RuntimeInformation.FrameworkDescription.StartsWith(
+            ".NET Framework",
+            StringComparison.OrdinalIgnoreCase))
+        {
+            // Trace listener configuration is loaded lazily. Initialize it on one thread before xUnit
+            // starts tests in parallel so concurrent first access cannot observe partial listener state.
+            _ = Trace.Listeners.Count;
+        }
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Properties/ModuleInitializerAttribute.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Properties/ModuleInitializerAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using Microsoft.Diagnostics.Symbols;
 using Microsoft.Diagnostics.Tracing.Etlx;
+using PerfView.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -948,6 +948,20 @@ namespace TraceEventTests
         }
 
         [Fact]
+        public void MatchOrInitPE_WhenElf_RejectsMismatch()
+        {
+            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
+            moduleFile.MatchOrInitElf();
+
+#if DEBUG
+            DebugAssertionTestConfiguration.AssertValid();
+            Assert.ThrowsAny<Exception>(() => moduleFile.MatchOrInitPE());
+#else
+            Assert.Null(moduleFile.MatchOrInitPE());
+#endif
+        }
+
+        [Fact]
         public void MatchOrInitElf_WhenNull_CreatesElfSymbolInfo()
         {
             var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
@@ -964,6 +978,20 @@ namespace TraceEventTests
             var elf1 = moduleFile.MatchOrInitElf();
             var elf2 = moduleFile.MatchOrInitElf();
             Assert.Same(elf1, elf2);
+        }
+
+        [Fact]
+        public void MatchOrInitElf_WhenPE_RejectsMismatch()
+        {
+            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
+            moduleFile.MatchOrInitPE();
+
+#if DEBUG
+            DebugAssertionTestConfiguration.AssertValid();
+            Assert.ThrowsAny<Exception>(() => moduleFile.MatchOrInitElf());
+#else
+            Assert.Null(moduleFile.MatchOrInitElf());
+#endif
         }
 
         #endregion
@@ -999,62 +1027,5 @@ namespace TraceEventTests
         }
 
         #endregion
-    }
-
-    /// <summary>
-    /// Defines the tests that temporarily modify the process-wide trace listener collection.
-    /// </summary>
-    [CollectionDefinition("Trace listener mutation tests", DisableParallelization = true)]
-    public sealed class TraceListenerMutationTestCollection
-    {
-    }
-
-    /// <summary>
-    /// Verifies binary-format mismatch behavior that intentionally triggers and suppresses assertions.
-    /// </summary>
-    [Collection("Trace listener mutation tests")]
-    public class TraceListenerMutationTests
-    {
-        [Fact]
-        public void MatchOrInitPE_WhenElf_ReturnsNull()
-        {
-            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
-            moduleFile.MatchOrInitElf(); // Set as ELF first
-
-            // Suppress Debug.Assert so we can verify the return value.
-            var listeners = new TraceListener[Trace.Listeners.Count];
-            Trace.Listeners.CopyTo(listeners, 0);
-            Trace.Listeners.Clear();
-            try
-            {
-                var pe = moduleFile.MatchOrInitPE();
-                Assert.Null(pe);
-            }
-            finally
-            {
-                Trace.Listeners.AddRange(listeners);
-            }
-        }
-
-        [Fact]
-        public void MatchOrInitElf_WhenPE_ReturnsNull()
-        {
-            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
-            moduleFile.MatchOrInitPE(); // Set as PE first
-
-            // Suppress Debug.Assert so we can verify the return value.
-            var listeners = new TraceListener[Trace.Listeners.Count];
-            Trace.Listeners.CopyTo(listeners, 0);
-            Trace.Listeners.Clear();
-            try
-            {
-                var elf = moduleFile.MatchOrInitElf();
-                Assert.Null(elf);
-            }
-            finally
-            {
-                Trace.Listeners.AddRange(listeners);
-            }
-        }
     }
 }

--- a/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Symbols/ElfSymbolModuleTests.cs
@@ -948,27 +948,6 @@ namespace TraceEventTests
         }
 
         [Fact]
-        public void MatchOrInitPE_WhenElf_ReturnsNull()
-        {
-            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
-            moduleFile.MatchOrInitElf(); // Set as ELF first
-
-            // Suppress Debug.Assert so we can verify the return value.
-            var listeners = new TraceListener[Trace.Listeners.Count];
-            Trace.Listeners.CopyTo(listeners, 0);
-            Trace.Listeners.Clear();
-            try
-            {
-                var pe = moduleFile.MatchOrInitPE();
-                Assert.Null(pe);
-            }
-            finally
-            {
-                Trace.Listeners.AddRange(listeners);
-            }
-        }
-
-        [Fact]
         public void MatchOrInitElf_WhenNull_CreatesElfSymbolInfo()
         {
             var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
@@ -985,27 +964,6 @@ namespace TraceEventTests
             var elf1 = moduleFile.MatchOrInitElf();
             var elf2 = moduleFile.MatchOrInitElf();
             Assert.Same(elf1, elf2);
-        }
-
-        [Fact]
-        public void MatchOrInitElf_WhenPE_ReturnsNull()
-        {
-            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
-            moduleFile.MatchOrInitPE(); // Set as PE first
-
-            // Suppress Debug.Assert so we can verify the return value.
-            var listeners = new TraceListener[Trace.Listeners.Count];
-            Trace.Listeners.CopyTo(listeners, 0);
-            Trace.Listeners.Clear();
-            try
-            {
-                var elf = moduleFile.MatchOrInitElf();
-                Assert.Null(elf);
-            }
-            finally
-            {
-                Trace.Listeners.AddRange(listeners);
-            }
         }
 
         #endregion
@@ -1041,5 +999,62 @@ namespace TraceEventTests
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Defines the tests that temporarily modify the process-wide trace listener collection.
+    /// </summary>
+    [CollectionDefinition("Trace listener mutation tests", DisableParallelization = true)]
+    public sealed class TraceListenerMutationTestCollection
+    {
+    }
+
+    /// <summary>
+    /// Verifies binary-format mismatch behavior that intentionally triggers and suppresses assertions.
+    /// </summary>
+    [Collection("Trace listener mutation tests")]
+    public class TraceListenerMutationTests
+    {
+        [Fact]
+        public void MatchOrInitPE_WhenElf_ReturnsNull()
+        {
+            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
+            moduleFile.MatchOrInitElf(); // Set as ELF first
+
+            // Suppress Debug.Assert so we can verify the return value.
+            var listeners = new TraceListener[Trace.Listeners.Count];
+            Trace.Listeners.CopyTo(listeners, 0);
+            Trace.Listeners.Clear();
+            try
+            {
+                var pe = moduleFile.MatchOrInitPE();
+                Assert.Null(pe);
+            }
+            finally
+            {
+                Trace.Listeners.AddRange(listeners);
+            }
+        }
+
+        [Fact]
+        public void MatchOrInitElf_WhenPE_ReturnsNull()
+        {
+            var moduleFile = new TraceModuleFile(null, 0, (ModuleFileIndex)0);
+            moduleFile.MatchOrInitPE(); // Set as PE first
+
+            // Suppress Debug.Assert so we can verify the return value.
+            var listeners = new TraceListener[Trace.Listeners.Count];
+            Trace.Listeners.CopyTo(listeners, 0);
+            Trace.Listeners.Clear();
+            try
+            {
+                var elf = moduleFile.MatchOrInitElf();
+                Assert.Null(elf);
+            }
+            finally
+            {
+                Trace.Listeners.AddRange(listeners);
+            }
+        }
     }
 }

--- a/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
+++ b/src/TraceEvent/TraceEvent.Tests/TraceEvent.Tests.csproj
@@ -51,6 +51,8 @@
     <Compile Include="..\..\PerfView.TestUtilities\DebugAssertionTests.cs">
       <Link>DebugAssertionTests.cs</Link>
     </Compile>
+    <Compile Remove="Properties\ModuleInitializerAttribute.cs" />
+    <Compile Include="Properties\ModuleInitializerAttribute.cs" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TraceEvent/TraceEvent.Tests/app.config
+++ b/src/TraceEvent/TraceEvent.Tests/app.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.diagnostics>
+    <assert assertuienabled="false" />
     <trace>
       <listeners>
         <remove name="Default" />


### PR DESCRIPTION
## Summary

Prevent assertion dialogs from blocking test runs while preserving parallel execution.

- Stop the ELF mismatch tests from clearing and restoring the process-wide `Trace.Listeners` collection.
- Eagerly initialize the .NET Framework trace-listener configuration from a `TraceEventTests` module initializer before xUnit starts test methods in parallel.
- Validate the existing listener configuration before intentionally triggering assertions; the tests do not install or repair listeners.
- Disable interactive assertion UI in test `app.config` files while retaining `ThrowingTraceListener`.
- Add the previously missing listener configuration to `FastSerialization.Tests`.

## Root cause

`Trace.Listeners` is process-wide state and its configuration is loaded lazily. The ELF mismatch tests previously cleared and restored that collection while other tests could use it, allowing assertion tests to run with `DefaultTraceListener` and open an interactive assertion dialog.

Removing the explicit listener mutation fixed that race, but the full parallel `TraceEventTests` workload also reproduced concurrent first access to the lazily initialized listener configuration. The module initializer now forces that configuration to finish loading on one thread before any test method executes. Test parallelization remains enabled.

On .NET Framework, `AssertValid()` verifies that `DefaultTraceListener` is absent and `ThrowingTraceListener` was registered by the test assembly's `app.config`. It only inspects the collection because repairing process-wide listener state could introduce another race. Modern .NET ignores this `app.config` diagnostics section, but its built-in assertion behavior already throws; the assertion tests verify that behavior directly.

## Validation

- `TraceEvent.Tests` builds successfully for `net462` and `net8.0`.
- Three exact seven-assembly VSTest 18.9.0 Debug/Release stress iterations passed with `TraceEvent.Tests` parallelization enabled.
- Removing the listener configuration causes the validation test to fail through xUnit within seconds instead of opening an assertion dialog.
- Twenty consecutive public Azure DevOps PR merge-ref runs against `2acb78c01d6d3331e6b091740827b80c15dfd1e9` completed both the `PerfView_Debug` and `PerfView_Release` test tasks without a hang. Nineteen builds passed; build 1583681 completed normally but had two unrelated transient `TdhEnumerateProviders` test failures.

CI build IDs: 1583568, 1583609, 1583612, 1583613, 1583614, 1583615, 1583652, 1583653, 1583654, 1583655, 1583656, 1583678, 1583679, 1583680, 1583681, 1583682, 1583734, 1583735, 1583736, 1583737.