### PR TITLE
Bump PerfView to 3.2.7 and rely on SourceLink

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <ReleaseVersion>3.2.6</ReleaseVersion>
+    <ReleaseVersion>3.2.7</ReleaseVersion>
     <FastSerializationVersion>$(ReleaseVersion)</FastSerializationVersion>
     <HeapDumpDllVersion>$(ReleaseVersion)</HeapDumpDllVersion>
     <MemoryGraphVersion>$(ReleaseVersion)</MemoryGraphVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <PublishRepositoryUrl>false</PublishRepositoryUrl>
-    <EmbedAllSources>true</EmbedAllSources>
+    <EmbedAllSources>false</EmbedAllSources>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
PerfView now supports SourceLink, so embedding every source file in portable PDBs is no longer necessary.

- Bump the shared release version to 3.2.7.
- Disable source embedding globally while retaining portable PDB and SourceLink generation.
- Leave the intentionally embedded-PDB test fixture unchanged.